### PR TITLE
GenotypeConcordance could overflow if there were too many sites for an

### DIFF
--- a/src/java/picard/vcf/GenotypeConcordance.java
+++ b/src/java/picard/vcf/GenotypeConcordance.java
@@ -358,7 +358,7 @@ public class GenotypeConcordance extends CommandLineProgram {
         scheme.validateScheme();
         for (final TruthState truthState : TruthState.values()) {
             for (final CallState callState : CallState.values()) {
-                final int count = counter.getCount(truthState, callState);
+                final long count = counter.getCount(truthState, callState);
                 final String contingencyValues = scheme.getContingencyStateString(truthState, callState);
                 if (count > 0 || OUTPUT_ALL_ROWS) {
                     final GenotypeConcordanceDetailMetrics detailMetrics = new GenotypeConcordanceDetailMetrics();

--- a/src/java/picard/vcf/GenotypeConcordanceContingencyMetrics.java
+++ b/src/java/picard/vcf/GenotypeConcordanceContingencyMetrics.java
@@ -27,7 +27,7 @@ public class GenotypeConcordanceContingencyMetrics extends MetricBase {
         scheme.validateScheme();
         concordanceCounts.validateCountsAgainstScheme(scheme);
 
-        Map<ContingencyState, Integer> counts = concordanceCounts.getContingencyStateCounts(scheme);
+        Map<ContingencyState, Long> counts = concordanceCounts.getContingencyStateCounts(scheme);
         this.TP_COUNT = counts.get(ContingencyState.TP);
         this.TN_COUNT = counts.get(ContingencyState.TN);
         this.FP_COUNT = counts.get(ContingencyState.FP);
@@ -45,17 +45,17 @@ public class GenotypeConcordanceContingencyMetrics extends MetricBase {
     public String CALL_SAMPLE;
 
     /** The TP (true positive) count across all variants */
-    public int TP_COUNT;
+    public long TP_COUNT;
 
     /** The TN (true negative) count across all variants */
-    public int TN_COUNT;
+    public long TN_COUNT;
 
     /** The FP (false positive) count across all variants */
-    public int FP_COUNT;
+    public long FP_COUNT;
 
     /** The FN (false negative) count across all variants */
-    public int FN_COUNT;
+    public long FN_COUNT;
 
     /** The empty (no contingency info) count across all variants */
-    public int EMPTY_COUNT;
+    public long EMPTY_COUNT;
 }

--- a/src/java/picard/vcf/GenotypeConcordanceCounts.java
+++ b/src/java/picard/vcf/GenotypeConcordanceCounts.java
@@ -103,7 +103,7 @@ public class GenotypeConcordanceCounts {
                 }
                 else if (includeHomRef || isVar(truthState, callState)) {
                     final TruthAndCallStates truthAndCallStates = new TruthAndCallStates(truthState, callState);
-                    final int count = getCount(truthAndCallStates);
+                    final long count = getCount(truthAndCallStates);
                     if (truthState.getCode()==callState.getCode()) {
                         //If we enter this, we are 'on the diagonal'
                         numerator += count;
@@ -146,7 +146,7 @@ public class GenotypeConcordanceCounts {
         for (final TruthState truthState : truthStateArray) {
             for (final CallState callState : CallState.values()) {
                 final TruthAndCallStates truthAndCallStates = new TruthAndCallStates(truthState, callState);
-                final int count = getCount(truthAndCallStates);
+                final long count = getCount(truthAndCallStates);
                 for (final ContingencyState contingencyState : scheme.getConcordanceStateArray(truthAndCallStates)) {
                     if (ContingencyState.TP == contingencyState) {
                         numerator += count;
@@ -176,7 +176,7 @@ public class GenotypeConcordanceCounts {
         for (final CallState callState : callStateList) {
             for (final TruthState truthState : TruthState.values()) {
                 final TruthAndCallStates truthAndCallStates = new TruthAndCallStates(truthState, callState);
-                final int count = getCount(truthAndCallStates);
+                final long count = getCount(truthAndCallStates);
                 for (final ContingencyState contingencyState : scheme.getConcordanceStateArray(truthAndCallStates)) {
                     if (ContingencyState.TP == contingencyState) {
                         numerator += count;
@@ -206,7 +206,7 @@ public class GenotypeConcordanceCounts {
         for (final TruthState truthState : truthStateArray) {
             for (final CallState callState : CallState.values()) {
                 final TruthAndCallStates truthAndCallStates = new TruthAndCallStates(truthState, callState);
-                final int count = getCount(truthAndCallStates);
+                final long count = getCount(truthAndCallStates);
                 for (final ContingencyState contingencyState : scheme.getConcordanceStateArray(truthAndCallStates)) {
                     if (ContingencyState.TN == contingencyState) {
                         numerator += count;
@@ -223,16 +223,16 @@ public class GenotypeConcordanceCounts {
     /**
      * Returns the count defined by the truth state set and call state set.
      */
-    public int getCount(final TruthState truthState, final CallState callState) {
+    public long getCount(final TruthState truthState, final CallState callState) {
         return getCount(new TruthAndCallStates(truthState, callState));
     }
 
     /**
      * Returns the count defined by the truth state set and call state set.
      */
-    public int getCount(final TruthAndCallStates truthAndCallStates) {
+    public long getCount(final TruthAndCallStates truthAndCallStates) {
         final Histogram<TruthAndCallStates>.Bin bin = this.counter.get(truthAndCallStates);
-        return (bin == null ? 0 : (int) bin.getValue());
+        return (bin == null ? 0L : (long) bin.getValue());
     }
 
     /**
@@ -259,8 +259,8 @@ public class GenotypeConcordanceCounts {
     /**
      * Returns the sum of all pairs of tuples defined by the truth state set and call state set.
      */
-    public int getSum(final Set<TruthState> truthStateSet, final Set<CallState> callStateSet) {
-        int count = 0;
+    public long getSum(final Set<TruthState> truthStateSet, final Set<CallState> callStateSet) {
+        long count = 0;
         for (final TruthState truthState : truthStateSet) {
             for (final CallState callState : callStateSet) {
                 count += getCount(truthState, callState);
@@ -272,19 +272,19 @@ public class GenotypeConcordanceCounts {
     /**
      * Returns the sum of all pairs of tuples defined by the truth state set and call state set.
      */
-    public int getSum() {
+    public long getSum() {
         return getSum(new HashSet<TruthState>(Arrays.asList(TruthState.values())), new HashSet<CallState>(Arrays.asList(CallState.values())));
     }
 
     /**
      * Returns the total number of times each contingency state is encountered, summed across all truth/call state pairs.
      */
-    public Map<ContingencyState, Integer> getContingencyStateCounts(final GenotypeConcordanceScheme scheme) {
+    public Map<ContingencyState, Long> getContingencyStateCounts(final GenotypeConcordanceScheme scheme) {
         scheme.validateScheme();
 
-        final Map<ContingencyState, Integer> counts = new HashMap<ContingencyState, Integer>();
+        final Map<ContingencyState, Long> counts = new HashMap<ContingencyState, Long>();
         for (final ContingencyState contingencyState : ContingencyState.values()) {
-            counts.put(contingencyState, 0);
+            counts.put(contingencyState, 0L);
         }
 
         for (final TruthState truthState : TruthState.values()) {
@@ -292,7 +292,7 @@ public class GenotypeConcordanceCounts {
                 final TruthAndCallStates truthAndCallStates = new TruthAndCallStates(truthState, callState);
                 final ContingencyState[] contingencyStateArray = scheme.getConcordanceStateArray(truthAndCallStates);
                 for (final ContingencyState contingencyState : contingencyStateArray) {
-                    final int newCount = counts.get(contingencyState) + getCount(truthAndCallStates);
+                    final long newCount = counts.get(contingencyState) + getCount(truthAndCallStates);
                     counts.put(contingencyState, newCount);
                 }
             }


### PR DESCRIPTION
integer, which could happen for true negative sites for whole genomes
when using MISSING_SITES_HOM_REF=true.