### PR TITLE
use the correct codec when spilling read ends to disk within

### DIFF
--- a/src/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -265,13 +265,15 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
         final int maxInMemory = (int) ((Runtime.getRuntime().maxMemory() * SORTING_COLLECTION_SIZE_RATIO) / sizeInBytes);
         log.info("Will retain up to " + maxInMemory + " data points before spilling to disk.");
 
-        final ReadEndsForMarkDuplicatesCodec fragCodec, pairCodec;
+        final ReadEndsForMarkDuplicatesCodec fragCodec, pairCodec, diskCodec;
         if (useBarcodes) {
             fragCodec = new ReadEndsForMarkDuplicatesWithBarcodesCodec();
             pairCodec = new ReadEndsForMarkDuplicatesWithBarcodesCodec();
+            diskCodec = new ReadEndsForMarkDuplicatesWithBarcodesCodec();
         } else {
             fragCodec = new ReadEndsForMarkDuplicatesCodec();
             pairCodec = new ReadEndsForMarkDuplicatesCodec();
+            diskCodec = new ReadEndsForMarkDuplicatesCodec();
         }
 
         this.pairSort = SortingCollection.newInstance(ReadEndsForMarkDuplicates.class,
@@ -288,7 +290,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
 
         final SamHeaderAndIterator headerAndIterator = openInputs();
         final SAMFileHeader header = headerAndIterator.header;
-        final ReadEndsForMarkDuplicatesMap tmp = new DiskBasedReadEndsForMarkDuplicatesMap(MAX_FILE_HANDLES_FOR_READ_ENDS_MAP);
+        final ReadEndsForMarkDuplicatesMap tmp = new DiskBasedReadEndsForMarkDuplicatesMap(MAX_FILE_HANDLES_FOR_READ_ENDS_MAP, diskCodec);
         long index = 0;
         final ProgressLogger progress = new ProgressLogger(log, (int) 1e6, "Read");
         final CloseableIterator<SAMRecord> iterator = headerAndIterator.iterator;

--- a/src/java/picard/sam/markduplicates/util/DiskBasedReadEndsForMarkDuplicatesMap.java
+++ b/src/java/picard/sam/markduplicates/util/DiskBasedReadEndsForMarkDuplicatesMap.java
@@ -53,8 +53,8 @@ import java.util.*;
 public class DiskBasedReadEndsForMarkDuplicatesMap implements ReadEndsForMarkDuplicatesMap {
     private final CoordinateSortedPairInfoMap<String, ReadEndsForMarkDuplicates> pairInfoMap;
 
-    public DiskBasedReadEndsForMarkDuplicatesMap(int maxOpenFiles) {
-        pairInfoMap = new CoordinateSortedPairInfoMap<String, ReadEndsForMarkDuplicates>(maxOpenFiles, new Codec());
+    public DiskBasedReadEndsForMarkDuplicatesMap(int maxOpenFiles, final ReadEndsForMarkDuplicatesCodec readEndsForMarkDuplicatesCodec) {
+        pairInfoMap = new CoordinateSortedPairInfoMap<String, ReadEndsForMarkDuplicates>(maxOpenFiles, new Codec(readEndsForMarkDuplicatesCodec));
     }
 
     public ReadEndsForMarkDuplicates remove(int mateSequenceIndex, String key) {
@@ -74,7 +74,11 @@ public class DiskBasedReadEndsForMarkDuplicatesMap implements ReadEndsForMarkDup
     }
 
     private static class Codec implements CoordinateSortedPairInfoMap.Codec<String, ReadEndsForMarkDuplicates> {
-        private final ReadEndsForMarkDuplicatesCodec readEndsForMarkDuplicatesCodec = new ReadEndsForMarkDuplicatesCodec();
+        private final ReadEndsForMarkDuplicatesCodec readEndsForMarkDuplicatesCodec;
+
+        public Codec(final ReadEndsForMarkDuplicatesCodec readEndsForMarkDuplicatesCodec) {
+            this.readEndsForMarkDuplicatesCodec = readEndsForMarkDuplicatesCodec;
+        }
 
         public void setInputStream(final InputStream is) {
             readEndsForMarkDuplicatesCodec.setInputStream(is);


### PR DESCRIPTION
MarkDuplicates