### PR TITLE
squid:S1170 - Public constants and fields initialized at declaration …

### DIFF
--- a/src/java/picard/Test.java
+++ b/src/java/picard/Test.java
@@ -9,7 +9,7 @@ import java.util.StringTokenizer;
  *
  */
 public class Test {
-    private final String text = "C0A69ACXX111213:6:1101:10000:144257\t83\t5\t128984606\t60\t76M\t=\t128984542\t-140\tAGTGTTAGAACTTCCTCCCCAAAGCATATACTTCAGTGGCAAGCTGTCCTGGATGAAGGTATGACCAACCAGATCA\t@FFFEECC>EFHBJIGIFGIEIJJJIHED<IEHIGIIJIIIGJIGJIIIIIJGGCJIIGIHHHBHGHFFDFFFC@@\tXT:A:U\tNM:i:0\tSM:i:37\tAM:i:37\tX0:i:1\tX1:i:0\tXM:i:0\tXO:i:0\tXG:i:0\tMD:Z:76";
+    private static final String TEXT = "C0A69ACXX111213:6:1101:10000:144257\t83\t5\t128984606\t60\t76M\t=\t128984542\t-140\tAGTGTTAGAACTTCCTCCCCAAAGCATATACTTCAGTGGCAAGCTGTCCTGGATGAAGGTATGACCAACCAGATCA\t@FFFEECC>EFHBJIGIFGIEIJJJIHED<IEHIGIIJIIIGJIGJIIIIIJGGCJIIGIHHHBHGHFFDFFFC@@\tXT:A:U\tNM:i:0\tSM:i:37\tAM:i:37\tX0:i:1\tX1:i:0\tXM:i:0\tXO:i:0\tXG:i:0\tMD:Z:76";
 
     public static void main(String[] args) {
         new Test().run();
@@ -22,7 +22,7 @@ public class Test {
 
         watch.start();
         for (int i=0; i<ITERATIONS; ++i) {
-            if (StringUtil.split(text, fields, '\t') > 100) {
+            if (StringUtil.split(TEXT, fields, '\t') > 100) {
                 System.out.println("Mama Mia that's a lot of tokens!!");
             }
         }
@@ -32,7 +32,7 @@ public class Test {
         
         watch.start();
         for (int i=0; i<ITERATIONS; ++i) {
-            if (split(text, fields, "\t") > 100) {
+            if (split(TEXT, fields, "\t") > 100) {
                 System.out.println("Mama Mia that's a lot of tokens!!");
             }
         }

--- a/src/java/picard/illumina/parser/fakers/BarcodeFileFaker.java
+++ b/src/java/picard/illumina/parser/fakers/BarcodeFileFaker.java
@@ -6,11 +6,11 @@ import java.nio.ByteBuffer;
  * Created by jcarey on 3/13/14.
  */
 public class BarcodeFileFaker extends FileFaker {
-    private final String barcodeString = "1\tn\t \n";
+    private static final String BARCODE_STRING = "1\tn\t \n";
 
     @Override
     protected void fakeFile(final ByteBuffer buffer) {
-        buffer.put(barcodeString.getBytes());
+        buffer.put(BARCODE_STRING.getBytes());
     }
 
     @Override
@@ -20,6 +20,6 @@ public class BarcodeFileFaker extends FileFaker {
 
     @Override
     protected int bufferSize() {
-        return barcodeString.getBytes().length;
+        return BARCODE_STRING.getBytes().length;
     }
 }

--- a/src/java/picard/illumina/parser/fakers/PosFileFaker.java
+++ b/src/java/picard/illumina/parser/fakers/PosFileFaker.java
@@ -6,11 +6,11 @@ import java.nio.ByteBuffer;
  * Created by jcarey on 3/13/14.
  */
 public class PosFileFaker extends FileFaker {
-    private final String posFileString = "102.0\t303.3\n";
+    private static final String POS_FILE_STRING = "102.0\t303.3\n";
 
     @Override
     protected void fakeFile(final ByteBuffer buffer) {
-        buffer.put(posFileString.getBytes());
+        buffer.put(POS_FILE_STRING.getBytes());
     }
 
     @Override
@@ -20,6 +20,6 @@ public class PosFileFaker extends FileFaker {
 
     @Override
     protected int bufferSize() {
-        return posFileString.getBytes().length;
+        return POS_FILE_STRING.getBytes().length;
     }
 }

--- a/src/java/picard/illumina/parser/readers/FilterFileReader.java
+++ b/src/java/picard/illumina/parser/readers/FilterFileReader.java
@@ -42,7 +42,7 @@ public class FilterFileReader implements Iterator<Boolean> {
     private static final int HEADER_SIZE  = 12;
 
     /** Expected Version */
-    public final int EXPECTED_VERSION = 3;
+    public static final int EXPECTED_VERSION = 3;
 
     /** Iterator over each cluster in the FilterFile */
     private final BinaryFileIterator<Byte> bbIterator;

--- a/src/java/picard/sam/util/PhysicalLocation.java
+++ b/src/java/picard/sam/util/PhysicalLocation.java
@@ -6,7 +6,7 @@ package picard.sam.util;
  * non-zero positive integers, x and y coordinates may be negative.
  */
 public interface PhysicalLocation {
-    public int NO_VALUE = -1;
+    public static int NO_VALUE = -1;
 
     public short getReadGroup();
 

--- a/src/tests/java/picard/util/BedToIntervalListTest.java
+++ b/src/tests/java/picard/util/BedToIntervalListTest.java
@@ -16,7 +16,7 @@ import java.io.InputStream;
  */
 public class BedToIntervalListTest {
 
-    private final String TEST_DATA_DIR = "testdata/picard/util/BedToIntervalListTest";
+    private static final String TEST_DATA_DIR = "testdata/picard/util/BedToIntervalListTest";
 
     private void doTest(final String inputBed, final String header) throws IOException, SAMException {
         final File outputFile  = File.createTempFile("bed_to_interval_list_test.", ".interval_list");

--- a/src/tests/java/picard/util/IntervalListToBedTest.java
+++ b/src/tests/java/picard/util/IntervalListToBedTest.java
@@ -11,7 +11,7 @@ import java.util.List;
  * Tests for IntervalListToBed
  */
 public class IntervalListToBedTest {
-    private final String TEST_DATA_DIR = "testdata/picard/util/";
+    private static final String TEST_DATA_DIR = "testdata/picard/util/";
     private final File INTERVAL_LIST = new File(TEST_DATA_DIR, "interval_list_to_bed_test.interval_list");
     private final File BED_FILE      = new File(TEST_DATA_DIR, "interval_list_to_bed_test.bed");
 

--- a/src/tests/java/picard/vcf/processor/VcfFileSegmentGeneratorTest.java
+++ b/src/tests/java/picard/vcf/processor/VcfFileSegmentGeneratorTest.java
@@ -39,7 +39,7 @@ public class VcfFileSegmentGeneratorTest {
     final static Log LOG = Log.getInstance(VcfFileSegmentGeneratorTest.class);
     
     final File VCF_WITH_LOGS_OF_GAPS =  new File("testdata/picard/vcf/chunking/multi_allelic_at_10M.vcf");
-    final int TEN_MILLION = (int) 10e6;
+    static final int TEN_MILLION = (int) 10e6;
 
     @Test
     public void ensureOverlapExclusionTest() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1170 - Public constants and fields initialized at declaration should be "static final" rather than merely "final"

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1170

Please let me know if you have any questions.

M-Ezzat