### PR TITLE
squid:CommentedOutCodeLine - Sections of code should not be "commente…

### DIFF
--- a/src/java/picard/analysis/directed/RnaSeqMetricsCollector.java
+++ b/src/java/picard/analysis/directed/RnaSeqMetricsCollector.java
@@ -341,16 +341,6 @@ public class RnaSeqMetricsCollector extends SAMRecordMultiLevelCollector<RnaSeqM
                         normalizedCoverageByNormalizedPosition.increment(percent, normalized / transcriptCount);
                     }
                 }
-
-                // Calculate gap bases per kilobase
-                //            {
-                //                int gapBases = 0;
-                //                final double minCoverage = mean * 0.1;
-                //                for (int i=0; i<coverage.length; ++i) {
-                //                    if (coverage[i] < minCoverage) ++gapBases;
-                //                }
-                //                gapBasesPerKb.increment(gapBases / (coverage.length / 1000d));
-                //            }
             }
 
             this.metrics.MEDIAN_CV_COVERAGE = cvs.getMedian();

--- a/src/java/picard/cmdline/ClassFinder.java
+++ b/src/java/picard/cmdline/ClassFinder.java
@@ -112,7 +112,7 @@ public class ClassFinder {
                     continue;
                 }
 
-                //Log.info("Looking for classes in location: " + urlPath);
+                log.debug("Looking for classes in location: " + urlPath);
                 final File file = new File(urlPath);
                 if ( file.isDirectory() ) {
                     scanDir(file, packageName);

--- a/src/java/picard/sam/DuplicationMetrics.java
+++ b/src/java/picard/sam/DuplicationMetrics.java
@@ -180,27 +180,5 @@ public class DuplicationMetrics extends MetricBase {
         for (Histogram<Double>.Bin bin : m.calculateRoiHistogram().values()) {
             System.out.println(bin.getId() + "\t" + bin.getValue());
         }
-
-//        DuplicationMetrics m = new DuplicationMetrics();
-//        m.READ_PAIRS_EXAMINED  = Long.parseLong(args[0]);
-//        m.READ_PAIR_DUPLICATES = Long.parseLong(args[1]);
-//        final long UNIQUE_READ_PAIRS = m.READ_PAIRS_EXAMINED - m.READ_PAIR_DUPLICATES;
-//        final double xCoverage = Double.parseDouble(args[2]);
-//        final double uniqueXCoverage = xCoverage * ((double) UNIQUE_READ_PAIRS / (double) m.READ_PAIRS_EXAMINED);
-//        final double oneOverCoverage = 1 / xCoverage;
-//
-//        m.calculateDerivedMetrics();
-//        System.out.println("Percent Duplication: " + m.PERCENT_DUPLICATION);
-//        System.out.println("Est. Library Size  : " + m.ESTIMATED_LIBRARY_SIZE);
-//        System.out.println();
-//
-//
-//        System.out.println("Coverage\tUnique Coverage\tDuplication");
-//        for (double d = oneOverCoverage; (int) (d*xCoverage)<=50; d+=oneOverCoverage) {
-//            double coverage = d * xCoverage;
-//            double uniqueCoverage = uniqueXCoverage * m.estimateRoi(m.ESTIMATED_LIBRARY_SIZE, d, m.READ_PAIRS_EXAMINED, UNIQUE_READ_PAIRS);
-//            double duplication = (coverage - uniqueCoverage) / coverage;
-//            System.out.println(coverage + "\t" + uniqueCoverage + "\t" + duplication);
-//        }
     }
 }

--- a/src/java/picard/sam/markduplicates/util/MarkQueue.java
+++ b/src/java/picard/sam/markduplicates/util/MarkQueue.java
@@ -32,6 +32,7 @@ import htsjdk.samtools.util.SamRecordTrackingBuffer;
 import picard.PicardException;
 import picard.sam.DuplicationMetrics;
 import htsjdk.samtools.DuplicateScoringStrategy.ScoringStrategy;
+import htsjdk.samtools.util.Log;
 
 import java.util.Comparator;
 import java.util.Set;
