### PR TITLE
restore correct usage of 'recordsRead' local variable

### DIFF
--- a/src/java/picard/sam/markduplicates/EstimateLibraryComplexity.java
+++ b/src/java/picard/sam/markduplicates/EstimateLibraryComplexity.java
@@ -406,7 +406,7 @@ public class EstimateLibraryComplexity extends AbstractOpticalDuplicateFinderCom
         log.info("Will store " + MAX_RECORDS_IN_RAM + " read pairs in memory before sorting.");
 
         final List<SAMReadGroupRecord> readGroups = new ArrayList<SAMReadGroupRecord>();
-        final int recordsRead = 0;
+        int recordsRead = 0;
         final SortingCollection<PairedReadSequence> sorter;
         final boolean useBarcodes = (null != BARCODE_TAG || null != READ_ONE_BARCODE_TAG || null != READ_TWO_BARCODE_TAG);
 
@@ -479,6 +479,7 @@ public class EstimateLibraryComplexity extends AbstractOpticalDuplicateFinderCom
                     sorter.add(prs);
                 }
 
+                ++recordsRead;
                 progress.record(rec);
             }
             CloserUtil.close(in);


### PR DESCRIPTION
Restore correct usage of 'recordsRead' local variable in EstimateLibraryComplexity

It seems that increment of the variable was accidentally deleted during the following refactoring:
git show ee98947e72d81ec7539217ef76334888b24ced46 -- **/EstimateLibraryComplexity.java

This pull request restores it.

This local variable influences on the groups omitting during the final phase of ELC.