### PR TITLE
Print default value for option that is a collection.

### DIFF
--- a/src/java/picard/cmdline/CommandLineParser.java
+++ b/src/java/picard/cmdline/CommandLineParser.java
@@ -789,7 +789,7 @@ public class CommandLineParser {
             sb.append(optionDefinition.doc);
             sb.append("  ");
         }
-        if (optionDefinition.optional && !optionDefinition.isCollection) {
+        if (optionDefinition.optional) {
             sb.append("Default value: ");
             sb.append(optionDefinition.defaultValue);
             sb.append(". ");


### PR DESCRIPTION
I don't know why this wasn't done originally.  The code dates back to 2009.  Who wrote this anyway???