### PR TITLE
Create TMP_DIR as owner writable instead of world writable

### DIFF
--- a/src/java/picard/cmdline/CommandLineProgram.java
+++ b/src/java/picard/cmdline/CommandLineProgram.java
@@ -180,8 +180,8 @@ public abstract class CommandLineProgram {
             // Intentially not checking the return values, because it may be that the program does not
             // need a tmp_dir. If this fails, the problem will be discovered downstream.
             if (!f.exists()) f.mkdirs();
-            f.setReadable(true, false);
-            f.setWritable(true, false);
+            f.setReadable(true, true);
+            f.setWritable(true, true);
             System.setProperty("java.io.tmpdir", f.getAbsolutePath()); // in loop so that last one takes effect
         }
 


### PR DESCRIPTION
The TMP_DIR is by default created world writable which is a security issue in a shared environment. This change creates the TMP_DIR as owner writable.