### PR TITLE
Added capability to CollectWgsMetrics to restrict to certain intervals.

### DIFF
--- a/src/tests/java/picard/analysis/CollectWgsMetricsTest.java
+++ b/src/tests/java/picard/analysis/CollectWgsMetricsTest.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2010 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package picard.analysis;
+
+import htsjdk.samtools.metrics.MetricsFile;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import picard.cmdline.CommandLineProgramTest;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+
+/**
+ * Tests CollectWgsMetrics
+ */
+public class CollectWgsMetricsTest extends CommandLineProgramTest {
+    private static final File TEST_DATA_DIR = new File("testdata/picard/sam/");
+
+    public String getCommandLineProgramName() {
+        return CollectWgsMetrics.class.getSimpleName();
+    }
+
+    /**
+     * Important note:
+     *   This test is simply confirming that the correct number of sites are being evaluated by the tool.
+     *   It is not testing correctness of the results.
+     *   The code in general requires significant further testing of correctness.
+     */
+    @Test
+    public void testIntervals() throws IOException {
+        final File input = new File(TEST_DATA_DIR, "aligned.sam");
+        final File outfile = File.createTempFile("test", ".wgs_metrics");
+        final File ref = new File(TEST_DATA_DIR, "merger.fasta");
+        final File intervals = new File(TEST_DATA_DIR, "several.interval_list");
+        outfile.deleteOnExit();
+        final String[] args = new String[] {
+                "INPUT="  + input.getAbsolutePath(),
+                "OUTPUT=" + outfile.getAbsolutePath(),
+                "REFERENCE_SEQUENCE=" + ref.getAbsolutePath(),
+                "INTERVALS=" + intervals.getAbsolutePath()
+        };
+        Assert.assertEquals(runPicardCommandLine(args), 0);
+
+        final MetricsFile<CollectWgsMetrics.WgsMetrics, Comparable<?>> output = new MetricsFile<CollectWgsMetrics.WgsMetrics, Comparable<?>>();
+        output.read(new FileReader(outfile));
+
+        for (final CollectWgsMetrics.WgsMetrics metrics : output.getMetrics()) {
+            Assert.assertEquals(metrics.GENOME_TERRITORY, 5);
+        }
+    }
+}

--- a/testdata/picard/sam/several.interval_list
+++ b/testdata/picard/sam/several.interval_list
@@ -1,0 +1,11 @@
+@HD	VN:1.0
+@SQ	SN:chr1	LN:101	UR:merger.fasta	M5:bd01f7e11515bb6beda8f7257902aa67
+@SQ	SN:chr2	LN:101	UR:merger.fasta	M5:31c33e2155b3de5e2554b693c475b310
+@SQ	SN:chr3	LN:101	UR:merger.fasta	M5:631593c6dd2048ae88dcce2bd505d295
+@SQ	SN:chr4	LN:101	UR:merger.fasta	M5:c60cb92f1ee5b78053c92bdbfa19abf1
+@SQ	SN:chr5	LN:101	UR:merger.fasta	M5:07ebc213c7611db0eacbb1590c3e9bda
+@SQ	SN:chr6	LN:101	UR:merger.fasta	M5:7be2f5e7ee39e60a6c3b5b6a41178c6d
+@SQ	SN:chr7	LN:404	UR:merger.fasta	M5:da488fc432cdaf2c20c96da473a7b630
+@SQ	SN:chr8	LN:202	UR:merger.fasta	M5:d339678efce576d5546e88b49a487b63
+chr7	10	11	+	.
+chr7	16	18	+	.


### PR DESCRIPTION
@yfarjoun it turns out that this feature is incredibly useful for rapid QC because we're going to end up with whole genome bams that have been sampled down to a small number of sites and (critically) we only want them assessed at those exact positions (i.e. we do not want to include the rest of the bases in the reads).
