### PR TITLE
updating how _includes/command-line-usage.html is generated on the docs

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -518,7 +518,7 @@
 
             <!-- include usage for each command -->
             <echo file="${command-line-html-dir}/inc/command-line-usage.html" append="true"
-                  message="&lt;!--#include virtual=&quot;@{title}.html&quot; -->${line.separator}"/>
+                  message="{% include @{title}.html %}${line.separator}"/>
         </sequential>
     </macrodef>
 


### PR DESCRIPTION
page: moving from virtual include to markdown include

see: https://github.com/broadinstitute/picard/issues/77
