### PR TITLE
After editing CollectGcBias to avoid using too much memory a bug was …

### DIFF
--- a/src/java/picard/analysis/CollectGcBiasMetrics.java
+++ b/src/java/picard/analysis/CollectGcBiasMetrics.java
@@ -72,7 +72,7 @@ public class CollectGcBiasMetrics extends SinglePassSamProgram {
     @Option(shortName = "S", doc = "The text file to write summary metrics to.")
     public File SUMMARY_OUTPUT;
 
-    @Option(shortName = "WIN", doc = "The size of the scanning windows on the reference genome that are used to bin reads.")
+    @Option(shortName = "WINDOW_SIZE", doc = "The size of the scanning windows on the reference genome that are used to bin reads.")
     public int SCAN_WINDOW_SIZE = 100;
 
     @Option(shortName = "MGF", doc = "For summary metrics, exclude GC windows that include less than this fraction of the genome.")

--- a/src/java/picard/analysis/GcBiasMetricsCollector.java
+++ b/src/java/picard/analysis/GcBiasMetricsCollector.java
@@ -55,6 +55,7 @@ public class GcBiasMetricsCollector extends MultiLevelCollector<GcBiasMetrics, I
     //will hold the relevant gc information per contig
     private byte [] gc = null;
     private int referenceIndex = -1;
+    private byte [] refBases = null;
 
     public GcBiasMetricsCollector(final Set<MetricAccumulationLevel> accumulationLevels, final int[] windowsByGc,
                                   final List<SAMReadGroupRecord> samRgRecords, final int scanWindowSize, final boolean bisulfite) {
@@ -125,13 +126,12 @@ public class GcBiasMetricsCollector extends MultiLevelCollector<GcBiasMetrics, I
             final SAMRecord rec = args.getRec();
             final String type;
             if (!rec.getReadUnmappedFlag()) {
-                final ReferenceSequence ref = args.getRef();
-                final byte[] refBases = ref.getBases();
-                StringUtil.toUpperCase(refBases);
-                final int refLength = refBases.length;
-                final int lastWindowStart = refLength - scanWindowSize;
-
                 if(referenceIndex != rec.getReferenceIndex() || gc == null){
+                    final ReferenceSequence ref = args.getRef();
+                    refBases = ref.getBases();
+                    StringUtil.toUpperCase(refBases);
+                    final int refLength = refBases.length;
+                    final int lastWindowStart = refLength - scanWindowSize;
                     gc = GcBiasUtils.calculateAllGcs(refBases, lastWindowStart, scanWindowSize);
                     referenceIndex=rec.getReferenceIndex();
                 }


### PR DESCRIPTION
…found that was causing the program to run for longer than expected in production. The cause was unnecesssarily pulling down the reference when it could be doing it less frequently. The call to pull down the reference was moved inside of an if statement, but to allow it to be used for the 'addRead' call I had to store the refBases byte[] in memory, it needed to be accessible outside of the if statement. The reference contig is used in the addRead function to calculate the error rate. 

@eitanbanks @yfarjoun Please let me know if you think storing the reference bases of one contig is too much memory.
