### PR TITLE
Added an option for per-base coverage output...

### DIFF
--- a/src/java/picard/analysis/directed/CollectHsMetrics.java
+++ b/src/java/picard/analysis/directed/CollectHsMetrics.java
@@ -98,11 +98,12 @@ public class CollectHsMetrics extends CollectTargetedMetrics<HsMetrics, HsMetric
                                               final List<SAMReadGroupRecord> samRgRecords,
                                               final ReferenceSequenceFile refFile,
                                               final File perTargetCoverage,
+                                              final File perBaseCoverage,
                                               final IntervalList targetIntervals,
                                               final IntervalList probeIntervals,
                                               final String probeSetName,
                                               final int nearProbeDistance) {
-        return new HsMetricCollector(accumulationLevels, samRgRecords, refFile, perTargetCoverage, targetIntervals, probeIntervals, probeSetName, nearProbeDistance,
+        return new HsMetricCollector(accumulationLevels, samRgRecords, refFile, perTargetCoverage, perBaseCoverage, targetIntervals, probeIntervals, probeSetName, nearProbeDistance,
                 MINIMUM_MAPPING_QUALITY, MINIMUM_BASE_QUALITY, CLIP_OVERLAPPING_READS, true, COVERAGE_CAP, SAMPLE_SIZE);
     }
 }

--- a/src/java/picard/analysis/directed/CollectTargetedMetrics.java
+++ b/src/java/picard/analysis/directed/CollectTargetedMetrics.java
@@ -52,6 +52,7 @@ public abstract class CollectTargetedMetrics<METRIC extends MultilevelMetrics, C
                                                final List<SAMReadGroupRecord> samRgRecords,
                                                final ReferenceSequenceFile refFile,
                                                final File perTargetCoverage,
+                                               final File perBaseCoverage,
                                                final IntervalList targetIntervals,
                                                final IntervalList probeIntervals,
                                                final String probeSetName,
@@ -72,6 +73,10 @@ public abstract class CollectTargetedMetrics<METRIC extends MultilevelMetrics, C
 
     @Option(optional = true, doc = "An optional file to output per target coverage information to.")
     public File PER_TARGET_COVERAGE;
+
+    @Option(optional = true, doc = "An optional file to output per base coverage information to. The per-base file contains " +
+            "one line per target base and can grow very large. It is not recommended for use with large target sets.")
+    public File PER_BASE_COVERAGE;
 
     @Option(optional = true, doc= "The maximum distance between a read and the nearest probe/bait/amplicon for the read to be " +
             "considered 'near probe' and included in percent selected.")
@@ -129,6 +134,7 @@ public abstract class CollectTargetedMetrics<METRIC extends MultilevelMetrics, C
                 reader.getFileHeader().getReadGroups(),
                 ref,
                 PER_TARGET_COVERAGE,
+                PER_BASE_COVERAGE,
                 targetIntervals,
                 getProbeIntervals(),
                 getProbeSetName(),

--- a/src/java/picard/analysis/directed/CollectTargetedPcrMetrics.java
+++ b/src/java/picard/analysis/directed/CollectTargetedPcrMetrics.java
@@ -77,11 +77,12 @@ public class CollectTargetedPcrMetrics extends CollectTargetedMetrics<TargetedPc
                                                         final List<SAMReadGroupRecord> samRgRecords,
                                                         final ReferenceSequenceFile refFile,
                                                         final File perTargetCoverage,
+                                                        final File perBaseCoverage,
                                                         final IntervalList targetIntervals,
                                                         final IntervalList probeIntervals,
                                                         final String probeSetName,
                                                         final int nearProbeDistance) {
-        return new TargetedPcrMetricsCollector(accumulationLevels, samRgRecords, refFile, perTargetCoverage, targetIntervals, probeIntervals, probeSetName, nearProbeDistance,
+        return new TargetedPcrMetricsCollector(accumulationLevels, samRgRecords, refFile, perTargetCoverage, perBaseCoverage, targetIntervals, probeIntervals, probeSetName, nearProbeDistance,
                 MINIMUM_MAPPING_QUALITY, MINIMUM_BASE_QUALITY, CLIP_OVERLAPPING_READS, true, COVERAGE_CAP, SAMPLE_SIZE);
     }
 }

