### PR TITLE
Clarify what a "non-PF read" is.

### DIFF
--- a/src/java/picard/sam/SamToFastq.java
+++ b/src/java/picard/sam/SamToFastq.java
@@ -95,7 +95,9 @@ public class SamToFastq extends CommandLineProgram {
     @Option(shortName = "INTER", doc = "Will generate an interleaved fastq if paired, each line will have /1 or /2 to describe which end it came from")
     public boolean INTERLEAVE = false;
 
-    @Option(shortName = "NON_PF", doc = "Include non-PF reads from the SAM file into the output FASTQ files.")
+    @Option(shortName = "NON_PF", doc = "Include non-PF reads from the SAM file into the output " +
+            "FASTQ files. PF means 'passes filtering'. Reads whose 'not passing quality controls' " +
+            "flag is set are non-PF reads.")
     public boolean INCLUDE_NON_PF_READS = false;
 
     @Option(shortName = "CLIP_ATTR", doc = "The attribute that stores the position at which " +


### PR DESCRIPTION
I've been having trouble finding an explanation for what the `INCLUDE_NON_PF_READS` option achieves. All hits on Google lead back to Picard, but the Picard docs never explain what `PF` means. This commit attempts to fix this, at least for SamToFastq.
