### PR TITLE
docker container as executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,7 @@ RUN ant clean all && \
     rm -rf lib && \
     rm build.xml
 
-ENTRYPOINT ["./docker_helper.sh"]
+RUN mkdir /usr/working
+WORKDIR /usr/working
+
+ENTRYPOINT ["/usr/picard/docker_helper.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,3 +32,4 @@ RUN mkdir /usr/working
 WORKDIR /usr/working
 
 ENTRYPOINT ["/usr/picard/docker_helper.sh"]
+CMD [""]

--- a/src/scripts/picard/docker_helper.sh
+++ b/src/scripts/picard/docker_helper.sh
@@ -24,4 +24,4 @@ done
 shift $(expr $OPTIND - 1)
 TOOL_WITH_ARGS=$@
 
-java ${JVM_ARGS} -jar picard.jar ${TOOL_WITH_ARGS}
+java ${JVM_ARGS} -jar /usr/picard/picard.jar ${TOOL_WITH_ARGS}


### PR DESCRIPTION
Pull request as discussed with Sheila on the GATK mailing list.

Made small changes to Dockerfile and docker_helper.sh to enable the usage of the Picard docker container as an executable. With the image built from this context (`docker build -t custompicard .`) I can run, e.g.:
`docker run -i -t -v $(pwd):/usr/working custompicard MergeSamFiles I=first.bam I=second.bam O=merged.bam` 
successfully if the bam files are present in the current working directory.