### PR TITLE
Plot all insert size orientations in CollectInsertMetrics when MIN_PCT=0

### DIFF
--- a/src/java/picard/analysis/directed/InsertSizeMetricsCollector.java
+++ b/src/java/picard/analysis/directed/InsertSizeMetricsCollector.java
@@ -6,7 +6,6 @@ import htsjdk.samtools.SamPairUtil;
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.util.Histogram;
-import picard.PicardException;
 import picard.analysis.InsertSizeMetrics;
 import picard.analysis.MetricAccumulationLevel;
 import picard.metrics.MultiLevelCollector;
@@ -36,9 +35,9 @@ public class InsertSizeMetricsCollector extends MultiLevelCollector<InsertSizeMe
     private final Integer histogramWidth;
 
     public InsertSizeMetricsCollector(final Set<MetricAccumulationLevel> accumulationLevels, final List<SAMReadGroupRecord> samRgRecords,
-                                      final double minimumPct, final Integer HistogramWidth, final double deviations) {
+                                      final double minimumPct, final Integer histogramWidth, final double deviations) {
         this.minimumPct = minimumPct;
-        this.histogramWidth = HistogramWidth;
+        this.histogramWidth = histogramWidth;
         this.deviations = deviations;
         setup(accumulationLevels, samRgRecords);
     }
@@ -76,7 +75,7 @@ public class InsertSizeMetricsCollector extends MultiLevelCollector<InsertSizeMe
 
     /** A Collector for individual InsertSizeMetrics for a given SAMPLE or SAMPLE/LIBRARY or SAMPLE/LIBRARY/READ_GROUP (depending on aggregation levels) */
     public class PerUnitInsertSizeMetricsCollector implements PerUnitMetricCollector<InsertSizeMetrics, Integer, InsertSizeCollectorArgs> {
-        final EnumMap<SamPairUtil.PairOrientation, Histogram<Integer>> Histograms = new EnumMap<SamPairUtil.PairOrientation, Histogram<Integer>>(SamPairUtil.PairOrientation.class);
+        final EnumMap<SamPairUtil.PairOrientation, Histogram<Integer>> histograms = new EnumMap<SamPairUtil.PairOrientation, Histogram<Integer>>(SamPairUtil.PairOrientation.class);
         final String sample;
         final String library;
         final String readGroup;
@@ -99,13 +98,13 @@ public class InsertSizeMetricsCollector extends MultiLevelCollector<InsertSizeMe
             else {
                 prefix = "All_Reads.";
             }
-            Histograms.put(SamPairUtil.PairOrientation.FR,     new Histogram<Integer>("insert_size", prefix + "fr_count"));
-            Histograms.put(SamPairUtil.PairOrientation.TANDEM, new Histogram<Integer>("insert_size", prefix + "tandem_count"));
-            Histograms.put(SamPairUtil.PairOrientation.RF,     new Histogram<Integer>("insert_size", prefix + "rf_count"));
+            histograms.put(SamPairUtil.PairOrientation.FR,     new Histogram<Integer>("insert_size", prefix + "fr_count"));
+            histograms.put(SamPairUtil.PairOrientation.TANDEM, new Histogram<Integer>("insert_size", prefix + "tandem_count"));
+            histograms.put(SamPairUtil.PairOrientation.RF,     new Histogram<Integer>("insert_size", prefix + "rf_count"));
         }
 
         public void acceptRecord(final InsertSizeCollectorArgs args) {
-            Histograms.get(args.getPairOrientation()).increment(args.getInsertSize());
+            histograms.get(args.getPairOrientation()).increment(args.getInsertSize());
         }
 
         public void finish() { }
