### PR TITLE
Fixed IlluminaBaseCallsToFastq's dealing with UMI's

### DIFF
--- a/src/java/picard/illumina/IlluminaBasecallsConverter.java
+++ b/src/java/picard/illumina/IlluminaBasecallsConverter.java
@@ -453,8 +453,8 @@ public class IlluminaBasecallsConverter<CLUSTER_OUTPUT_RECORD> {
 
         private synchronized SortingCollection<CLUSTER_OUTPUT_RECORD> newSortingCollection() {
             final int maxRecordsInRam =
-                    maxReadsInRamPerTile /
-                            barcodeRecordWriterMap.size();
+                    Math.max(1, maxReadsInRamPerTile /
+                            barcodeRecordWriterMap.size());
             return SortingCollection.newInstance(
                     outputRecordClass,
                     codecPrototype.clone(),

--- a/src/java/picard/illumina/IlluminaBasecallsToFastq.java
+++ b/src/java/picard/illumina/IlluminaBasecallsToFastq.java
@@ -115,7 +115,7 @@ public class IlluminaBasecallsToFastq extends CommandLineProgram {
     public File MULTIPLEX_PARAMS;
 
     @Option(doc = "Which adapters to look for in the read.")
-    public List<IlluminaUtil.IlluminaAdapterPair> ADAPTERS_TO_CHECK = new ArrayList<IlluminaUtil.IlluminaAdapterPair>(
+    public List<IlluminaUtil.IlluminaAdapterPair> ADAPTERS_TO_CHECK = new ArrayList<>(
             Arrays.asList(IlluminaUtil.IlluminaAdapterPair.INDEXED,
                     IlluminaUtil.IlluminaAdapterPair.DUAL_INDEXED,
                     IlluminaUtil.IlluminaAdapterPair.NEXTERA_V2,
@@ -169,19 +169,14 @@ public class IlluminaBasecallsToFastq extends CommandLineProgram {
         CASAVA_1_8, ILLUMINA
     }
     
-    private final Map<String, FastqRecordsWriter> sampleBarcodeFastqWriterMap = new HashMap<String, FastqRecordsWriter>();
+    private final Map<String, FastqRecordsWriter> sampleBarcodeFastqWriterMap = new HashMap<>();
     private ReadStructure readStructure;
     IlluminaBasecallsConverter<FastqRecordsForCluster> basecallsConverter;
     private static final Log log = Log.getInstance(IlluminaBasecallsToFastq.class);
     private final FastqWriterFactory fastqWriterFactory = new FastqWriterFactory();
     private ReadNameEncoder readNameEncoder;
-    private static final Comparator<FastqRecordsForCluster> queryNameComparator = new Comparator<FastqRecordsForCluster>() {
-        @Override
-        public int compare(final FastqRecordsForCluster r1, final FastqRecordsForCluster r2) {
-            return SAMRecordQueryNameComparator.compareReadNames(r1.templateRecords[0].getReadHeader(),
-                    r2.templateRecords[0].getReadHeader());
-        }
-    };
+    private static final Comparator<FastqRecordsForCluster> queryNameComparator = (r1, r2) -> SAMRecordQueryNameComparator.compareReadNames(r1.templateRecords[0].getReadHeader(),
+            r2.templateRecords[0].getReadHeader());
 
     @Override
     protected int doWork() {
@@ -238,8 +233,8 @@ public class IlluminaBasecallsToFastq extends CommandLineProgram {
             demultiplex = true;
         }
         final int readsPerCluster = readStructure.templates.length() + readStructure.sampleBarcodes.length();
-        basecallsConverter = new IlluminaBasecallsConverter<FastqRecordsForCluster>(BASECALLS_DIR, BARCODES_DIR, LANE, readStructure,
-                sampleBarcodeFastqWriterMap, demultiplex, MAX_READS_IN_RAM_PER_TILE / readsPerCluster, TMP_DIR, NUM_PROCESSORS,
+        basecallsConverter = new IlluminaBasecallsConverter<>(BASECALLS_DIR, BARCODES_DIR, LANE, readStructure,
+                sampleBarcodeFastqWriterMap, demultiplex, Math.max(1, MAX_READS_IN_RAM_PER_TILE / readsPerCluster), TMP_DIR, NUM_PROCESSORS,
                 FORCE_GC, FIRST_TILE, TILE_LIMIT, queryNameComparator,
                 new FastqRecordsForClusterCodec(readStructure.templates.length(),
                         readStructure.sampleBarcodes.length(), readStructure.molecularBarcode.length()), FastqRecordsForCluster.class, bclQualityEvaluationStrategy,
@@ -248,8 +243,8 @@ public class IlluminaBasecallsToFastq extends CommandLineProgram {
         log.info("READ STRUCTURE IS " + readStructure.toString());
 
         basecallsConverter.setConverter(
-		        new ClusterToFastqRecordsForClusterConverter(
-				        basecallsConverter.getFactory().getOutputReadStructure()));
+                new ClusterToFastqRecordsForClusterConverter(
+                        basecallsConverter.getFactory().getOutputReadStructure()));
     }
 
     /**
@@ -259,7 +254,7 @@ public class IlluminaBasecallsToFastq extends CommandLineProgram {
      * @param expectedCols The columns that are REQUIRED
      */
     private void assertExpectedColumns(final Set<String> actualCols, final Set<String> expectedCols) {
-        final Set<String> missingColumns = new HashSet<String>(expectedCols);
+        final Set<String> missingColumns = new HashSet<>(expectedCols);
         missingColumns.removeAll(actualCols);
 
         if (missingColumns.size() > 0) {
@@ -278,7 +273,7 @@ public class IlluminaBasecallsToFastq extends CommandLineProgram {
         final TabbedTextFileWithHeaderParser libraryParamsParser = new TabbedTextFileWithHeaderParser(MULTIPLEX_PARAMS);
 
         final Set<String> expectedColumnLabels = CollectionUtil.makeSet("OUTPUT_PREFIX");
-        final List<String> sampleBarcodeColumnLabels = new ArrayList<String>();
+        final List<String> sampleBarcodeColumnLabels = new ArrayList<>();
         for (int i = 1; i <= readStructure.sampleBarcodes.length(); i++) {
             sampleBarcodeColumnLabels.add("BARCODE_" + i);
         }
@@ -290,7 +285,7 @@ public class IlluminaBasecallsToFastq extends CommandLineProgram {
             List<String> sampleBarcodeValues = null;
 
             if (sampleBarcodeColumnLabels.size() > 0) {
-                sampleBarcodeValues = new ArrayList<String>();
+                sampleBarcodeValues = new ArrayList<>();
                 for (final String sampleBarcodeLabel : sampleBarcodeColumnLabels) {
                     sampleBarcodeValues.add(row.getField(sampleBarcodeLabel));
                 }
@@ -487,7 +482,7 @@ public class IlluminaBasecallsToFastq extends CommandLineProgram {
             if (numSampleBarcodes != val.sampleBarcodeRecords.length) throw new IllegalStateException();
             encodeArray(val.templateRecords);
             encodeArray(val.sampleBarcodeRecords);
- //           encodeArray(val.molecularBarcodeRecords);
+            encodeArray(val.molecularBarcodeRecords);
             writer.flush();
         }
 

--- a/src/tests/java/picard/illumina/IlluminaBasecallsToFastqTest.java
+++ b/src/tests/java/picard/illumina/IlluminaBasecallsToFastqTest.java
@@ -69,7 +69,8 @@ public class IlluminaBasecallsToFastqTest extends CommandLineProgramTest {
                 "OUTPUT_PREFIX=" + outputPrefix,
                 "RUN_BARCODE=HiMom",
                 "MACHINE_NAME=machine1",
-                "FLOWCELL_BARCODE=abcdeACXX"
+                "FLOWCELL_BARCODE=abcdeACXX",
+                "MAX_READS_IN_RAM_PER_TILE=100" //force spill to disk to test encode/decode
         });
         IOUtil.assertFilesEqual(outputFastq1, new File(TEST_DATA_DIR, "nonBarcoded.1.fastq"));
         IOUtil.assertFilesEqual(outputFastq2, new File(TEST_DATA_DIR, "nonBarcoded.2.fastq"));
@@ -94,7 +95,8 @@ public class IlluminaBasecallsToFastqTest extends CommandLineProgramTest {
                     "OUTPUT_PREFIX=" + outputPrefix.getAbsolutePath(),
                     "MACHINE_NAME=machine1",
                     "FLOWCELL_BARCODE=abcdeACXX",
-                    "READ_NAME_FORMAT=" + IlluminaBasecallsToFastq.ReadNameFormat.ILLUMINA
+                    "READ_NAME_FORMAT=" + IlluminaBasecallsToFastq.ReadNameFormat.ILLUMINA,
+                    "MAX_READS_IN_RAM_PER_TILE=100" //force spill to disk to test encode/decode
             });
 
             final String[] filenames = new String[]{
@@ -182,7 +184,8 @@ public class IlluminaBasecallsToFastqTest extends CommandLineProgramTest {
                     "READ_STRUCTURE=" + readStructureString,
                     "MULTIPLEX_PARAMS=" + libraryParams,
                     "MACHINE_NAME=machine1",
-                    "FLOWCELL_BARCODE=abcdeACXX"
+                    "FLOWCELL_BARCODE=abcdeACXX",
+                    "MAX_READS_IN_RAM_PER_TILE=100" //force spill to disk to test encode/decode
             });
 
             final ReadStructure readStructure = new ReadStructure(readStructureString);


### PR DESCRIPTION
- fixed IlluminaBaseCallsToFastq's dealing with UMI's. The problem was that the encoding for the sorting collection wasn't done right, but tests didn't have to spill-to-disk and so this wasn't exposed.
- changed tests so that spill-to-disk happens (now tests fail without code changes)
- java8 sugar
