### PR TITLE
Enable `CollectTargetedPcrMetrics` and `CalculateHsMetrics` to target multiple baitsets.

### DIFF
--- a/src/java/picard/analysis/directed/CollectTargetedPcrMetrics.java
+++ b/src/java/picard/analysis/directed/CollectTargetedPcrMetrics.java
@@ -2,6 +2,7 @@ package picard.analysis.directed;
 
 import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
+import htsjdk.samtools.util.IntervalList;
 import picard.analysis.MetricAccumulationLevel;
 import picard.cmdline.Option;
 import picard.cmdline.Usage;
@@ -14,7 +15,7 @@ import java.util.Set;
  * Collect metric information for target pcr metrics runs.  See CollectTargetedMetrics and TargetPcrMetricsCollector for
  * more information
  */
-public class CollectTargetedPcrMetrics extends CollectTargetedMetrics {
+public class CollectTargetedPcrMetrics extends CollectTargetedMetrics<TargetedPcrMetrics, TargetedPcrMetricsCollector> {
 
     @Usage
     public final String USAGE =
@@ -22,18 +23,18 @@ public class CollectTargetedPcrMetrics extends CollectTargetedMetrics {
                     "or BAM file. If a reference sequence is provided, AT/GC dropout metrics will " +
                     "be calculated, and the PER_TARGET_COVERAGE option can be used to output GC and " +
                     "mean coverage information for every target.";
-    @Option(shortName="AI", doc="An interval list file that contains the locations of the baits used.")
+    @Option(shortName = "AI", doc = "An interval list file that contains the locations of the baits used.")
     public File AMPLICON_INTERVALS;
 
-    @Option(shortName="N",  doc="Custom amplicon set name. If not provided it is inferred from the filename of the AMPLICON_INTERVALS intervals.", optional=true)
+    @Option(shortName = "N", doc = "Custom amplicon set name. If not provided it is inferred from the filename of the AMPLICON_INTERVALS intervals.", optional = true)
     public String CUSTOM_AMPLICON_SET_NAME;
 
     /**
      * @return AMPLICON_INTERVALS
      */
     @Override
-    protected File getProbeIntervals() {
-        return AMPLICON_INTERVALS;
+    protected IntervalList getProbeIntervals() {
+        return IntervalList.fromFile(AMPLICON_INTERVALS);
     }
 
     /**
@@ -41,7 +42,7 @@ public class CollectTargetedPcrMetrics extends CollectTargetedMetrics {
      */
     @Override
     protected String getProbeSetName() {
-        return CUSTOM_AMPLICON_SET_NAME;
+        return CUSTOM_AMPLICON_SET_NAME != null ? CUSTOM_AMPLICON_SET_NAME : CollectTargetedMetrics.renderProbeNameFromFile(AMPLICON_INTERVALS);
     }
 
     /** Stock main method. */
@@ -50,13 +51,13 @@ public class CollectTargetedPcrMetrics extends CollectTargetedMetrics {
     }
 
     @Override
-    protected TargetMetricsCollector makeCollector(final Set<MetricAccumulationLevel> accumulationLevels,
-                                                   final List<SAMReadGroupRecord> samRgRecords,
-                                                   final ReferenceSequenceFile refFile,
-                                                   final File perTargetCoverage,
-                                                   final File targetIntervals,
-                                                   final File probeIntervals,
-                                                   final String probeSetName) {
+    protected TargetedPcrMetricsCollector makeCollector(final Set<MetricAccumulationLevel> accumulationLevels,
+                                                        final List<SAMReadGroupRecord> samRgRecords,
+                                                        final ReferenceSequenceFile refFile,
+                                                        final File perTargetCoverage,
+                                                        final IntervalList targetIntervals,
+                                                        final IntervalList probeIntervals,
+                                                        final String probeSetName) {
         return new TargetedPcrMetricsCollector(accumulationLevels, samRgRecords, refFile, perTargetCoverage, targetIntervals, probeIntervals, probeSetName);
     }
 }

--- a/src/java/picard/analysis/directed/HsMetricCollector.java
+++ b/src/java/picard/analysis/directed/HsMetricCollector.java
@@ -26,6 +26,7 @@ package picard.analysis.directed;
 
 import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
+import htsjdk.samtools.util.IntervalList;
 import picard.analysis.MetricAccumulationLevel;
 import picard.sam.DuplicationMetrics;
 
@@ -42,7 +43,7 @@ import java.util.Set;
  */
 public class HsMetricCollector extends TargetMetricsCollector<HsMetrics> {
 
-    public HsMetricCollector(final Set<MetricAccumulationLevel> accumulationLevels, final List<SAMReadGroupRecord> samRgRecords, final ReferenceSequenceFile refFile, final File perTargetCoverage, final File targetIntervals, final File probeIntervals, final String probeSetName) {
+    public HsMetricCollector(final Set<MetricAccumulationLevel> accumulationLevels, final List<SAMReadGroupRecord> samRgRecords, final ReferenceSequenceFile refFile, final File perTargetCoverage, final IntervalList targetIntervals, final IntervalList probeIntervals, final String probeSetName) {
         super(accumulationLevels, samRgRecords, refFile, perTargetCoverage, targetIntervals, probeIntervals, probeSetName);
     }
 

--- a/src/java/picard/analysis/directed/TargetMetricsCollector.java
+++ b/src/java/picard/analysis/directed/TargetMetricsCollector.java
@@ -81,9 +81,6 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
     //If perTargetCoverage != null then coverage is computed for each specified target and output to this file
     private final File perTargetCoverage;
 
-    //The intervals covered by the targeting mechanism (baits in Hybrid Selection, amplicons in TSCA) of this sequencing run
-    private final File probeIntervals;
-
     //The name of the set of probes used
     private final String probeSetName;
 
@@ -188,24 +185,12 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
     }
 
     public TargetMetricsCollector(final Set<MetricAccumulationLevel> accumulationLevels, final List<SAMReadGroupRecord> samRgRecords, final ReferenceSequenceFile refFile,
-                                  final File perTargetCoverage, final File targetIntervals, final File probeIntervals, final String probeSetName) {
+                                  final File perTargetCoverage, final IntervalList targetIntervals, final IntervalList probeIntervals, final String probeSetName) {
         this.perTargetCoverage = perTargetCoverage;
-        this.probeIntervals    = probeIntervals;
+        this.probeSetName = probeSetName;
 
-        if(probeSetName == null) {
-            final String baitFileName = probeIntervals.getName();
-            final int tmp = baitFileName.indexOf(".");
-            if (tmp > 0) {
-                this.probeSetName = baitFileName.substring(0, tmp);
-            } else {
-                this.probeSetName = null;
-            }
-        } else {
-            this.probeSetName = probeSetName;
-        }
-
-        this.allProbes  = IntervalList.fromFile(probeIntervals);
-        this.allTargets = IntervalList.fromFile(targetIntervals);
+        this.allProbes  = probeIntervals;
+        this.allTargets = targetIntervals;
 
         final List<Interval> uniqueBaits = this.allProbes.getUniqueIntervals();
         this.probeDetector = new OverlapDetector<Interval>(-NEAR_PROBE_DISTANCE, 0);
@@ -247,7 +232,7 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
 
     @Override
     protected PerUnitMetricCollector<METRIC_TYPE, Integer, SAMRecord> makeChildCollector(final String sample, final String library, final String readGroup) {
-        final PerUnitTargetMetricCollector collector =  new PerUnitTargetMetricCollector(probeIntervals.getName(), coverageByTargetForRead.keySet(),
+        final PerUnitTargetMetricCollector collector =  new PerUnitTargetMetricCollector(probeSetName, coverageByTargetForRead.keySet(),
                                                                                          sample, library, readGroup, probeTerritory, targetTerritory, genomeSize,
                                                                                          intervalToGc);
         if (this.probeSetName != null) {

--- a/src/java/picard/analysis/directed/TargetedPcrMetricsCollector.java
+++ b/src/java/picard/analysis/directed/TargetedPcrMetricsCollector.java
@@ -26,6 +26,7 @@ package picard.analysis.directed;
 
 import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
+import htsjdk.samtools.util.IntervalList;
 import picard.analysis.MetricAccumulationLevel;
 
 import java.io.File;
@@ -42,7 +43,7 @@ import java.util.Set;
 public class TargetedPcrMetricsCollector extends TargetMetricsCollector<TargetedPcrMetrics> {
     //maybe instead just inject this into the TargetedMetricCollector ->
 
-    public TargetedPcrMetricsCollector(final Set<MetricAccumulationLevel> accumulationLevels, final List<SAMReadGroupRecord> samRgRecords, final ReferenceSequenceFile refFile, final File perTargetCoverage, final File targetIntervals, final File probeIntervals, final String probeSetName) {
+    public TargetedPcrMetricsCollector(final Set<MetricAccumulationLevel> accumulationLevels, final List<SAMReadGroupRecord> samRgRecords, final ReferenceSequenceFile refFile, final File perTargetCoverage, final IntervalList targetIntervals, final IntervalList probeIntervals, final String probeSetName) {
         super(accumulationLevels, samRgRecords, refFile, perTargetCoverage, targetIntervals, probeIntervals, probeSetName);
     }
 


### PR DESCRIPTION
- Both command line programs' `TARGET_INTERVALS` argument accept multiple values.
- `CalculateHsMetrics`'s `BAIT_INTERVALS` accepts multiple values.
