### PR TITLE
Moved calculation of values for %selected back to before filtering to unique reads.

### DIFF
--- a/src/java/picard/analysis/directed/TargetMetricsCollector.java
+++ b/src/java/picard/analysis/directed/TargetMetricsCollector.java
@@ -476,16 +476,9 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
                 }
             }
 
-            ///////////////////////////////////////////////////////////////////
-            // Duplicate reads can be totally ignored beyond this point
-            ///////////////////////////////////////////////////////////////////
-            if (record.getDuplicateReadFlag()) {
-                this.metrics.PCT_EXC_DUPE += basesAlignedInRecord;
-                return;
-            }
-
-            // Compute the bait-related metrics *before* applying the overlap clipping and
-            // the map-q threshold, since those would skew the assay-related metrics
+            // Compute the bait-related metrics *before* applying the duplicate read
+            // filtering, overlap clipping and the map-q threshold, since those would
+            // skew the assay-related metrics
             {
                 final int mappedBases = basesAlignedInRecord;
                 int onBaitBases = 0;
@@ -506,6 +499,14 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
                 } else {
                     this.metrics.OFF_PROBE_BASES += mappedBases;
                 }
+            }
+
+            ///////////////////////////////////////////////////////////////////
+            // Duplicate reads can be totally ignored beyond this point
+            ///////////////////////////////////////////////////////////////////
+            if (record.getDuplicateReadFlag()) {
+                this.metrics.PCT_EXC_DUPE += basesAlignedInRecord;
+                return;
             }
 
             ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Previously %selected was calculated over all reads, and in the changes introduced in or around e6d54be it was moved to be calculated on only unique reads.  For most experiments the values calculated on all reads and unique reads only are very similar.  However, for experiments at extremely deep coverage, and thus with very high on-target duplication, if the rate of duplicate off-target is sufficiently different the %selected values calculated on all reads vs. just unique reads can diverge quite dramatically.

This change restores the old behaviour of calculating on all reads, which I think is more correct in that it is a more accurate estimate of the fraction of molecules/sequencing reads that were _selected_ for, vs. those that are off-target.