### PR TITLE
Outputs arguments with redundant short names and removes INTERVALS short…

### DIFF
--- a/src/java/picard/analysis/CollectWgsMetrics.java
+++ b/src/java/picard/analysis/CollectWgsMetrics.java
@@ -116,7 +116,7 @@ public class CollectWgsMetrics extends CommandLineProgram {
     @Option(doc="Sample Size used for Theoretical Het Sensitivity sampling. Default is 10000.", optional = true)
     public int SAMPLE_SIZE=10000;
 
-    @Option(shortName = "INTERVALS", doc = "An interval list file that contains the positions to restrict the assessment. Please note that " +
+    @Option(doc = "An interval list file that contains the positions to restrict the assessment. Please note that " +
             "all bases of reads that overlap these intervals will be considered, even if some of those bases extend beyond the boundaries of " +
             "the interval. The ideal use case for this argument is to use it to restrict the calculation to a subset of (whole) contigs. To " +
             "restrict the calculation just to individual positions without overlap, please see CollectWgsMetricsFromSampledSites.",

--- a/src/java/picard/analysis/CollectWgsMetricsFromSampledSites.java
+++ b/src/java/picard/analysis/CollectWgsMetricsFromSampledSites.java
@@ -53,7 +53,7 @@ import java.io.File;
 
 public class CollectWgsMetricsFromSampledSites extends CollectWgsMetrics {
 
-    @Option(shortName = "INTERVALS", doc = "An interval list file that contains the locations of the positions to assess.", optional = false)
+    @Option(doc = "An interval list file that contains the locations of the positions to assess.", optional = false)
     public File INTERVALS = null;
 
     public static void main(final String[] args) {

--- a/src/java/picard/cmdline/CommandLineParser.java
+++ b/src/java/picard/cmdline/CommandLineParser.java
@@ -979,7 +979,7 @@ public class CommandLineParser {
             if (!optionDefinition.overridable && optionMap.containsKey(optionDefinition.name)) {
                 throw new CommandLineParserDefinitionException(optionDefinition.name + " has already been used.");
             }
-            if (!optionDefinition.shortName.isEmpty()) {
+            if (!optionDefinition.shortName.isEmpty() && !optionDefinition.shortName.equals(optionDefinition.name)) {
                 if (optionMap.containsKey(optionDefinition.shortName)) {
                     if (!optionDefinition.overridable) {
                         throw new CommandLineParserDefinitionException(optionDefinition.shortName +

--- a/src/tests/java/picard/cmdline/CommandLineParserTest.java
+++ b/src/tests/java/picard/cmdline/CommandLineParserTest.java
@@ -121,6 +121,13 @@ public class CommandLineParserTest {
         public String frob;
     }
 
+    class OptionsWithSameShortName {
+        @Option(shortName = "SAME_SHORT_NAME", overridable = true, optional = true)
+        public String SAME_SHORT_NAME;
+        @Option(shortName = "SOMETHING_ELSE", overridable = true, optional = true)
+        public String DIFF_SHORT_NAME;
+    }
+
     class MutexOptions {
         @Option(mutex = {"M", "N", "Y", "Z"})
         public String A;
@@ -165,6 +172,24 @@ public class CommandLineParserTest {
         final CommandLineParser clp = new CommandLineParser(fo);
         clp.usage(System.out, true);
     }
+
+    /**
+     * If the short name is set to be the same as the long name we still want the argument to appear in the commandLine.
+     */
+    @Test
+    public void testForIdenticalShortName() {
+        final String[] args = {
+                "SAME_SHORT_NAME=FOO",
+                "SOMETHING_ELSE=BAR"
+        };
+        final OptionsWithSameShortName fo = new OptionsWithSameShortName();
+        final CommandLineParser clp = new CommandLineParser(fo);
+        clp.parseOptions(System.err, args);
+        final String commandLine = clp.getCommandLine();
+        Assert.assertTrue(commandLine.contains("DIFF_SHORT_NAME"));
+        Assert.assertTrue(commandLine.contains("SAME_SHORT_NAME"));
+    }
+
 
     @Test
     public void testPositive() {


### PR DESCRIPTION
…Name

Currently, if the short name of an argument is set to be the same as the long name, and if that argument is overridable, the argument is not included in the output of the command line arguments. This changes CommandLineParser to output arguments with matching short names that are overridable (as well as those that are not overridable which are already currently being output) and removes the redundant short name for the INTERVALS argument in CollectWgsMetrics.
