### PR TITLE
Fix the number of parameters in a test method

### DIFF
--- a/src/tests/java/picard/illumina/parser/IlluminaDataProviderTest.java
+++ b/src/tests/java/picard/illumina/parser/IlluminaDataProviderTest.java
@@ -259,10 +259,12 @@ public class IlluminaDataProviderTest {
     }
 
     @Test(dataProvider = "badData", expectedExceptions = {PicardException.class, IllegalArgumentException.class})
-    public void testIlluminaDataProviderMissingDatas(final int lane,
-                                                     final IlluminaDataType[] actualDts,
-                                                     final String illuminaConfigStr,
-                                                     final File basecallsDirectory)
+    public void testIlluminaDataProviderMissingDatas(
+            final String testName, final int lane, final int size,
+            final List<Integer> tiles,
+            final IlluminaDataType[] actualDts,
+            final String illuminaConfigStr,
+            final File basecallsDirectory)
             throws Exception {
         final IlluminaDataProviderFactory factory = new IlluminaDataProviderFactory(basecallsDirectory, lane, new ReadStructure(illuminaConfigStr), bclQualityEvaluationStrategy, actualDts);
         factory.makeDataProvider();


### PR DESCRIPTION
The provided data have 7 values, so the method needs 7 parameters (else the provided data should be reduced)