### PR TITLE
squid:S2275 - Printf-style format strings should not lead to unexpected

### DIFF
--- a/src/java/picard/cmdline/PicardCommandLine.java
+++ b/src/java/picard/cmdline/PicardCommandLine.java
@@ -228,7 +228,7 @@ public class PicardCommandLine {
 
             if (!commandListOnly) {
                 builder.append(KWHT + "--------------------------------------------------------------------------------------\n" + KNRM);
-                builder.append(String.format("%s%-48s %-45s%s\n", KRED, programGroup.getName() + ":", programGroup.getDescription(), KNRM));
+                builder.append(String.format("%s%-48s %-45s%s%n", KRED, programGroup.getName() + ":", programGroup.getDescription(), KNRM));
             }
 
             final List<Class> sortedClasses = new ArrayList<Class>();
@@ -242,16 +242,16 @@ public class PicardCommandLine {
                 }
                 if (!commandListOnly) {
                     if (clazz.getSimpleName().length() >= 45) {
-                        builder.append(String.format("%s    %s    %s%s%s\n", KGRN, clazz.getSimpleName(), KCYN, property.usageShort(), KNRM));
+                        builder.append(String.format("%s    %s    %s%s%s%n", KGRN, clazz.getSimpleName(), KCYN, property.usageShort(), KNRM));
                     } else {
-                        builder.append(String.format("%s    %-45s%s%s%s\n", KGRN, clazz.getSimpleName(), KCYN, property.usageShort(), KNRM));
+                        builder.append(String.format("%s    %-45s%s%s%s%n", KGRN, clazz.getSimpleName(), KCYN, property.usageShort(), KNRM));
                     }
                 }
                 else {
                     builder.append(clazz.getSimpleName() + "\n");
                 }
             }
-            if (!commandListOnly) builder.append(String.format("\n"));
+            if (!commandListOnly) builder.append(String.format("%n"));
         }
         if (!commandListOnly) builder.append(KWHT + "--------------------------------------------------------------------------------------\n\n" + KNRM);
         if (toStdout) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2275 - Printf-style format strings should not lead to unexpected behavior at runtime

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2275

Please let me know if you have any questions.

M-Ezzat