### PR TITLE
For _barcode.txt files, don't consider an empty file to represent a miss...

### DIFF
--- a/src/java/picard/illumina/parser/IlluminaFileUtil.java
+++ b/src/java/picard/illumina/parser/IlluminaFileUtil.java
@@ -142,7 +142,7 @@ public class IlluminaFileUtil {
                     utils.put(SupportedIlluminaFormat.Filter, parameterizedFileUtil);
                     break;
                 case Barcode:
-                    parameterizedFileUtil = new PerTileFileUtil("_barcode.txt", barcodeDir != null ? barcodeDir : basecallDir, new BarcodeFileFaker(), lane);
+                    parameterizedFileUtil = new PerTileFileUtil("_barcode.txt", barcodeDir != null ? barcodeDir : basecallDir, new BarcodeFileFaker(), lane, false);
                     utils.put(SupportedIlluminaFormat.Barcode, parameterizedFileUtil);
                     break;
                 case MultiTileFilter:

--- a/src/java/picard/illumina/parser/ParameterizedFileUtil.java
+++ b/src/java/picard/illumina/parser/ParameterizedFileUtil.java
@@ -44,14 +44,22 @@ public abstract class ParameterizedFileUtil {
     protected final File base;
     protected final FileFaker faker;
 
+    protected static final boolean DefaultSkipEmptyFiles = true;
+    protected final boolean skipEmptyFiles;
+
     public ParameterizedFileUtil(final boolean laneTileRegex, final String extension, final File base,
-                                 final FileFaker faker, final int lane) {
-        this(extension, base, faker, lane);
+                                 final FileFaker faker, final int lane, final boolean skipEmptyFiles) {
+        this(extension, base, faker, lane, skipEmptyFiles);
         if (laneTileRegex) {
             matchPattern = Pattern.compile(escapePeriods(makeLaneTileRegex(processTxtExtension(extension), lane)));
         } else {
             matchPattern = Pattern.compile(escapePeriods(makeLaneRegex(extension, lane)));
         }
+    }
+
+    public ParameterizedFileUtil(final boolean laneTileRegex, final String extension, final File base,
+                                 final FileFaker faker, final int lane) {
+        this(laneTileRegex, extension, base, faker, lane, DefaultSkipEmptyFiles);
     }
 
     public ParameterizedFileUtil(final String pattern, final String extension, final File base, final FileFaker faker,
@@ -62,10 +70,16 @@ public abstract class ParameterizedFileUtil {
 
     private ParameterizedFileUtil(final String extension, final File base, final FileFaker faker,
                                   final int lane) {
+        this(extension, base, faker, lane, DefaultSkipEmptyFiles);
+    }
+
+    private ParameterizedFileUtil(final String extension, final File base, final FileFaker faker,
+                                  final int lane, final boolean skipEmptyFiles) {
         this.faker = faker;
         this.extension = extension;
         this.base = base;
         this.lane = lane;
+        this.skipEmptyFiles = skipEmptyFiles;
     }
 
     /**
@@ -162,7 +176,7 @@ public abstract class ParameterizedFileUtil {
             IOUtil.assertDirectoryIsReadable(baseDirectory);
             final File[] files = IOUtil.getFilesMatchingRegexp(baseDirectory, pattern);
             for (final File file : files) {
-                if (file.length() > 0) {
+                if (!skipEmptyFiles || file.length() > 0) {
                     fileMap.put(fileToTile(file.getName()), file);
                 }
             }

--- a/src/java/picard/illumina/parser/PerTileFileUtil.java
+++ b/src/java/picard/illumina/parser/PerTileFileUtil.java
@@ -14,7 +14,12 @@ public class PerTileFileUtil extends ParameterizedFileUtil {
 
     public PerTileFileUtil(final String extension, final File base,
                            final FileFaker faker, final int lane) {
-        super(true, extension, base, faker, lane);
+        this(extension, base, faker, lane, DefaultSkipEmptyFiles);
+    }
+
+    public PerTileFileUtil(final String extension, final File base,
+        final FileFaker faker, final int lane, final boolean skipEmptyFiles) {
+        super(true, extension, base, faker, lane, skipEmptyFiles);
         this.fileMap = getTiledFiles(base, matchPattern);
         if (fileMap.size() > 0) {
             this.tiles = Collections.unmodifiableList(new ArrayList<Integer>(this.fileMap.keySet()));


### PR DESCRIPTION
...ing tile.

Unlike other files read by IlluminaBasecallsToSam, _barcode.txt files have no header, so if a tile contains no reads, the file is zero length.  Currently, ParameterizedFileUtil treats an empty file the same as a missing file, so IlluminaBasecallsToSam reports

Formats do not have the same number of tiles!
	at picard.illumina.parser.IlluminaFileUtil.getActualTiles(IlluminaFileUtil.java:206)
	at picard.illumina.parser.IlluminaDataProviderFactory.(IlluminaDataProviderFactory.java:177)
	at picard.illumina.IlluminaBasecallsConverter.(IlluminaBasecallsConverter.java:243)
	at picard.illumina.IlluminaBasecallsToSam.initialize(IlluminaBasecallsToSam.java:241)
	at picard.illumina.IlluminaBasecallsToSam.doWork(IlluminaBasecallsToSam.java:212)
	at picard.cmdline.CommandLineProgram.instanceMain(CommandLineProgram.java:187)
	at picard.cmdline.PicardCommandLine.instanceMain(PicardCommandLine.java:95)
	at picard.cmdline.PicardCommandLine.main(PicardCommandLine.java:105)

This change causes the FileUtil for barcodes.txt file type to consider an empty file to represent a valid tile.