### PR TITLE
Adding logging to opticalDuplicateFinder when duplicate set is large

### DIFF
--- a/src/tests/java/picard/sam/markduplicates/util/OpticalDuplicateFinderTest.java
+++ b/src/tests/java/picard/sam/markduplicates/util/OpticalDuplicateFinderTest.java
@@ -1,13 +1,10 @@
 package picard.sam.markduplicates.util;
 
-import htsjdk.samtools.util.CollectionUtil;
 import htsjdk.samtools.util.Log;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.Assert;
 import picard.sam.util.PhysicalLocation;
 import picard.sam.util.PhysicalLocationInt;
-import picard.sam.util.PhysicalLocationShort;
 import picard.sam.util.ReadNameParser;
 
 import java.util.ArrayList;


### PR DESCRIPTION
Resolves #472 by slowing *down* and providing "safe points" to the code (I guess)...

This seems to make the problem go away..

@nh13 @tfenne It seems that you are the authors of this code, would one of you be able to take a look? I didn't change anything functional, just added a few logging and progress statements when the duplicate set are large. These cases should be _very_ rare (duplicate sets greater than 1000)