### PR TITLE
This commit enables MarkDuplicate to process query-sorted input.

### DIFF
--- a/src/java/picard/cmdline/StandardOptionDefinitions.java
+++ b/src/java/picard/cmdline/StandardOptionDefinitions.java
@@ -38,6 +38,7 @@ public class StandardOptionDefinitions {
     public static final String SEQUENCE_DICTIONARY_SHORT_NAME = "SD";
     public static final String METRICS_FILE_SHORT_NAME = "M";
     public static final String ASSUME_SORTED_SHORT_NAME = "AS";
+    public static final String ASSUME_SORT_ORDER_SHORT_NAME = "ASO";
     public static final String PF_READS_ONLY_SHORT_NAME = "PF";
     public static final String MINIMUM_MAPPING_QUALITY_SHORT_NAME = "MQ";
     public static final String READ_GROUP_ID_SHORT_NAME = "RG";

--- a/src/java/picard/sam/DuplicationMetrics.java
+++ b/src/java/picard/sam/DuplicationMetrics.java
@@ -41,10 +41,13 @@ public class DuplicationMetrics extends MetricBase {
      */
     public long UNPAIRED_READS_EXAMINED;
 
-    /** The number of mapped read pairs examined. */
+    /** The number of mapped read pairs examined. (Primary, non-supplemental) */
     public long READ_PAIRS_EXAMINED;
 
-    /** The total number of unmapped reads examined. */
+    /** The number of reads that were either secondary or supplementary */
+    public long SECONDARY_OR_SUPPLEMENTARY_RDS;
+
+    /** The total number of unmapped reads examined. (Primary, non-supplemental) */
     public long UNMAPPED_READS;
 
     /** The number of fragments that were marked as duplicates. */

--- a/src/java/picard/sam/markduplicates/MarkDuplicatesWithMateCigar.java
+++ b/src/java/picard/sam/markduplicates/MarkDuplicatesWithMateCigar.java
@@ -24,6 +24,7 @@
 
 package picard.sam.markduplicates;
 
+import picard.PicardException;
 import picard.cmdline.CommandLineProgramProperties;
 import picard.cmdline.Option;
 import htsjdk.samtools.util.Histogram;
@@ -120,8 +121,11 @@ public class MarkDuplicatesWithMateCigar extends AbstractMarkDuplicatesCommandLi
 
         // Create the output header
         final SAMFileHeader outputHeader = header.clone();
-        outputHeader.setSortOrder(SAMFileHeader.SortOrder.coordinate);
-        for (final String comment : COMMENT) outputHeader.addComment(comment);
+        if (outputHeader.getSortOrder() != SAMFileHeader.SortOrder.coordinate) {
+            throw new PicardException("This program requires inputs in coordinate SortOrder");
+        }
+
+        COMMENT.forEach(outputHeader::addComment);
 
         // Since this is one-pass, unlike MarkDuplicates, we cannot only chain together program
         // group records we have seen, we have to assume all of them may be seen.  We can perhaps

--- a/src/java/picard/sam/markduplicates/util/ReadEndsForMarkDuplicatesCodec.java
+++ b/src/java/picard/sam/markduplicates/util/ReadEndsForMarkDuplicatesCodec.java
@@ -28,7 +28,7 @@ import picard.PicardException;
 
 import java.io.*;
 
-/** Coded for ReadEnds that just outputs the primitive fields and reads them back. */
+/** Codec for ReadEnds that just outputs the primitive fields and reads them back. */
 public class ReadEndsForMarkDuplicatesCodec implements SortingCollection.Codec<ReadEndsForMarkDuplicates> {
     protected DataInputStream in;
     protected DataOutputStream out;

--- a/src/tests/java/picard/sam/markduplicates/QuerySortedMarkDuplicatesTest.java
+++ b/src/tests/java/picard/sam/markduplicates/QuerySortedMarkDuplicatesTest.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam.markduplicates;
+
+/**
+ * This is the testing class for the QuerySortedMarkDuplicates (it's the same CLP, only it
+ * takes a query-sorted bam as input.) The difference in the tests themselves is that
+ * supplementary and secondary reads will be marked the same as their primary alignments,
+ * and that unmapped reads with mapped mates will be marked according to their mapped mate.
+ */
+public class QuerySortedMarkDuplicatesTest extends MarkDuplicatesTest {
+
+    @Override
+    protected boolean markUnmappedRecordsLikeTheirMates() {
+        return true;
+    }
+
+    @Override
+    protected boolean markSecondaryAndSupplementaryRecordsLikeTheCanonical() { return true; }
+
+    @Override
+    protected AbstractMarkDuplicatesCommandLineProgramTester getTester() { return new QuerySortedMarkDuplicatesTester(); }
+}

--- a/src/tests/java/picard/sam/markduplicates/QuerySortedMarkDuplicatesTester.java
+++ b/src/tests/java/picard/sam/markduplicates/QuerySortedMarkDuplicatesTester.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam.markduplicates;
+
+import htsjdk.samtools.DuplicateScoringStrategy;
+import htsjdk.samtools.SAMFileHeader;
+import picard.cmdline.CommandLineProgram;
+
+/**
+ * This class is an extension of AbstractMarkDuplicatesCommandLineProgramTester used to test MarkDuplicates with SAM files generated on the fly.
+ * This performs the underlying tests defined by classes such as see AbstractMarkDuplicatesCommandLineProgramTest and MarkDuplicatesTest.
+ */
+public class QuerySortedMarkDuplicatesTester extends AbstractMarkDuplicatesCommandLineProgramTester {
+
+    public QuerySortedMarkDuplicatesTester() {
+        super(DuplicateScoringStrategy.ScoringStrategy.TOTAL_MAPPED_REFERENCE_LENGTH, SAMFileHeader.SortOrder.queryname);
+    }
+
+    @Override
+    protected CommandLineProgram getProgram() { return new MarkDuplicates(); }
+}


### PR DESCRIPTION
Additionally, if the input is query-sorted it will mark the supplementary and secondary reads in the same manner as their primary counter-parts (with the same query-name). Furthermore, in this case a unmapped read will be duplicate-marked as its mapped mate (assuming, it is mated of-course).

Some tests had to be changed slightly to accommodate for the different behaviors. Tests have been added to test for the expected functionality around supplementary and secondary reads (which was untested), in both query and coordinate-sorted inputs.

I think that it should be possible (and correct) to mark unmapped-records the same as their mapped mates even in coordinate-sorted inputs, but I will leave that for a future discussion.

**NOTE:**
This commit includes an API change regarding the CLP parameter ASSUME_SORTED. This boolean has been replaced with a SortOrder parameter name ASSUME_SORT_ORDER which defaults to null (making the default behavior the same). It enables the user to force either query-sort or coordinate-sort behavior.


