### PR TITLE
adding an explicit call to ant to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ before_install:
   - sed -i -e 's_git@github.com:_https://github.com/_' build.xml
 script:
   - ant -lib lib/ant clone-htsjdk 
+  - ant
   - ant test


### PR DESCRIPTION
adding a call to 'ant' before 'ant test' since ant with no targets does a different build than 'ant test'
this should catch problems like the jacoco build issue