### PR TITLE
Added a new CLP which will traverse a sorted sam/bam and fix the UQ and NM tags

### DIFF
--- a/src/java/picard/sam/AbstractAlignmentMerger.java
+++ b/src/java/picard/sam/AbstractAlignmentMerger.java
@@ -496,12 +496,12 @@ public abstract class AbstractAlignmentMerger {
      *
      * @param record the record to be fixed
      * @param refSeqWalker a ReferenceSequenceWalker that will be used to traverse the reference
-     * @param isBisulfiteSequence a flagg indicating if the sequence cam from bisulfite-Sequencing which would imply a different
+     * @param isBisulfiteSequence a flag indicating whether the sequence came from bisulfite-sequencing which would imply a different
      * calculation of the NM tag.
      *
      * No return value, modifies the provided record.
      */
-    static public void fixNMandUQ(final SAMRecord record, final ReferenceSequenceFileWalker refSeqWalker, final boolean isBisulfiteSequence){
+    public static void fixNMandUQ(final SAMRecord record, final ReferenceSequenceFileWalker refSeqWalker, final boolean isBisulfiteSequence) {
         final byte[] referenceBases = refSeqWalker.get(refSeqWalker.getSequenceDictionary().getSequenceIndex(record.getReferenceName())).getBases();
         record.setAttribute(SAMTag.NM.name(), SequenceUtil.calculateSamNmTag(record, referenceBases, 0, isBisulfiteSequence));
 

--- a/src/java/picard/sam/AbstractAlignmentMerger.java
+++ b/src/java/picard/sam/AbstractAlignmentMerger.java
@@ -478,12 +478,7 @@ public abstract class AbstractAlignmentMerger {
             for (final SAMRecord rec : sink.sorter) {
                 if (!rec.getReadUnmappedFlag()) {
                     if (refSeq != null) {
-                        final byte[] referenceBases = refSeq.get(sequenceDictionary.getSequenceIndex(rec.getReferenceName())).getBases();
-                        rec.setAttribute(SAMTag.NM.name(), SequenceUtil.calculateSamNmTag(rec, referenceBases, 0, bisulfiteSequence));
-
-                        if (rec.getBaseQualities() != SAMRecord.NULL_QUALS) {
-                            rec.setAttribute(SAMTag.UQ.name(), SequenceUtil.sumQualitiesOfMismatches(rec, referenceBases, 0, bisulfiteSequence));
-                        }
+                        fixNMandUQ(rec, refSeq, bisulfiteSequence);
                     }
                 }
                 writer.addAlignment(rec);
@@ -495,6 +490,24 @@ public abstract class AbstractAlignmentMerger {
 
         CloserUtil.close(unmappedSam);
         log.info("Wrote " + aligned + " alignment records and " + (alignedReadsOnly ? 0 : unmapped) + " unmapped reads.");
+    }
+
+    /** Recalculate and sets the NM and UQ tags from the record and the reference
+     *
+     * @param record the record to be fixed
+     * @param refSeqWalker a ReferenceSequenceWalker that will be used to traverse the reference
+     * @param isBisulfiteSequence a flagg indicating if the sequence cam from bisulfite-Sequencing which would imply a different
+     * calculation of the NM tag.
+     *
+     * No return value, modifies the provided record.
+     */
+    static public void fixNMandUQ(final SAMRecord record, final ReferenceSequenceFileWalker refSeqWalker, final boolean isBisulfiteSequence){
+        final byte[] referenceBases = refSeqWalker.get(refSeqWalker.getSequenceDictionary().getSequenceIndex(record.getReferenceName())).getBases();
+        record.setAttribute(SAMTag.NM.name(), SequenceUtil.calculateSamNmTag(record, referenceBases, 0, isBisulfiteSequence));
+
+        if (record.getBaseQualities() != SAMRecord.NULL_QUALS) {
+            record.setAttribute(SAMTag.UQ.name(), SequenceUtil.sumQualitiesOfMismatches(record, referenceBases, 0, isBisulfiteSequence));
+        }
     }
 
     /**

--- a/src/java/picard/sam/FixNmAndUqTags.java
+++ b/src/java/picard/sam/FixNmAndUqTags.java
@@ -60,8 +60,8 @@ public class FixNmAndUqTags extends CommandLineProgram {
             "<h4>Usage example:</h4>" +
             "<pre>" +
             "java -jar picard.jar FixNmAndUqTags \\<br />" +
-            "      I=input.bam \\<br />" +
-            "      O=sorted.bam \\<br />"+
+            "      I=sorted.bam \\<br />" +
+            "      O=fixed.bam \\<br />"+
             "</pre>" +
             "<hr />";
     @Option(doc = "The BAM or SAM file to fix.", shortName = StandardOptionDefinitions.INPUT_SHORT_NAME)
@@ -96,13 +96,13 @@ public class FixNmAndUqTags extends CommandLineProgram {
         IOUtil.assertFileIsWritable(OUTPUT);
         final SamReader reader = SamReaderFactory.makeDefault().referenceSequence(REFERENCE_SEQUENCE).open(INPUT);
 
-        if( !ASSUME_SORTED && reader.getFileHeader().getSortOrder() != SAMFileHeader.SortOrder.coordinate) {
+        if (!ASSUME_SORTED && reader.getFileHeader().getSortOrder() != SAMFileHeader.SortOrder.coordinate) {
             throw new SAMException("Input must be coordinate-sorted, or ASSUME_SORTED must be true.");
         }
-        if( ASSUME_SORTED && reader.getFileHeader().getSortOrder() != SAMFileHeader.SortOrder.coordinate) {
+        if (ASSUME_SORTED && reader.getFileHeader().getSortOrder() != SAMFileHeader.SortOrder.coordinate) {
             log.warn("File indicates sort-order " + reader.getFileHeader().getSortOrder() + " but ASSUME_SORTED is true, so continuing.");
         }
-        reader.getFileHeader().setSortOrder(SAMFileHeader.SortOrder.coordinate);
+
         final SAMFileWriter writer = new SAMFileWriterFactory().makeSAMOrBAMWriter(reader.getFileHeader(), true, OUTPUT);
         writer.setProgressLogger(
                 new ProgressLogger(log, (int) 1e7, "Wrote", "records"));

--- a/src/java/picard/sam/FixNmAndUqTags.java
+++ b/src/java/picard/sam/FixNmAndUqTags.java
@@ -1,0 +1,123 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package picard.sam;
+
+import htsjdk.samtools.SAMException;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.reference.ReferenceSequenceFileWalker;
+import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Log;
+import htsjdk.samtools.util.ProgressLogger;
+import picard.cmdline.CommandLineProgram;
+import picard.cmdline.CommandLineProgramProperties;
+import picard.cmdline.Option;
+import picard.cmdline.StandardOptionDefinitions;
+import picard.cmdline.programgroups.SamOrBam;
+
+import java.io.File;
+
+/**
+ * @author Yossi Farjoun
+ */
+@CommandLineProgramProperties(
+        usage = FixNmAndUqTags.USAGE_SUMMARY + FixNmAndUqTags.USAGE_DETAILS,
+        usageShort = FixNmAndUqTags.USAGE_SUMMARY,
+        programGroup = SamOrBam.class
+)
+public class FixNmAndUqTags extends CommandLineProgram {
+    static final String USAGE_SUMMARY = "Fixes the UQ and NM tags in a SAM file.  ";
+    static final String USAGE_DETAILS = "This tool takes in a SAM or BAM file (sorted by coordinate) and calculates the NM and UQ tags by comparing with the reference."+
+            "<br />" +
+                    "This may be needed when MergeBamAlignment was run with SORT_ORDER different from 'coordinate' and thus could not fix\n"+
+                    "these tags then.<br />"+
+            "<h4>Usage example:</h4>" +
+            "<pre>" +
+            "java -jar picard.jar FixNmAndUqTags \\<br />" +
+            "      I=input.bam \\<br />" +
+            "      O=sorted.bam \\<br />"+
+            "</pre>" +
+            "<hr />";
+    @Option(doc = "The BAM or SAM file to fix.", shortName = StandardOptionDefinitions.INPUT_SHORT_NAME)
+    public File INPUT;
+
+    @Option(doc = "The fixed BAM or SAM output file. ", shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME)
+    public File OUTPUT;
+
+    @Option(doc = "If true, assume that the input files are in the same sort order as the requested output sort order, even if their headers say otherwise.",
+            shortName = StandardOptionDefinitions.ASSUME_SORTED_SHORT_NAME)
+    public boolean ASSUME_SORTED = false;
+
+    @Option(doc = "Whether the file contains bisulfite sequence (used when calculating the NM tag).")
+    public boolean IS_BISULFITE_SEQUENCE = false;
+
+    @Override
+    protected String[] customCommandLineValidation() {
+        if (REFERENCE_SEQUENCE == null)
+            return new String[]
+                    {"Must have a non-null REFERENCE_SEQUENCE"};
+        return super.customCommandLineValidation();
+    }
+
+    private final Log log = Log.getInstance(FixNmAndUqTags.class);
+
+    public static void main(final String[] argv) {
+        new FixNmAndUqTags().instanceMainWithExit(argv);
+    }
+
+    protected int doWork() {
+        IOUtil.assertFileIsReadable(INPUT);
+        IOUtil.assertFileIsWritable(OUTPUT);
+        final SamReader reader = SamReaderFactory.makeDefault().referenceSequence(REFERENCE_SEQUENCE).open(INPUT);
+
+        if( !ASSUME_SORTED && reader.getFileHeader().getSortOrder() != SAMFileHeader.SortOrder.coordinate) {
+            throw new SAMException("Input must be coordinate-sorted, or ASSUME_SORTED must be true.");
+        }
+        if( ASSUME_SORTED && reader.getFileHeader().getSortOrder() != SAMFileHeader.SortOrder.coordinate) {
+            log.warn("File indicates sort-order " + reader.getFileHeader().getSortOrder() + " but ASSUME_SORTED is true, so continuing.");
+        }
+        reader.getFileHeader().setSortOrder(SAMFileHeader.SortOrder.coordinate);
+        final SAMFileWriter writer = new SAMFileWriterFactory().makeSAMOrBAMWriter(reader.getFileHeader(), true, OUTPUT);
+        writer.setProgressLogger(
+                new ProgressLogger(log, (int) 1e7, "Wrote", "records"));
+
+        final ReferenceSequenceFileWalker refSeq = new ReferenceSequenceFileWalker(REFERENCE_SEQUENCE);
+
+        for (final SAMRecord rec : reader) {
+            if (!rec.getReadUnmappedFlag()) {
+                AbstractAlignmentMerger.fixNMandUQ(rec, refSeq, IS_BISULFITE_SEQUENCE);
+            }
+            writer.addAlignment(rec);
+        }
+
+        CloserUtil.close(reader);
+        writer.close();
+        return 0;
+    }
+}

--- a/src/java/picard/sam/SamAlignmentMerger.java
+++ b/src/java/picard/sam/SamAlignmentMerger.java
@@ -67,6 +67,8 @@ public class SamAlignmentMerger extends AbstractAlignmentMerger {
      *                                          alignment.  Alignments with more than this many gaps will be ignored.
      *                                          -1 means to allow any number of gaps.
      * @param attributesToRetain                attributes from the alignment record that should be
+     *                                          removed when merging.
+     * @param attributesToRemove                attributes from the alignment record that should be
      *                                          removed when merging.  This overrides attributesToRetain if they share
      *                                          common tags.
      * @param read1BasesTrimmed                 The number of bases trimmed from start of read 1 prior to alignment.  Optional.

--- a/src/tests/java/picard/sam/FixNmAndUqTagsTest.java
+++ b/src/tests/java/picard/sam/FixNmAndUqTagsTest.java
@@ -1,0 +1,73 @@
+package picard.sam;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Created by farjoun on 4/14/16.
+ */
+public class FixNmAndUqTagsTest {
+
+    private static final File fasta = new File("testdata/picard/sam/merger.fasta");
+    @DataProvider(name="filesToFix")
+    Object[][] TestValidSortData() {
+        return new Object[][]{
+                new Object[]{new File("testdata/picard/sam/aligned.sam"), fasta},
+                new Object[]{new File("testdata/picard/sam/aligned_queryname_sorted.sam"), fasta},
+                new Object[]{new File("testdata/picard/sam/aligned_queryname_sorted.sam"), fasta},
+        };
+    }
+
+    @Test(dataProvider = "filesToFix")
+    public void TestValidSort(final File input, final File reference) throws IOException {
+        final File sortOutput = File.createTempFile("Sort", ".bam");
+        sortOutput.deleteOnExit();
+        final File fixOutput = File.createTempFile("Fix", ".bam");
+        fixOutput.deleteOnExit();
+        final File validateOutput = File.createTempFile("Sort", ".validation_report");
+        validateOutput.deleteOnExit();
+
+        sort(input, sortOutput);
+        fixFile(sortOutput, fixOutput, reference);
+        validate(fixOutput,validateOutput, reference);
+    }
+
+    private void validate(final File input, final File output, final File reference) {
+
+        final String[] args = new String[] {
+                "INPUT="+input,
+                "OUTPUT="+output,
+                "MODE=VERBOSE",
+                "REFERENCE_SEQUENCE="+reference };
+
+        ValidateSamFile validateSam = new ValidateSamFile();
+        Assert.assertEquals(validateSam.instanceMain(args), 0, "validate did not succeed");
+    }
+
+    private void sort(final File input, final File output) {
+
+        final String[] args = new String[] {
+                "INPUT=" + input,
+                "OUTPUT=" + output,
+                "SORT_ORDER=coordinate"
+               };
+
+        SortSam sortSam = new SortSam();
+        Assert.assertEquals(sortSam.instanceMain(args), 0, "Sort did not succeed");
+    }
+
+    private void fixFile(final File input, final File output, final File reference) throws IOException {
+
+        final String[] args = new String[] {
+                "INPUT="+input,
+                "OUTPUT="+output,
+                "REFERENCE_SEQUENCE="+reference };
+
+        FixNmAndUqTags fixNmAndUqTags = new FixNmAndUqTags();
+        Assert.assertEquals(fixNmAndUqTags.instanceMain(args), 0, "Fix did not succeed");
+    }
+}


### PR DESCRIPTION
It does it in the same way that MergeBamAlignment does. Since MergeBamAlignment does not update the UQ and NM tags when the output is not set to 'coordinate', this allows setting these tags further downstream once the data is sorted.

- [x] documented
- [x] tested
- [x] tests pass
- [ ] reviewed