### PR TITLE
squid:S1197 - Array designators [] should be on the type, not the var…

### DIFF
--- a/src/java/picard/analysis/directed/TargetMetricsCollector.java
+++ b/src/java/picard/analysis/directed/TargetMetricsCollector.java
@@ -604,8 +604,8 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
             double totalCoverage = 0;
 
             // The "how many bases at at-least X" calculations.
-            final int targetBasesDepth[] = {0, 1, 2, 10, 20, 30, 40, 50, 100}; // NB: this should be in ascending order
-            final int targetBases[] = new int[targetBasesDepth.length]; // counts for how many target bases are at at least X coverage, where X corresponds to the value at the same offset in targetBasesDepth
+            final int[] targetBasesDepth = {0, 1, 2, 10, 20, 30, 40, 50, 100}; // NB: this should be in ascending order
+            final int[] targetBases = new int[targetBasesDepth.length]; // counts for how many target bases are at at least X coverage, where X corresponds to the value at the same offset in targetBasesDepth
 
             // consider all bases in calculating the mean, median etc.
             for (final Coverage c : this.coverageByTarget.values()) {

--- a/src/java/picard/fingerprint/CrosscheckReadGroupFingerprints.java
+++ b/src/java/picard/fingerprint/CrosscheckReadGroupFingerprints.java
@@ -291,7 +291,7 @@ public class CrosscheckReadGroupFingerprints extends CommandLineProgram {
     private String getReadGroupDetails(final SAMReadGroupRecord readGroupRecord) {
         final List<String> elements = new ArrayList<>(5);
 
-        final String tmp[] = readGroupRecord.getPlatformUnit().split("\\.");    // Expect to look like: D047KACXX110901.1.ACCAACTG
+        final String[] tmp = readGroupRecord.getPlatformUnit().split("\\.");    // Expect to look like: D047KACXX110901.1.ACCAACTG
         String runBarcode = "?";
         String lane = "?";
         String molBarcode = "?";

--- a/src/java/picard/fingerprint/HaplotypeProbabilitiesFromGenotypeLikelihoods.java
+++ b/src/java/picard/fingerprint/HaplotypeProbabilitiesFromGenotypeLikelihoods.java
@@ -50,7 +50,7 @@ public class HaplotypeProbabilitiesFromGenotypeLikelihoods extends HaplotypeProb
      * @param logGenotypeLikelihoods correspond to the logLikelihoods of [AA, AB, BB]. Log is assumed to be in base 10.
      */
 
-    public void addToLogLikelihoods(final Snp snp, final List<Allele> alleles, final double logGenotypeLikelihoods[]) {
+    public void addToLogLikelihoods(final Snp snp, final List<Allele> alleles, final double[] logGenotypeLikelihoods) {
         assertSnpPartOfHaplotype(snp);
 
         // only allow biallelic snps

--- a/src/java/picard/illumina/ClusterDataToSamConverter.java
+++ b/src/java/picard/illumina/ClusterDataToSamConverter.java
@@ -156,7 +156,7 @@ public class ClusterDataToSamConverter implements
         // Get and transform the unmatched barcode, if any, to store with the reads
         String unmatchedBarcode = null;
         if (hasSampleBarcode && cluster.getMatchedBarcode() == null) {
-            final byte barcode[][] = new byte[sampleBarcodeIndices.length][];
+            final byte[][] barcode = new byte[sampleBarcodeIndices.length][];
             for (int i = 0; i < sampleBarcodeIndices.length; i++) {
                 barcode[i] = cluster.getRead(sampleBarcodeIndices[i]).getBases();
             }
@@ -167,8 +167,8 @@ public class ClusterDataToSamConverter implements
         final String joinedMolecularIndexQ ;
         if (hasMolecularBarcode) {
             final StringBuilder joinedMolecularIndexQBuilder = new StringBuilder();
-            final byte molecularIndex[][] = new byte[molecularBarcodeIndices.length][];
-            final byte molecularIndexQ[][] = new byte[molecularBarcodeIndices.length][];
+            final byte[][] molecularIndex = new byte[molecularBarcodeIndices.length][];
+            final byte[][] molecularIndexQ = new byte[molecularBarcodeIndices.length][];
             for (int i = 0; i < molecularBarcodeIndices.length; i++) {
                 molecularIndex[i]  = cluster.getRead(molecularBarcodeIndices[i]).getBases();
                 molecularIndexQ[i] = cluster.getRead(molecularBarcodeIndices[i]).getQualities();

--- a/src/java/picard/illumina/ExtractIlluminaBarcodes.java
+++ b/src/java/picard/illumina/ExtractIlluminaBarcodes.java
@@ -386,7 +386,7 @@ public class ExtractIlluminaBarcodes extends CommandLineProgram {
         final int numBarcodes = readStructure.sampleBarcodes.length();
         final Set<String> barcodes = new HashSet<String>();
         for (final TabbedTextFileWithHeaderParser.Row row : barcodesParser) {
-            final String bcStrings[] = new String[numBarcodes];
+            final String[] bcStrings = new String[numBarcodes];
             int barcodeNum = 1;
             for (final ReadDescriptor rd : readStructure.descriptors) {
                 if (rd.type != ReadType.Barcode) continue;
@@ -584,8 +584,8 @@ public class ExtractIlluminaBarcodes extends CommandLineProgram {
                 //(see customCommnandLineValidation), therefore we must use the outputReadStructure to index into the output cluster data
                 final int[] barcodeIndices = outputReadStructure.sampleBarcodes.getIndices();
                 final BufferedWriter writer = IOUtil.openFileForBufferedWriting(barcodeFile);
-                final byte barcodeSubsequences[][] = new byte[barcodeIndices.length][];
-                final byte qualityScores[][] = usingQualityScores ? new byte[barcodeIndices.length][] : null;
+                final byte[][] barcodeSubsequences = new byte[barcodeIndices.length][];
+                final byte[][] qualityScores = usingQualityScores ? new byte[barcodeIndices.length][] : null;
                 while (provider.hasNext()) {
                     // Extract the barcode from the cluster and write it to the file for the tile
                     final ClusterData cluster = provider.next();

--- a/src/java/picard/sam/FastqToSam.java
+++ b/src/java/picard/sam/FastqToSam.java
@@ -462,7 +462,7 @@ public class FastqToSam extends CommandLineProgram {
         if(readName.equals("")) throw new PicardException(error(freader,"Pair read name "+pairNum+" cannot be empty: "+readName));
 
         final int idx = readName.lastIndexOf("/");
-        final String result[] = new String[2];
+        final String[] result = new String[2];
 
         if (idx == -1) {
             result[0] = readName;

--- a/src/java/picard/sam/RevertSam.java
+++ b/src/java/picard/sam/RevertSam.java
@@ -313,7 +313,7 @@ public class RevertSam extends CommandLineProgram {
                     // The only valid quality score encoding scheme is standard; if it's not standard, change it.
                     final FastqQualityFormat recordFormat = readGroupToFormat.get(rec.getReadGroup());
                     if (!recordFormat.equals(FastqQualityFormat.Standard)) {
-                        final byte quals[] = rec.getBaseQualities();
+                        final byte[] quals = rec.getBaseQualities();
                         for (int i = 0; i < quals.length; i++) {
                             quals[i] -= SolexaQualityConverter.ILLUMINA_TO_PHRED_SUBTRAHEND;
                         }

--- a/src/java/picard/util/BasicInputParser.java
+++ b/src/java/picard/util/BasicInputParser.java
@@ -166,8 +166,8 @@ public class BasicInputParser extends AbstractInputParser
         return currentLineNumber;
     }
 
-    private static InputStream[] filesToInputStreams(final File files[]) {
-        final InputStream result[] = new InputStream[files.length];
+    private static InputStream[] filesToInputStreams(final File[] files) {
+        final InputStream[] result = new InputStream[files.length];
         for (int i = 0; i < files.length; i++) {
             result[i] = IOUtil.openFileForReading(files[i]);
         }

--- a/src/java/picard/util/IlluminaUtil.java
+++ b/src/java/picard/util/IlluminaUtil.java
@@ -200,7 +200,7 @@ public class IlluminaUtil {
      * @param barcodes
      * @return A single string representation of all the barcodes
      */
-    public static String barcodeSeqsToString(final String barcodes[]) {
+    public static String barcodeSeqsToString(final String[] barcodes) {
         return stringSeqsToString(barcodes, BARCODE_DELIMITER);
     }
 
@@ -209,11 +209,11 @@ public class IlluminaUtil {
      * @param barcodes
      * @return A single string representation of all the barcodes
      */
-    public static String barcodeSeqsToString(final byte barcodes[][]) {
+    public static String barcodeSeqsToString(final byte[][] barcodes) {
         return byteArrayToString(barcodes, BARCODE_DELIMITER);
     }
 
-    public static String stringSeqsToString(final String barcodes[], String delim) {
+    public static String stringSeqsToString(final String[] barcodes, String delim) {
         final StringBuilder sb = new StringBuilder();
         for (final String bc : barcodes) {
             if (sb.length() > 0) sb.append(delim);
@@ -227,8 +227,8 @@ public class IlluminaUtil {
      * @param barcodes
      * @return A single string representation of all the barcodes
      */
-    public static String byteArrayToString(final byte barcodes[][], String delim) {
-        final String bcs[] = new String[barcodes.length];
+    public static String byteArrayToString(final byte[][] barcodes, String delim) {
+        final String[] bcs = new String[barcodes.length];
         for (int i = 0; i < barcodes.length; i++) {
             bcs[i] = StringUtil.bytesToString(barcodes[i]);
         }

--- a/src/java/picard/util/MathUtil.java
+++ b/src/java/picard/util/MathUtil.java
@@ -370,7 +370,7 @@ final public class MathUtil {
 
         /** Returns the log-representation of the provided decimal array. */
         public double[] getLogValue(final double[] nonLogArray) {
-            final double logArray[] = new double[nonLogArray.length];
+            final double[] logArray = new double[nonLogArray.length];
             for (int i = 0; i < nonLogArray.length; i++) {
                 logArray[i] = getLogValue(nonLogArray[i]);
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar squid:S1197 - Array designators "[]" should be on the type, not the variable

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1197

Please let me know if you have any questions.

M-Ezzat