@@ -116,80 +115,72 @@ public class InsertSizeMetricsCollector extends MultiLevelCollector<InsertSizeMe
 
         public void addMetricsToFile(final MetricsFile<InsertSizeMetrics,Integer> file) {
             // get the number of inserts, and the maximum and minimum keys across, across all orientations
-            int minKey = Integer.MAX_VALUE, maxKey = Integer.MIN_VALUE;
-            for (final Histogram<Integer> h : this.Histograms.values()) {
+            for (final Histogram<Integer> h : this.histograms.values()) {
                 totalInserts += h.getCount();
-                if (!h.isEmpty()) {
-                    int curMin = Collections.min(h.keySet()), curMax = Collections.max(h.keySet());
-                    if (curMin < minKey) minKey = curMin;
-                    if (maxKey < curMax) maxKey = curMax;
-                }
             }
             if (0 == totalInserts) return; // nothing to store
 
-            for(final Map.Entry<SamPairUtil.PairOrientation, Histogram<Integer>> entry : Histograms.entrySet()) {
+            for(final Map.Entry<SamPairUtil.PairOrientation, Histogram<Integer>> entry : histograms.entrySet()) {
                 final SamPairUtil.PairOrientation pairOrientation = entry.getKey();
-                final Histogram<Integer> Histogram = entry.getValue();
-                final double total = Histogram.getCount();
+                final Histogram<Integer> histogram = entry.getValue();
+                final double total = histogram.getCount();
 
                 // Only include a category if it has a sufficient percentage of the data in it
                 if( total >= totalInserts * minimumPct ) {
-                    // in the case that minimumPct == 0 and total == 0, just make an empty histogram with zero values for the entire range
-                    if (Histogram.isEmpty()) {
-                        for (int key = minKey; key <= maxKey; key++) Histogram.increment(key, 0);
-                        if (Histogram.isEmpty()) throw new PicardException("BUG: minKey=" + minKey + " maxKey=" + maxKey);
-                    }
-
                     final InsertSizeMetrics metrics = new InsertSizeMetrics();
                     metrics.SAMPLE             = this.sample;
                     metrics.LIBRARY            = this.library;
                     metrics.READ_GROUP         = this.readGroup;
                     metrics.PAIR_ORIENTATION   = pairOrientation;
-                    metrics.READ_PAIRS         = (long) total;
-                    metrics.MAX_INSERT_SIZE    = (int) Histogram.getMax();
-                    metrics.MIN_INSERT_SIZE    = (int) Histogram.getMin();
-                    metrics.MEDIAN_INSERT_SIZE = Histogram.getMedian();
-                    metrics.MEDIAN_ABSOLUTE_DEVIATION = Histogram.getMedianAbsoluteDeviation();
+                    if (!histogram.isEmpty()) {
+                        metrics.READ_PAIRS = (long) total;
+                        metrics.MAX_INSERT_SIZE = (int) histogram.getMax();
+                        metrics.MIN_INSERT_SIZE = (int) histogram.getMin();
+                        metrics.MEDIAN_INSERT_SIZE = histogram.getMedian();
+                        metrics.MEDIAN_ABSOLUTE_DEVIATION = histogram.getMedianAbsoluteDeviation();
 
-                    final double median  = Histogram.getMedian();
-                    double covered = 0;
-                    double low  = median;
-                    double high = median;
+                        final double median = histogram.getMedian();
+                        double covered = 0;
+                        double low = median;
+                        double high = median;
 
-                    while (low >= Histogram.getMin() || high <= Histogram.getMax()) {
-                        final Histogram<Integer>.Bin lowBin = Histogram.get((int) low);
-                        if (lowBin != null) covered += lowBin.getValue();
+                        while (low >= histogram.getMin() || high <= histogram.getMax()) {
+                            final Histogram<Integer>.Bin lowBin = histogram.get((int) low);
+                            if (lowBin != null) covered += lowBin.getValue();
 
-                        if (low != high) {
-                            final Histogram<Integer>.Bin highBin = Histogram.get((int) high);
-                            if (highBin != null) covered += highBin.getValue();
+                            if (low != high) {
+                                final Histogram<Integer>.Bin highBin = histogram.get((int) high);
+                                if (highBin != null) covered += highBin.getValue();
+                            }
+
+                            final double percentCovered = covered / total;
+                            final int distance = (int) (high - low) + 1;
+                            if (percentCovered >= 0.1 && metrics.WIDTH_OF_10_PERCENT == 0) metrics.WIDTH_OF_10_PERCENT = distance;
+                            if (percentCovered >= 0.2 && metrics.WIDTH_OF_20_PERCENT == 0) metrics.WIDTH_OF_20_PERCENT = distance;
+                            if (percentCovered >= 0.3 && metrics.WIDTH_OF_30_PERCENT == 0) metrics.WIDTH_OF_30_PERCENT = distance;
+                            if (percentCovered >= 0.4 && metrics.WIDTH_OF_40_PERCENT == 0) metrics.WIDTH_OF_40_PERCENT = distance;
+                            if (percentCovered >= 0.5 && metrics.WIDTH_OF_50_PERCENT == 0) metrics.WIDTH_OF_50_PERCENT = distance;
+                            if (percentCovered >= 0.6 && metrics.WIDTH_OF_60_PERCENT == 0) metrics.WIDTH_OF_60_PERCENT = distance;
+                            if (percentCovered >= 0.7 && metrics.WIDTH_OF_70_PERCENT == 0) metrics.WIDTH_OF_70_PERCENT = distance;
+                            if (percentCovered >= 0.8 && metrics.WIDTH_OF_80_PERCENT == 0) metrics.WIDTH_OF_80_PERCENT = distance;
+                            if (percentCovered >= 0.9 && metrics.WIDTH_OF_90_PERCENT == 0) metrics.WIDTH_OF_90_PERCENT = distance;
+                            if (percentCovered >= 0.99 && metrics.WIDTH_OF_99_PERCENT == 0) metrics.WIDTH_OF_99_PERCENT = distance;
+
+                            --low;
+                            ++high;
                         }
-
-                        final double percentCovered = covered / total;
-                        final int distance = (int) (high - low) + 1;
-                        if (percentCovered >= 0.1  && metrics.WIDTH_OF_10_PERCENT == 0) metrics.WIDTH_OF_10_PERCENT = distance;
-                        if (percentCovered >= 0.2  && metrics.WIDTH_OF_20_PERCENT == 0) metrics.WIDTH_OF_20_PERCENT = distance;
-                        if (percentCovered >= 0.3  && metrics.WIDTH_OF_30_PERCENT == 0) metrics.WIDTH_OF_30_PERCENT = distance;
-                        if (percentCovered >= 0.4  && metrics.WIDTH_OF_40_PERCENT == 0) metrics.WIDTH_OF_40_PERCENT = distance;
-                        if (percentCovered >= 0.5  && metrics.WIDTH_OF_50_PERCENT == 0) metrics.WIDTH_OF_50_PERCENT = distance;
-                        if (percentCovered >= 0.6  && metrics.WIDTH_OF_60_PERCENT == 0) metrics.WIDTH_OF_60_PERCENT = distance;
-                        if (percentCovered >= 0.7  && metrics.WIDTH_OF_70_PERCENT == 0) metrics.WIDTH_OF_70_PERCENT = distance;
-                        if (percentCovered >= 0.8  && metrics.WIDTH_OF_80_PERCENT == 0) metrics.WIDTH_OF_80_PERCENT = distance;
-                        if (percentCovered >= 0.9  && metrics.WIDTH_OF_90_PERCENT == 0) metrics.WIDTH_OF_90_PERCENT = distance;
-                        if (percentCovered >= 0.99 && metrics.WIDTH_OF_99_PERCENT == 0) metrics.WIDTH_OF_99_PERCENT = distance;
-
-                        --low;
-                        ++high;
                     }
 
                     // Trim the Histogram down to get rid of outliers that would make the chart useless.
-                    final Histogram<Integer> trimmedHisto = Histogram; //alias it
-                    trimmedHisto.trimByWidth(getWidthToTrimTo(metrics));
+                    final Histogram<Integer> trimmedHistogram = histogram; // alias it
+                    trimmedHistogram.trimByWidth(getWidthToTrimTo(metrics));
 
-                    metrics.MEAN_INSERT_SIZE = trimmedHisto.getMean();
-                    metrics.STANDARD_DEVIATION = trimmedHisto.getStandardDeviation();
+                    if (!trimmedHistogram.isEmpty()) {
+                        metrics.MEAN_INSERT_SIZE = trimmedHistogram.getMean();
+                        metrics.STANDARD_DEVIATION = trimmedHistogram.getStandardDeviation();
+                    }
 
-                    file.addHistogram(trimmedHisto);
+                    file.addHistogram(trimmedHistogram);
                     file.addMetric(metrics);
                 }
             }

--- a/src/scripts/picard/analysis/insertSizeHistogram.R
+++ b/src/scripts/picard/analysis/insertSizeHistogram.R
@@ -30,7 +30,7 @@ getCumulative <- function(y, yrange) {
   yLength <- nrow(y)
   ySum <- sum(y[,1])
   for (i in 1:yLength) {
-    yNew[i] <- (yrange * sum(y[i:yLength,1]) / ySum)
+    yNew[i] <- (yrange * sum(as.numeric(y[i:yLength,1])) / ySum)
   }
   return (yNew)
 }
@@ -87,19 +87,19 @@ for (i in 1:length(levels)) {
 
   if (fr %in% names(histogram) ) {
     lines(histogram$insert_size, as.matrix(histogram[fr]),  type="h", col="red")
-    lines(histogram$insert_size, getCumulative(histogram[fr], yrange), col="darkred", lty=2)
+    lines(histogram$insert_size, getCumulative(histogram[fr], frrange), col="darkred", lty=2)
     colors <- c(colors, "red")
     labels <- c(labels, "FR")
   }
   if (rf %in% names(histogram)) {
     lines(histogram$insert_size, as.matrix(histogram[rf]),  type="h", col="blue")
-    lines(histogram$insert_size, getCumulative(histogram[rf], yrange), col="darkblue", lty=2)
+    lines(histogram$insert_size, getCumulative(histogram[rf], rfrange), col="darkblue", lty=2)
     colors <- c(colors, "blue")
     labels <- c(labels, "RF")
    }
   if (tandem %in% names(histogram)) {
     lines(histogram$insert_size, as.matrix(histogram[tandem]),  type="h", col="orange")
-    lines(histogram$insert_size, getCumulative(histogram[tandem], yrange), col="darkorange", lty=2)
+    lines(histogram$insert_size, getCumulative(histogram[tandem], tandemrange), col="darkorange", lty=2)
     colors <- c(colors, "orange")
     labels <- c(labels, "TANDEM")
   }


### PR DESCRIPTION
The minimum percentage for a paired orientation should be greater than or equal, not greater than.  We have to be careful if there are no inserts, which `testHistogramWidthIsSetProperly` captures in `CollectInsertSizeMetricsTest`.