### PR TITLE
Fixed error in FilterFileFaker.  

### DIFF
--- a/src/java/picard/illumina/parser/fakers/FilterFileFaker.java
+++ b/src/java/picard/illumina/parser/fakers/FilterFileFaker.java
@@ -4,14 +4,20 @@ import java.nio.ByteBuffer;
 
 /**
  * Created by jcarey on 3/13/14.
+ *
+ * Illumina uses an algorithm described in "Theory of RTA" that determines whether or not a cluster passes filter("PF") or not.
+ * These values are written as sequential bytes to Filter Files.  The structure of a filter file is as follows:
+ * Bytes 0-3  : 0
+ * Bytes 4-7  : unsigned int version
+ * Bytes 8-11 : unsigned int numClusters
  */
 public class FilterFileFaker extends FileFaker {
 
     @Override
     protected void fakeFile(final ByteBuffer buffer) {
-        buffer.putInt(0);
-        buffer.putInt(3);
-        buffer.putInt(1);
+        buffer.putInt(0);       // 0
+        buffer.putInt(3);       // Version number
+        buffer.putInt(0);       // Number of clusters
     }
 
     @Override

--- a/src/tests/java/picard/illumina/parser/readers/FilterFileReaderTest.java
+++ b/src/tests/java/picard/illumina/parser/readers/FilterFileReaderTest.java
@@ -5,6 +5,9 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import picard.PicardException;
+import picard.illumina.parser.IlluminaDataProviderFactory;
+import picard.illumina.parser.IlluminaFileUtil;
+import picard.illumina.parser.fakers.FilterFileFaker;
 
 import java.io.File;
 import java.util.NoSuchElementException;
@@ -30,6 +33,18 @@ public class FilterFileReaderTest {
         }
 
         Assert.assertEquals(false, reader.hasNext());
+    }
+
+    @Test void readFakedFile() throws Exception {
+        final File fakeFile = File.createTempFile("FilterFileFakerTest", ".filter");
+        fakeFile.deleteOnExit();
+
+        new FilterFileFaker().fakeFile(fakeFile, 100);      // We are creating
+
+        // By reading in the file, we are testing the validity
+        final FilterFileReader reader = new FilterFileReader(fakeFile);
+
+        Assert.assertEquals(reader.numClusters, 0);
     }
 
     @Test(expectedExceptions = NoSuchElementException.class)


### PR DESCRIPTION
The faked files that it created were not readable by our own software.   Added a test to catch this.