--- a/src/java/picard/analysis/directed/HsMetricCollector.java
+++ b/src/java/picard/analysis/directed/HsMetricCollector.java
@@ -47,6 +47,7 @@ public class HsMetricCollector extends TargetMetricsCollector<HsMetrics> {
                              final List<SAMReadGroupRecord> samRgRecords,
                              final ReferenceSequenceFile refFile,
                              final File perTargetCoverage,
+                             final File perBaseCoverage,
                              final IntervalList targetIntervals,
                              final IntervalList probeIntervals,
                              final String probeSetName,
@@ -56,13 +57,14 @@ public class HsMetricCollector extends TargetMetricsCollector<HsMetrics> {
                              final boolean clipOverlappingReads,
                              final int coverageCap,
                              final int sampleSize) {
-        super(accumulationLevels, samRgRecords, refFile, perTargetCoverage, targetIntervals, probeIntervals, probeSetName, nearProbeDistance, minimumMappingQuality, minimumBaseQuality, clipOverlappingReads, coverageCap, sampleSize);
+        super(accumulationLevels, samRgRecords, refFile, perTargetCoverage, perBaseCoverage, targetIntervals, probeIntervals, probeSetName, nearProbeDistance, minimumMappingQuality, minimumBaseQuality, clipOverlappingReads, coverageCap, sampleSize);
     }
 
     public HsMetricCollector(final Set<MetricAccumulationLevel> accumulationLevels,
                              final List<SAMReadGroupRecord> samRgRecords,
                              final ReferenceSequenceFile refFile,
                              final File perTargetCoverage,
+                             final File perBaseCoverage,
                              final IntervalList targetIntervals,
                              final IntervalList probeIntervals,
                              final String probeSetName,
@@ -73,7 +75,7 @@ public class HsMetricCollector extends TargetMetricsCollector<HsMetrics> {
                              final boolean noSideEffects,
                              final int coverageCap,
                              final int sampleSize) {
-        super(accumulationLevels, samRgRecords, refFile, perTargetCoverage, targetIntervals, probeIntervals, probeSetName, nearProbeDistance, minimumMappingQuality, minimumBaseQuality, clipOverlappingReads, noSideEffects, coverageCap, sampleSize);
+        super(accumulationLevels, samRgRecords, refFile, perTargetCoverage, perBaseCoverage, targetIntervals, probeIntervals, probeSetName, nearProbeDistance, minimumMappingQuality, minimumBaseQuality, clipOverlappingReads, noSideEffects, coverageCap, sampleSize);
     }
 
     @Override

--- a/src/java/picard/analysis/directed/TargetedPcrMetricsCollector.java
+++ b/src/java/picard/analysis/directed/TargetedPcrMetricsCollector.java
@@ -47,6 +47,7 @@ public class TargetedPcrMetricsCollector extends TargetMetricsCollector<Targeted
                                        final List<SAMReadGroupRecord> samRgRecords,
                                        final ReferenceSequenceFile refFile,
                                        final File perTargetCoverage,
+                                       final File perBaseCoverage,
                                        final IntervalList targetIntervals,
                                        final IntervalList probeIntervals,
                                        final String probeSetName,
@@ -56,13 +57,14 @@ public class TargetedPcrMetricsCollector extends TargetMetricsCollector<Targeted
                                        final boolean clipOverlappingReads,
                                        final int coverageCap,
                                        final int sampleSize) {
-        super(accumulationLevels, samRgRecords, refFile, perTargetCoverage, targetIntervals, probeIntervals, probeSetName, nearProbeDistance, minimumMappingQuality, minimumBaseQuality, clipOverlappingReads, coverageCap, sampleSize);
+        super(accumulationLevels, samRgRecords, refFile, perTargetCoverage, perBaseCoverage, targetIntervals, probeIntervals, probeSetName, nearProbeDistance, minimumMappingQuality, minimumBaseQuality, clipOverlappingReads, coverageCap, sampleSize);
     }
 
     public TargetedPcrMetricsCollector(final Set<MetricAccumulationLevel> accumulationLevels,
                                        final List<SAMReadGroupRecord> samRgRecords,
                                        final ReferenceSequenceFile refFile,
                                        final File perTargetCoverage,
+                                       final File perBaseCoverage,
                                        final IntervalList targetIntervals,
                                        final IntervalList probeIntervals,
                                        final String probeSetName,
@@ -73,7 +75,7 @@ public class TargetedPcrMetricsCollector extends TargetMetricsCollector<Targeted
                                        final boolean noSideEffects,
                                        final int coverageCap,
                                        final int sampleSize) {
-        super(accumulationLevels, samRgRecords, refFile, perTargetCoverage, targetIntervals, probeIntervals, probeSetName, nearProbeDistance, minimumMappingQuality, minimumBaseQuality, clipOverlappingReads, noSideEffects, coverageCap, sampleSize);
+        super(accumulationLevels, samRgRecords, refFile, perTargetCoverage, perBaseCoverage, targetIntervals, probeIntervals, probeSetName, nearProbeDistance, minimumMappingQuality, minimumBaseQuality, clipOverlappingReads, noSideEffects, coverageCap, sampleSize);
     }
     @Override
     public TargetedPcrMetrics convertMetric(final TargetMetrics targetMetrics) {


### PR DESCRIPTION
...for both CollectHsMetrics and CollectTargetedPcrMetrics.

The output file is fairly minimalistic (just chrom,pos,coverage tab-separated) and when gzipped is approximately 10X larger than the per-target output, so I'd generally recommend it only for small targeted panels, not exomes or similar.