### PR TITLE
Adding a category and plot to WgsMetrics

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -449,6 +449,7 @@
         <document-command title="CollectWgsMetrics"                 main-class="picard.analysis.CollectWgsMetrics"/>
         <document-command title="CollectWgsMetricsFromQuerySorted"  main-class="picard.analysis.CollectWgsMetricsFromQuerySorted"/>
         <document-command title="CollectWgsMetricsFromSampledSites" main-class="picard.analysis.CollectWgsMetricsFromSampledSites"/>
+        <document-command title="CollectWgsMetricsWithNonZeroCoverage" main-class="picard.analysis.CollectWgsMetricsWithNonZeroCoverage"/>
         <document-command title="CompareMetrics"                    main-class="picard.analysis.CompareMetrics"/>
         <document-command title="CompareSAMs"                       main-class="picard.sam.CompareSAMs"/>
         <document-command title="ConvertSequencingArtifactToOxoG"   main-class="picard.analysis.artifacts.ConvertSequencingArtifactToOxoG"/>

--- a/src/java/picard/analysis/CollectWgsMetricsWithNonZeroCoverage.java
+++ b/src/java/picard/analysis/CollectWgsMetricsWithNonZeroCoverage.java
@@ -1,0 +1,171 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Nils Homer
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.analysis;
+
+import htsjdk.samtools.SAMReadGroupRecord;
+import htsjdk.samtools.metrics.MetricsFile;
+import htsjdk.samtools.util.Histogram;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Log;
+import htsjdk.samtools.util.StringUtil;
+import picard.PicardException;
+import picard.cmdline.CommandLineProgramProperties;
+import picard.cmdline.Option;
+import picard.cmdline.programgroups.Alpha;
+import picard.filter.CountingFilter;
+import picard.filter.CountingPairedFilter;
+import picard.util.RExecutor;
+
+import java.io.File;
+import java.util.List;
+
+@CommandLineProgramProperties(
+        usage = CollectWgsMetricsWithNonZeroCoverage.USAGE_SUMMARY + CollectWgsMetricsWithNonZeroCoverage.USAGE_DETAILS,
+        usageShort = CollectWgsMetricsWithNonZeroCoverage.USAGE_SUMMARY,
+        programGroup = Alpha.class
+)
+public class CollectWgsMetricsWithNonZeroCoverage extends CollectWgsMetrics {
+
+    static final String USAGE_SUMMARY = "Collect metrics about coverage and performance of whole genome sequencing (WGS) experiments.";
+    static final String USAGE_DETAILS = "This tool collects metrics about the percentages of reads that pass base- and mapping- quality " +
+            "filters as well as coverage (read-depth) levels. Both minimum base- and mapping-quality values as well as the maximum " +
+            "read depths (coverage cap) are user defined.  This extends CollectWgsMetrics by including metrics related only to sites" +
+            "with non-zero (>0) coverage." +
+            "<h4>Usage Example:</h4>" +
+            "<pre>"  +
+            "java -jar picard.jar CollectWgsMetricsWithNonZeroCoverage \\<br /> " +
+            "      I=input.bam \\<br /> "+
+            "      O=collect_wgs_metrics.txt \\<br /> " +
+            "      CHART=collect_wgs_metrics.pdf  \\<br /> " +
+            "      R=reference_sequence.fasta " +
+            "</pre>" +
+            "Please see " +
+            "<a href='https://broadinstitute.github.io/picard/picard-metric-definitions.html#CollectWgsMetricsWithNonZeroCoverage.WgsMetricsWithNonZeroCoverage'>" +
+            "the WgsMetricsWithNonZeroCoverage documentation</a> for detailed explanations of the output metrics." +
+            "<hr />";
+
+    @Option(shortName = "CHART", doc = "A file (with .pdf extension) to write the chart to.")
+    public File CHART_OUTPUT;
+
+    private final Log log = Log.getInstance(CollectWgsMetricsWithNonZeroCoverage.class);
+
+    // Store this here since we need access to it in the doWork method
+    private WgsMetricsWithNonZeroCoverageCollector collector = null;
+
+    /** Metrics for evaluating the performance of whole genome sequencing experiments. */
+    public static class WgsMetricsWithNonZeroCoverage extends WgsMetrics {
+        public enum Category { WHOLE_GENOME, NON_ZERO_REGIONS }
+
+        /** One of either WHOLE_GENOME or NON_ZERO_REGIONS */
+        public Category CATEGORY;
+    }
+
+    public static void main(final String[] args) {
+        new CollectWgsMetrics().instanceMainWithExit(args);
+    }
+
+    @Override
+    protected int doWork() {
+        IOUtil.assertFileIsWritable(CHART_OUTPUT);
+
+        this.collector = new WgsMetricsWithNonZeroCoverageCollector(COVERAGE_CAP);
+
+        final List<SAMReadGroupRecord> readGroups = this.getSamFileHeader().getReadGroups();
+        final String plotSubtitle = (readGroups.size() == 1) ? StringUtil.asEmptyIfNull(readGroups.get(0).getLibrary()) : "";
+
+        super.doWork();
+
+        if (collector.areHistogramsEmpty()) {
+            log.warn("No valid bases found in input file. No plot will be produced.");
+        } else {
+            final int rResult = RExecutor.executeFromClasspath("picard/analysis/wgsHistogram.R",
+                    OUTPUT.getAbsolutePath(),
+                    CHART_OUTPUT.getAbsolutePath(),
+                    INPUT.getName(),
+                    plotSubtitle);
+            if (rResult != 0) {
+                throw new PicardException("R script wgsHistogram.R failed with return code " + rResult);
+            }
+        }
+
+        return 0;
+    }
+
+    @Override
+    protected WgsMetricsWithNonZeroCoverage generateWgsMetrics() {
+        return new WgsMetricsWithNonZeroCoverage();
+    }
+
+    @Override
+    protected WgsMetricsCollector getCollector(final int coverageCap) {
+        assert(coverageCap == this.collector.coverageCap);
+        return this.collector;
+    }
+
+    protected class WgsMetricsWithNonZeroCoverageCollector extends WgsMetricsCollector {
+        Histogram<Integer> depthHistogram = null;
+
+        public WgsMetricsWithNonZeroCoverageCollector(final int coverageCap) {
+            super(coverageCap);
+        }
+
+        @Override
+        public void addToMetricsFile(final MetricsFile<WgsMetrics, Integer> file,
+                                     final boolean includeBQHistogram,
+                                     final CountingFilter dupeFilter,
+                                     final CountingFilter mapqFilter,
+                                     final CountingPairedFilter pairFilter) {
+            this.depthHistogram                            = getDepthHistogram();
+            final Histogram<Integer> depthHistogramNonZero = depthHistogramNonZero();
+
+            final WgsMetricsWithNonZeroCoverage metrics        = (WgsMetricsWithNonZeroCoverage) getMetrics(depthHistogram, dupeFilter, mapqFilter, pairFilter);
+            final WgsMetricsWithNonZeroCoverage metricsNonZero = (WgsMetricsWithNonZeroCoverage) getMetrics(depthHistogramNonZero, dupeFilter, mapqFilter, pairFilter);
+
+            metrics.CATEGORY        = WgsMetricsWithNonZeroCoverage.Category.WHOLE_GENOME;
+            metricsNonZero.CATEGORY = WgsMetricsWithNonZeroCoverage.Category.NON_ZERO_REGIONS;
+
+            file.addMetric(metrics);
+            file.addMetric(metricsNonZero);
+
+            if (includeBQHistogram) {
+                addBaseQHistogram(file);
+            }
+        }
+
+        private Histogram<Integer> depthHistogramNonZero() {
+            final Histogram<Integer> depthHistogram = new Histogram<>("coverage", "count");
+            // do not include the zero-coverage bin
+            for (int i = 1; i<histogramArray.length; ++i) {
+                depthHistogram.increment(i, histogramArray[i]);
+            }
+            return depthHistogram;
+        }
+
+        public boolean areHistogramsEmpty() {
+            return (null == depthHistogram || depthHistogram.isEmpty());
+        }
+    }
+
+}

