### PR TITLE
Return 0 when lhs and rhs are identical in EstimateLibraryComplexity.PairedReadComparator

### DIFF
--- a/src/java/picard/sam/markduplicates/EstimateLibraryComplexity.java
+++ b/src/java/picard/sam/markduplicates/EstimateLibraryComplexity.java
@@ -339,8 +339,9 @@ public class EstimateLibraryComplexity extends AbstractOpticalDuplicateFinderCom
 
     /**
      * Comparator that orders read pairs on the first N bases of both reads.
+     * There is no tie-breaking, so any sort is stable, not total.
      */
-    class PairedReadComparator implements Comparator<PairedReadSequence> {
+    private class PairedReadComparator implements Comparator<PairedReadSequence> {
         final int BASES = EstimateLibraryComplexity.this.MIN_IDENTICAL_BASES;
 
         public int compare(final PairedReadSequence lhs, final PairedReadSequence rhs) {
@@ -356,7 +357,7 @@ public class EstimateLibraryComplexity extends AbstractOpticalDuplicateFinderCom
                 if (retval != 0) return retval;
             }
 
-            return System.identityHashCode(lhs) - System.identityHashCode(rhs);
+            return 0;
         }
     }
 


### PR DESCRIPTION
EstimateLibraryComplexity.PairedReadComparator returns System.identityHashCode(lhs) - System.identityHashCode(rhs) when lh and rhs are equal.

This leads to slightly different results in different sequential launches of the metric. It makes difficult to run  regression tests.

We propose to replace the returned expression with zero to provide the results' consistency.