### PR TITLE
FORCE_GC=false causes NPE in log

### DIFF
--- a/src/java/picard/illumina/IlluminaBasecallsConverter.java
+++ b/src/java/picard/illumina/IlluminaBasecallsConverter.java
@@ -187,10 +187,10 @@ public class IlluminaBasecallsConverter<CLUSTER_OUTPUT_RECORD> {
             gcTimerTask = new TimerTask() {
                 @Override
                 public void run() {
-                    System.out.println("Before explicit GC, Runtime.totalMemory()=" + Runtime.getRuntime().totalMemory());
+                    log.info("Before explicit GC, Runtime.totalMemory()=" + Runtime.getRuntime().totalMemory());
                     System.gc();
                     System.runFinalization();
-                    System.out.println("After explicit GC, Runtime.totalMemory()=" + Runtime.getRuntime().totalMemory());
+                    log.info("After explicit GC, Runtime.totalMemory()=" + Runtime.getRuntime().totalMemory());
                 }
             };
             gcTimer.scheduleAtFixedRate(gcTimerTask, delay, delay);
@@ -281,7 +281,7 @@ public class IlluminaBasecallsConverter<CLUSTER_OUTPUT_RECORD> {
 
         } finally {
             try {
-                gcTimerTask.cancel();
+            	if (gcTimerTask != null) gcTimerTask.cancel();
             } catch (final Throwable ex) {
                 log.warn(ex, "Ignoring exception stopping background GC thread.");
             }


### PR DESCRIPTION
If IlluminaBasecallsToFastq is started with FORCE_GC=false a NullPointerException is written to the log. Fixed by adding a check before calling gcTimerTask.cancel()

Also change the System.out.println() calls to log.info(). Better to have all information go through the logging mechanism so that the output can be controlled with the VERBOSITY parameter.

/Nicklas