@@ -46,7 +47,7 @@ import java.util.TreeSet;
  * read ends to arrive.  This reduces the memory footprint of this data structure.
  */
 public class MarkQueue {
-
+    private static final Log LOG = Log.getInstance(MarkQueue.class);
     /**
      * Comparator to order the mark queue nonDuplicateReadEndsSet.  The nonDuplicateReadEndsSet of all the read ends that are compared to be the same should
      * be used for duplicate marking.
@@ -225,7 +226,6 @@ public class MarkQueue {
             }
 
             // remove from the nonDuplicateReadEndsSet fragments and unpaired, which only have two possible orientations
-            //this.tmpReadEnds.orientation = orientation;
             if (this.nonDuplicateReadEndsSet.contains(this.tmpReadEnds)) { // found in the nonDuplicateReadEndsSet
                 // get the duplicate read end
                 final SortedSet<ReadEndsForMateCigar> sortedSet = this.nonDuplicateReadEndsSet.subSet(this.tmpReadEnds, true, this.tmpReadEnds, true);
@@ -352,8 +352,8 @@ public class MarkQueue {
             }
             this.nonDuplicateReadEndsSet.add(other);
         }
-        //System.err.println("\tSET SIZE=" + this.nonDuplicateReadEndsSet.size());
 
+        LOG.debug("\tSET SIZE=" + this.nonDuplicateReadEndsSet.size());
         // add to the physical locations for optical duplicate tracking
         final SAMRecord record = other.getRecord();
         if (record.getReadPairedFlag() && !record.getReadUnmappedFlag() && !record.getMateUnmappedFlag() && addToLocationSet) {

--- a/src/tests/java/picard/illumina/parser/CycleIlluminaFileMapTest.java
+++ b/src/tests/java/picard/illumina/parser/CycleIlluminaFileMapTest.java
@@ -75,42 +75,4 @@ public class CycleIlluminaFileMapTest {
             },
         };
     }
-
-  /*  @Test(dataProvider = "iteratorTestData")
-    public void cycledFilesIteratorTest(final File parentDir, final int lane, final int tile, final String fileType, final List<File> expectedFiles, final int [] cycles) {
-        final CycleFilesIterator toTest = new CycleFilesIterator(parentDir, lane, tile, cycles, fileType);
-        Iterator<File> expectedIter = expectedFiles.iterator();
-        while(expectedIter.hasNext()) {
-            final File currentExpected = expectedIter.next();
-            Assert.assertTrue(toTest.hasNext(), "CycledFileSetIterator is missing file: " + currentExpected.getAbsolutePath());
-            Assert.assertEquals(toTest.next().getAbsolutePath(), currentExpected.getAbsolutePath());
-        }
-        
-        Assert.assertTrue(!toTest.hasNext(), "CycledFilesIterator has extra files!");
-    }
-
-    @Test
-    public void passingAssertCycledIlluminaFileMapTest() {
-        final CycleIlluminaFileMap fileMap = new CycleIlluminaFileMap();
-        fileMap.put(1101, new CycleFilesIterator(TEST_DATA_DIR, 1, 1101, ALL_CYCLES, ".bcl"));
-        fileMap.put(1201, new CycleFilesIterator(TEST_DATA_DIR, 1, 1201, ALL_CYCLES, ".bcl"));
-        fileMap.assertValid(makeList(1101,1201), ALL_CYCLES);
-    }
-
-    @Test(expectedExceptions = PicardException.class)
-    public void tileFailingAssertCycledIlluminaFileMapTest() {
-        final CycleIlluminaFileMap fileMap = new CycleIlluminaFileMap();
-        fileMap.put(1, new CycleFilesIterator(TEST_DATA_DIR, 1, 1, ALL_CYCLES, ".bcl"));
-        fileMap.put(2, new CycleFilesIterator(TEST_DATA_DIR, 1, 2, ALL_CYCLES, ".bcl"));
-        fileMap.assertValid(makeList(1,2,3), ALL_CYCLES);
-    }
-
-    @Test(expectedExceptions = PicardException.class)
-    public void cycleFailingAssertCycledIlluminaFileMapTest() {
-        final CycleIlluminaFileMap fileMap = new CycleIlluminaFileMap();
-        fileMap.put(1, new CycleFilesIterator(TEST_DATA_DIR, 1, 1, ALL_CYCLES, ".bcl"));
-        fileMap.put(2, new CycleFilesIterator(TEST_DATA_DIR, 1, 2, ALL_CYCLES, ".bcl"));
-        fileMap.assertValid(makeList(1,2), new int[]{1,2,3,4,5});
-    }*/
-
 }

--- a/src/tests/java/picard/illumina/parser/IlluminaDataProviderTest.java
+++ b/src/tests/java/picard/illumina/parser/IlluminaDataProviderTest.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 
 import static htsjdk.samtools.util.CollectionUtil.makeList;
-//import static htsjdk.samtools.util.CollectionUtil.*;
 
 /**
  * @author jburke@broadinstitute.org

--- a/src/tests/java/picard/util/IlluminaUtilTest.java
+++ b/src/tests/java/picard/util/IlluminaUtilTest.java
@@ -73,15 +73,4 @@ public class IlluminaUtilTest {
             }
         };
     }
-
-    /*
-    @Test(dataProvider = "solexaQualStrToPhreds")
-    public void makePhredBinaryFromSolexaQualityAscii_1_3_toArrays(final String solexaQualities, final int offset, final byte [][] expectedBuffers) {
-        byte [][] actualBuffers = byteBuffersSizeCopy(expectedBuffers);
-        IlluminaUtil.makePhredBinaryFromSolexaQualityAscii_1_3(solexaQualities, offset, actualBuffers);
-
-        for(int i = 0; i < expectedBuffers.length; i++) {
-            Assert.assertEquals(expectedBuffers[i], actualBuffers[i]);
-        }
-    }*/
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:CommentedOutCodeLine - Sections of code should not be "commented out"

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/coding_rules#q=squid:CommentedOutCodeLine

Please let me know if you have any questions.

M-Ezzat
