### PR TITLE
bugfix (non critical) and more testing in MarkDuplicates

### DIFF
--- a/src/tests/java/picard/sam/markduplicates/MarkDuplicateWithMissingBarcodeTest.java
+++ b/src/tests/java/picard/sam/markduplicates/MarkDuplicateWithMissingBarcodeTest.java
@@ -1,0 +1,33 @@
+package picard.sam.markduplicates;
+
+/**
+ * The purpose of this class is to show that MarkDuplicates gives the same results when run on files that do not have a
+ * molecular barcode tag, even if the code is trying to use the molecular barcode
+ */
+
+abstract public class MarkDuplicateWithMissingBarcodeTest extends MarkDuplicatesTest {
+
+    protected AbstractMarkDuplicatesCommandLineProgramTester getTester() {
+        return new MarkDuplicatesWithMissingBarcodesTester();
+    }
+
+    abstract protected String getArgumentName();
+
+    abstract protected String getTagValue();
+
+    private class MarkDuplicatesWithMissingBarcodesTester extends MarkDuplicatesTester {
+        @Override
+        public void runTest() {
+            boolean hasRX = false;
+            for (final String argument : this.getArgs()) {
+                if (argument.startsWith(getArgumentName())) {
+                    hasRX = true;
+                    break;
+                }
+            }
+            if (!hasRX) addArg(getArgumentName() + "=" + getTagValue());
+
+            super.runTest();
+        }
+    }
+}

--- a/src/tests/java/picard/sam/markduplicates/MarkDuplicateWithMissingReadOneBarcodeTest.java
+++ b/src/tests/java/picard/sam/markduplicates/MarkDuplicateWithMissingReadOneBarcodeTest.java
@@ -1,0 +1,22 @@
+package picard.sam.markduplicates;
+
+/**
+ * Created by farjoun on 12/8/15.
+ *
+ * The purpose of this class is to show that MarkDuplicates gives the same results when run on files that do not have a
+ * molecular barcode tag, even if the code is trying to use the molecular barcode
+ *
+ */
+
+public class MarkDuplicateWithMissingReadOneBarcodeTest extends MarkDuplicateWithMissingBarcodeTest {
+
+    @Override
+    protected String getArgumentName() {
+        return "READ_TWO_BARCODE_TAG";
+    }
+
+    @Override
+    protected String getTagValue() {
+        return "RX";
+    }
+}

--- a/src/tests/java/picard/sam/markduplicates/MarkDuplicateWithMissingReadTwoBarcodeTest.java
+++ b/src/tests/java/picard/sam/markduplicates/MarkDuplicateWithMissingReadTwoBarcodeTest.java
@@ -1,0 +1,21 @@
+package picard.sam.markduplicates;
+
+/**
+ *
+ * The purpose of this class is to show that MarkDuplicates gives the same results when run on files that do not have a
+ * molecular barcode tag, even if the code is trying to use the molecular barcode
+ *
+ */
+
+public class MarkDuplicateWithMissingReadTwoBarcodeTest extends MarkDuplicateWithMissingBarcodeTest {
+
+    @Override
+    protected String getArgumentName() {
+        return "READ_TWO_BARCODE_TAG";
+    }
+
+    @Override
+    protected String getTagValue() {
+        return "RX";
+    }
+}

--- a/src/tests/java/picard/sam/markduplicates/MarkDuplicateWithMissingSampleBarcodeTest.java
+++ b/src/tests/java/picard/sam/markduplicates/MarkDuplicateWithMissingSampleBarcodeTest.java
@@ -1,0 +1,21 @@
+package picard.sam.markduplicates;
+
+/**
+ *
+ * The purpose of this class is to show that MarkDuplicates gives the same results when run on files that do not have a
+ * molecular barcode tag, even if the code is trying to use the molecular barcode
+ *
+ */
+
+public class MarkDuplicateWithMissingSampleBarcodeTest extends MarkDuplicateWithMissingBarcodeTest {
+
+    @Override
+    protected String getArgumentName() {
+        return "BARCODE_TAG";
+    }
+
+    @Override
+    protected String getTagValue() {
+        return "BC";
+    }
+}


### PR DESCRIPTION
- Fixed a small bug in MarkDuplicates that would break running on non-paired reads.
- Added tests that check that the results remain the same when using one of
    * SAMPLE_BARCODE_TAG
    * READ_ONE_BARCODE_TAG
    * READ_TWO_BARCODE_TAG

when the tags themselves are missing from the sam-records