### PR TITLE
Fix NPE when nonstandard bases are found

### DIFF
--- a/src/java/picard/analysis/artifacts/ArtifactCounter.java
+++ b/src/java/picard/analysis/artifacts/ArtifactCounter.java
@@ -83,10 +83,12 @@ class ArtifactCounter {
      * Add a record to all the accumulators.
      */
     public void countRecord(final String refContext, final char calledBase, final SAMRecord rec) {
-        this.fullContextAccumulator.countRecord(refContext, calledBase, rec);
-        this.halfContextAccumulator.countRecord(this.leadingContextMap.get(refContext), calledBase, rec);
-        this.halfContextAccumulator.countRecord(this.trailingContextMap.get(refContext), calledBase, rec);
-        this.zeroContextAccumulator.countRecord(this.zeroContextMap.get(refContext), calledBase, rec);
+        if (this.fullContexts.contains(refContext)) {
+            this.fullContextAccumulator.countRecord(refContext, calledBase, rec);
+            this.halfContextAccumulator.countRecord(this.leadingContextMap.get(refContext), calledBase, rec);
+            this.halfContextAccumulator.countRecord(this.trailingContextMap.get(refContext), calledBase, rec);
+            this.zeroContextAccumulator.countRecord(this.zeroContextMap.get(refContext), calledBase, rec);
+        }
     }
 
     /**


### PR DESCRIPTION
Deal with an edge case when non-standard (i.e. not ACGTN) bases are found in the reference.