### PR TITLE
Add support for sequential FASTQ files in SamToFastq using the

### DIFF
--- a/testdata/picard/sam/fastq2bam/sequential-files/paired_end_R1_001.fastq
+++ b/testdata/picard/sam/fastq2bam/sequential-files/paired_end_R1_001.fastq
@@ -1,0 +1,4 @@
+@FAKE0001 Original version has PHRED scores from 93 to 0 inclusive (in that order)
+ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACG
++
+@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~

--- a/testdata/picard/sam/fastq2bam/sequential-files/paired_end_R1_002.fastq
+++ b/testdata/picard/sam/fastq2bam/sequential-files/paired_end_R1_002.fastq
@@ -1,0 +1,4 @@
+@FAKE0001 Original version has PHRED scores from 93 to 0 inclusive (in that order)
+ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACG
++
+@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~

--- a/testdata/picard/sam/fastq2bam/sequential-files/paired_end_R2_001.fastq
+++ b/testdata/picard/sam/fastq2bam/sequential-files/paired_end_R2_001.fastq
@@ -1,0 +1,4 @@
+@FAKE0001 Original version has PHRED scores from 93 to 0 inclusive (in that order)
+ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACG
++
+@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~

--- a/testdata/picard/sam/fastq2bam/sequential-files/paired_end_R2_002.fastq
+++ b/testdata/picard/sam/fastq2bam/sequential-files/paired_end_R2_002.fastq
@@ -1,0 +1,4 @@
+@FAKE0001 Original version has PHRED scores from 93 to 0 inclusive (in that order)
+ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACG
++
+@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~

--- a/testdata/picard/sam/fastq2bam/sequential-files/single_end_R1_001.fastq
+++ b/testdata/picard/sam/fastq2bam/sequential-files/single_end_R1_001.fastq
@@ -1,0 +1,4 @@
+@FAKE0001 Original version has PHRED scores from 93 to 0 inclusive (in that order)
+ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACG
++
+@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~

--- a/testdata/picard/sam/fastq2bam/sequential-files/single_end_R1_002.fastq
+++ b/testdata/picard/sam/fastq2bam/sequential-files/single_end_R1_002.fastq
@@ -1,0 +1,4 @@
+@FAKE0001 Original version has PHRED scores from 93 to 0 inclusive (in that order)
+ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACG
++
+@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~


### PR DESCRIPTION
USE_SEQUENTIAL_FASTQS optionl.  Sometimes we have the Fastq records for
a one end of a read in multiple files with the suffix
<prefix>_001.fastq, <prefix>_002.fastq, ..., <prefix>_XYZ.fastq, and we
want to treat them all as one file.