### PR TITLE
addressing review comments for yf_add_CLP_FixNmAndUqTags 

### DIFF
--- a/src/java/picard/sam/AbstractAlignmentMerger.java
+++ b/src/java/picard/sam/AbstractAlignmentMerger.java
@@ -492,7 +492,7 @@ public abstract class AbstractAlignmentMerger {
         log.info("Wrote " + aligned + " alignment records and " + (alignedReadsOnly ? 0 : unmapped) + " unmapped reads.");
     }
 
-    /** Recalculate and sets the NM and UQ tags from the record and the reference
+    /** Calculates and sets the NM and UQ tags from the record and the reference
      *
      * @param record the record to be fixed
      * @param refSeqWalker a ReferenceSequenceWalker that will be used to traverse the reference

--- a/src/java/picard/sam/SamAlignmentMerger.java
+++ b/src/java/picard/sam/SamAlignmentMerger.java
@@ -67,7 +67,8 @@ public class SamAlignmentMerger extends AbstractAlignmentMerger {
      *                                          alignment.  Alignments with more than this many gaps will be ignored.
      *                                          -1 means to allow any number of gaps.
      * @param attributesToRetain                attributes from the alignment record that should be
-     *                                          removed when merging.
+     *                                          retained when merging, overridden by attributesToRemove if they share
+     *                                          common tags.
      * @param attributesToRemove                attributes from the alignment record that should be
      *                                          removed when merging.  This overrides attributesToRetain if they share
      *                                          common tags.

--- a/src/java/picard/sam/SetNmAndUqTags.java
+++ b/src/java/picard/sam/SetNmAndUqTags.java
@@ -71,10 +71,6 @@ public class SetNmAndUqTags extends CommandLineProgram {
     @Option(doc = "The fixed BAM or SAM output file. ", shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME)
     public File OUTPUT;
 
-    @Option(doc = "If true, assume that the input files are in the same sort order as the requested output sort order, even if their headers say otherwise.",
-            shortName = StandardOptionDefinitions.ASSUME_SORTED_SHORT_NAME)
-    public boolean ASSUME_SORTED = false;
-
     @Option(doc = "Whether the file contains bisulfite sequence (used when calculating the NM tag).")
     public boolean IS_BISULFITE_SEQUENCE = false;
 
@@ -97,11 +93,8 @@ public class SetNmAndUqTags extends CommandLineProgram {
         IOUtil.assertFileIsWritable(OUTPUT);
         final SamReader reader = SamReaderFactory.makeDefault().referenceSequence(REFERENCE_SEQUENCE).open(INPUT);
 
-        if (!ASSUME_SORTED && reader.getFileHeader().getSortOrder() != SAMFileHeader.SortOrder.coordinate) {
-            throw new SAMException("Input must be coordinate-sorted, or ASSUME_SORTED must be true.");
-        }
-        if (ASSUME_SORTED && reader.getFileHeader().getSortOrder() != SAMFileHeader.SortOrder.coordinate) {
-            log.warn("File indicates sort-order " + reader.getFileHeader().getSortOrder() + " but ASSUME_SORTED is true, so continuing.");
+        if (reader.getFileHeader().getSortOrder() != SAMFileHeader.SortOrder.coordinate) {
+            throw new SAMException("Input must be coordinate-sorted for this program to run. Found: " + reader.getFileHeader().getSortOrder());
         }
 
         final SAMFileWriter writer = new SAMFileWriterFactory().makeSAMOrBAMWriter(reader.getFileHeader(), true, OUTPUT);

--- a/src/java/picard/sam/SetNmAndUqTags.java
+++ b/src/java/picard/sam/SetNmAndUqTags.java
@@ -42,16 +42,17 @@ import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.programgroups.SamOrBam;
 
 import java.io.File;
+import java.util.stream.StreamSupport;
 
 /**
  * @author Yossi Farjoun
  */
 @CommandLineProgramProperties(
-        usage = FixNmAndUqTags.USAGE_SUMMARY + FixNmAndUqTags.USAGE_DETAILS,
-        usageShort = FixNmAndUqTags.USAGE_SUMMARY,
+        usage = SetNmAndUqTags.USAGE_SUMMARY + SetNmAndUqTags.USAGE_DETAILS,
+        usageShort = SetNmAndUqTags.USAGE_SUMMARY,
         programGroup = SamOrBam.class
 )
