### PR TITLE
AlignedReads int overflow bug in GcBias

### DIFF
--- a/src/java/picard/analysis/GcBiasMetricsCollector.java
+++ b/src/java/picard/analysis/GcBiasMetricsCollector.java
@@ -191,7 +191,7 @@ public class GcBiasMetricsCollector extends MultiLevelCollector<GcBiasMetrics, I
                 final long[] errorsByGc = gcCur.errorsByGc;
                 final long[] basesByGc = gcCur.basesByGc;
                 final int totalClusters = gcCur.totalClusters;
-                final int totalAlignedReads = gcCur.totalAlignedReads;
+                final long totalAlignedReads = gcCur.totalAlignedReads;
                 final String group = gcCur.group;
 
                 final GcBiasMetrics metrics = new GcBiasMetrics();
@@ -206,22 +206,21 @@ public class GcBiasMetricsCollector extends MultiLevelCollector<GcBiasMetrics, I
                         detail.GC = i;
                         detail.WINDOWS = windowsByGc[i];
                         detail.READ_STARTS = readsByGc[i];
-                        if (errorsByGc[i] > 0) detail.MEAN_BASE_QUALITY = QualityUtil.getPhredScoreFromObsAndErrors(basesByGc[i], errorsByGc[i]);
+                        if (errorsByGc[i] > 0) {
+                            detail.MEAN_BASE_QUALITY = QualityUtil.getPhredScoreFromObsAndErrors(basesByGc[i], errorsByGc[i]);
+                        }
                         if (windowsByGc[i] != 0) {
                             detail.NORMALIZED_COVERAGE = (detail.READ_STARTS / (double) detail.WINDOWS) / meanReadsPerWindow;
                             detail.ERROR_BAR_WIDTH = (Math.sqrt(detail.READ_STARTS) / (double) detail.WINDOWS) / meanReadsPerWindow;
-                        }
-                        else{
+                        } else {
                             detail.NORMALIZED_COVERAGE = 0;
                             detail.ERROR_BAR_WIDTH = 0;
                         }
                         detail.ACCUMULATION_LEVEL = group;
-                        if (group.equals("Read Group")) {
-                            detail.READ_GROUP = gcType;}
-                        else if (group.equals("Sample")) {
-                            detail.SAMPLE = gcType;}
-                        else if (group.equals("Library")) {
-                            detail.LIBRARY = gcType;}
+                        if (group.equals("Read Group")) {detail.READ_GROUP = gcType;}
+                        else if (group.equals("Sample")) {detail.SAMPLE = gcType;}
+                        else if (group.equals("Library")) {detail.LIBRARY = gcType;}
+
                         metrics.DETAILS.addMetric(detail);
                     }
 
@@ -283,7 +282,7 @@ public class GcBiasMetricsCollector extends MultiLevelCollector<GcBiasMetrics, I
     /////////////////////////////////////////////////////////////////////////////
     class GcObject {
         int totalClusters = 0;
-        int totalAlignedReads = 0;
+        long totalAlignedReads = 0;
         int[] readsByGc = new int[BINS];
         long[] basesByGc = new long[BINS];
         long[] errorsByGc = new long[BINS];

--- a/src/java/picard/analysis/GcBiasSummaryMetrics.java
+++ b/src/java/picard/analysis/GcBiasSummaryMetrics.java
@@ -41,7 +41,7 @@ public class GcBiasSummaryMetrics extends MultilevelMetrics {
     public int TOTAL_CLUSTERS;
 
     /** The total number of aligned reads used to compute the gc bias metrics. */
-    public int ALIGNED_READS;
+    public long ALIGNED_READS;
 
     /**
      * Illumina-style AT dropout metric.  Calculated by taking each GC bin independently and calculating


### PR DESCRIPTION
Ran into a bug in CollectGcBias with a 100X coverage genome, where the number of aligned reads was greater than MAX_INT. In the latest version, the gc detail and summary metrics were only calculated and written out if totalAlignedReads was >0. Because of the overflow, totalAlignedReads was a random negative number, and thus no metrics were output, but empty (except header) metrics files still were written and no errors were thrown.

To address this, I've changed totalAlignedReads to a long and I've changed the if statement to skip only if totalAlignedReads==0. 