### PR TITLE
Moved the test for duplicate @PD.IDs into AbstractAlignmentMerger to avo...

### DIFF
--- a/src/java/picard/sam/SamAlignmentMerger.java
+++ b/src/java/picard/sam/SamAlignmentMerger.java
@@ -132,21 +132,7 @@ public class SamAlignmentMerger extends AbstractAlignmentMerger {
             }
             tmpReader.close();
         }
-        // If not null, the program record was already added in the superclass.  DO NOT RE-ADD!
 
-        if (getProgramRecord() != null) {
-            final SAMFileReader tmp = new SAMFileReader(unmappedBamFile);
-            try {
-                for (final SAMProgramRecord pg : tmp.getFileHeader().getProgramRecords()) {
-                    if (pg.getId().equals(getProgramRecord().getId())) {
-                        throw new PicardException("Program Record ID already in use in unmapped BAM file.");
-                    }
-                }
-            }
-            finally {
-                tmp.close();
-            }
-        }
         log.info("Processing SAM file(s): " + alignedSamFile != null ? alignedSamFile : read1AlignedSamFile + "," + read2AlignedSamFile);
     }
 


### PR DESCRIPTION
...id opening the unmapped SAM file twice.
