### PR TITLE
Added an ASSUME_SORTED flag to FixMateInformation

### DIFF
--- a/src/java/picard/sam/FixMateInformation.java
+++ b/src/java/picard/sam/FixMateInformation.java
@@ -77,6 +77,10 @@ public class FixMateInformation extends CommandLineProgram {
     doc="Optional sort order if the OUTPUT file should be sorted differently than the INPUT file.")
     public SortOrder SORT_ORDER;
 
+    @Option(doc="If true, assume that the input file is queryname sorted, even if the header says otherwise.", 
+    shortName=StandardOptionDefinitions.ASSUME_SORTED_SHORT_NAME)
+    public boolean ASSUME_SORTED = false;
+
     @Option(shortName="MC", optional=true, doc="Adds the mate CIGAR tag (MC) if true, does not if false.")
     public Boolean ADD_MATE_CIGAR = true;
 
@@ -146,7 +150,7 @@ public class FixMateInformation extends CommandLineProgram {
             }
 
             // And now deal with re-sorting if necessary
-            if (allQueryNameSorted) {
+            if (ASSUME_SORTED || allQueryNameSorted) {
                 iterator = new PeekableIterator<SAMRecord>(tmp);
             }
             else {


### PR DESCRIPTION
Added an ASSUME_SORTED flag to FixMateInformation to allow grouped reads (similar to running bamshuff) to be analysed directly without prior queryname sorting.
