### PR TITLE
Fix null library name problem in LibraryIdGenerator constructor

### DIFF
--- a/src/java/picard/sam/markduplicates/MarkDuplicatesWithMateCigarIterator.java
+++ b/src/java/picard/sam/markduplicates/MarkDuplicatesWithMateCigarIterator.java
@@ -143,7 +143,7 @@ public class MarkDuplicatesWithMateCigarIterator implements SAMRecordIterator {
 
         // set up metrics
         for (final SAMReadGroupRecord readGroup : header.getReadGroups()) {
-            final String library = readGroup.getLibrary();
+            final String library = LibraryIdGenerator.getReadGroupLibraryName(readGroup);
             DuplicationMetrics metrics = libraryIdGenerator.getMetricsByLibrary(library);
             if (metrics == null) {
                 metrics = new DuplicationMetrics();

--- a/src/java/picard/sam/markduplicates/util/LibraryIdGenerator.java
+++ b/src/java/picard/sam/markduplicates/util/LibraryIdGenerator.java
@@ -32,6 +32,7 @@ import picard.sam.DuplicationMetrics;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * A class to generate library Ids and keep duplication metrics by library IDs.
@@ -40,6 +41,8 @@ import java.util.Map;
  */
 public class LibraryIdGenerator {
 
+    private static final String UNKNOWN_LIBRARY = "Unknown Library";
+   
     private final SAMFileHeader header;
     private final Map<String, Short> libraryIds = new HashMap<String, Short>(); // from library string to library id
     private short nextLibraryId = 1;
@@ -51,7 +54,7 @@ public class LibraryIdGenerator {
         this.header = header;
 
         for (final SAMReadGroupRecord readGroup : header.getReadGroups()) {
-            final String library = readGroup.getLibrary();
+            final String library = LibraryIdGenerator.getReadGroupLibraryName(readGroup);
             DuplicationMetrics metrics = metricsByLibrary.get(library);
             if (metrics == null) {
                 metrics = new DuplicationMetrics();
@@ -67,6 +70,11 @@ public class LibraryIdGenerator {
 
     public Histogram<Short> getOpticalDuplicatesByLibraryIdMap() { return this.opticalDuplicatesByLibraryId; }
 
+	public static String getReadGroupLibraryName(SAMReadGroupRecord readGroup) {
+		return Optional.ofNullable(readGroup.getLibrary())
+				.orElse(UNKNOWN_LIBRARY);
+	}
+   
     /**
      * Gets the library name from the header for the record. If the RG tag is not present on
      * the record, or the library isn't denoted on the read group, a constant string is
@@ -83,7 +91,7 @@ public class LibraryIdGenerator {
             }
         }
 
-        return "Unknown Library";
+        return UNKNOWN_LIBRARY;
     }
 
     /** Get the library ID for the given SAM record. */

--- a/src/tests/java/picard/sam/markduplicates/AbstractMarkDuplicatesCommandLineProgramTester.java
+++ b/src/tests/java/picard/sam/markduplicates/AbstractMarkDuplicatesCommandLineProgramTester.java
@@ -150,8 +150,8 @@ abstract public class AbstractMarkDuplicatesCommandLineProgramTester extends Sam
             catch (final FileNotFoundException ex) {
                 System.err.println("Metrics file not found: " + ex);
             }
-            // NB: Test writes an initial metrics line with a null entry for LIBRARY and 0 values for all metrics. Why?
-            final DuplicationMetrics observedMetrics = metricsOutput.getMetrics().get(metricsOutput.getMetrics().size() - 1);
+            Assert.assertEquals(metricsOutput.getMetrics().size(), 1);
+            final DuplicationMetrics observedMetrics = metricsOutput.getMetrics().get(0);
             Assert.assertEquals(observedMetrics.UNPAIRED_READS_EXAMINED, expectedMetrics.UNPAIRED_READS_EXAMINED, "UNPAIRED_READS_EXAMINED does not match expected");
             Assert.assertEquals(observedMetrics.READ_PAIRS_EXAMINED, expectedMetrics.READ_PAIRS_EXAMINED, "READ_PAIRS_EXAMINED does not match expected");
             Assert.assertEquals(observedMetrics.UNMAPPED_READS, expectedMetrics.UNMAPPED_READS, "UNMAPPED_READS does not match expected");


### PR DESCRIPTION
There are cases when there is header with no libraryName. For example:

```
@HD VN:1.0  SO:coordinate
@SQ SN:chr1 LN:101
@SQ SN:chr2 LN:101
@SQ SN:chr3 LN:101
@SQ SN:chr4 LN:101
@SQ SN:chr5 LN:101
@SQ SN:chr6 LN:101
@SQ SN:chr7 LN:404
@SQ SN:chr8 LN:202
@RG ID:1AAXX.1  SM:Hi,Mom!  PL:ILLUMINA
@PG ID:MarkDuplicates   PN:MarkDuplicates   VN:1    CL:MarkDuplicates merge1.sam    PP:bwa
@PG ID:bwa  PN:bwa  VN:1    CL:bwa aln
```
In such situations picard.sam.markduplicates.util.LibraryIdGenerator constructor creates new DuplicationMetrics and puts it to metricsByLibrary Map by key null.  But when MarkDuplicates works it uses getLibraryName method that returns not null but "Unknown Library" value. As a result, when picard.sam.markduplicates.util.AbstractMarkDuplicatesCommandLineProgram::finalizeAndWriteMetrics method is called, there are 2 metrics by library in libraryIdGenerator: first id is null and it's empty, second is "Unknown Library" with some data. So in that case metric by unknown library and histogram will not be shown in metrics file.

The proposed fix uses "Unknown Library" instead of null String for library name.