### PR TITLE
Add support for reading data from Google Genomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,21 @@
 
 A set of Java command line tools for maniuplating high-throughput sequencing data (HTS) data and formats.  
 
-Picard is implemented using the HTSJDK Java library[HTSJDK][1], supporting acce
+Picard is implemented using the HTSJDK Java library[HTSJDK][1], supporting
 accessing of common file formats, such as [SAM][2] and [VCF][3], used for high-throughput
 sequencing data.  
+
+Its also possible to build a version of Picard that supports reading from
+GA4GH API, e.g. Google Genomics:
+1.Fetch gatk-tools-java library from https://github.com/iliat/gatk-tools-java
+2.Build: ant gatk-tools-java-picard-jar
+3.Copy the resulting jar to lib/gatk-tools-java/ under Picard folder, e.g.
+cp dist/gatk-tools-java-picard-1.0.jar ../picard/lib/gatk-tools-java/
+4.Build Picard: ant -lib lib/ant package-commands-ga4gh
+5.You can now run 
+java -jar dist/picard.jar ViewSam \
+INPUT=https://www.googleapis.com/genomics/v1beta2/readgroupsets/CK256frpGBD44IWHwLP22R4/ \
+GA4GH_CLIENT_SECRETS=../client_secrets.json
 
 Please see the [Picard Documentation](http://broadinstitute.github.io/picard) for more information.
 

--- a/build.xml
+++ b/build.xml
@@ -62,6 +62,7 @@
     <property environment="env"/>
     <property name="htsjdk" value="htsjdk"/>
     <property name="htsjdk_src" value="${htsjdk}/src/java"/>
+    <property name="jar_opt" value=".jar_opt"/>
     <condition property="isUnix">
         <os family="unix"/>
     </condition>
@@ -76,9 +77,6 @@
     <!-- INIT -->
     <target name="init">
         <path id="classpath">
-            <fileset dir="${lib}">
-                <include name="**/*.jar"/>
-            </fileset>
             <fileset dir="${htsjdk_lib_dir}">
                 <include name="*.jar"/>
                 <include name="**/*.jar"/>
@@ -88,6 +86,9 @@
                 <include name="*.jar"/>
                 <include name="**/*.jar"/>
             </fileset>
+            <fileset dir="${lib}">
+        	    <include name="**/*.jar"/>
+        	  </fileset>
         </path>
         <path id="metrics.classpath">
             <pathelement path="${classpath}"/>
@@ -98,7 +99,7 @@
     </target>
 
     <!-- CLEAN -->
-    <target name="clean-local" description="Delete local build products but not nested project">
+    <target name="clean-local" description="Delete local build products but not nested project" depends="clean-jar-opt">
         <delete dir="${classes}"/>
         <delete dir="${classes.test}"/>
         <delete dir="${test.output}"/>
@@ -240,25 +241,40 @@
         </testng>
     </target>
 
-    <target name="picard-jar" depends="compile"
-            description="Builds the main executable picard.jar">
-        <mkdir dir="${dist}"/>
-
-        <mkdir dir="${dist.tmp}"/>
-        <unjar dest="${dist.tmp}">
-            <fileset dir="${lib}">
-                <include name="*.jar"/>
-            </fileset>
-            <fileset dir="${htsjdk_lib_dir}">
-                <include name="*.jar"/>
-            </fileset>
-        </unjar>
+    <target name="process-external-jars" depends="clean-jar-opt, maybe-add-gatk-tools-java">
+    </target>
+	
+	  <target name="clean-jar-opt">
+      <delete dir="${jar_opt}"/>
+	  	<mkdir dir="${jar_opt}"/>
+    </target>
+	
+	  <target name="maybe-add-gatk-tools-java" if="addGATKToolsJava">
+    	<mkdir dir="${jar_opt}"/>
+      <unzip dest="${jar_opt}">
+    	  <fileset dir="${lib}/gatk-tools-java">
+    	    <include name="*.jar"/>
+    	  </fileset>
+    	</unzip>
+    </target>
+	
+    <target name="picard-jar" depends="compile, process-external-jars"
+        description="Builds the main executable picard.jar">
+       <mkdir dir="${dist}"/>
+       <mkdir dir="${dist.tmp}"/>
+       <unjar dest="${dist.tmp}">
+           <fileset dir="${lib}" />
+           <fileset dir="${htsjdk_lib_dir}">
+               <include name="*.jar"/>
+           </fileset>
+       </unjar>
 
         <jar destfile="${dist}/picard.jar" compress="no">
             <fileset dir="${classes}" includes="picard/**/*.*, META-INF/**/*"/>
             <fileset dir="${src.scripts}" includes="**/*.R"/>
             <fileset dir="${htsjdk-classes}" includes ="${htsjdk}/*/**/*.*"/>
             <fileset dir="${dist.tmp}" includes="**/*"/>
+	          <fileset dir="${jar_opt}" includes="**/*"/>
 
             <manifest>
                 <attribute name="Implementation-Version" value="${picard-version}(${repository.revision})"/>
@@ -362,6 +378,12 @@
         </javadoc>
     </target>
 
+    <target name="add-ga4gh-support">
+    	<property name="addGATKToolsJava" value="1"/>	
+    </target>
+
+	  <target name="package-commands-ga4gh" depends="add-ga4gh-support, compile, picard-jar" />
+	
     <target name="package-commands" depends="compile, picard-jar">
         <delete dir="${command-line-html-dir}"/>
         <!-- If you don't want to generate on-line doc for a command, use package-command instead of document-command -->


### PR DESCRIPTION
implementation of GA4GH API.
With this it will be possible to pass these urls as INPUT params. E.g.: 
java -jar dist/picard.jar ViewSam \
INPUT=https://www.googleapis.com/genomics/v1beta2/readgroupsets/CK256frpGBD44IWHwLP22R4/ \
GA4GH_CLIENT_SECRETS=../client_secrets.json
