### PR TITLE
Added the ability to produce insert size metrics including duplicates.

### DIFF
--- a/src/java/picard/analysis/directed/InsertSizeMetricsCollector.java
+++ b/src/java/picard/analysis/directed/InsertSizeMetricsCollector.java
@@ -34,11 +34,16 @@ public class InsertSizeMetricsCollector extends MultiLevelCollector<InsertSizeMe
     //Also, when calculating mean and stdev, only bins <= Histogram_WIDTH will be included.
     private final Integer histogramWidth;
 
+    // If set to true, then duplicates will also be included in the histogram
+    private final boolean includeDuplicates;
+
     public InsertSizeMetricsCollector(final Set<MetricAccumulationLevel> accumulationLevels, final List<SAMReadGroupRecord> samRgRecords,
-                                      final double minimumPct, final Integer histogramWidth, final double deviations) {
+                                      final double minimumPct, final Integer histogramWidth, final double deviations,
+                                      final boolean includeDuplicates) {
         this.minimumPct = minimumPct;
         this.histogramWidth = histogramWidth;
         this.deviations = deviations;
+        this.includeDuplicates = includeDuplicates;
         setup(accumulationLevels, samRgRecords);
     }
 
@@ -65,7 +70,7 @@ public class InsertSizeMetricsCollector extends MultiLevelCollector<InsertSizeMe
                 record.getMateUnmappedFlag() ||
                 record.getFirstOfPairFlag() ||
                 record.isSecondaryOrSupplementary() ||
-                record.getDuplicateReadFlag() ||
+                (record.getDuplicateReadFlag() && !this.includeDuplicates) ||
                 record.getInferredInsertSize() == 0) {
             return;
         }


### PR DESCRIPTION
This is helpful when working with deeply over-sequenced libraries as in that case the post-dedupe distribution is skewed towards the under-represented fragments.