### PR TITLE
Fixed typo in output filename according to issue #159

### DIFF
--- a/src/java/picard/analysis/CollectMultipleMetrics.java
+++ b/src/java/picard/analysis/CollectMultipleMetrics.java
@@ -49,7 +49,7 @@ public class CollectMultipleMetrics extends CommandLineProgram {
             public SinglePassSamProgram makeInstance(final String outbase) {
                 final CollectInsertSizeMetrics program = new CollectInsertSizeMetrics();
                 program.OUTPUT = new File(outbase + ".insert_size_metrics");
-                program.Histogram_FILE = new File(outbase + ".insert_size_Histogram.pdf");
+                program.Histogram_FILE = new File(outbase + ".insert_size_histogram.pdf");
                 return program;
             }
         },


### PR DESCRIPTION
@nh13 Is this what you meant in issue #159 ? Couldn't find any other use of that name string. 

(Using this trivial case as a test first PR to Picard -- let me know if you have different process preferences)