### PR TITLE
New CLP for downsampling in a way that tries to keep neighboring reads together

### DIFF
--- a/src/java/picard/sam/PositionBasedDownsampleSam.java
+++ b/src/java/picard/sam/PositionBasedDownsampleSam.java
@@ -1,0 +1,380 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMProgramRecord;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.CollectionUtil;
+import htsjdk.samtools.util.Histogram;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Log;
+import htsjdk.samtools.util.ProgressLogger;
+import picard.PicardException;
+import picard.cmdline.CommandLineProgram;
+import picard.cmdline.CommandLineProgramProperties;
+import picard.cmdline.Option;
+import picard.cmdline.StandardOptionDefinitions;
+import picard.cmdline.programgroups.SamOrBam;
+import picard.sam.util.PhysicalLocation;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * Class to downsample a BAM file while respecting that we should either get rid
+ * of both ends of a pair or neither end of the pair. In addition, this program uses the read-name
+ * and extracts the position within the tile whence the read came from. The downsampling is based on this position.
+ * <p/>
+ * Note 1: This is technology and read-name dependent. If your read-names do not have coordinate information, or if your
+ * BAM contains reads from multiple technologies (flowcell versions, sequencing machines) this will not work properly.
+ * This has been designed with Illumina MiSeq/HiSeq in mind.
+ * <p/>
+ * Note 2: The downsampling is _not_ random. It is deterministically dependent on the position of the read within its tile. Specifically,
+ * it draws out an ellipse that covers a FRACTION fraction of the area and each of the edges and uses this to determine whether to keep the
+ * record. Since reads with the same name have the same position (mates, secondary and supplemental alignments), the decision will be the same for all of them.
+ * <p/>
+ * Finally, the code has been designed to simulate sequencing less as accurately as possible, not for getting an exact downsample fraction.
+ * In particular, since the reads may be distributed non-evenly within the lanes/tiles, the resulting downsampling percentage will not be accurately
+ * determined by the input argument FRACTION. One should re-MarkDuplicates after downsampling in order to "expose" the duplicates whose representative has
+ * been downsampled away.
+ *
+ * @author Yossi Farjoun
+ */
+@CommandLineProgramProperties(
+        usage = "Class to downsample a BAM file while respecting that we should either get rid of both ends of a pair or neither \n" +
+                "end of the pair. In addition, this program uses the read-name and extracts the position within the tile whence \n" +
+                "the read came from. The downsampling is based on this position. Results with the exact same input will produce the \n" +
+                "same results.\n" +
+                "\n" +
+                "Note 1: This is technology and read-name dependent. If your read-names do not have coordinate information, or if your\n" +
+                "BAM contains reads from multiple technologies (flowcell versions, sequencing machines) this will not work properly. \n" +
+                "This has been designed with Illumina MiSeq/HiSeq in mind.\n" +
+                "Note 2: The downsampling is not random. It is deterministically dependent on the position of the read within its tile.\n" +
+                "Note 3: Downsampling twice with this program is not supported.\n" +
+                "Note 4: You should call MarkDuplicates after downsampling.\n" +
+                "\n" +
+                "Finally, the code has been designed to simulate sequencing less as accurately as possible, not for getting an exact downsample \n" +
+                "fraction. In particular, since the reads may be distributed non-evenly within the lanes/tiles, the resulting downsampling \n" +
+                "percentage will not be accurately determined by the input argument FRACTION.",
+        usageShort = "Downsample a SAM or BAM file to retain a subset of the reads based on the reads location in each tile in the flowcell.",
+        programGroup = SamOrBam.class
+)
+public class PositionBasedDownsampleSam extends CommandLineProgram {
+
+    @Option(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "The input SAM or BAM file to downsample.")
+    public File INPUT;
+
+    @Option(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "The output, downsampled, SAM or BAM file to write.")
+    public File OUTPUT;
+
+    @Option(shortName = "F", doc = "The (approximate) fraction of reads to be kept, between 0 and 1.", optional = false)
+    public Double FRACTION = null;
+
+    @Option(doc = "Stop after processing N reads, mainly for debugging.", optional = true)
+    public Long STOP_AFTER = null;
+
+    @Option(doc = "Allow Downsampling again despite this being a bad idea with possibly unexpected results.", optional = true)
+    public boolean ALLOW_MULTIPLE_DOWNSAMPLING_DESPITE_WARNINGS = false;
+
+    @Option(doc = "Determines whether the duplicate tag should be reset since the downsampling requires re-marking duplicates.")
+    public boolean REMOVE_DUPLICATE_INFORMATION = true;
+
+    private final Log log = Log.getInstance(PositionBasedDownsampleSam.class);
+
+    private PhysicalLocation opticalDuplicateFinder;
+    private long total = 0;
+    private long kept = 0;
+    public static String PG_PROGRAM_NAME = "PositionBasedDownsampleSam";
+    private final static double ACCEPTABLE_FUDGE_FACTOR = 0.2;
+
+    /* max-position in tile as a function of tile. We might need to
+       look per-readgroup, but at this point I'm making the assumptions that I need to downsample a
+       sample where all the readgroups came from the same type of flowcell. */
+
+    CollectionUtil.DefaultingMap.Factory<Coord, Short> defaultingMapFactory = new CollectionUtil.DefaultingMap.Factory<Coord, Short>() {
+        @Override
+        public Coord make(final Short aShort) {
+            return new Coord();
+        }
+    };
+
+    final private Map<Short, Coord> tileCoord = new CollectionUtil.DefaultingMap<Short, Coord>(defaultingMapFactory, true);
+
+
+    final Map<Short, Histogram<Short>> xPositions = new HashMap<Short, Histogram<Short>>();
+    final Map<Short, Histogram<Short>> yPositions = new HashMap<Short, Histogram<Short>>();
+
+    public static void main(final String[] args) {
+        new PositionBasedDownsampleSam().instanceMainWithExit(args);
+    }
+
+    @Override
+    protected String[] customCommandLineValidation() {
+        final List<String> errors = new ArrayList<String>();
+
+        if (FRACTION < 0 || FRACTION > 1) {
+            errors.add("FRACTION must be a value between 0 and 1, found: " + FRACTION);
+        }
+
+        if (errors.isEmpty()) {
+            return null;
+        } else {
+            return errors.toArray(new String[errors.size()]);
+        }
+    }
+
+    @Override
+    protected int doWork() {
+
+        IOUtil.assertFileIsReadable(INPUT);
+        IOUtil.assertFileIsWritable(OUTPUT);
+
+        log.info("Checking to see if input file has been downsampled with this program before.");
+        checkProgramRecords();
+
+        opticalDuplicateFinder = new PhysicalLocation();
+
+        log.info("Starting first pass. Examining read distribution in tiles.");
+        fillTileMinMaxCoord();
+        log.info("First pass done.");
+
+        log.info("Starting second pass. Outputting reads.");
+        outputSamRecords();
+        log.info("Second pass done.");
+
+        final double finalP = kept / (double) total;
+        if (Math.abs(finalP - FRACTION) / (Math.min(finalP, FRACTION) + 1e-10) > ACCEPTABLE_FUDGE_FACTOR) {
+            log.warn(String.format("You've requested FRACTION=%g, the resulting downsampling resulted in a rate of %f.", FRACTION, finalP));
+        }
+        log.info(String.format("Finished! Kept %d out of %d reads (P=%g).", kept, total, finalP));
+
+        return 0;
+    }
+
+    private void outputSamRecords() {
+
+        final ProgressLogger progress = new ProgressLogger(log, (int) 1e7);
+        final SamReader in = SamReaderFactory.makeDefault().referenceSequence(REFERENCE_SEQUENCE).open(INPUT);
+
+        final SAMFileHeader header = in.getFileHeader().clone();
+        final SAMFileHeader.PgIdGenerator pgIdGenerator = new SAMFileHeader.PgIdGenerator(header);
+        final SAMProgramRecord programRecord = new SAMProgramRecord(pgIdGenerator.getNonCollidingId(PG_PROGRAM_NAME));
+
+        programRecord.setProgramName(PG_PROGRAM_NAME);
+        programRecord.setCommandLine(getCommandLine());
+        programRecord.setProgramVersion(getVersion());
+        header.addProgramRecord(programRecord);
+
+        final SAMFileWriter out = new SAMFileWriterFactory().makeSAMOrBAMWriter(header, true, OUTPUT);
+
+        final CircleSelector selector = new CircleSelector(FRACTION);
+
+        for (final SAMRecord rec : in) {
+            if (STOP_AFTER != null && total >= STOP_AFTER) break;
+
+            total++;
+
+            final PhysicalLocation pos = getSamRecordLocation(rec);
+
+            if (!xPositions.containsKey(pos.getTile())) {
+                xPositions.put(pos.getTile(), new Histogram<Short>(pos.getTile() + "-xpos", "count"));
+            }
+            if (!yPositions.containsKey(pos.getTile())) {
+                yPositions.put(pos.getTile(), new Histogram<Short>(pos.getTile() + "-ypos", "count"));
+            }
+
+            final boolean keepRecord = selector.select(pos, tileCoord.get(pos.getTile()));
+
+            if (keepRecord) {
+                if (REMOVE_DUPLICATE_INFORMATION) rec.setDuplicateReadFlag(false);
+                out.addAlignment(rec);
+                kept++;
+            }
+            progress.record(rec);
+        }
+
+        out.close();
+
+        CloserUtil.close(in);
+    }
+
+    private void checkProgramRecords() {
+        final SamReader in = SamReaderFactory
+                .makeDefault()
+                .referenceSequence(REFERENCE_SEQUENCE)
+                .open(INPUT);
+
+        for (final SAMProgramRecord pg : in.getFileHeader().getProgramRecords()) {
+            if (pg.getProgramName() != null && pg.getProgramName().equals(PG_PROGRAM_NAME)) {
+
+                final String outText = "Found previous Program Record that indicates that this BAM has been downsampled already with this program. Operation not supported! Previous PG: " + pg.toString();
+
+                if (ALLOW_MULTIPLE_DOWNSAMPLING_DESPITE_WARNINGS) {
+                    log.warn(outText);
+                } else {
+                    log.error(outText);
+                    throw new PicardException(outText);
+                }
+            }
+        }
+        CloserUtil.close(in);
+    }
+
+    // scan all the tiles and find the smallest and largest coordinate (x & y) in that tile.
+    private void fillTileMinMaxCoord() {
+
+        final SamReader in = SamReaderFactory.makeDefault().referenceSequence(REFERENCE_SEQUENCE).open(INPUT);
+
+        final ProgressLogger progress = new ProgressLogger(log, (int) 1e7, "Read");
+
+        int total = 0;
+
+        for (final SAMRecord rec : in) {
+            if (STOP_AFTER != null && total >= STOP_AFTER) break;
+
+            total++;
+            progress.record(rec);
+            final PhysicalLocation location = getSamRecordLocation(rec);
+
+            //Defaulting map will create a new Coord if it's not there.
+
+            final Coord Pos = tileCoord.get(location.getTile());
+
+            Pos.maxX = Math.max(Pos.maxX, location.getX());
+            Pos.minX = Math.min(Pos.minX, location.getX());
+
+            Pos.maxY = Math.max(Pos.maxY, location.getY());
+            Pos.minY = Math.min(Pos.minY, location.getY());
+
+            Pos.count++;
+
+        }
+
+        // now that we know what the maximal/minimal numbers were, we should increase/decrease them a little, to account for sampling error
+        for (final Coord coord : tileCoord.values()) {
+
+            final int diffX = coord.maxX - coord.minX;
+            final int diffY = coord.maxY - coord.minY;
+
+            coord.maxX += diffX / coord.count;
+            coord.minX -= diffX / coord.count;
+
+            coord.maxY += diffY / coord.count;
+            coord.minY -= diffY / coord.count;
+        }
+
+        CloserUtil.close(in);
+    }
+
+    private PhysicalLocation getSamRecordLocation(final SAMRecord rec) {
+        final PhysicalLocation pos = new PhysicalLocation();
+        opticalDuplicateFinder.addLocationInformation(rec.getReadName(), pos);
+        return pos;
+    }
+
+    /*
+     * The reads are selected depending on whether they are in a periodically repeating circle whose representative
+     * overlaps the boundary of the tile. The circle is chosen as to have an area of FRACTION and the also a overlap
+     * of FRACTION with both the bottom and left edges of the unit square ([0,1] x [0,1]), which defines it uniquely.
+     * Finally the repeating pattern is there to make sure that the mask on the flowcell also has minimal boundary.
+     *
+     * The position of the reads is mapped into the unit square using the min/max coordinates of the tile prior to
+     * masking
+     *
+     * This choice of a mask is intended to accomplish several goasl:
+     *  - pick out a fraction FRACTION of the reads
+     *  - pick out a fraction FRACTION of the reads that are near the boundaries
+     *  - keep nearby reads (in a tile) together by minimizing the boundary of the mask itself
+     *  - keep nearby reads (in neighboring tiles) together (since they might be optical duplicates) by keeping that the
+     *  mask is the same on all tiles, and by having the same mask on the left edge as on the right (same for top/bottom).
+     */
+    private class CircleSelector {
+
+        private final double radiusSquared;
+        private final double offset;
+        private final boolean positiveSelection;
+
+        CircleSelector(final double fraction) {
+
+            final double p;
+            if (fraction > 0.5) {
+                p = 1 - fraction;
+                positiveSelection = false;
+            } else {
+                p = fraction;
+                positiveSelection = true;
+            }
+            radiusSquared = p / Math.PI; //thus the area is \pi r^2 = p, thus a fraction p of the unit square will be captured
+
+            /* if offset is used as the center of the circle (both x and y), this makes the overlap
+             region with each of the boundaries of the unit square have length p (and thus a fraction
+             p of the boundaries of each tile will be removed) */
+
+            if (p < 0) {
+                // at this point a negative p will result in a square-root of a negative number in the next step.
+                throw new PicardException("This shouldn't happen...");
+            }
+            offset = Math.sqrt(radiusSquared - p * p / 4);
+        }
+
+        private double roundedPart(final double x) {return x - Math.round(x);}
+
+        // this function checks to see if the location of the read is within the masking circle
+        private boolean select(final PhysicalLocation coord, final Coord tileCoord) {
+            // r^2 = (x-x_0)^2 + (y-y_0)^2, where both x_0 and y_0 equal offset
+            final double distanceSquared =
+                            Math.pow(roundedPart(((coord.getX() - tileCoord.minX) / (double) (tileCoord.maxX - tileCoord.minX)) - offset), 2) +
+                            Math.pow(roundedPart(((coord.getY() - tileCoord.minY) / (double) (tileCoord.maxY - tileCoord.minY)) - offset), 2);
+
+            return (distanceSquared > radiusSquared) ^ positiveSelection;
+        }
+    }
+
+    private class Coord {
+        public int minX;
+        public int minY;
+        public int maxX;
+        public int maxY;
+        public int count;
+
+        public Coord() {
+            count = 0;
+            minX = 0;
+            minY = 0;
+            maxX = 0;
+            maxY = 0;
+        }
+    }
+}

