### PR TITLE
squid:S2864 - entrySet() should be iterated when both the key and val…

### DIFF
--- a/src/java/picard/fingerprint/CrosscheckReadGroupFingerprints.java
+++ b/src/java/picard/fingerprint/CrosscheckReadGroupFingerprints.java
@@ -196,9 +196,9 @@ public class CrosscheckReadGroupFingerprints extends CommandLineProgram {
      */
     private void crossCheckLibraries(final Map<SAMReadGroupRecord,Fingerprint> fingerprints, final PrintStream out) {
         final List<Fingerprint> fixedFps = new ArrayList<>();
-        for (final SAMReadGroupRecord rg : fingerprints.keySet()) {
-            final Fingerprint old = fingerprints.get(rg);
-            final String name = rg.getSample() + "::" + rg.getLibrary();
+        for (final Map.Entry<SAMReadGroupRecord, Fingerprint> samReadGroupRecordFingerprintEntry : fingerprints.entrySet()) {
+            final Fingerprint old = samReadGroupRecordFingerprintEntry.getValue();
+            final String name = samReadGroupRecordFingerprintEntry.getKey().getSample() + "::" + samReadGroupRecordFingerprintEntry.getKey().getLibrary();
             final Fingerprint newFp = new Fingerprint(name, old.getSource(), old.getInfo());
             newFp.putAll(old);
 

--- a/src/java/picard/fingerprint/FingerprintChecker.java
+++ b/src/java/picard/fingerprint/FingerprintChecker.java
@@ -544,10 +544,10 @@ public class FingerprintChecker {
                 resultsList.add(results);
 
             } else {
-                for (final SAMReadGroupRecord rg : fingerprintsByReadGroup.keySet()) {
-                    final FingerprintResults results = new FingerprintResults(f, rg.getPlatformUnit());
+                for (final Map.Entry<SAMReadGroupRecord, Fingerprint> samReadGroupRecordFingerprintEntry : fingerprintsByReadGroup.entrySet()) {
+                    final FingerprintResults results = new FingerprintResults(f, samReadGroupRecordFingerprintEntry.getKey().getPlatformUnit());
                     for (final Fingerprint expectedFp : expectedFingerprints) {
-                        final MatchResults result = calculateMatchResults(fingerprintsByReadGroup.get(rg), expectedFp, 0, pLossofHet);
+                        final MatchResults result = calculateMatchResults(samReadGroupRecordFingerprintEntry.getValue(), expectedFp, 0, pLossofHet);
                         results.addResults(result);
                     }
 

--- a/src/java/picard/illumina/CollectIlluminaBasecallingMetrics.java
+++ b/src/java/picard/illumina/CollectIlluminaBasecallingMetrics.java
@@ -39,6 +39,7 @@ import htsjdk.samtools.util.StringUtil;
 
 import java.io.File;
 import java.lang.Comparable;import java.lang.Double;import java.lang.Exception;import java.lang.Integer;import java.lang.Math;import java.lang.Override;import java.lang.String;import java.lang.StringBuilder;import java.text.DecimalFormat;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -180,8 +181,8 @@ public class CollectIlluminaBasecallingMetrics extends CommandLineProgram {
         try {
             final MetricsFile<IlluminaBasecallingMetrics, Comparable<?>> file = getMetricsFile();
             final IlluminaMetricCounts allLaneCounts = new IlluminaMetricCounts(null, null, LANE);
-            for (final String s : barcodeToMetricCounts.keySet()) {
-                final IlluminaMetricCounts counts = barcodeToMetricCounts.get(s);
+            for (final Map.Entry<String, IlluminaMetricCounts> stringIlluminaMetricCountsEntry : barcodeToMetricCounts.entrySet()) {
+                final IlluminaMetricCounts counts = stringIlluminaMetricCountsEntry.getValue();
                 counts.addMetricsToFile(file);
                 allLaneCounts.addIlluminaMetricCounts(counts);
             }

--- a/src/java/picard/illumina/ExtractIlluminaBarcodes.java
+++ b/src/java/picard/illumina/ExtractIlluminaBarcodes.java
@@ -224,8 +224,8 @@ public class ExtractIlluminaBarcodes extends CommandLineProgram {
 
         LOG.info("Processed " + extractors.size() + " tiles.");
         for (final PerTileBarcodeExtractor extractor : extractors) {
-            for (final String key : barcodeToMetrics.keySet()) {
-                barcodeToMetrics.get(key).merge(extractor.getMetrics().get(key));
+            for (final Map.Entry<String, BarcodeMetric> stringBarcodeMetricEntry : barcodeToMetrics.entrySet()) {
+                stringBarcodeMetricEntry.getValue().merge(extractor.getMetrics().get(stringBarcodeMetricEntry.getKey()));
             }
             noMatchMetric.merge(extractor.getNoMatchMetric());
             if (extractor.getException() != null) {
@@ -553,8 +553,8 @@ public class ExtractIlluminaBarcodes extends CommandLineProgram {
             this.minMismatchDelta = minMismatchDelta;
             this.minimumBaseQuality = minimumBaseQuality;
             this.metrics = new LinkedHashMap<String, BarcodeMetric>(barcodeToMetrics.size());
-            for (final String key : barcodeToMetrics.keySet()) {
-                this.metrics.put(key, BarcodeMetric.copy(barcodeToMetrics.get(key)));
+            for (final Map.Entry<String, BarcodeMetric> stringBarcodeMetricEntry : barcodeToMetrics.entrySet()) {
+                this.metrics.put(stringBarcodeMetricEntry.getKey(), BarcodeMetric.copy(stringBarcodeMetricEntry.getValue()));
             }
             this.noMatch = BarcodeMetric.copy(noMatchMetric);
             this.provider = factory.makeDataProvider(Arrays.asList(tile));

--- a/src/java/picard/illumina/IlluminaBasecallsConverter.java
+++ b/src/java/picard/illumina/IlluminaBasecallsConverter.java
@@ -650,8 +650,8 @@ public class IlluminaBasecallsConverter<CLUSTER_OUTPUT_RECORD> {
              * (more negative) priority.
              */
             int priority = 0;
-            for (final Tile tile : this.tileRecords.keySet()) {
-                final TileReader reader = new TileReader(tile, this, this.tileRecords.get(tile));
+            for (final Map.Entry<Tile, TileProcessingRecord> tileTileProcessingRecordEntry : this.tileRecords.entrySet()) {
+                final TileReader reader = new TileReader(tileTileProcessingRecordEntry.getKey(), this, this.tileRecords.get(tileTileProcessingRecordEntry.getKey()));
                 this.prioritizingThreadPool.execute(new PriorityRunnable(--priority) {
                     @Override
                     public void run() {

--- a/src/java/picard/illumina/parser/Tile.java
+++ b/src/java/picard/illumina/parser/Tile.java
@@ -107,8 +107,8 @@ public class Tile {
                 tilePhasingValues.stream().collect(Collectors.groupingBy(TilePhasingValue::getTileTemplateRead));
 
         final Collection<TilePhasingValue> newTilePhasingValues = new LinkedList<>();
-        for (final TileTemplateRead read : partitionedMap.keySet()) {
-            newTilePhasingValues.add(CollectionUtil.getSoleElement(partitionedMap.get(read)));
+        for (final Map.Entry<TileTemplateRead, List<TilePhasingValue>> tileTemplateReadListEntry : partitionedMap.entrySet()) {
+            newTilePhasingValues.add(CollectionUtil.getSoleElement(tileTemplateReadListEntry.getValue()));
         }
 
         return newTilePhasingValues;

--- a/src/java/picard/sam/RevertSam.java
+++ b/src/java/picard/sam/RevertSam.java
@@ -260,8 +260,8 @@ public class RevertSam extends CommandLineProgram {
                 readGroupToFormat.put(rg, QualityEncodingDetector.detect(QualityEncodingDetector.DEFAULT_MAX_RECORDS_TO_ITERATE, new FilteringIterator(reader.iterator(), filter), RESTORE_ORIGINAL_QUALITIES));
                 CloserUtil.close(reader);
             }
-            for (final SAMReadGroupRecord r : readGroupToFormat.keySet()) {
-                log.info("Detected quality format for " + r.getReadGroupId() + ": " + readGroupToFormat.get(r));
+            for (final Map.Entry<SAMReadGroupRecord, FastqQualityFormat> samReadGroupRecordFastqQualityFormatEntry : readGroupToFormat.entrySet()) {
+                log.info("Detected quality format for " + samReadGroupRecordFastqQualityFormatEntry.getKey().getReadGroupId() + ": " + samReadGroupRecordFastqQualityFormatEntry.getValue());
             }
             if (readGroupToFormat.values().contains(FastqQualityFormat.Solexa)) {
                 log.error("No quality score encoding conversion implemented for " + FastqQualityFormat.Solexa);

--- a/src/java/picard/vcf/GenotypeConcordance.java
+++ b/src/java/picard/vcf/GenotypeConcordance.java
@@ -373,8 +373,8 @@ public class GenotypeConcordance extends CommandLineProgram {
         genotypeConcordanceContingencyMetricsFile.addMetric(contingencyMetrics);
         genotypeConcordanceContingencyMetricsFile.write(contingencyMetricsFile);
 
-        for (final String condition : unClassifiedStatesMap.keySet()) {
-            log.info("Uncovered truth/call Variant Context Type Counts: " + condition + " " + unClassifiedStatesMap.get(condition));
+        for (final Map.Entry<String, Integer> stringIntegerEntry : unClassifiedStatesMap.entrySet()) {
+            log.info("Uncovered truth/call Variant Context Type Counts: " + stringIntegerEntry.getKey() + " " + stringIntegerEntry.getValue());
         }
 
         return 0;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar squid:S2864 - "entrySet()" should be iterated when both the key and value are needed

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2864

Please let me know if you have any questions.

M-Ezzat