### PR TITLE
Allow the genome territory to be specified on the command-line if desired

### DIFF
--- a/src/java/picard/analysis/CollectWgsMetricsFromQuerySorted.java
+++ b/src/java/picard/analysis/CollectWgsMetricsFromQuerySorted.java
@@ -32,17 +32,20 @@ public class CollectWgsMetricsFromQuerySorted extends CommandLineProgram {
     @Option(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "Output metrics file.")
     public File OUTPUT;
 
-    @Option(shortName = "USABLE_MQ", doc = "Minimum mapping quality for a read to contribute to usable coverage.", overridable = true)
+    @Option(shortName = "USABLE_MQ", doc = "Minimum mapping quality for a read to contribute to usable coverage.", overridable = true, optional = true)
     public int MINIMUM_USABLE_MAPPING_QUALITY = 20;
 
-    @Option(shortName = "USABLE_Q", doc = "Minimum base quality for a base to contribute to usable coverage.", overridable = true)
+    @Option(shortName = "USABLE_Q", doc = "Minimum base quality for a base to contribute to usable coverage.", overridable = true, optional = true)
     public int MINIMUM_USABLE_BASE_QUALITY = 20;
 
-    @Option(shortName = "RAW_MQ", doc = "Minimum mapping quality for a read to contribute to raw coverage.", overridable = true)
+    @Option(shortName = "RAW_MQ", doc = "Minimum mapping quality for a read to contribute to raw coverage.", overridable = true, optional = true)
     public int MINIMUM_RAW_MAPPING_QUALITY = 0;
 
-    @Option(shortName = "RAW_Q", doc = "Minimum base quality for a base to contribute to raw coverage.", overridable = true)
+    @Option(shortName = "RAW_Q", doc = "Minimum base quality for a base to contribute to raw coverage.", overridable = true, optional = true)
     public int MINIMUM_RAW_BASE_QUALITY = 3;
+
+    @Option(doc = "The number of bases in the genome build of the input file to be used for calculating MEAN_COVERAGE. If not provided, we will assume that ALL bases in the genome should be used (including e.g. Ns)", overridable = true, optional = true)
+    public Long GENOME_TERRITORY = null;
 
     private final Log log = Log.getInstance(CollectWgsMetricsFromQuerySorted.class);
 
@@ -118,7 +121,7 @@ public class CollectWgsMetricsFromQuerySorted extends CommandLineProgram {
         }
 
         // finalize and write the metrics
-        final long genomeTerritory = reader.getFileHeader().getSequenceDictionary().getReferenceLength();
+        final long genomeTerritory = (GENOME_TERRITORY == null || GENOME_TERRITORY < 1L) ? reader.getFileHeader().getSequenceDictionary().getReferenceLength() : GENOME_TERRITORY;
         usableMetrics.metrics.GENOME_TERRITORY = genomeTerritory;
         finalizeMetrics(usableMetrics);
         rawMetrics.metrics.GENOME_TERRITORY = genomeTerritory;


### PR DESCRIPTION
This is useful because one may want to ignore Ns and other non-ideal bases.