### PR TITLE
Modified CommandLineProgram to, when the VALIDATION_STRINGENCY is eit…

### DIFF
--- a/src/java/picard/cmdline/CommandLineProgram.java
+++ b/src/java/picard/cmdline/CommandLineProgram.java
@@ -37,6 +37,8 @@ import htsjdk.samtools.util.BlockCompressedStreamConstants;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.zip.DeflaterFactory;
+import htsjdk.variant.variantcontext.writer.Options;
+import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 
 import java.io.File;
 import java.lang.annotation.Annotation;
@@ -165,6 +167,7 @@ public abstract class CommandLineProgram {
         }
         SamReaderFactory.setDefaultValidationStringency(VALIDATION_STRINGENCY);
         BlockCompressedOutputStream.setDefaultCompressionLevel(COMPRESSION_LEVEL);
+        if (VALIDATION_STRINGENCY != ValidationStringency.STRICT) VariantContextWriterBuilder.setDefaultOption(Options.ALLOW_MISSING_FIELDS_IN_HEADER);
 
         if (MAX_RECORDS_IN_RAM != null) {
             SAMFileWriterImpl.setDefaultMaxRecordsInRam(MAX_RECORDS_IN_RAM);

--- a/src/java/picard/vcf/LiftoverVcf.java
+++ b/src/java/picard/vcf/LiftoverVcf.java
@@ -2,6 +2,7 @@ package picard.vcf;
 
 import htsjdk.samtools.Defaults;
 import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.ValidationStringency;
 import htsjdk.samtools.liftover.LiftOver;
 import htsjdk.samtools.reference.ReferenceSequenceFileWalker;
 import htsjdk.samtools.util.CloserUtil;
@@ -137,7 +138,7 @@ public class LiftoverVcf extends CommandLineProgram {
         log.info("Lifting variants over and sorting.");
 
         final SortingCollection<VariantContext> sorter = SortingCollection.newInstance(VariantContext.class,
-                new VCFRecordCodec(outHeader),
+                new VCFRecordCodec(outHeader, VALIDATION_STRINGENCY != ValidationStringency.STRICT),
                 outHeader.getVCFRecordComparator(),
                 MAX_RECORDS_IN_RAM,
                 TMP_DIR);

--- a/src/java/picard/vcf/SortVcf.java
+++ b/src/java/picard/vcf/SortVcf.java
@@ -2,6 +2,7 @@ package picard.vcf;
 
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.ValidationStringency;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
@@ -143,7 +144,7 @@ public class SortVcf extends CommandLineProgram {
         final SortingCollection<VariantContext> sorter =
                 SortingCollection.newInstance(
                         VariantContext.class,
-                        new VCFRecordCodec(outputHeader),
+                        new VCFRecordCodec(outputHeader, VALIDATION_STRINGENCY != ValidationStringency.STRICT),
                         outputHeader.getVCFRecordComparator(),
                         MAX_RECORDS_IN_RAM,
                         TMP_DIR);


### PR DESCRIPTION
…her LENIENT or SILENT, set the default option on VariantContextWriterBuilder to allow fields that are not defined in the VCFHeader. The result being that it is now possible to use all VCF modifying programs (e.g. FilterVcf, LiftoverVcf, etc.) with input VCFs that have incomplete headers, by specifying VALIDATION_STRINGENCY=LENIENT on the command line.