### PR TITLE
Added PCT_TARGET_BASES_200X and PCT_TARGET_BASES_300X to HsMetrics

### DIFF
--- a/src/java/picard/analysis/directed/HsMetrics.java
+++ b/src/java/picard/analysis/directed/HsMetrics.java
@@ -130,6 +130,10 @@ public class HsMetrics extends MultilevelMetrics {
 	public double PCT_TARGET_BASES_50X;
 	/** The percentage of ALL target bases achieving 100X or greater coverage. */
 	public double PCT_TARGET_BASES_100X;
+    /** The percentage of ALL target bases acheiving 200X or greater coverage. */
+    public double PCT_TARGET_BASES_200X;
+    /** The percentage of ALL target bases acheiving 300X or greater coverage. */
+    public double PCT_TARGET_BASES_300X;
 
     /** The estimated number of unique molecules in the selected part of the library. */
     public Long HS_LIBRARY_SIZE;

--- a/src/java/picard/analysis/directed/TargetMetricsCollector.java
+++ b/src/java/picard/analysis/directed/TargetMetricsCollector.java
@@ -460,6 +460,8 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
 	        int targetBases40x = 0;
 	        int targetBases50x = 0;
 	        int targetBases100x = 0;
+            int targetBases200x = 0;
+            int targetBases300x = 0;
 
             for (final Coverage c : this.coverageByTarget.values()) {
                 for (final short depth : c.getDepths()) {
@@ -478,7 +480,13 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
 		                                if (depth >=50) {
 			                                ++targetBases50x;
 			                                if (depth >=100) {
-				                                ++targetBases100x;
+                                                ++targetBases100x;
+                                                if (depth >=200) {
+                                                    ++targetBases200x;
+                                                    if (depth >=300) {
+                                                        ++targetBases300x;
+                                                    }
+                                                }
 			                                }
 		                                }
 	                                }
@@ -495,7 +503,9 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
 	        this.metrics.PCT_TARGET_BASES_30X = (double) targetBases30x / (double) totalTargetBases;
 	        this.metrics.PCT_TARGET_BASES_40X = (double) targetBases40x / (double) totalTargetBases;
 	        this.metrics.PCT_TARGET_BASES_50X = (double) targetBases50x / (double) totalTargetBases;
-	        this.metrics.PCT_TARGET_BASES_100X = (double) targetBases100x / (double) totalTargetBases;
+            this.metrics.PCT_TARGET_BASES_100X = (double) targetBases100x / (double) totalTargetBases;
+            this.metrics.PCT_TARGET_BASES_200X = (double) targetBases200x / (double) totalTargetBases;
+            this.metrics.PCT_TARGET_BASES_300X = (double) targetBases300x / (double) totalTargetBases;
         }
 
         private void calculateGcMetrics() {
@@ -734,8 +744,12 @@ class TargetMetrics extends MultilevelMetrics {
 	public double PCT_TARGET_BASES_40X;
 	/** The percentage of ALL target bases acheiving 50X or greater coverage. */
 	public double PCT_TARGET_BASES_50X;
-	/** The percentage of ALL target bases acheiving 100X or greater coverage. */
-	public double PCT_TARGET_BASES_100X;
+    /** The percentage of ALL target bases acheiving 100X or greater coverage. */
+    public double PCT_TARGET_BASES_100X;
+    /** The percentage of ALL target bases acheiving 200X or greater coverage. */
+    public double PCT_TARGET_BASES_200X;
+    /** The percentage of ALL target bases acheiving 300X or greater coverage. */
+    public double PCT_TARGET_BASES_300X;
 
     /**
      * A measure of how undercovered <= 50% GC regions are relative to the mean. For each GC bin [0..50]


### PR DESCRIPTION
Our lab does pretty deep exome sequencing. 
We wanted to see deeper coverage stats.
So we made these changes.
