### PR TITLE
Minor change to BedToIntervalList to make sorting and uniquing option…

### DIFF
--- a/src/java/picard/util/BedToIntervalList.java
+++ b/src/java/picard/util/BedToIntervalList.java
@@ -44,6 +44,12 @@ public class BedToIntervalList extends CommandLineProgram {
     @Option(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "The output Picard Interval List")
     public File OUTPUT;
 
+    @Option(doc="If true, sort the output interval list before writing it.")
+    public boolean SORT = true;
+
+    @Option(doc="If true, unique the output interval list by merging overlapping regions, before writing it (implies sort=true).")
+    public boolean UNIQUE = true;
+
     final Log LOG = Log.getInstance(getClass());
 
     // Stock main method
@@ -109,7 +115,10 @@ public class BedToIntervalList extends CommandLineProgram {
             CloserUtil.close(bedReader);
 
             // Sort and write the output
-            intervalList.uniqued().write(OUTPUT);
+            IntervalList out = intervalList;
+            if (SORT) out = out.sorted();
+            if (UNIQUE) out = out.uniqued();
+            out.write(OUTPUT);
 
         } catch (final IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
…al vs. the prior behaviour of always sorting and uniquing the intervals.  Makes is easier to create an interval list that exactly matches a BED file when the BED file is out of order or contains overlapping regions.