--- a/src/java/picard/sam/util/PhysicalLocation.java
+++ b/src/java/picard/sam/util/PhysicalLocation.java
@@ -1,0 +1,118 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam.util;
+
+import picard.PicardException;
+import picard.sam.markduplicates.util.OpticalDuplicateFinder;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Contains class for figuring out the location of reads.
+ *
+ * @author Tim Fennell
+ * @author Nils Homer
+ * @author Yossi Farjoun
+ */
+
+/**
+ * Small interface that provides access to the physical location information about a cluster.
+ * All values should be defaulted to -1 if unavailable.  Tile should only allow
+ * non-zero positive integers, x and y coordinates must be non-negative.
+ * This is different from OpticalDuplicateFinder.PhysicalLocation in that the x and y positions are ints, not shorts
+ * thus, they do not overflow within a HiSeqX tile.
+ */
+public class PhysicalLocation {
+                                                        //FLOWCELL----:LANE-:TILE----:X_COORD-:Y_COORD-UNK
+    public static final String DEFAULT_READ_NAME_REGEX = "[a-zA-Z0-9]+:[0-9]:([0-9]+):([0-9]+):([0-9]+).*";
+
+    private final String readNameRegex;
+
+    public PhysicalLocation() {this(DEFAULT_READ_NAME_REGEX);}
+
+    public PhysicalLocation(final String readNameRegExp) {this.readNameRegex = readNameRegExp;}
+
+    private Pattern readNamePattern;
+
+    private short tile = -1;
+    private int x = -1, y = -1;
+
+
+    public short getTile() { return tile; }
+
+    public void setTile(final short tile) { this.tile = tile; }
+
+    public int getX() { return x; }
+
+    public void setX(final int x) { this.x = x; }
+
+    public int getY() { return y; }
+
+    public void setY(final int y) { this.y = y; }
+
+
+    private final int[] tmpLocationFields = new int[10]; // for optimization of addLocationInformation
+
+    /**
+     * Method used to extract tile/x/y from the read name and add it to the PhysicalLocation so that it
+     * can be used later to determine optical duplication
+     *
+     * @param readName the name of the read/cluster
+     * @param loc      the object to add tile/x/y to
+     * @return true if the read name contained the information in parsable form, false otherwise
+     */
+    public boolean addLocationInformation(final String readName, final PhysicalLocation loc) {
+        // Optimized version if using the default read name regex (== used on purpose):
+        if (readNameRegex == DEFAULT_READ_NAME_REGEX) {
+            final int fields = ReadNameParsingUtils.getRapidDefaultReadNameRegexSplit(readName, ':', tmpLocationFields);
+            if (!(fields == 5 || fields == 7)) {
+                throw new PicardException(String.format(" READ_NAME_REGEX '%s' did not match read name '%s'.  " ,
+                        this.readNameRegex, readName));
+            }
+
+            final int offset = fields == 7 ? 2 : 0;
+            loc.setTile((short) tmpLocationFields[offset + 2]);
+            loc.setX(tmpLocationFields[offset + 3]);
+            loc.setY(tmpLocationFields[offset + 4]);
+            return true;
+        } else if (readNameRegex == null) {
+            return false;
+        } else {
+            // Standard version that will use the regex
+            if (readNamePattern == null) readNamePattern = Pattern.compile(readNameRegex);
+
+            final Matcher m = readNamePattern.matcher(readName);
+            if (m.matches()) {
+                loc.setTile((short) Integer.parseInt(m.group(1)));
+                loc.setX(Integer.parseInt(m.group(2)));
+                loc.setY(Integer.parseInt(m.group(3)));
+                return true;
+            } else {
+                throw new PicardException(String.format("READ_NAME_REGEX '%s' did not match read name '%s'. ", readNameRegex, readName));
+            }
+        }
+    }
+}

