### PR TITLE
squid:S2974 - Classes without public constructors should be final

### DIFF
--- a/src/java/picard/analysis/MeanQualityByCycle.java
+++ b/src/java/picard/analysis/MeanQualityByCycle.java
@@ -97,7 +97,7 @@ public class MeanQualityByCycle extends SinglePassSamProgram {
         System.exit(new MeanQualityByCycle().instanceMain(args));
     }
 
-    private static class HistogramGenerator {
+    private static final class HistogramGenerator {
         final boolean useOriginalQualities;
         int maxLengthSoFar = 0;
         double[] firstReadTotalsByCycle  = new double[maxLengthSoFar];

--- a/src/java/picard/cmdline/CommandLineParser.java
+++ b/src/java/picard/cmdline/CommandLineParser.java
@@ -1121,7 +1121,7 @@ public class CommandLineParser {
     	
     }
     
-    protected static class OptionDefinition {
+    protected static final class OptionDefinition {
         final Field field;
         final String name;
         final String shortName;
@@ -1172,7 +1172,7 @@ public class CommandLineParser {
     /**
      * Holds a command-line argument that is destined for a child parser.  Prefix has been stripped from name.
      */
-    private static class ChildOptionArg {
+    private static final class ChildOptionArg {
         final String name;
         final String value;
         final boolean fromFile;

--- a/src/java/picard/illumina/IlluminaBasecallsToFastq.java
+++ b/src/java/picard/illumina/IlluminaBasecallsToFastq.java
@@ -344,7 +344,7 @@ public class IlluminaBasecallsToFastq extends CommandLineProgram {
      * Container for various FastqWriters, one for each template read, one for each sample barcode read,
      * and one for each molecular barcode read.
      */
-    private static class FastqRecordsWriter implements IlluminaBasecallsConverter.ConvertedClusterDataWriter<FastqRecordsForCluster> {
+    private static final class FastqRecordsWriter implements IlluminaBasecallsConverter.ConvertedClusterDataWriter<FastqRecordsForCluster> {
         final FastqWriter[] templateWriters;
         final FastqWriter[] sampleBarcodeWriters;
         final FastqWriter[] molecularBarcodeWriters;

--- a/src/java/picard/illumina/IlluminaBasecallsToSam.java
+++ b/src/java/picard/illumina/IlluminaBasecallsToSam.java
@@ -453,7 +453,7 @@ public class IlluminaBasecallsToSam extends CommandLineProgram {
         return messages.toArray(new String[messages.size()]);
     }
 
-    private static class SAMFileWriterWrapper
+    private static final class SAMFileWriterWrapper
             implements IlluminaBasecallsConverter.ConvertedClusterDataWriter<SAMRecordsForCluster> {
         public final SAMFileWriter writer;
 

--- a/src/java/picard/illumina/MarkIlluminaAdapters.java
+++ b/src/java/picard/illumina/MarkIlluminaAdapters.java
@@ -241,7 +241,7 @@ public class MarkIlluminaAdapters extends CommandLineProgram {
         return 0;
     }
 
-    private class CustomAdapterPair implements AdapterPair {
+    private final class CustomAdapterPair implements AdapterPair {
 
         final String fivePrime, threePrime, fivePrimeReadOrder;
         final byte[] fivePrimeBytes, threePrimeBytes, fivePrimeReadOrderBytes;

--- a/src/java/picard/illumina/parser/TileIndex.java
+++ b/src/java/picard/illumina/parser/TileIndex.java
@@ -134,7 +134,7 @@ public class TileIndex implements Iterable<TileIndex.TileIndexRecord> {
         throw new NoSuchElementException(String.format("Tile %d not found in %s", tileNumber, tileIndexFile));
     }
 
-    public static class TileIndexRecord {
+    public static final class TileIndexRecord {
         /**
          * Number of the tile, e.g. 11101.  These don't necessarily start at 0, and there may be gaps.
          */

--- a/src/java/picard/sam/SamAlignmentMerger.java
+++ b/src/java/picard/sam/SamAlignmentMerger.java
@@ -227,7 +227,7 @@ public class SamAlignmentMerger extends AbstractAlignmentMerger {
         };
     }
 
-    private class SuffixTrimingSamRecordIterator implements CloseableIterator<SAMRecord> {
+    private final class SuffixTrimingSamRecordIterator implements CloseableIterator<SAMRecord> {
         private final CloseableIterator<SAMRecord> underlyingIterator;
         private final String suffixToTrim;
 

--- a/src/java/picard/sam/SamToFastq.java
+++ b/src/java/picard/sam/SamToFastq.java
@@ -438,7 +438,7 @@ public class SamToFastq extends CommandLineProgram {
      * Allows for lazy construction of the second-of-pair writer, since when we are in the "output per read group mode", we only wish to
      * generate a second-of-pair fastq if we encounter a second-of-pair read.
      */
-    static class FastqWriters {
+    static final class FastqWriters {
         private final FastqWriter firstOfPair, unpaired;
         private final Lazy<FastqWriter> secondOfPair;
 

--- a/src/java/picard/util/AdapterMarker.java
+++ b/src/java/picard/util/AdapterMarker.java
@@ -277,7 +277,7 @@ public class AdapterMarker {
         }
     }
 
-    private static class TruncatedAdapterPair implements AdapterPair {
+    private static final class TruncatedAdapterPair implements AdapterPair {
         String name;
         final String fivePrime, threePrime, fivePrimeReadOrder;
         final byte[]  fivePrimeBytes, threePrimeBytes, fivePrimeReadOrderBytes;

--- a/src/java/picard/vcf/processor/VcfFileSegment.java
+++ b/src/java/picard/vcf/processor/VcfFileSegment.java
@@ -52,7 +52,7 @@ public abstract class VcfFileSegment {
         return new SequenceSizedChunk(sequence, vcf);
     }
     
-    static class SequenceSizedChunk extends VcfFileSegment {
+    static final class SequenceSizedChunk extends VcfFileSegment {
         final SAMSequenceRecord sequence;
         final File vcf;
 

--- a/src/java/picard/vcf/processor/VcfFileSegmentGenerator.java
+++ b/src/java/picard/vcf/processor/VcfFileSegmentGenerator.java
@@ -118,7 +118,7 @@ public abstract class VcfFileSegmentGenerator {
      *
      * @author mccowan
      */
-    static class WidthLimitingDecorator extends VcfFileSegmentGenerator {
+    static final class WidthLimitingDecorator extends VcfFileSegmentGenerator {
         final VcfFileSegmentGenerator underlyingStrategy;
         final long width;
 
@@ -135,7 +135,7 @@ public abstract class VcfFileSegmentGenerator {
          * The thing that does the work; accepts a {@link VcfFileSegment} (produced by the parent {@link VcfFileSegmentGenerator}) and breaks
          * it down into subsegments.
          */
-        private class VcfFileSegmentSubdivider implements Iterable<VcfFileSegment> {
+        private final class VcfFileSegmentSubdivider implements Iterable<VcfFileSegment> {
             final VcfFileSegment basis;
 
             private VcfFileSegmentSubdivider(final VcfFileSegment basis) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2974 - Classes without public constructors should be final

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2974

Please let me know if you have any questions.

M-Ezzat