### PR TITLE
Update RExecutor.java

### DIFF
--- a/src/java/picard/util/RExecutor.java
+++ b/src/java/picard/util/RExecutor.java
@@ -94,7 +94,7 @@ public class RExecutor {
             IOUtil.copyStream(scriptStream, scriptFileStream);
             return scriptFile;
         } catch (IOException e) {
-            throw new PicardException("Unexpected exception creating R script file", e);
+            throw new PicardException("Unexpected exception creating R script file [" + rScriptName + "]", e);
         } finally {
             if (scriptStream != null) {
                 try {


### PR DESCRIPTION
Provide file location as part of error.  This can help track down issue related to file creation failure.