### PR TITLE
Adding a tool SimpleMarkDuplicatesWithMateCigar that uses the new HTSJDK

### DIFF
--- a/src/java/picard/sam/CompareSAMs.java
+++ b/src/java/picard/sam/CompareSAMs.java
@@ -126,6 +126,7 @@ public class CompareSAMs extends CommandLineProgram {
                 return compareCoordinateSortedAlignments();
             case queryname:
                 return compareQueryNameSortedAlignments();
+            case duplicate:
             case unsorted:
                 return compareUnsortedAlignments();
             default:

--- a/src/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -87,7 +87,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
     private SortingLongCollection duplicateIndexes;
     private int numDuplicateIndices = 0;
 
-    private LibraryIdGenerator libraryIdGenerator = null; // this is initialized in buildSortedReadEndLists
+    protected LibraryIdGenerator libraryIdGenerator = null; // this is initialized in buildSortedReadEndLists
 
     public MarkDuplicates() {
         DUPLICATE_SCORING_STRATEGY = ScoringStrategy.SUM_OF_BASE_QUALITIES;

--- a/src/java/picard/sam/markduplicates/util/AbstractMarkDuplicatesCommandLineProgram.java
+++ b/src/java/picard/sam/markduplicates/util/AbstractMarkDuplicatesCommandLineProgram.java
@@ -266,6 +266,12 @@ public abstract class AbstractMarkDuplicatesCommandLineProgram extends AbstractO
     /**
      * Looks through the set of reads and identifies how many of the duplicates are
      * in fact optical duplicates, and stores the data in the instance level histogram.
+     * 
+     * We expect only reads with FR or RF orientations, not a mixture of both. 
+     * 
+     * In PCR duplicate detection, a duplicates can be a have FR and RF when fixing the orientation order to the first end of the mate.  In
+     * optical duplicate detection, we do not consider them duplicates if one read as FR ann the other RF when we order orientation by the
+     * first mate sequenced (read #1 of the pair).
      */
     private static void trackOpticalDuplicates(final List<? extends OpticalDuplicateFinder.PhysicalLocation> list,
                                                final OpticalDuplicateFinder opticalDuplicateFinder,

--- a/src/tests/java/picard/sam/markduplicates/AbstractMarkDuplicatesCommandLineProgramTest.java
+++ b/src/tests/java/picard/sam/markduplicates/AbstractMarkDuplicatesCommandLineProgramTest.java
@@ -50,6 +50,14 @@ public abstract class AbstractMarkDuplicatesCommandLineProgramTest {
     }
 
     @Test
+    public void testTwoUnmappedFragments() {
+        final AbstractMarkDuplicatesCommandLineProgramTester tester = getTester();
+        tester.addUnmappedFragment(-1, DEFAULT_BASE_QUALITY);
+        tester.addUnmappedFragment(-1, DEFAULT_BASE_QUALITY);
+        tester.runTest();
+    }
+
+    @Test
     public void testSingleUnmappedPair() {
         final AbstractMarkDuplicatesCommandLineProgramTester tester = getTester();
         tester.addUnmappedPair(-1, DEFAULT_BASE_QUALITY);
@@ -120,7 +128,7 @@ public abstract class AbstractMarkDuplicatesCommandLineProgramTest {
         tester.addUnmappedFragment(-1, DEFAULT_BASE_QUALITY); // unmapped fragment at end of file
         tester.runTest();
     }
-
+    
     @Test
     public void testTwoMappedPairsAndTerminalUnmappedPair() {
         final AbstractMarkDuplicatesCommandLineProgramTester tester = getTester();
@@ -155,7 +163,7 @@ public abstract class AbstractMarkDuplicatesCommandLineProgramTest {
         tester.addMatePair("RUNID:7:1203:2884:16834", 1, 485253, 485253, false, false, false, false, "59S42M", "42M59S", true, false, false, false, false, DEFAULT_BASE_QUALITY);
         tester.runTest();
     }
-
+    
     @Test
     public void testOpticalDuplicateClusterSamePositionNoOpticalDuplicatesWithinPixelDistance() {
         final AbstractMarkDuplicatesCommandLineProgramTester tester = getTester();
@@ -234,11 +242,13 @@ public abstract class AbstractMarkDuplicatesCommandLineProgramTest {
     @Test
     public void testTwoMappedPairsWithSoftClippingBoth() {
         final AbstractMarkDuplicatesCommandLineProgramTester tester = getTester();
+        // mapped reference length: 73 + 42 = 115
         tester.addMappedPair(1, 10046, 10002, true, true, "3S73M", "6S42M28S", true, false, false, DEFAULT_BASE_QUALITY);
+        // mapped reference length: 68 + 48 = 116
         tester.addMappedPair(1, 10051, 10002, false, false, "8S68M", "6S48M22S", true, false, false, DEFAULT_BASE_QUALITY);
         tester.runTest();
     }
-
+    
     @Test
     public void testMatePairSecondUnmapped() {
         final AbstractMarkDuplicatesCommandLineProgramTester tester = getTester();
@@ -260,7 +270,7 @@ public abstract class AbstractMarkDuplicatesCommandLineProgramTest {
         tester.addMappedFragment(1, 10049, true, DEFAULT_BASE_QUALITY); // duplicate
         tester.runTest();
     }
-
+    
     @Test
     public void testMappedFragmentAndMatePairFirstUnmapped() {
         final AbstractMarkDuplicatesCommandLineProgramTester tester = getTester();
@@ -298,6 +308,7 @@ public abstract class AbstractMarkDuplicatesCommandLineProgramTest {
         tester.runTest();
     }
 
+
     @Test
     public void testMappedPairAndMappedFragmentAndMatePairSecondUnmapped() {
         final AbstractMarkDuplicatesCommandLineProgramTester tester = getTester();
@@ -333,7 +344,7 @@ public abstract class AbstractMarkDuplicatesCommandLineProgramTest {
         tester.addMappedPair(1, 10182, 10038, true, true, "32S44M", "66M10S", true, false, false, DEFAULT_BASE_QUALITY); // -/+
         tester.runTest();
     }
-
+    
     @Test
     public void testThreeMappedPairsWithMatchingSecondMate() {
         final AbstractMarkDuplicatesCommandLineProgramTester tester = getTester();
@@ -346,7 +357,7 @@ public abstract class AbstractMarkDuplicatesCommandLineProgramTest {
         tester.addMappedPair(1, 10180, 10058, false, false, "36S40M", "50M26S", true, false, false, DEFAULT_BASE_QUALITY); // -/+, both are duplicates
         tester.runTest();
     }
-
+    
     @Test
     public void testMappedPairWithSamePosition() {
         final AbstractMarkDuplicatesCommandLineProgramTester tester = getTester();
@@ -403,7 +414,6 @@ public abstract class AbstractMarkDuplicatesCommandLineProgramTest {
         tester.runTest();
     }
 
-
     @Test
     public void testTwoGroupsOnDifferentChromosomesOfTwoMappedPairs() {
         final AbstractMarkDuplicatesCommandLineProgramTester tester = getTester();
@@ -440,7 +450,7 @@ public abstract class AbstractMarkDuplicatesCommandLineProgramTest {
         tester.addMappedPair(2, 1, 100, true, true, DEFAULT_BASE_QUALITY); // duplicate!!!
         tester.runTest();
     }
-
+    
     @Test
     public void testBulkFragmentsNoDuplicates() {
         final AbstractMarkDuplicatesCommandLineProgramTester tester = getTester();
@@ -467,8 +477,8 @@ public abstract class AbstractMarkDuplicatesCommandLineProgramTest {
     public void testStackOverFlowPairSetSwap() {
         final AbstractMarkDuplicatesCommandLineProgramTester tester = getTester();
 
-        File input = new File("testdata/picard/sam/MarkDuplicates/markDuplicatesWithMateCigar.pairSet.swap.sam");
-        SamReader reader = SamReaderFactory.makeDefault().open(input);
+        final File input = new File("testdata/picard/sam/MarkDuplicates/markDuplicatesWithMateCigar.pairSet.swap.sam");
+        final SamReader reader = SamReaderFactory.makeDefault().open(input);
         tester.setHeader(reader.getFileHeader());
         for (final SAMRecord record : reader) {
             tester.addRecord(record);
@@ -477,7 +487,7 @@ public abstract class AbstractMarkDuplicatesCommandLineProgramTest {
         tester.setExpectedOpticalDuplicate(1);
         tester.runTest();
     }
-
+    
     @Test
     public void testSecondEndIsBeforeFirstInCoordinate() {
         final AbstractMarkDuplicatesCommandLineProgramTester tester = getTester();
@@ -495,12 +505,12 @@ public abstract class AbstractMarkDuplicatesCommandLineProgramTest {
         tester.addMatePair("RUNID:3:1:15029:113060", 0, 129384554, 129384554, false, false, true, true, "68M", "68M", false, false, false, false, false, DEFAULT_BASE_QUALITY);
 
         // Create the pathology
-        CloseableIterator<SAMRecord> iterator = tester.getRecordIterator();
-        int[] qualityOffset = {20, 30, 10, 40}; // creates an interesting pathological ordering
+        final CloseableIterator<SAMRecord> iterator = tester.getRecordIterator();
+        final int[] qualityOffset = {20, 30, 10, 40}; // creates an interesting pathological ordering
         int index = 0;
         while (iterator.hasNext()) {
             final SAMRecord record = iterator.next();
-            byte[] quals = new byte[record.getReadLength()];
+            final byte[] quals = new byte[record.getReadLength()];
             for (int i = 0; i < record.getReadLength(); i++) {
                 quals[i] = (byte)(qualityOffset[index] + 10);
             }

--- a/src/tests/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigar.java
+++ b/src/tests/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigar.java
@@ -1,0 +1,222 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam.markduplicates;
+
+import htsjdk.samtools.DuplicateSet;
+import htsjdk.samtools.DuplicateSetIterator;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMTag;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.IterableAdapter;
+import htsjdk.samtools.util.Log;
+import htsjdk.samtools.util.ProgressLogger;
+import picard.cmdline.CommandLineProgramProperties;
+import picard.cmdline.programgroups.Testing;
+import picard.sam.DuplicationMetrics;
+import picard.sam.markduplicates.util.AbstractMarkDuplicatesCommandLineProgram;
+import picard.sam.markduplicates.util.LibraryIdGenerator;
+import picard.sam.markduplicates.util.ReadEnds;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This is a simple tool to mark duplicates using the DuplicateSetIterator, DuplicateSet, and SAMRecordDuplicateComparator.
+ * 
+ * Users should continue to use MarkDuplicates in general.  The main motivation of this tool was the fact that 
+ * MarkDuplicates has many, many, many useful test cases, but few unit tests for validating individual duplicate sets. To
+ * test the DuplicateSetIterator, DuplicateSet, and SAMRecordDuplicateComparator, the most expedient method was to write
+ * this tool and make sure it behaves similarly to MarkDuplicates.  Not the best, I know, but good enough.  NH 06/25/2015.
+ *  
+ * 
+ * See MarkDuplicates for more details.
+ *
+ * @author nhomer
+ */
+@CommandLineProgramProperties(
+        usage = "Examines aligned records in the supplied SAM or BAM file to locate duplicate molecules. " +
+                "All records are then written to the output file with the duplicate records flagged.",
+        usageShort = "Examines aligned records in the supplied SAM or BAM file to locate duplicate molecules.",
+        programGroup = Testing.class
+)
+public class SimpleMarkDuplicatesWithMateCigar extends MarkDuplicates {
+    private final Log log = Log.getInstance(MarkDuplicatesWithMateCigar.class);
+
+    /** Stock main method. */
+    public static void main(final String[] args) {
+        new MarkDuplicatesWithMateCigar().instanceMainWithExit(args);
+    }
+
+    private class ReadEndsForSimpleMarkDuplicatesWithMateCigar extends ReadEnds {
+    }
+    
+    private static boolean isPairedAndBothMapped(final SAMRecord record) {
+        return record.getReadPairedFlag() &&
+                !record.getReadUnmappedFlag() &&
+                !record.getMateUnmappedFlag();
+        
+    }
+
+    /**
+     * Main work method.
+     */
+    protected int doWork() {
+        IOUtil.assertInputsAreValid(INPUT);
+        IOUtil.assertFileIsWritable(OUTPUT);
+        IOUtil.assertFileIsWritable(METRICS_FILE);
+
+        // Open the inputs
+        final SamHeaderAndIterator headerAndIterator = openInputs();
+        final SAMFileHeader header = headerAndIterator.header;
+
+        // Create the output header
+        final SAMFileHeader outputHeader = header.clone();
+        outputHeader.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+        for (final String comment : COMMENT) outputHeader.addComment(comment);
+        
+        // Key: previous PG ID on a SAM Record (or null).  Value: New PG ID to replace it.
+        final Map<String, String> chainedPgIds = getChainedPgIds(outputHeader);
+
+        // Open the output
+        final SAMFileWriter out = new SAMFileWriterFactory().makeSAMOrBAMWriter(outputHeader,
+                false,
+                OUTPUT);
+        
+        final DuplicateSetIterator iterator = new DuplicateSetIterator(headerAndIterator.iterator,
+                headerAndIterator.header);
+        
+        iterator.setScoringStrategy(this.DUPLICATE_SCORING_STRATEGY);
+
+        // progress logger!
+        final ProgressLogger progress = new ProgressLogger(log, (int) 1e6, "Read");
+
+        int numDuplicates = 0;
+        
+        libraryIdGenerator = new LibraryIdGenerator(headerAndIterator.header);
+        
+        for (final DuplicateSet duplicateSet : new IterableAdapter<DuplicateSet>(iterator)) {
+            final SAMRecord representative = duplicateSet.getRepresentative();
+            final boolean doOpticalDuplicateTracking = (this.READ_NAME_REGEX != null) &&
+                    isPairedAndBothMapped(representative) &&
+                    representative.getFirstOfPairFlag();
+            final Set<String> duplicateReadEndsSeen = new HashSet<String>();
+            
+            final List<ReadEnds> duplicateReadEnds = new ArrayList<ReadEnds>();
+            for (final SAMRecord record : duplicateSet.getRecords()) {
+
+                if (!record.isSecondaryOrSupplementary()) {
+                    final String library = LibraryIdGenerator.getLibraryName(header, record);
+                    DuplicationMetrics metrics = libraryIdGenerator.getMetricsByLibrary(library);
+                    if (metrics == null) {
+                        metrics = new DuplicationMetrics();
+                        metrics.LIBRARY = library;
+                        libraryIdGenerator.addMetricsByLibrary(library, metrics);
+                    }
+
+                    // First bring the simple metrics up to date
+                    if (record.getReadUnmappedFlag()) {
+                        ++metrics.UNMAPPED_READS;
+                    } else if (!record.getReadPairedFlag() || record.getMateUnmappedFlag()) {
+                        ++metrics.UNPAIRED_READS_EXAMINED;
+                    } else {
+                        ++metrics.READ_PAIRS_EXAMINED; // will need to be divided by 2 at the end
+                    }
+
+                    if (record.getDuplicateReadFlag()) {
+                        // Update the duplication metrics
+                        if (!record.getReadPairedFlag() || record.getMateUnmappedFlag()) {
+                            ++metrics.UNPAIRED_READ_DUPLICATES;
+                        } else {
+                            ++metrics.READ_PAIR_DUPLICATES;// will need to be divided by 2 at the end
+                        }
+                        numDuplicates++;
+                    }
+                    
+                    // To track optical duplicates, store a set of locations for mapped pairs, first end only.  We care about orientation relative
+                    // to the first end of the pair for optical duplicate tracking, which is more stringent than PCR duplicate tracking.
+                    if (doOpticalDuplicateTracking &&
+                            isPairedAndBothMapped(record) &&
+                            !duplicateReadEndsSeen.contains(record.getReadName())) {
+                        
+                        final ReadEndsForSimpleMarkDuplicatesWithMateCigar readEnd = new ReadEndsForSimpleMarkDuplicatesWithMateCigar();
+                        // set orientation for optical duplicates
+                        if (record.getFirstOfPairFlag()) {
+                            readEnd.orientationForOpticalDuplicates = ReadEnds.getOrientationByte(record.getReadNegativeStrandFlag(), record.getMateNegativeStrandFlag());
+                        } else {
+                            readEnd.orientationForOpticalDuplicates = ReadEnds.getOrientationByte(record.getMateNegativeStrandFlag(), record.getReadNegativeStrandFlag());
+                        }
+                        if (opticalDuplicateFinder.addLocationInformation(record.getReadName(), readEnd)) {
+                            if (null != record.getReadGroup()) {
+                                final short index = libraryIdGenerator.getLibraryId(record);
+                                readEnd.setLibraryId(index);
+                            }
+                        }
+                        duplicateReadEnds.add(readEnd);
+                        duplicateReadEndsSeen.add(record.getReadName());
+                    }
+                }
+
+                if (!this.REMOVE_DUPLICATES || !record.getDuplicateReadFlag()) {
+                    if (PROGRAM_RECORD_ID != null) {
+                        record.setAttribute(SAMTag.PG.name(), chainedPgIds.get(record.getStringAttribute(SAMTag.PG.name())));
+                    }
+                    out.addAlignment(record);
+                    progress.record(record);
+                }
+            }
+
+            // Track the optical duplicates
+            if (this.READ_NAME_REGEX != null && 1 < duplicateReadEnds.size()) {
+                AbstractMarkDuplicatesCommandLineProgram.trackOpticalDuplicates(duplicateReadEnds, opticalDuplicateFinder, libraryIdGenerator);
+            }
+        }
+
+        // remember to close the inputs
+        iterator.close();
+
+        out.close();
+
+        if (this.READ_NAME_REGEX == null) {
+            log.warn("Skipped optical duplicate cluster discovery; library size estimation may be inaccurate!");
+        } else {
+            log.info("Found " + (this.libraryIdGenerator.getNumberOfOpticalDuplicateClusters()) + " optical duplicate clusters.");
+        }
+
+        // Log info
+        log.info("Processed " + progress.getCount() + " records");
+        log.info("Marking " + numDuplicates + " records as duplicates.");
+
+        // Write out the metrics
+        finalizeAndWriteMetrics(libraryIdGenerator);
+
+        return 0;
+    }
+}

--- a/src/tests/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigarTest.java
+++ b/src/tests/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigarTest.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam.markduplicates;
+
+import htsjdk.samtools.SAMException;
+import org.testng.annotations.Test;
+
+/**
+ * @author nhomer
+ */
+public class SimpleMarkDuplicatesWithMateCigarTest extends AbstractMarkDuplicatesCommandLineProgramTest {
+    protected AbstractMarkDuplicatesCommandLineProgramTester getTester() {
+        return new SimpleMarkDuplicatesWithMateCigarTester();
+    }
+
+    /** We require mate cigars for this tool */
+    @Test(expectedExceptions = SAMException.class)
+    @Override
+    public void testTwoMappedPairsWithSoftClippingFirstOfPairOnlyNoMateCigar() {
+        super.testTwoMappedPairsWithSoftClippingFirstOfPairOnlyNoMateCigar();
+    }
+}

--- a/src/tests/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigarTester.java
+++ b/src/tests/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigarTester.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam.markduplicates;
+
+import htsjdk.samtools.DuplicateScoringStrategy;
+import picard.cmdline.CommandLineProgram;
+
+/**
+ * @author nhomer
+ */
+public class SimpleMarkDuplicatesWithMateCigarTester extends AbstractMarkDuplicatesCommandLineProgramTester {
+
+    public SimpleMarkDuplicatesWithMateCigarTester() {
+        // NB: to be equivalent to MarkDuplicates we need to use SUM_OF_BASE_QUALITIES
+        super(DuplicateScoringStrategy.ScoringStrategy.TOTAL_MAPPED_REFERENCE_LENGTH);
+
+        addArg("MAX_RECORDS_IN_RAM=1000");
+    }
+
+    @Override
+    protected CommandLineProgram getProgram() { return new SimpleMarkDuplicatesWithMateCigar(); }
+}
+


### PR DESCRIPTION
DuplicateSetIterator.

Depends on: https://github.com/samtools/htsjdk/pull/225.

<!---
@huboard:{"order":158.0,"milestone_order":200,"custom_state":""}
-->
