### PR TITLE
Updated CollectRnaSeqMetrics to make coverage collection optional

### DIFF
--- a/src/java/picard/analysis/CollectRnaSeqMetrics.java
+++ b/src/java/picard/analysis/CollectRnaSeqMetrics.java
@@ -82,6 +82,9 @@ public class CollectRnaSeqMetrics extends SinglePassSamProgram {
     @Option(doc="This percentage of the length of a fragment must overlap one of the ribosomal intervals for a read or read pair by this must in order to be considered rRNA.")
     public double RRNA_FRAGMENT_PERCENTAGE = 0.8;
 
+    @Option(doc="Determines if per-transcript coverage metrics are gathered.  Turn this off if you have many read groups and don't have available memory, or if you don't wish to gather coverage.")
+    public Boolean COLLECT_COVERAGE = true;
+    
     @Option(shortName="LEVEL", doc="The level(s) at which to accumulate metrics.  ")
     private Set<MetricAccumulationLevel> METRIC_ACCUMULATION_LEVEL = CollectionUtil.makeSet(MetricAccumulationLevel.ALL_READS);
 
@@ -111,7 +114,7 @@ public class CollectRnaSeqMetrics extends SinglePassSamProgram {
         final HashSet<Integer> ignoredSequenceIndices = RnaSeqMetricsCollector.makeIgnoredSequenceIndicesSet(header, IGNORE_SEQUENCE);
 
         collector = new RnaSeqMetricsCollector(METRIC_ACCUMULATION_LEVEL, header.getReadGroups(), ribosomalBasesInitialValue,
-                geneOverlapDetector, ribosomalSequenceOverlapDetector, ignoredSequenceIndices, MINIMUM_LENGTH, STRAND_SPECIFICITY, RRNA_FRAGMENT_PERCENTAGE);
+                geneOverlapDetector, ribosomalSequenceOverlapDetector, ignoredSequenceIndices, MINIMUM_LENGTH, STRAND_SPECIFICITY, RRNA_FRAGMENT_PERCENTAGE, COLLECT_COVERAGE);
 
         // If we're working with a single library, assign that library's name as a suffix to the plot title
         final List<SAMReadGroupRecord> readGroups = header.getReadGroups();

--- a/src/java/picard/analysis/directed/RnaSeqMetricsCollector.java
+++ b/src/java/picard/analysis/directed/RnaSeqMetricsCollector.java
@@ -42,11 +42,12 @@ public class RnaSeqMetricsCollector extends SAMRecordMultiLevelCollector<RnaSeqM
 
     private final OverlapDetector<Gene> geneOverlapDetector;
     private final OverlapDetector<Interval> ribosomalSequenceOverlapDetector;
-
+    private final boolean collectCoverageStatistics;
+    
     public RnaSeqMetricsCollector(final Set<MetricAccumulationLevel> accumulationLevels, final List<SAMReadGroupRecord> samRgRecords,
                                   final Long ribosomalBasesInitialValue, OverlapDetector<Gene> geneOverlapDetector, OverlapDetector<Interval> ribosomalSequenceOverlapDetector,
                                   final HashSet<Integer> ignoredSequenceIndices, final int minimumLength, final StrandSpecificity strandSpecificity,
-                                  final double rrnaFragmentPercentage) {
+                                  final double rrnaFragmentPercentage, boolean collectCoverageStatistics) {
         this.ribosomalInitialValue  = ribosomalBasesInitialValue;
         this.ignoredSequenceIndices = ignoredSequenceIndices;
         this.geneOverlapDetector    = geneOverlapDetector;
@@ -54,6 +55,7 @@ public class RnaSeqMetricsCollector extends SAMRecordMultiLevelCollector<RnaSeqM
         this.minimumLength          = minimumLength;
         this.strandSpecificity      = strandSpecificity;
         this.rrnaFragmentPercentage = rrnaFragmentPercentage;
+        this.collectCoverageStatistics=collectCoverageStatistics;
         setup(accumulationLevels, samRgRecords);
     }
 
@@ -96,6 +98,7 @@ public class RnaSeqMetricsCollector extends SAMRecordMultiLevelCollector<RnaSeqM
     private class PerUnitRnaSeqMetricsCollector implements PerUnitMetricCollector<RnaSeqMetrics, Integer, SAMRecord> {
 
         final RnaSeqMetrics metrics = new RnaSeqMetrics();
+        
         private final Map<Gene.Transcript, int[]> coverageByTranscript = new HashMap<Gene.Transcript, int[]>();
 
         public PerUnitRnaSeqMetricsCollector(final String sample,
@@ -106,6 +109,7 @@ public class RnaSeqMetricsCollector extends SAMRecordMultiLevelCollector<RnaSeqM
             this.metrics.LIBRARY = library;
             this.metrics.READ_GROUP = readGroup;
             this.metrics.RIBOSOMAL_BASES = ribosomalBasesInitialValue;
+            
         }
 
         public void acceptRecord(SAMRecord rec) {
@@ -169,16 +173,20 @@ public class RnaSeqMetricsCollector extends SAMRecordMultiLevelCollector<RnaSeqM
                 for (final Gene gene : overlappingGenes) {
                     for (final Gene.Transcript transcript : gene) {
                         transcript.assignLocusFunctionForRange(alignmentBlock.getReferenceStart(), locusFunctions);
-
+                        // if you want to gather coverage statistics, this variable should be true.
+                        // added for cases with many units [samples/read groups] which overwhelm memory.                
                         // Add coverage to our coverage counter for this transcript
-                        int[] coverage = this.coverageByTranscript.get(transcript);
-                        if (coverage == null) {
-                            coverage = new int[transcript.length()];
-                            this.coverageByTranscript.put(transcript, coverage);
+                        if (collectCoverageStatistics) {
+                        	int[] coverage = this.coverageByTranscript.get(transcript);
+                            if (coverage == null) {
+                                coverage = new int[transcript.length()];
+                                this.coverageByTranscript.put(transcript, coverage);
+                            }
+                            transcript.addCoverageCounts(alignmentBlock.getReferenceStart(),
+                                    CoordMath.getEnd(alignmentBlock.getReferenceStart(), alignmentBlock.getLength()),
+                                    coverage);
                         }
-                        transcript.addCoverageCounts(alignmentBlock.getReferenceStart(),
-                                CoordMath.getEnd(alignmentBlock.getReferenceStart(), alignmentBlock.getLength()),
-                                coverage);
+                        
                     }
                 }
 


### PR DESCRIPTION
CollectRnaSeqMetrics uses huge amounts of memory during coverage collection when there are many unit gathering groups (read groups, samples, etc.)  This flag allows coverage collection to be disabled in these cases so that bulk annotations (frac exonic/intronic/etc) data about what fraction of each unit group can still be gathered.