--- a/src/java/picard/sam/util/ReadNameParsingUtils.java
+++ b/src/java/picard/sam/util/ReadNameParsingUtils.java
@@ -1,0 +1,83 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package picard.sam.util;
+
+/**
+ * Common functions for quickly parsing strings. Used for parsing the tile and coordinates from the read names
+ */
+public class ReadNameParsingUtils {
+
+    /**
+     * Single pass method to parse the read name for the default regex.  This will only insert the 2nd to the 4th
+     * tokens (inclusive).  It will also stop after the fifth token has been successfully parsed.
+     */
+    public static int getRapidDefaultReadNameRegexSplit(final String readName, final char delim, final int[] tokens) {
+        int tokensIdx = 0;
+        int prevIdx = 0;
+        for (int i = 0; i < readName.length(); i++) {
+            if (readName.charAt(i) == delim) {
+                if (1 < tokensIdx && tokensIdx < 5)
+                    tokens[tokensIdx] = rapidParseInt(readName.substring(prevIdx, i)); // only fill in 2-4 inclusive
+                tokensIdx++;
+                if (4 < tokensIdx) return tokensIdx; // early return, only consider the first five tokens
+                prevIdx = i + 1;
+            }
+        }
+        if (prevIdx < readName.length()) {
+            if (1 < tokensIdx && tokensIdx < 5)
+                tokens[tokensIdx] = rapidParseInt(readName.substring(prevIdx, readName.length())); // only fill in 2-4 inclusive
+            tokensIdx++;
+        }
+        return tokensIdx;
+    }
+
+    /**
+     * Very specialized method to rapidly parse a sequence of digits from a String up until the first
+     * non-digit character.
+     */
+    public static int rapidParseInt(final String input) {
+        final int len = input.length();
+        int val = 0;
+        int i = 0;
+        boolean isNegative = false;
+
+        if (0 < len && '-' == input.charAt(0)) {
+            i = 1;
+            isNegative = true;
+        }
+
+        for (; i < len; ++i) {
+            final char ch = input.charAt(i);
+            if (Character.isDigit(ch)) {
+                val = (val * 10) + (ch - 48);
+            } else {
+                break;
+            }
+        }
+
+        if (isNegative) val = -val;
+
+        return val;
+    }
+}

