### PR TITLE
Disable escaping html of preamble text in doc generation

### DIFF
--- a/src/java/picard/analysis/CollectAlignmentSummaryMetrics.java
+++ b/src/java/picard/analysis/CollectAlignmentSummaryMetrics.java
@@ -64,12 +64,21 @@ import java.util.Set;
  * @author Doug Voet (dvoet at broadinstitute dot org)
  */
 @CommandLineProgramProperties(
-        usage = CollectAlignmentSummaryMetrics.USAGE,
-        usageShort = CollectAlignmentSummaryMetrics.USAGE,
+        usage = CollectAlignmentSummaryMetrics.USAGE_SUMMARY + CollectAlignmentSummaryMetrics.USAGE_DETAILS,
+        usageShort = CollectAlignmentSummaryMetrics.USAGE_SUMMARY,
         programGroup = Metrics.class
 )
 public class CollectAlignmentSummaryMetrics extends SinglePassSamProgram {
-    static final String USAGE = "Produces from a SAM or BAM a file containing summary alignment metrics";
+    static final String USAGE_SUMMARY = "Produces a file containing summary alignment metrics from a SAM or BAM.";
+    static final String USAGE_DETAILS = "<br />" +
+            "<h4>Usage example:</h4>" +
+            "<pre>" +
+            "    java -jar picard.jar CollectAlignmentMetrics \\<br />" +
+            "        R=reference.fasta \\<br />" +
+            "        I=input.bam \\<br />" +
+            "        O=output.txt" +
+            "</pre>" +
+            "<hr />";
     
     private static final Log log = Log.getInstance(CollectAlignmentSummaryMetrics.class);
 

--- a/src/java/picard/cmdline/CommandLineParser.java
+++ b/src/java/picard/cmdline/CommandLineParser.java
@@ -351,7 +351,7 @@ public class CommandLineParser {
         stream.println("<a id=\"" + programName + "\"/>");
         stream.println("<h3>" + programName + "</h3>");
         stream.println("<section>");
-        stream.println("<p>" + htmlEscape(getUsagePreamble()) + "</p>");
+        stream.println("<p>" + getUsagePreamble() + "</p>");
         boolean hasOptions = false;
         for (final OptionDefinition optionDefinition : optionDefinitions) {
             if (!optionDefinition.isCommon || printCommon) {


### PR DESCRIPTION
Done to enable use of HTML formatting in the documentation. Includes an example of what this allows us to do; see CollectAlignmentSummaryMetrics.java

For a preview of what the result looks like, build from source and see the raw html page in dist/html/program_usage