### PR TITLE
Added an option to require a minimum read length after applying adapter clipping to reads.

### DIFF
--- a/src/java/picard/sam/SamToFastq.java
+++ b/src/java/picard/sam/SamToFastq.java
@@ -128,6 +128,11 @@ public class SamToFastq extends CommandLineProgram {
             "clipped region.", optional = true)
     public String CLIPPING_ACTION;
 
+    @Option(shortName = "CLIP_MIN", doc = "When performing clipping with the CLIPPING_ATTRIBUTE and CLIPPING_ACTION " +
+            "parameters, ensure that the resulting reads after clipping are at least CLIPPING_MIN_LENGTH bases long. " +
+            "If the original read is shorter than CLIPPING_MIN_LENGTH then the original read length will be maintained.")
+    public int CLIPPING_MIN_LENGTH = 0;
+
     @Option(shortName = "R1_TRIM", doc = "The number of bases to trim from the beginning of read 1.")
     public int READ1_TRIM = 0;
 
@@ -297,7 +302,11 @@ public class SamToFastq extends CommandLineProgram {
 
         // If we're clipping, do the right thing to the bases or qualities
         if (CLIPPING_ATTRIBUTE != null) {
-            final Integer clipPoint = (Integer) read.getAttribute(CLIPPING_ATTRIBUTE);
+            Integer clipPoint = (Integer) read.getAttribute(CLIPPING_ATTRIBUTE);
+            if (clipPoint != null && clipPoint < CLIPPING_MIN_LENGTH) {
+                clipPoint = Math.min(readString.length(), CLIPPING_MIN_LENGTH);
+            }
+
             if (clipPoint != null) {
                 if (CLIPPING_ACTION.equalsIgnoreCase("X")) {
                     readString = clip(readString, clipPoint, null, !read.getReadNegativeStrandFlag());


### PR DESCRIPTION
I've been running into problems where:
a) Some aligners (e.g. STAR) don't like having large strings of Ns at the ends of reads, and also don't like having adapter sequences present _unless_ you let them to the adapter trimming
b) Hard-clipping (using `CLIPPING_ACTION=N`) causes some arguably invalid fastq records to be omitted because the reads are being entirely clipped, so I get a header then a blank line, and that makes the aligner unhappy.

This change introduces an option (turned off to retain backward compatibility) to establish a minimum length to which to clip, that will preserve some minimum number of bases when doing adapter-based clipping in `SamToFastq`.