### PR TITLE
Minor change to stylesheet to widen the viewport

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -13,7 +13,7 @@ body {
 }
 
 .wrapper {
-  width: 740px;
+  width: 1000px;
   margin: 0 auto;
   background: #CCCCCC;
   -webkit-border-radius: 8px;


### PR DESCRIPTION
Adjusted wrapper from 740 to 1000px, which enables the adapter oligonucleotides to fit within the wrapper of the Tool Documentation page hen viewed in standard conditions.  Moreover, this change reduces the amount of scrolling required to navigate from the top to the bottom of the pages.

This is an ad-hoc fix; ideally we'd introduce some responsive web design elements (as done on GATK website) but time is the fire in which we burn.