### PR TITLE
Issue and pull-request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,52 @@
+### Instructions
+
+- Use a **concise** yet **descriptive** title;
+- Determine whether your issue is a **bug report**, a **feature request**, or a **documentation request**;
+- Choose the corresponding template block below and fill it in, replacing or deleting text in italics (surrounded by `_`) as appropriate;
+- Delete the other template blocks and this header.
+
+----
+
+## Bug Report
+
+### Affected tool(s)
+_Tool name(s), special parameters?_
+
+### Affected version(s)
+- [ ] Latest public release version [version?]
+- [ ] Latest development/master branch as of [date of test?]
+
+### Description 
+_Describe the problem below. Provide **screenshots** , **stacktrace** , **logs** where appropriate._
+
+#### Steps to reproduce
+_Tell us how to reproduce this issue. If possible, include command lines that reproduce the problem and provide a minimal test case._
+
+#### Expected behavior
+_Tell us what should happen_
+
+#### Actual behavior
+_Tell us what happens instead_
+
+----
+
+## Feature request
+
+### Tool(s) involved
+_Tool name(s), special parameters?_
+
+### Description
+_Specify whether you want a modification of an existing behavior or addition of a new capability._
+_Provide **examples**, **screenshots**, where appropriate._
+
+----
+
+## Documentation request
+
+### Tool(s) involved
+_Tool name(s), parameters?_
+
+### Description 
+_Describe what needs to be added or modified._
+
+----

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+### Description
+
+_Give your PR a **concise** yet **descriptive** title_
+_Please explain the changes you made here._
+_Explain the **motivation** for making this change. What existing problem does the pull request solve?_
+_Mention any issues fixed, addressed or otherwise related to this pull request, including issue numbers or hard links for issues in other repos._
+_You can delete these instructions once you have written your PR description._
+
+----
+
+### Checklist (never delete this)
+
+Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.
+
+#### Content
+- [ ] Added or modified tests to cover changes and any new functionality
+- [ ] Edited the README / documentation (if applicable)
+- [ ] All tests passing on Travis
+
+#### Review
+- [ ] Final thumbs-up from reviewer
+- [ ] Rebase, squash and reword as applicable
+
+For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests
+


### PR DESCRIPTION
This adds github templates to help ensure that new issues and pull request messages are informative and requirements for merging are clearer. These templates are modeled after those used in htsjdk and gsa-unstable, which are already proving quite helpful.
