### PR TITLE
Adds WMC (Warn on missing contig) option to LiftoverVcf

### DIFF
--- a/src/java/picard/vcf/LiftoverVcf.java
+++ b/src/java/picard/vcf/LiftoverVcf.java
@@ -85,6 +85,13 @@ public class LiftoverVcf extends CommandLineProgram {
                     "accompanying sequence dictionary (.dict file).")
     public File REFERENCE_SEQUENCE = Defaults.REFERENCE_FASTA;
 
+    // Option on whether or not to provide a warning, or error message and exit if a missing contig is encountered
+    @Option(shortName = "WMC", doc = "Warn on missing contig.", optional = true)
+    public boolean WARN_ON_MISSING_CONTIG = false;
+
+    // When a contig used in the chain is not in the reference, exit with this value instead of 0.
+    protected static int EXIT_CODE_WHEN_CONTIG_NOT_IN_REFERENCE = 1;
+
     /** Filter name to use when a target cannot be lifted over. */
     public static final String FILTER_CANNOT_LIFTOVER_INDEL = "ReverseComplementedIndel";
 
@@ -173,8 +180,18 @@ public class LiftoverVcf extends CommandLineProgram {
                 final String reason = (target == null) ? FILTER_NO_TARGET : FILTER_CANNOT_LIFTOVER_INDEL;
                 rejects.add(new VariantContextBuilder(ctx).filter(reason).make());
                 failedLiftover++;
-            }
-            else {
+            } else if (!refSeqs.containsValue(target.getContig())) {
+                rejects.add(new VariantContextBuilder(ctx).filter(FILTER_NO_TARGET).make());
+                failedLiftover++;
+
+                String missingContigMessage = "Encountered a contig, " + target.getContig() + " that is not part of the target reference.";
+                if(WARN_ON_MISSING_CONTIG) {
+                    log.warn(missingContigMessage);
+                } else {
+                    log.error(missingContigMessage);
+                    return EXIT_CODE_WHEN_CONTIG_NOT_IN_REFERENCE;
+                }
+            } else {
                 // Fix the alleles if we went from positive to negative strand
                 reverseComplementAlleleMap.clear();
                 final List<Allele> alleles = new ArrayList<Allele>();

--- a/testdata/picard/vcf/test.over.badContig.chain
+++ b/testdata/picard/vcf/test.over.badContig.chain
@@ -1,0 +1,2 @@
+chain 540 missingContig 540 + 0 540 missingContig 540 - 0 540 2
+540

--- a/testdata/picard/vcf/testLiftoverUsingMissingContig.vcf
+++ b/testdata/picard/vcf/testLiftoverUsingMissingContig.vcf
@@ -1,0 +1,4 @@
+##fileformat=VCFv4.1
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr1	1	.	C	T	15676.17	PASS	.
+missingContig	61	.	C	G	724.43	PASS	.


### PR DESCRIPTION
@yfarjoun This is a new branch (from mf_liftoverbug)
I'd like to kill the other pull request, and use this one instead.

Unfortunately I've lost your previous PR comments, but I have addressed the following:

"break this up into a test and a dataprovider" in LiftoverVcfTest.java

"long name should be descriptive: WARN_ON_MISSING_CONTIG.
as opposed to what? what happens if this is false?" 

"I don't think this should be an input option. make it a protected (for testing) static value."

"use
} else {  
(all in the same line)"

"here too } else {"

"reference -> target reference"

"What about the same protection for LiftOverIntervalList? there you'll see the same problem:
the add() in line 99 will throw an IllegalArgumentException if the contig isn't in the dictionary."

I will address this in a separate pull request
