### PR TITLE
Performance improvements to CollectSequencingArtifactMetrics to make it faster.

### DIFF
--- a/src/java/picard/analysis/artifacts/Transition.java
+++ b/src/java/picard/analysis/artifacts/Transition.java
@@ -2,6 +2,8 @@ package picard.analysis.artifacts;
 
 import htsjdk.samtools.util.SequenceUtil;
 
+import java.util.Arrays;
+
 enum Transition {
     AtoA('A','A'), AtoC('A','C'), AtoG('A','G'), AtoT('A','T'),
     CtoA('C','A'), CtoC('C','C'), CtoG('C','G'), CtoT('C','T'),
@@ -21,7 +23,7 @@ enum Transition {
     }
 
     public static Transition transitionOf(final char ref, final char call) {
-        return valueOf(ref + "to" + call);
+        return transitionIndexMap[baseIndexMap[ref]][baseIndexMap[call]];
     }
 
     /**
@@ -36,13 +38,6 @@ enum Transition {
         return transitionOf((char) SequenceUtil.complement((byte) this.ref), (char) SequenceUtil.complement((byte) this.call));
     }
 
-    /**
-     * Return the ref:ref transition corresponding to this ref:alt transition.
-     */
-    public Transition matchingRef() {
-        return transitionOf(this.ref, this.ref);
-    }
-
     public char ref() { return this.ref; }
 
     public char call() { return this.call; }
@@ -50,5 +45,36 @@ enum Transition {
     @Override
     public String toString() {
         return this.ref + ">" + this.call;
+    }
+
+    protected enum Base {
+        A ('A'),
+        C ('C'),
+        G ('G'),
+        T ('T');
+
+        public byte base;
+
+        private Base(final char base) {
+            this.base = (byte)base;
+        }
+    }
+
+    // only 4 of the values will be used but we want to optimize for speed by accessing via the int value of a char
+    static protected final int[] baseIndexMap = new int[256];
+    static {
+        Arrays.fill(baseIndexMap, -1);
+        for (final Base b : Base.values()) {
+            baseIndexMap[b.base] = b.ordinal();
+        }
+    }
+
+    static private final Transition[][] transitionIndexMap = new Transition[Base.values().length][Base.values().length];
+    static {
+        for (final Base b1 : Base.values()) {
+            for (final Base b2 : Base.values()) {
+                transitionIndexMap[b1.ordinal()][b2.ordinal()] = Transition.valueOf(b1.toString() + "to" + b2.toString());
+            }
+        }
     }
 }


### PR DESCRIPTION
DO NOT MERGE YET.  NEEDS SIGNIFICANT IN-PERSON REVIEW WITH YOSSI.

1. 40% of the runtime went to reading and parsing the original qualities from the BAM.
Given that it is only used as a quality cutoff, we can just use the standard (recalibrated)
quals and save this pain.

2. Get rid of the nested maps; there are a known number of possible transitions so use an array.

3. Stop doing String addition in the Transition class; array lookups are faster.

4. Cache the upper-cased string version of the reference; don't create a string for every
base in every read.