### PR TITLE
Multivcf

### DIFF
--- a/src/java/picard/vcf/MergeVcfs.java
+++ b/src/java/picard/vcf/MergeVcfs.java
@@ -77,7 +77,7 @@ public class MergeVcfs extends CommandLineProgram {
 
     @Option(shortName= StandardOptionDefinitions.INPUT_SHORT_NAME, doc="VCF or BCF input files File format is determined by file extension."+
         "A suffix \'.list\' is interpreted as a text file containing the paths to the input file.  ", minElements=1)
-    public List<String> INPUT;
+    public List<File> INPUT;
 
     @Option(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "The merged VCF or BCF file. File format is determined by file extension.")
     public File OUTPUT;
@@ -100,11 +100,12 @@ public class MergeVcfs extends CommandLineProgram {
     private Set<File> getInputFiles()
         {
         Set<File> input_files = new LinkedHashSet<File>();
-        for (final String filename : this.INPUT) {
-            if(filename.endsWith(".list")) {/*suffix is list: read the paths */
+        for (final File file : this.INPUT) {
+            IOUtil.assertFileIsReadable(file);
+            if(file.getName().endsWith(".list")) {/*suffix is list: read the paths */
                 BufferedReader br = null;
                 try {
-                    br = IOUtil.openFileForBufferedReading(new File(filename));
+                    br = IOUtil.openFileForBufferedReading(file);
                     String line;
                     while((line = br.readLine())!=null)
                         {
@@ -113,7 +114,7 @@ public class MergeVcfs extends CommandLineProgram {
                         }
                     }
                 catch(IOException err) {
-                    throw new PicardException("Error while reading "+ filename +
+                    throw new PicardException("Error while reading "+ file +
                         " : "+err.getMessage());
                     }
                 finally {
@@ -121,7 +122,7 @@ public class MergeVcfs extends CommandLineProgram {
                     }
                 }
             else { /* BCF or VCF file */
-                input_files.add(new File(filename));
+                input_files.add(file);
                 }
             }
         return input_files;

--- a/src/tests/java/picard/vcf/AbstractVcfMergingClpTester.java
+++ b/src/tests/java/picard/vcf/AbstractVcfMergingClpTester.java
@@ -133,6 +133,25 @@ public abstract class AbstractVcfMergingClpTester {
         runClp(inputs, output, indexing, 0);
         validateResultsForMultipleInputs(output, positionQueues);
 	}
+	
+	@Test
+	private void testMergeListOfVcf() throws IOException {
+	    final List<File> list = Arrays.asList(new File(TEST_DATA_PATH, "vcf.list"));
+	    final File output = File.createTempFile("merge-list-output.", ".vcf");
+	    output.deleteOnExit();
+	    final List<String> indexing = Arrays.asList("CREATE_INDEX=false");
+	    runClp(list, output, indexing, 0);
+	} 
+
+    @Test (expectedExceptions = htsjdk.samtools.SAMException.class)
+	private void testMergeListOfVcfMissing() throws IOException {
+	    final List<File> list = Arrays.asList(new File(TEST_DATA_PATH, "vcf-missing.list"));
+	    final File output = File.createTempFile("merge-list-output.", ".vcf");
+	    output.deleteOnExit();
+	    final List<String> indexing = Arrays.asList("CREATE_INDEX=false");
+	    runClp(list, output, indexing, 0);
+	} 
+
 
     private void validateResultsForMultipleInputs(final File output, final List<Queue<String>> positionQueues) {
         final VCFFileReader outputReader = new VCFFileReader(output, false);

--- a/testdata/picard/vcf/vcf-misssing.list
+++ b/testdata/picard/vcf/vcf-misssing.list
@@ -1,0 +1,6 @@
+testdata/picard/vcf/CEUTrio-random-scatter-0.vcf
+testdata/picard/vcf/CEUTrio-random-scatter-1.vcf
+testdata/picard/vcf/CEUTrio-random-scatter-2.vcf
+testdata/picard/vcf/CEUTrio-random-scatter-3.vcf
+testdata/picard/vcf/CEUTrio-random-scatter-4.vcf
+testdata/picard/vcf/non-existing-file.vcf

--- a/testdata/picard/vcf/vcf.list
+++ b/testdata/picard/vcf/vcf.list
@@ -1,0 +1,6 @@
+testdata/picard/vcf/CEUTrio-random-scatter-0.vcf
+testdata/picard/vcf/CEUTrio-random-scatter-1.vcf
+testdata/picard/vcf/CEUTrio-random-scatter-2.vcf
+testdata/picard/vcf/CEUTrio-random-scatter-3.vcf
+testdata/picard/vcf/CEUTrio-random-scatter-4.vcf
+testdata/picard/vcf/CEUTrio-random-scatter-5.vcf


### PR DESCRIPTION
This pull request is for __MergeVcfs__ 

If want to avoid to put all the INPUT files in one the command line when I need to merge a few hundred VCF files.

If a INPUT ends with '*.list', the file is interpreted as file containing a list of path to some vcf/bcf.

I've added two tests:  'testMergeListOfVcfMissing' and 'testMergeListOfVcf' in AbstractVcfMergingClpTester
```bash
$ java -cp (...) org.testng.TestNG -testclass picard.vcf.MergeVcfsTest

===============================================
Command line suite
Total tests run: 7, Failures: 0, Skips: 0
===============================================
```
