### PR TITLE
- removing unnecessary storage of a string in the Read Ends in Mark

### DIFF
--- a/src/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -340,7 +340,6 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
         ends.orientation = rec.getReadNegativeStrandFlag() ? ReadEnds.R : ReadEnds.F;
         ends.read1IndexInFile = index;
         ends.score = DuplicateScoringStrategy.computeDuplicateScore(rec, this.DUPLICATE_SCORING_STRATEGY);
-        ends.name = rec.getReadName();
 
         // Doing this lets the ends object know that it's part of a pair
         if (rec.getReadPairedFlag() && !rec.getMateUnmappedFlag()) {

--- a/src/java/picard/sam/markduplicates/util/ReadEndsForMarkDuplicates.java
+++ b/src/java/picard/sam/markduplicates/util/ReadEndsForMarkDuplicates.java
@@ -30,12 +30,18 @@ package picard.sam.markduplicates.util;
  * @author Nils Homer
  */
 public class ReadEndsForMarkDuplicates extends ReadEnds {
-    public static final int SIZE_OF = (1 * 1) + (2 * 1) + (4 * 4) + (8 * 2) + 2 + 1 + 2 + 2
+    /*
+    What do we need to store you ask?  Well, we need to store:
+       - byte: orientation
+       - short: libraryId, readGroup, tile, x, y, score
+       - int: read1ReferenceIndex, read1Coordinate, read2ReferenceIndex, read2Coordinate
+       - long: read1IndexInFile, read2IndexInFile
+     */
+    public static final int SIZE_OF = (1 * 1) + (5 * 2) + (4 * 4) + (8 * 2) + 1
             + 8 + // last 8 == reference overhead
             13; // This is determined experimentally with JProfiler
 
     public short score = 0;
     public long read1IndexInFile = -1;
     public long read2IndexInFile = -1;
-    public String name = "";
 }

--- a/src/java/picard/sam/markduplicates/util/ReadEndsForMarkDuplicatesCodec.java
+++ b/src/java/picard/sam/markduplicates/util/ReadEndsForMarkDuplicatesCodec.java
@@ -68,8 +68,6 @@ public class ReadEndsForMarkDuplicatesCodec implements SortingCollection.Codec<R
             this.out.writeShort(read.tile);
             this.out.writeShort(read.x);
             this.out.writeShort(read.y);
-            this.out.writeInt(read.name.length());
-            this.out.writeBytes(read.name);
             this.out.writeByte(read.orientationForOpticalDuplicates);
         } catch (final IOException ioe) {
             throw new PicardException("Exception writing ReadEnds to file.", ioe);
@@ -102,10 +100,6 @@ public class ReadEndsForMarkDuplicatesCodec implements SortingCollection.Codec<R
             read.tile = this.in.readShort();
             read.x = this.in.readShort();
             read.y = this.in.readShort();
-
-            final byte[] bytes = new byte[this.in.readInt()];
-            this.in.read(bytes);
-            read.name = new String(bytes);
 
             read.orientationForOpticalDuplicates = this.in.readByte();
 


### PR DESCRIPTION
Duplicates
- clarifying the size of ReadEndsForMarkDuplicates