-public class FixNmAndUqTags extends CommandLineProgram {
+public class SetNmAndUqTags extends CommandLineProgram {
     static final String USAGE_SUMMARY = "Fixes the UQ and NM tags in a SAM file.  ";
     static final String USAGE_DETAILS = "This tool takes in a SAM or BAM file (sorted by coordinate) and calculates the NM and UQ tags by comparing with the reference."+
             "<br />" +
@@ -59,7 +60,7 @@ public class FixNmAndUqTags extends CommandLineProgram {
                     "these tags then.<br />"+
             "<h4>Usage example:</h4>" +
             "<pre>" +
-            "java -jar picard.jar FixNmAndUqTags \\<br />" +
+            "java -jar picard.jar SetNmAndUqTags \\<br />" +
             "      I=sorted.bam \\<br />" +
             "      O=fixed.bam \\<br />"+
             "</pre>" +
@@ -79,16 +80,16 @@ public class FixNmAndUqTags extends CommandLineProgram {
 
     @Override
     protected String[] customCommandLineValidation() {
-        if (REFERENCE_SEQUENCE == null)
-            return new String[]
-                    {"Must have a non-null REFERENCE_SEQUENCE"};
+        if (REFERENCE_SEQUENCE == null) {
+            return new String[]{"Must have a non-null REFERENCE_SEQUENCE"};
+        }
         return super.customCommandLineValidation();
     }
 
-    private final Log log = Log.getInstance(FixNmAndUqTags.class);
+    private final Log log = Log.getInstance(SetNmAndUqTags.class);
 
     public static void main(final String[] argv) {
-        new FixNmAndUqTags().instanceMainWithExit(argv);
+        new SetNmAndUqTags().instanceMainWithExit(argv);
     }
 
     protected int doWork() {
@@ -109,12 +110,9 @@ public class FixNmAndUqTags extends CommandLineProgram {
 
         final ReferenceSequenceFileWalker refSeq = new ReferenceSequenceFileWalker(REFERENCE_SEQUENCE);
 
-        for (final SAMRecord rec : reader) {
-            if (!rec.getReadUnmappedFlag()) {
-                AbstractAlignmentMerger.fixNMandUQ(rec, refSeq, IS_BISULFITE_SEQUENCE);
-            }
-            writer.addAlignment(rec);
-        }
+       StreamSupport.stream(reader.spliterator(),false)
+                .peek(rec->{if(!rec.getReadUnmappedFlag()) AbstractAlignmentMerger.fixNMandUQ(rec, refSeq, IS_BISULFITE_SEQUENCE);})
+                .forEach(writer::addAlignment);
 
         CloserUtil.close(reader);
         writer.close();

--- a/src/tests/java/picard/sam/SetNmAndUqTagsTest.java
+++ b/src/tests/java/picard/sam/SetNmAndUqTagsTest.java
@@ -7,10 +7,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 
-/**
- * Created by farjoun on 4/14/16.
- */
-public class FixNmAndUqTagsTest {
+public class SetNmAndUqTagsTest {
 
     private static final File fasta = new File("testdata/picard/sam/merger.fasta");
     @DataProvider(name="filesToFix")
@@ -67,7 +64,7 @@ public class FixNmAndUqTagsTest {
                 "OUTPUT="+output,
                 "REFERENCE_SEQUENCE="+reference };
 
-        FixNmAndUqTags fixNmAndUqTags = new FixNmAndUqTags();
-        Assert.assertEquals(fixNmAndUqTags.instanceMain(args), 0, "Fix did not succeed");
+        SetNmAndUqTags setNmAndUqTags = new SetNmAndUqTags();
+        Assert.assertEquals(setNmAndUqTags.instanceMain(args), 0, "Fix did not succeed");
     }
 }


### PR DESCRIPTION
I merged yf_add_CLP_FixNmAndUqTags too quickly and failed to incorporate some reviewer comments.

@nh13:  Sorry about that. I'm addressing your comments here.
I didn't change the issue regarding the sort order because I think that if the input file is valid then the output should be valid...please correct me if I'm missing something. I agree that if the input has "coordinate" in the header, but is not actually sorted, then it will fail...but that's true for other programs too, no?