### PR TITLE
Additonal output stats to CollectInsertSizeMetrics.  

### DIFF
--- a/src/java/picard/analysis/InsertSizeMetrics.java
+++ b/src/java/picard/analysis/InsertSizeMetrics.java
@@ -91,4 +91,10 @@ public class InsertSizeMetrics extends MultilevelMetrics {
     public int WIDTH_OF_90_PERCENT;
     /** The "width" of the bins, centered around the median, that encompass 100% of all read pairs. */
     public int WIDTH_OF_99_PERCENT;
+
+    /** Value of the insert size histogram bin where 02.5%, 25%, 75%, and 97.5% of the data falls. Useful for boxplots and such. */
+    public double PERCENT_02_5_INSERT_SIZE;
+    public double PERCENT_25_INSERT_SIZE;
+    public double PERCENT_75_INSERT_SIZE;
+    public double PERCENT_97_5_INSERT_SIZE;
 }

--- a/src/java/picard/analysis/InsertSizeMetrics.java
+++ b/src/java/picard/analysis/InsertSizeMetrics.java
@@ -92,9 +92,12 @@ public class InsertSizeMetrics extends MultilevelMetrics {
     /** The "width" of the bins, centered around the median, that encompass 100% of all read pairs. */
     public int WIDTH_OF_99_PERCENT;
 
-    /** Value of the insert size histogram bin where 02.5%, 25%, 75%, and 97.5% of the data falls. Useful for boxplots and such. */
+    /** Insert size for which 2.5% of all read pairs have an insert size &le; that value. */
     public double PERCENT_02_5_INSERT_SIZE;
+    /** Insert size for which 25% of all read pairs have an insert size &le; that value. The first quartile of the insert size distribution. This value along with MEDIAN_INSERT_SIZE, PERCENT_75_INSERT_SIZE, and MIN/MAX_INSERT_SIZE is what one needs for a boxplot. */
     public double PERCENT_25_INSERT_SIZE;
+    /** Insert size for which 75% of all read pairs have an insert size &le; that value. The thrid quartile of the insert size distribution. */
     public double PERCENT_75_INSERT_SIZE;
+    /** Insert size for which 97.5% of all read pairs have an insert size &le; that value. */
     public double PERCENT_97_5_INSERT_SIZE;
 }

--- a/src/java/picard/analysis/InsertSizeMetrics.java
+++ b/src/java/picard/analysis/InsertSizeMetrics.java
@@ -92,12 +92,12 @@ public class InsertSizeMetrics extends MultilevelMetrics {
     /** The "width" of the bins, centered around the median, that encompass 100% of all read pairs. */
     public int WIDTH_OF_99_PERCENT;
 
-    /** Insert size for which 2.5% of all read pairs have an insert size &le; that value. */
+    /** Insert size for which 2.5% of all read pairs have an insert size <= that value. */
     public double PERCENT_02_5_INSERT_SIZE;
-    /** Insert size for which 25% of all read pairs have an insert size &le; that value. The first quartile of the insert size distribution. This value along with MEDIAN_INSERT_SIZE, PERCENT_75_INSERT_SIZE, and MIN/MAX_INSERT_SIZE is what one needs for a boxplot. */
+    /** Insert size for which 25% of all read pairs have an insert size <= that value. The first quartile of the insert size distribution. This value along with MEDIAN_INSERT_SIZE, PERCENT_75_INSERT_SIZE, and MIN/MAX_INSERT_SIZE is what one needs for a boxplot. */
     public double PERCENT_25_INSERT_SIZE;
-    /** Insert size for which 75% of all read pairs have an insert size &le; that value. The thrid quartile of the insert size distribution. */
+    /** Insert size for which 75% of all read pairs have an insert size <= that value. The thrid quartile of the insert size distribution. */
     public double PERCENT_75_INSERT_SIZE;
-    /** Insert size for which 97.5% of all read pairs have an insert size &le; that value. */
+    /** Insert size for which 97.5% of all read pairs have an insert size <= that value. */
     public double PERCENT_97_5_INSERT_SIZE;
 }

--- a/src/java/picard/analysis/directed/InsertSizeMetricsCollector.java
+++ b/src/java/picard/analysis/directed/InsertSizeMetricsCollector.java
@@ -132,6 +132,10 @@ public class InsertSizeMetricsCollector extends MultiLevelCollector<InsertSizeMe
                     metrics.MIN_INSERT_SIZE    = (int) Histogram.getMin();
                     metrics.MEDIAN_INSERT_SIZE = Histogram.getMedian();
                     metrics.MEDIAN_ABSOLUTE_DEVIATION = Histogram.getMedianAbsoluteDeviation();
+                    metrics.PERCENT_02_5_INSERT_SIZE = Histogram.getPercentile(0.025);
+                    metrics.PERCENT_25_INSERT_SIZE = Histogram.getPercentile(0.25);
+                    metrics.PERCENT_75_INSERT_SIZE = Histogram.getPercentile(0.75);
+                    metrics.PERCENT_97_5_INSERT_SIZE = Histogram.getPercentile(0.975);
 
                     final double median  = Histogram.getMedian();
                     double covered = 0;


### PR DESCRIPTION
Small addition to the output of CollectInsertSizeMetrics.
Gives 2.5%, 25%, 75%, and 97.5% percentile values useful for making boxplots and such.

Just uses the methods already available in the Histogram class, so it is a very simple addition.
New output is at the end of the current stats fields (though before SAMPLE, LIBRARY, and READ_GROUP), so impact on tools which process the output might exist, but should be minimal.

<!---
@huboard:{"custom_state":"blocked"}
-->
