### PR TITLE
File faker bug fixes.

### DIFF
--- a/src/java/picard/illumina/parser/PerTilePerCycleFileUtil.java
+++ b/src/java/picard/illumina/parser/PerTilePerCycleFileUtil.java
@@ -203,7 +203,7 @@ public class PerTilePerCycleFileUtil extends ParameterizedFileUtil {
         }
 
         final CycleIlluminaFileMap cfm = getPerTilePerCycleFiles();
-        Long cycleSize = null;
+        final Map<Integer, Integer> tileToSizeMap = new HashMap<Integer, Integer>();
         for (final int currentCycle : expectedCycles) {
             final IlluminaFileMap fileMap = cfm.get(currentCycle);
 
@@ -211,8 +211,8 @@ public class PerTilePerCycleFileUtil extends ParameterizedFileUtil {
                 for (final Integer tile : expectedTiles) {
                     final File fileToFake = new File(base + File.separator + getFileForCycle(currentCycle, tile));
                     try {
-                        if (cycleSize != null) {
-                            faker.fakeFile(fileToFake, cycleSize.intValue());
+                        if (tileToSizeMap.containsKey(tile)) {
+                            faker.fakeFile(fileToFake, tileToSizeMap.get(tile));
                         }
                         else{
                             faker.fakeFile(fileToFake, 1);
@@ -224,14 +224,14 @@ public class PerTilePerCycleFileUtil extends ParameterizedFileUtil {
             } else {
                 for (final int tile : expectedTiles) {
                     final File cycleFile = fileMap.get(tile);
-                    if (cycleFile != null && cycleSize == null) {
-                        cycleSize = BclReader.getNumberOfClusters(cycleFile);
+                    if (cycleFile != null && !tileToSizeMap.containsKey(tile)) {
+                        tileToSizeMap.put(tile, (int) BclReader.getNumberOfClusters(cycleFile));
                     }
                     try {
                         if (cycleFile == null) {
                             final File fileToFake = new File(base + File.separator + getFileForCycle(currentCycle, tile));
-                            if (cycleSize != null) {
-                                faker.fakeFile(fileToFake, cycleSize.intValue());
+                            if (tileToSizeMap.containsKey(tile)) {
+                                faker.fakeFile(fileToFake, tileToSizeMap.get(tile));
                             } else {
                                 faker.fakeFile(fileToFake, 1);
                             }

--- a/src/java/picard/illumina/parser/fakers/ClocsFileFaker.java
+++ b/src/java/picard/illumina/parser/fakers/ClocsFileFaker.java
@@ -9,8 +9,8 @@ public class ClocsFileFaker extends FileFaker {
         buffer.put((byte) 1);
         buffer.putInt(1);
         buffer.put((byte) (0xff & 1));
-        buffer.putFloat((byte) (0xff & 5));
-        buffer.putFloat((byte) (0xff & 5));
+        buffer.put((byte) (0xff & 5));
+        buffer.put((byte) (0xff & 5));
     }
 
     @Override
@@ -20,6 +20,6 @@ public class ClocsFileFaker extends FileFaker {
 
     @Override
     protected int bufferSize() {
-        return (Integer.SIZE * 2) + (Float.SIZE * 3);
+        return Integer.SIZE + (Byte.SIZE * 4);
     }
 }


### PR DESCRIPTION
- `ClocsFileFaker` emits too many bytes in single-record file.
- `PerTilePerCycleFileUtil` wasn't careful about cycle collisions.
