### PR TITLE
fixes a case where we have a fragment read and we want to use barcodes

### DIFF
--- a/src/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -428,7 +428,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
         if (useBarcodes) {
             final ReadEndsForMarkDuplicatesWithBarcodes endsWithBarcode = (ReadEndsForMarkDuplicatesWithBarcodes) ends;
             endsWithBarcode.barcode = getBarcodeValue(rec);
-            if (rec.getFirstOfPairFlag()) {
+            if (!rec.getReadPairedFlag() || rec.getFirstOfPairFlag()) {
                 endsWithBarcode.readOneBarcode = getReadOneBarcodeValue(rec);
             } else {
                 endsWithBarcode.readTwoBarcode = getReadTwoBarcodeValue(rec);

--- a/src/tests/java/picard/sam/markduplicates/MarkDuplicatesTest.java
+++ b/src/tests/java/picard/sam/markduplicates/MarkDuplicatesTest.java
@@ -210,6 +210,32 @@ public class MarkDuplicatesTest extends AbstractMarkDuplicatesCommandLineProgram
     }
 
     @Test
+    public void testWithBarcodeFragmentDuplicate() {
+        final AbstractMarkDuplicatesCommandLineProgramTester tester = getTester();
+        tester.addMappedFragment(2, 41212324, false, "50M", DEFAULT_BASE_QUALITY);
+        tester.addMappedFragment(2, 41212324, true, "50M", DEFAULT_BASE_QUALITY);
+        final String barcodeTag = "BC";
+        for (final SAMRecord record : new IterableAdapter<SAMRecord>(tester.getRecordIterator())) {
+            record.setAttribute(barcodeTag, "Barcode1");
+        }
+        tester.addArg("BARCODE_TAG=" + barcodeTag);
+        tester.runTest();
+    }
+
+    public void addMappedFragment(final int referenceSequenceIndex, final int alignmentStart, final boolean isDuplicate, final String cigar,
+                                  final int defaultQualityScore) {
+        final AbstractMarkDuplicatesCommandLineProgramTester tester = getTester();
+        tester.addMatePair("RUNID:1:1:15993:13361", 2, 41212324, 41212310, false, false, false, false, "33S35M", "19S49M", true, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.addMatePair("RUNID:2:2:15993:13362", 2, 41212324, 41212310, false, false, true, true, "33S35M", "19S49M", true, true, false, false, false, DEFAULT_BASE_QUALITY);
+        final String barcodeTag = "BC";
+        for (final SAMRecord record : new IterableAdapter<SAMRecord>(tester.getRecordIterator())) {
+            record.setAttribute(barcodeTag, "Barcode1");
+        }
+        tester.addArg("BARCODE_TAG=" + barcodeTag);
+        tester.runTest();
+    }
+
+    @Test
     public void testWithBarcodeDuplicate() {
         final AbstractMarkDuplicatesCommandLineProgramTester tester = getTester();
         tester.addMatePair("RUNID:1:1:15993:13361", 2, 41212324, 41212310, false, false, false, false, "33S35M", "19S49M", true, true, false, false, false, DEFAULT_BASE_QUALITY);


### PR DESCRIPTION
for MarkDuplicates.