--- a/src/tests/java/picard/sam/PositionBasedDownsampleSamTest.java
+++ b/src/tests/java/picard/sam/PositionBasedDownsampleSamTest.java
@@ -1,0 +1,248 @@
+package picard.sam;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMReadGroupRecord;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMRecordSetBuilder;
+import htsjdk.samtools.SAMTextHeaderCodec;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.util.BufferedLineReader;
+import htsjdk.samtools.util.IOUtil;
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import picard.PicardException;
+import picard.cmdline.CommandLineProgramTest;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.testng.Assert.assertEquals;
+
+public class PositionBasedDownsampleSamTest extends CommandLineProgramTest {
+    final static String sample = "TestSample";
+    final static String readGroupId = "TestReadGroup";
+    final static String platform = "ILLUMINA";
+    final static String library = "TestLibrary";
+
+    final static File TEST_DIR = new File("testdata/picard/sam/PositionalDownsampleSam/");
+    final File dict = new File(TEST_DIR, "header.dict");
+
+    File tempDir;
+    File tempSamFile;
+
+    SAMRecordSetBuilder setBuilder = new SAMRecordSetBuilder(true, SAMFileHeader.SortOrder.coordinate);
+    SAMReadGroupRecord readGroupRecord = new SAMReadGroupRecord(readGroupId);
+
+    @Override
+    public String getCommandLineProgramName() {
+        return PositionBasedDownsampleSam.class.getSimpleName();
+    }
+
+    //create a samfile with one tile and randomly placed reads within it.
+    @BeforeTest
+    void setupBuilder() throws IOException {
+        final int numReads = 10000;
+        final String flowCellBarcode = "TESTBARCODE";
+        final int maxX = 10000;
+        final int maxY = 20000;
+        final int minX = 1000;
+        final int minY = 2000;
+
+        final String separator = ":";
+        final int lane = 1;
+        final int tile = 2203;
+
+        //use fixed random seed to eliminate possibility of intermittent failures
+        final Random rg = new Random(31);
+        setBuilder.setReadGroup(readGroupRecord);
+        setBuilder.setUseNmFlag(true);
+
+        for (int i = 0; i < numReads; i++) {
+            final int x = rg.nextInt(maxX) + minX;
+            final int y = rg.nextInt(maxY) + minY;
+
+            final String readName = flowCellBarcode + separator + lane + separator + tile + separator + x + separator + y;
+            setBuilder.addPair(readName, 1, 1, 100);
+        }
+
+        tempDir = IOUtil.createTempDir("pds_test", "PositionalDownsampling");
+        tempSamFile = File.createTempFile("PositionalDownsampleSam", ".bam", tempDir);
+
+        BufferedLineReader bufferedLineReader = null;
+        try {
+            bufferedLineReader = new BufferedLineReader(new FileInputStream(dict));
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+
+        final SAMTextHeaderCodec codec = new SAMTextHeaderCodec();
+        final SAMFileHeader header = codec.decode(bufferedLineReader, dict.toString());
+
+        readGroupRecord.setSample(sample);
+        readGroupRecord.setPlatform(platform);
+        readGroupRecord.setLibrary(library);
+
+        header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+        header.addReadGroup(readGroupRecord);
+
+        setBuilder.setHeader(header);
+
+        final SAMFileWriter writer = new SAMFileWriterFactory()
+                .setCreateIndex(true).makeBAMWriter(header, false, tempSamFile);
+
+        for (final SAMRecord record : setBuilder) {
+            writer.addAlignment(record);
+        }
+        writer.close();
+    }
+
+    @AfterTest
+    private void tearDown() {
+        IOUtil.deleteDirectoryTree(tempDir);
+    }
+
+    @Test //this is actually a test of SAMRecordSetBuilder
+    public void TestBuilder() {
+        final ValidateSamFile validateSamFile = new ValidateSamFile();
+
+        validateSamFile.INPUT = tempSamFile;
+        assertEquals(validateSamFile.doWork(), 0);
+    }
+
+    @DataProvider(name = "ValidArgumentsTestProvider")
+    public Object[][] ValidArgumentsTestProvider() {
+        final List<Object[]> objects = new ArrayList<Object[]>();
+        for (double i = 0.3; i <= 1; i += .1) {
+            final Object[] array = {i};
+            objects.add(array);
+        }
+        return objects.toArray(new Object[1][]);
+    }
+
+    // test removing some reads from a sparse, single tile bam
+    @Test(dataProvider = "ValidArgumentsTestProvider")
+    public void testDownsampleSingleTile(final double fraction) throws IOException {
+        testDownsampleWorker(tempSamFile, fraction);
+    }
+
+    public void testDownsampleWorker(final File samFile, final double fraction) throws IOException {
+
+        final File downsampled = File.createTempFile("PositionalDownsampleSam", ".bam", tempDir);
+        final String[] args = new String[]{
+                "INPUT=" + samFile.getAbsolutePath(),
+                "OUTPUT=" + downsampled.getAbsolutePath(),
+                "FRACTION=" + fraction,
+                "CREATE_INDEX=true"
+        };
+
+        // make sure results is successful
+        assertEquals(runPicardCommandLine(args), 0);
+
+        // make sure that the resulting BAM is valid.
+        final ValidateSamFile validateSamFile = new ValidateSamFile();
+
+        validateSamFile.INPUT = downsampled;
+        assertEquals(validateSamFile.doWork(), 0);
+
+        //make sure that the total number of record in the resulting file in in the ballpark:
+        assertGreaterThan(countSamTotalRecord(downsampled), fraction * .8 * countSamTotalRecord(samFile));
+        assertLessThan(countSamTotalRecord(downsampled), fraction * 1.2 * countSamTotalRecord(samFile));
+    }
+
+    private long countSamTotalRecord(final File samFile) {
+        final SamReader reader = SamReaderFactory.make().open(samFile);
+        assert reader.hasIndex();
+        long total = 0;
+
+        for (int i = 0; i < reader.getFileHeader().getSequenceDictionary().size(); i++) {
+            total += reader.indexing().getIndex().getMetaData(i).getAlignedRecordCount();
+            total += reader.indexing().getIndex().getMetaData(i).getUnalignedRecordCount();
+        }
+        return total;
+    }
+
+    @DataProvider(name="allowTwiceData")
+    public Object[][] allowTwiceData(){
+        return new Object[][]{{true},{false}};
+    }
+
+    // test that downsampling twice yields an error.
+    @Test(dataProvider = "allowTwiceData")
+    public void TestInvalidTwice(final boolean allowMultiple) throws IOException {
+        final File samFile = tempSamFile;
+        final File downsampled = File.createTempFile("PositionalDownsampleSam", ".bam", tempDir);
+        downsampled.deleteOnExit();
+        final double fraction = .1;
+        downsampled.deleteOnExit();
+        final String[] args1 = new String[]{
+                "INPUT=" + samFile.getAbsolutePath(),
+                "OUTPUT=" + downsampled.getAbsolutePath(),
+                "FRACTION=" + fraction
+        };
+        runPicardCommandLine(args1);
+
+        final File downsampledTwice = File.createTempFile("PositionalDownsampleSam", ".bam", tempDir);
+        downsampledTwice.deleteOnExit();
+
+        final List<String> args2 = new ArrayList<String>();
+
+        args2.add("INPUT=" + downsampled.getAbsolutePath());
+        args2.add("OUTPUT=" + downsampledTwice.getAbsolutePath());
+        args2.add("FRACTION=" + fraction);
+
+        if(allowMultiple) args2.add("ALLOW_MULTIPLE_DOWNSAMPLING_DESPITE_WARNINGS=true");
+
+        //should blow up due to bad inputs
+        if(allowMultiple)
+            runPicardCommandLine(args2);
+        else
+            try {
+                runPicardCommandLine(args2);
+                throw new PicardException("Should have thrown an error!!");
+            } catch (final PicardException ignored){
+
+            }
+    }
+
+    // test that program fails on p<0  or p>1
+    @DataProvider(name = "InvalidArgumentsTestProvider")
+    public Object[][] InvalidArgumentsTestProvider() {
+        return new Object[][]{{-1.0}, {-.00001}, {-5.0}, {1.00001}, {5.0}, {50.0}, {Double.MAX_VALUE}, {Double.POSITIVE_INFINITY}, {Double.NEGATIVE_INFINITY}};
+    }
+
+    @Test(dataProvider = "InvalidArgumentsTestProvider")
+    public void TestInvalidArguments(final double fraction) throws IOException {
+        final File samFile = tempSamFile;
+
+        final File downsampled = File.createTempFile("PositionalDownsampleSam", ".bam", tempDir);
+        downsampled.deleteOnExit();
+        final String[] args = new String[]{
+                "INPUT=" + samFile.getAbsolutePath(),
+                "OUTPUT=" + downsampled.getAbsolutePath(),
+                "FRACTION=" + fraction
+        };
+        //should blow up due to bad inputs
+        assert runPicardCommandLine(args) != 0;
+    }
+
+    // these fit in a TestNG.Utils class, but there isn't one in picard-public...
+    static public void assertGreaterThan(final double lhs, final double rhs) {
+        Assert.assertTrue(lhs > rhs, String.format("Expected inequality is not true: %g > %g", lhs, rhs));
+    }
+
+    static public void assertLessThan(final double lhs, final double rhs) {
+        Assert.assertTrue(lhs < rhs, String.format("Expected inequality is not true: %g < %g", lhs, rhs));
+    }
+
+}

--- a/src/tests/java/picard/sam/markduplicates/util/OpticalDuplicateFinderTest.java
+++ b/src/tests/java/picard/sam/markduplicates/util/OpticalDuplicateFinderTest.java
@@ -3,7 +3,7 @@ package picard.sam.markduplicates.util;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.Assert;
-import picard.sam.markduplicates.util.OpticalDuplicateFinder;
+import picard.sam.util.ReadNameParsingUtils;
 
 /**
  * Tests for OpticalDuplicateFinder
@@ -17,12 +17,12 @@ public class OpticalDuplicateFinderTest {
     public void testRapidParseInt() {
         final OpticalDuplicateFinder opticalDuplicateFinder = new OpticalDuplicateFinder();
         for (int i = -100; i < 100; i++) {
-            Assert.assertEquals(opticalDuplicateFinder.rapidParseInt(Integer.toString(i)), i);
+            Assert.assertEquals(ReadNameParsingUtils.rapidParseInt(Integer.toString(i)), i);
 
             // trailing characters
-            Assert.assertEquals(opticalDuplicateFinder.rapidParseInt(Integer.toString(i)+"A"), i);
-            Assert.assertEquals(opticalDuplicateFinder.rapidParseInt(Integer.toString(i)+"ACGT"), i);
-            Assert.assertEquals(opticalDuplicateFinder.rapidParseInt(Integer.toString(i)+".1"), i);
+            Assert.assertEquals(ReadNameParsingUtils.rapidParseInt(Integer.toString(i)+"A"), i);
+            Assert.assertEquals(ReadNameParsingUtils.rapidParseInt(Integer.toString(i)+"ACGT"), i);
+            Assert.assertEquals(ReadNameParsingUtils.rapidParseInt(Integer.toString(i)+".1"), i);
         }
     }
 
@@ -40,7 +40,7 @@ public class OpticalDuplicateFinderTest {
         if (2 < numFields) expectedFields[2] = 2;
         if (3 < numFields) expectedFields[3] = 3;
         if (4 < numFields) expectedFields[4] = 4;
-        Assert.assertEquals(opticalDuplicateFinder.getRapidDefaultReadNameRegexSplit(readName, ':', inputFields), numFields);
+        Assert.assertEquals(ReadNameParsingUtils.getRapidDefaultReadNameRegexSplit(readName, ':', inputFields), numFields);
         for (int i = 0; i < inputFields.length; i++) {
             Assert.assertEquals(inputFields[i], expectedFields[i]);
         }

--- a/testdata/picard/sam/PositionalDownsampleSam/header.dict
+++ b/testdata/picard/sam/PositionalDownsampleSam/header.dict
@@ -1,0 +1,9 @@
+@HD	VN:1.0	SO:unsorted
+@SQ	SN:chr1	LN:10100	UR:header.fasta
+@SQ	SN:chr2	LN:10100	UR:header.fasta
+@SQ	SN:chr3	LN:10100	UR:header.fasta
+@SQ	SN:chr4	LN:10100	UR:header.fasta
+@SQ	SN:chr5	LN:10100	UR:header.fasta
+@SQ	SN:chr6	LN:10100	UR:header.fasta
+@SQ	SN:chr7	LN:40400	UR:header.fasta
+@SQ	SN:chr8	LN:20200	UR:header.fasta


### PR DESCRIPTION
This is intended to mimic to a higher degree the results of sequencing less. The idea is to create a periodic mask of reads based on their location within their tile. The mask is setup in such a way so that the same percentage of reads is removed from the bulk and from the boundaries of each tile, and so that neighboring tiles agree on which part of their shared boundary to keep or remove. 

Since this is based on location, mates (and secondary alignments) are treated equally.


<!---
@huboard:{"order":159.0,"milestone_order":196,"custom_state":""}
-->
