### PR TITLE
Fixing bugs in CollectMultipleMetrics

### DIFF
--- a/src/java/picard/analysis/CollectMultipleMetrics.java
+++ b/src/java/picard/analysis/CollectMultipleMetrics.java
@@ -218,7 +218,7 @@ public class CollectMultipleMetrics extends CommandLineProgram {
         final List<SinglePassSamProgram> programs = new ArrayList<SinglePassSamProgram>();
         for (final ProgramInterface program : new HashSet<ProgramInterface>(programsToRun)) {
             if (program.needsReferenceSequence() && REFERENCE_SEQUENCE==null) {
-                throw new PicardException("A program you are trying to run needs a Reference Sequence, please set REFERENCE_SEQUENCE in the command line");
+                throw new PicardException("The " + program.toString() + " program needs a Reference Sequence, please set REFERENCE_SEQUENCE in the command line");
             }
             final SinglePassSamProgram instance = program.makeInstance(OUTPUT, INPUT, REFERENCE_SEQUENCE);
 


### PR DESCRIPTION
Needs to notify a user if reference sequence is not specified but is needed. Also removes CollectGcBiasMetrics from the list of default programs. In response to #225.