### PR TITLE
Added 'deleteOnExit' to address Issue 302 where a temp file wasn't being deleted

### DIFF
--- a/src/tests/java/picard/analysis/CollectGcBiasMetricsTest.java
+++ b/src/tests/java/picard/analysis/CollectGcBiasMetricsTest.java
@@ -203,6 +203,7 @@ public class CollectGcBiasMetricsTest extends CommandLineProgramTest {
     /////////////////////////////////////////////////////////////////////////////
     public File build (final List<SAMRecordSetBuilder> setBuilder, final File unsortedSam, final SAMFileHeader header) throws IOException {
         final File sortedSam = File.createTempFile("CollectGcBias", ".bam", TEST_DIR);
+        sortedSam.deleteOnExit();
 
         final SAMFileWriter writer = new SAMFileWriterFactory()
                 .setCreateIndex(true).makeBAMWriter(header, false, unsortedSam);


### PR DESCRIPTION
#302 pointed out I forgot to delete On Exit a temp file. This has a fix. @mattsooknah 