--- a/src/scripts/picard/analysis/wgsHistogram.R
+++ b/src/scripts/picard/analysis/wgsHistogram.R
@@ -1,0 +1,121 @@
+##
+# Copyright (c) 2016, Nils Homer
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+##
+
+# Script to generate a chart for the fraction of bases at a given mean fold coverage.
+# @author Nils Homer
+
+# Parse the arguments
+args <- commandArgs(trailing=T)
+metricsFile  <- args[1]
+outputFile   <- args[2]
+bamFile  <- ifelse(length(args) < 3, NA, args[3])
+subtitle <- ifelse(length(args) < 4, "", args[4])
+
+# Figure out where the metrics and the histogram are in the file and parse them out
+startFinder <- scan(metricsFile, what="character", sep="\n", quiet=TRUE, blank.lines.skip=FALSE)
+
+firstBlankLine=0
+
+for (i in 1:length(startFinder))
+{
+        if (startFinder[i] == "") {
+                if (firstBlankLine==0) {
+                        firstBlankLine=i+1
+                } else {
+                        secondBlankLine=i+1
+                        break
+                }
+        }
+}
+
+metrics <- read.table(metricsFile, header=T, nrows=2, sep="\t", skip=firstBlankLine)
+histogram <- read.table(metricsFile, header=T, sep="\t", skip=secondBlankLine)
+
+coverages = rbind(histogram$coverage, histogram$coverage)
+counts = rbind(histogram$count_WHOLE_GENOME, histogram$count_NON_ZERO_REGIONS)
+labels = c("Whole Genome", "Non-Zero Regions")
+colors = c("blue", "green")
+
+ymins = c();
+ymaxs = c();
+percentOfMeans = c()
+percentCovereds = c();
+
+for (i in 1:2) {
+	coverage = coverages[i,];
+	count = counts[i,];
+
+	coverage = coverage[!is.na(count)];
+	count = count[!is.na(count)];
+
+	meanCoverage = metrics$MEAN_COVERAGE[i];
+	percentOfMean <- coverage / meanCoverage; # x-axis
+	percentCovered <- rep(0, length(count)); # y-axis
+
+	# must do a cumulative sume of percentCovered
+	totalCount = sum(as.numeric(count));
+	for (j in 1:length(percentCovered)) {
+		percentCovered[j] = 100.0# sum(as.numeric(count[j:length(percentCovered)])) / totalCount;
+	}
+
+	ymin = percentCovered[round(meanCoverage+1)]
+	ymax = min(100,max(percentCovered));
+
+	ymins = append(ymins, ymin);
+	ymaxs = append(ymaxs, ymax);
+	percentOfMeans = append(percentOfMeans, list(percentOfMean));
+	percentCovereds = append(percentCovereds, list(percentCovered));
+}
+
+ymin = min(ymins);
+ymax = max(ymaxs);
+
+# Then plot the histogram as a PDF
+pdf(outputFile);
+
+plot(x=c(0, 1.0),
+		y=c(ymin, ymax),
+		xlim=c(0, 1.0),
+		ylim=c(ymin, ymax),
+		type="n",
+		main=paste("WGS Base Coverage Plot", ifelse(is.na(bamFile),"",paste("\nin file",bamFile))," ",ifelse(subtitle == "","",paste("(",subtitle,")",sep="")),sep=""),
+		xlab="Fold Coverage of Mean",
+		ylab="% of Bases Covered");
+
+for (i in 1:2) {
+	label = labels[i];
+	color = colors[i]
+	percentOfMean = percentOfMeans[[i]];
+	percentCovered = percentCovereds[[i]];
+
+	lines(percentOfMean, percentCovered, col=color, lwd=5);
+}
+
+legend(x="topright", legend=labels, lwd=5, col=colors);
+
+dev.off()
+


### PR DESCRIPTION
@yfarjoun this pull request is not complete, as it requires updating and adding tests, as well as one final pass.  What I wanted to do prior to putting any more effort into this change, is to get a :+1: that if I fix current tests and add some more tests, and respond to all the comments, that this will get merged.  If not, I can move the version of this tool elsewhere.  My reasoning is that this commit changes `WgsMetrics`, which may impact folks who rely on this class having a certain format, so it could be a painful change for some.  Nonetheless, I think the plot that is produced is useful, and the QC metrics (for non-zero coverage regions) are useful for folks doing low-coverage sequencing for technology development.

If you agree that this PR will be included in Picard, I will go back and do the rest of the work and then ask for a review.  Thanks for taking a look.
