### PR TITLE
Issue with InsertSizeMetricsCollector and CollectInsertSizeMetricsTest  [Please review, DON'T MERGE]

### DIFF
--- a/src/main/java/picard/analysis/directed/InsertSizeMetricsCollector.java
+++ b/src/main/java/picard/analysis/directed/InsertSizeMetricsCollector.java
@@ -149,7 +149,7 @@ public class InsertSizeMetricsCollector extends MultiLevelCollector<InsertSizeMe
                         double low = median;
                         double high = median;
 
-                        while (low >= histogram.getMin() || high <= histogram.getMax()) {
+                        while (low >= histogram.getMin()-1 || high <= histogram.getMax()+1) {
                             final Histogram.Bin<Integer> lowBin = histogram.get((int) low);
                             if (lowBin != null) covered += lowBin.getValue();
 

--- a/src/test/java/picard/analysis/CollectInsertSizeMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectInsertSizeMetricsTest.java
@@ -54,7 +54,10 @@ public class CollectInsertSizeMetricsTest extends CommandLineProgramTest {
         final String[] args = new String[] {
                 "INPUT="  + input.getAbsolutePath(),
                 "OUTPUT=" + outfile.getAbsolutePath(),
-                "HISTOGRAM_FILE=" + pdf.getAbsolutePath()
+                "HISTOGRAM_FILE=" + pdf.getAbsolutePath(),
+                "LEVEL=SAMPLE",
+                "LEVEL=LIBRARY",
+                "LEVEL=READ_GROUP"
         };
         Assert.assertEquals(runPicardCommandLine(args), 0);
 
@@ -112,39 +115,38 @@ public class CollectInsertSizeMetricsTest extends CommandLineProgramTest {
                 Assert.assertEquals(metrics.WIDTH_OF_80_PERCENT, 9);
                 Assert.assertEquals(metrics.WIDTH_OF_90_PERCENT, 11);
                 Assert.assertEquals(metrics.WIDTH_OF_99_PERCENT, 11);
-
             }
             else if (metrics.LIBRARY.equals("Solexa-41734") && metrics.READ_GROUP == null) {
-                Assert.assertEquals((int)metrics.MEDIAN_INSERT_SIZE, 26);
+                Assert.assertEquals((int)metrics.MEDIAN_INSERT_SIZE, 38);
                 Assert.assertEquals(metrics.MIN_INSERT_SIZE, 36);
                 Assert.assertEquals(metrics.MAX_INSERT_SIZE, 41);
-                Assert.assertEquals(metrics.READ_PAIRS, 9);
-                Assert.assertEquals(metrics.WIDTH_OF_10_PERCENT, 1);
-                Assert.assertEquals(metrics.WIDTH_OF_20_PERCENT, 1);
-                Assert.assertEquals(metrics.WIDTH_OF_30_PERCENT, 1);
-                Assert.assertEquals(metrics.WIDTH_OF_40_PERCENT, 1);
-                Assert.assertEquals(metrics.WIDTH_OF_50_PERCENT, 1);
-                Assert.assertEquals(metrics.WIDTH_OF_60_PERCENT, 11);
-                Assert.assertEquals(metrics.WIDTH_OF_70_PERCENT, 11);
-                Assert.assertEquals(metrics.WIDTH_OF_80_PERCENT, 11);
-                Assert.assertEquals(metrics.WIDTH_OF_90_PERCENT, 11);
-                Assert.assertEquals(metrics.WIDTH_OF_99_PERCENT, 11);
+                Assert.assertEquals(metrics.READ_PAIRS, 2);
+                Assert.assertEquals(metrics.WIDTH_OF_10_PERCENT, 5);
+                Assert.assertEquals(metrics.WIDTH_OF_20_PERCENT, 5);
+                Assert.assertEquals(metrics.WIDTH_OF_30_PERCENT, 5);
+                Assert.assertEquals(metrics.WIDTH_OF_40_PERCENT, 5);
+                Assert.assertEquals(metrics.WIDTH_OF_50_PERCENT, 5);
+                Assert.assertEquals(metrics.WIDTH_OF_60_PERCENT, 7);
+                Assert.assertEquals(metrics.WIDTH_OF_70_PERCENT, 7);
+                Assert.assertEquals(metrics.WIDTH_OF_80_PERCENT, 7);
+                Assert.assertEquals(metrics.WIDTH_OF_90_PERCENT, 7);
+                Assert.assertEquals(metrics.WIDTH_OF_99_PERCENT, 7);
             }
             else if (metrics.READ_GROUP.equals("62A79AAXX100907.7")) {
-                Assert.assertEquals((int)metrics.MEDIAN_INSERT_SIZE, 36);
+                Assert.assertEquals((int)metrics.MEDIAN_INSERT_SIZE, 37);
                 Assert.assertEquals(metrics.MIN_INSERT_SIZE, 36);
                 Assert.assertEquals(metrics.MAX_INSERT_SIZE, 41);
                 Assert.assertEquals(metrics.READ_PAIRS, 4);
-                Assert.assertEquals(metrics.WIDTH_OF_10_PERCENT, 1);
-                Assert.assertEquals(metrics.WIDTH_OF_20_PERCENT, 1);
-                Assert.assertEquals(metrics.WIDTH_OF_30_PERCENT, 1);
-                Assert.assertEquals(metrics.WIDTH_OF_40_PERCENT, 1);
-                Assert.assertEquals(metrics.WIDTH_OF_50_PERCENT, 1);
-                Assert.assertEquals(metrics.WIDTH_OF_60_PERCENT, 5);
-                Assert.assertEquals(metrics.WIDTH_OF_70_PERCENT, 5);
-                Assert.assertEquals(metrics.WIDTH_OF_80_PERCENT, 11);
-                Assert.assertEquals(metrics.WIDTH_OF_90_PERCENT, 11);
-                Assert.assertEquals(metrics.WIDTH_OF_99_PERCENT, 11);
+                Assert.assertEquals(metrics.WIDTH_OF_10_PERCENT, 3);
+                Assert.assertEquals(metrics.WIDTH_OF_20_PERCENT, 3);
+                Assert.assertEquals(metrics.WIDTH_OF_30_PERCENT, 3);
+                Assert.assertEquals(metrics.WIDTH_OF_40_PERCENT, 3);
+                Assert.assertEquals(metrics.WIDTH_OF_50_PERCENT, 3);
+                Assert.assertEquals(metrics.WIDTH_OF_60_PERCENT, 3);
+                Assert.assertEquals(metrics.WIDTH_OF_70_PERCENT, 3);
+                Assert.assertEquals(metrics.WIDTH_OF_80_PERCENT, 9);
+                Assert.assertEquals(metrics.WIDTH_OF_90_PERCENT, 9);
+                Assert.assertEquals(metrics.WIDTH_OF_99_PERCENT, 9);
             }
             else if (metrics.READ_GROUP.equals("62A79AAXX100907.6")) {
                 Assert.assertEquals((int)metrics.MEDIAN_INSERT_SIZE, 41);


### PR DESCRIPTION
There are currently several issues in the master branch that causes Picard to generate wrong results on Histogram bin width values when using `CollectInsertSizeMetrics` tool, and since the unit test in `CollectInsertSizeMetricsTest` is not catching it, this subtle bug slipped through the watching eyes.

Specifically, this PR addressed the following issues:
1. Added several `MetricAccumulationLevel` values so unit tests now could catch errors (master branch currently only test `MetricAccumulationLevel::ALL_READS`).
2. Corrected several expected values in the unit tests that were from running production Picard on the test bam file (see git diff for which values are changed).
3. The proposed correction on line 152 in `InsertSizeMetricsCollector` now generates "correct" bin width values for library "Solexa-41734", whose bin width, before the proposed fix, were calculated to be (5,5,5,5,5,0,0,0,0,0), which is apparently problematic, because this sequence should be a (not necessarily strict) monotonically increasing sequence.

@yfarjoun proposed this minimum-modification correction that will correct the mistake and leave other values unchanged. Alternative proposals on how to fix is to follow.

Thanks.

PS: some code is commented out for quick fix (R script for generating histogram plot). Python-related code change is mysteriously made by Intellij to work, which I don't quite understand yet. But these don't interfere with the issue raised.