### PR TITLE
Fix typo in log.warn in EstimateLibraryComplexity

### DIFF
--- a/src/java/picard/sam/markduplicates/EstimateLibraryComplexity.java
+++ b/src/java/picard/sam/markduplicates/EstimateLibraryComplexity.java
@@ -506,7 +506,7 @@ public class EstimateLibraryComplexity extends AbstractOpticalDuplicateFinderCom
                         "Mean=" + meanGroupSize + ", Actual=" + group.size() + ". Prefixes: " +
                         StringUtil.bytesToString(prs.read1, 0, MIN_IDENTICAL_BASES) +
                         " / " +
-                        StringUtil.bytesToString(prs.read1, 0, MIN_IDENTICAL_BASES));
+                        StringUtil.bytesToString(prs.read2, 0, MIN_IDENTICAL_BASES));
             } else {
                 final Map<String, List<PairedReadSequence>> sequencesByLibrary = splitByLibrary(group, readGroups);
 


### PR DESCRIPTION
Fix log.warn when omitting group because of group size exceeds expected mean number of read pairs.
It outputs prs.read1 twice instead of prs.read1 and prs.read2.