### PR TITLE
First pass at adding optical duplicate flagging/removal into MarkDupes

### DIFF
--- a/src/java/picard/sam/markduplicates/EstimateLibraryComplexity.java
+++ b/src/java/picard/sam/markduplicates/EstimateLibraryComplexity.java
@@ -545,7 +545,7 @@ public class EstimateLibraryComplexity extends AbstractOpticalDuplicateFinderCom
                             final int duplicateCount = dupes.size();
                             duplicationHisto.increment(duplicateCount);
 
-                            final boolean[] flags = opticalDuplicateFinder.findOpticalDuplicates(dupes);
+                            final boolean[] flags = opticalDuplicateFinder.findOpticalDuplicates(dupes, lhs);
                             for (final boolean b : flags) {
                                 if (b) opticalHisto.increment(duplicateCount);
                             }

--- a/src/java/picard/sam/markduplicates/MarkDuplicatesWithMateCigarIterator.java
+++ b/src/java/picard/sam/markduplicates/MarkDuplicatesWithMateCigarIterator.java
@@ -590,7 +590,7 @@ public class MarkDuplicatesWithMateCigarIterator implements SAMRecordIterator {
                 final Set<ReadEnds> locations = toMarkQueue.getLocations(next);
 
                 if (!locations.isEmpty()) {
-                    AbstractMarkDuplicatesCommandLineProgram.trackOpticalDuplicates(new ArrayList<ReadEnds>(locations),
+                    AbstractMarkDuplicatesCommandLineProgram.trackOpticalDuplicates(new ArrayList<ReadEnds>(locations), null,
                             opticalDuplicateFinder, libraryIdGenerator);
                 }
             }

--- a/src/java/picard/sam/markduplicates/util/ReadEnds.java
+++ b/src/java/picard/sam/markduplicates/util/ReadEnds.java
@@ -43,6 +43,9 @@ abstract public class ReadEnds extends PhysicalLocationShort {
     /** For optical duplicate detection the orientation matters regard to 1st or 2nd end of a mate */
     public byte orientationForOpticalDuplicates = -1;
 
+    /** A *transient* flag marking this read end as being an optical duplicate. */
+    public transient boolean isOpticalDuplicate = false;
+
     public boolean isPaired() { return this.read2ReferenceIndex != -1; }
 
     @Override

--- a/src/java/picard/sam/util/PhysicalLocation.java
+++ b/src/java/picard/sam/util/PhysicalLocation.java
@@ -6,6 +6,8 @@ package picard.sam.util;
  * non-zero positive integers, x and y coordinates may be negative.
  */
 public interface PhysicalLocation {
+    public int NO_VALUE = -1;
+
     public short getReadGroup();
 
     public void setReadGroup(short rg);
@@ -25,4 +27,9 @@ public interface PhysicalLocation {
     public short getLibraryId();
 
     public void setLibraryId(short libraryId);
+
+    /** Default implementation of a method to check whether real location data has been set. */
+    default public boolean hasLocation() {
+        return getTile() != NO_VALUE;
+    }
 }

--- a/src/tests/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigar.java
+++ b/src/tests/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigar.java
@@ -200,7 +200,7 @@ public class SimpleMarkDuplicatesWithMateCigar extends MarkDuplicates {
 
             // Track the optical duplicates
             if (this.READ_NAME_REGEX != null && 1 < duplicateReadEnds.size()) {
-                AbstractMarkDuplicatesCommandLineProgram.trackOpticalDuplicates(duplicateReadEnds, opticalDuplicateFinder, libraryIdGenerator);
+                AbstractMarkDuplicatesCommandLineProgram.trackOpticalDuplicates(duplicateReadEnds, duplicateReadEnds.get(0), opticalDuplicateFinder, libraryIdGenerator);
             }
         }
 

--- a/src/tests/java/picard/sam/markduplicates/util/OpticalDuplicateFinderTest.java
+++ b/src/tests/java/picard/sam/markduplicates/util/OpticalDuplicateFinderTest.java
@@ -1,5 +1,7 @@
 package picard.sam.markduplicates.util;
 
+import htsjdk.samtools.util.CollectionUtil;
+import htsjdk.samtools.util.Log;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.Assert;
@@ -8,7 +10,11 @@ import picard.sam.util.PhysicalLocationInt;
 import picard.sam.util.PhysicalLocationShort;
 import picard.sam.util.ReadNameParser;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
 
 /**
  * Tests for OpticalDuplicateFinder
@@ -32,7 +38,7 @@ public class OpticalDuplicateFinderTest {
         Assert.assertTrue(opticalDuplicateFinder.addLocationInformation(readName1, loc1));
         Assert.assertTrue(opticalDuplicateFinder.addLocationInformation(readName2, loc2));
 
-        final boolean[] opticalDuplicateFlags = opticalDuplicateFinder.findOpticalDuplicates(Arrays.asList(loc1, loc2));
+        final boolean[] opticalDuplicateFlags = opticalDuplicateFinder.findOpticalDuplicates(Arrays.asList(loc1, loc2), null);
         for (final boolean opticalDuplicateFlag : opticalDuplicateFlags) {
             Assert.assertFalse(opticalDuplicateFlag);
         }
@@ -54,10 +60,96 @@ public class OpticalDuplicateFinderTest {
         Assert.assertTrue(opticalDuplicateFinder.addLocationInformation(readName1, loc1));
         Assert.assertTrue(opticalDuplicateFinder.addLocationInformation(readName2, loc2));
 
-        final boolean[] opticalDuplicateFlags = opticalDuplicateFinder.findOpticalDuplicates(Arrays.asList(loc1, loc2));
+        final boolean[] opticalDuplicateFlags = opticalDuplicateFinder.findOpticalDuplicates(Arrays.asList(loc1, loc2), null);
         for (final boolean opticalDuplicateFlag : opticalDuplicateFlags) {
             Assert.assertFalse(opticalDuplicateFlag);
         }
     }
 
+    @Test
+    public void testKeeper() {
+        final Log log = Log.getInstance(OpticalDuplicateFinderTest.class);
+        final OpticalDuplicateFinder finder = new OpticalDuplicateFinder(OpticalDuplicateFinder.DEFAULT_READ_NAME_REGEX, 100, log);
+        List<PhysicalLocation> locs = Arrays.asList(
+                loc(7, 1500, 1500),
+                loc(7, 1501, 1501),
+                loc(5, 1500, 1500),
+                loc(7, 1490, 1502),
+                loc(7, 2500, 2500),
+                loc(7,   10,   10)
+        );
+
+        assertEquals(finder.findOpticalDuplicates(locs, null       ), new boolean[] {false, true,  false, true, false, false});
+        assertEquals(finder.findOpticalDuplicates(locs, locs.get(0)), new boolean[] {false, true,  false, true, false, false});
+        assertEquals(finder.findOpticalDuplicates(locs, locs.get(1)), new boolean[] {true,  false, false, true, false, false});
+        assertEquals(finder.findOpticalDuplicates(locs, locs.get(3)), new boolean[] {true,  true,  false, false, false, false});
+
+        for (int i=0; i<100; ++i) {
+            final Random random = new Random(i);
+            final List<PhysicalLocation> shuffled = new ArrayList<>(locs);
+            final List<PhysicalLocation> keepers  = Arrays.asList(locs.get(0), locs.get(1), locs.get(3));
+            final PhysicalLocation keeper = keepers.get(random.nextInt(keepers.size()));
+            Collections.shuffle(shuffled);
+
+            int opticalDupeCount = countTrue(finder.findOpticalDuplicates(shuffled, keeper));
+            Assert.assertEquals(opticalDupeCount, 2);
+        }
+    }
+
+    /**
+     * Tests the case where the "keeper" record is not in the list that is passed to the OpticalDuplicateFinder. This can happen
+     * when there are, e.g. FR and RF reads, which can all be molecular duplicates of one another, but cannot be duplicates of one
+     * another and are thus partitioned into two sets for optical duplicate checking.
+     */
+    @Test
+    public void testKeeperNotInList() {
+        final Log log = Log.getInstance(OpticalDuplicateFinderTest.class);
+        final OpticalDuplicateFinder finder = new OpticalDuplicateFinder(OpticalDuplicateFinder.DEFAULT_READ_NAME_REGEX, 100, log);
+        List<PhysicalLocation> locs = Arrays.asList(
+                loc(1, 100, 100),
+                loc(1, 101, 101),
+                loc(1,  99, 99),
+                loc(1,  99, 102)
+        );
+
+        Assert.assertEquals(countTrue(finder.findOpticalDuplicates(locs, loc(7, 5000, 5000))), 3);
+    }
+
+    @Test
+    public void testKeeperAtEndWithinCliqueOfAllOpticalDuplicates() {
+        final Log log = Log.getInstance(OpticalDuplicateFinderTest.class);
+        final OpticalDuplicateFinder finder = new OpticalDuplicateFinder(OpticalDuplicateFinder.DEFAULT_READ_NAME_REGEX, 15, log);
+        List<PhysicalLocation> locs = Arrays.asList(
+                loc(1, 10, 0),
+                loc(1, 20, 0),
+                loc(1, 30, 0)
+        );
+
+        assertEquals(finder.findOpticalDuplicates(locs, locs.get(2)), new boolean[] {true, true, false});
+    }
+
+    /** Helper method to create a physical location. */
+    private PhysicalLocation loc(final int tile, final int x, final int y) {
+        final PhysicalLocation l = new PhysicalLocationInt() {
+            @Override
+            public short getReadGroup() { return 1; }
+        };
+        l.setTile((short) tile);
+        l.setX(x);
+        l.setY(y);
+        return l;
+    }
+
+    void assertEquals(final boolean[] actual, final boolean[] expected) {
+        if (!Arrays.equals(actual, expected)) {
+            throw new AssertionError("expected: " + Arrays.toString(expected) + " but was: " + Arrays.toString(actual));
+        }
+    }
+
+    /** Simply counts the true values in a boolean array. */
+    int countTrue(final boolean[] bs) {
+        int count = 0;
+        for (final boolean b : bs) if (b) ++count;
+        return count;
+    }
 }


### PR DESCRIPTION
First pass at some changes to MarkDuplicates to allow optical (co-localized?) duplicates to be annotated in the output file and/or excluded from the output file.  So far support is only included in MarkDuplicates, though with a little help from @nh13 or @bradtaylor I'd be happy to extend support to MarkDuplicatesWithMateCigar also.

@nh13, @yfarjoun : Could you take a first look at this please and let me know what you think of the direction I've taken?  I'm not ready (yet) for a detailed review, just looking to get some extra eyes on this before I sink more time into writing tests and shining it up.  Thanks!