### PR TITLE
Protect against massive pileups so that we do not OOM even with several Gb of RAM

### DIFF
--- a/src/java/picard/analysis/CollectRawWgsMetrics.java
+++ b/src/java/picard/analysis/CollectRawWgsMetrics.java
@@ -80,6 +80,9 @@ public class CollectRawWgsMetrics extends CollectWgsMetrics{
     @Option(shortName="CAP", doc="Treat bases with coverage exceeding this value as if they had coverage at this value.")
     public int COVERAGE_CAP = 100000;
 
+    @Option(doc="At positions with coverage exceeding this value, completely ignore reads that accumulate beyond this value (so that they will not be considered for PCT_EXC_CAPPED).  Used to keep memory consumption in check, but could create bias if set too low")
+    public int LOCUS_ACCUMULATION_CAP = 200000;
+
     // rename the class so that in the metric file it is annotated differently.
     public static class RawWgsMetrics extends WgsMetrics {}
 


### PR DESCRIPTION
The signature of these pileups are several million copies of the same exact read which, when recorded in the locus iterator, spike our memory consumption.
What we lose by throwing these reads out is that the PCT_EXC_CAPPED will not be completely accurate.  However, I happen to know (from work on Rapid QC) that our lab at least does not look at that number at all. 
What we gain is the ability to always run CollectWgsMetrics and CollectRawWgsMetrics in under 2Gb of RAM, which greatly simplifies pipelines and also keeps compute costs way down.

Depends on: https://github.com/samtools/htsjdk/pull/456
