### PR TITLE
- added a test that fails if any CLP is missing its @CommandLineProgr…

### DIFF
--- a/src/tests/java/picard/cmdline/PicardCommandLineTest.java
+++ b/src/tests/java/picard/cmdline/PicardCommandLineTest.java
@@ -1,0 +1,18 @@
+package picard.cmdline;
+
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+
+/**
+ * Created by farjoun on 9/10/15.
+ */
+public class PicardCommandLineTest {
+
+    @Test
+    public void TestPicardPublic() { // this tests fails if any CLP in picard is missing its @CommandLineProgramProperties annotation
+        PicardCommandLine picardCommandLine = new PicardCommandLine();
+        picardCommandLine.instanceMain(new String[]{""});
+    }
+
+}


### PR DESCRIPTION
…amProperties annotation.