### PR TITLE
Fix an error with too many open files for Multi-Tile BCLs.

### DIFF
--- a/src/java/picard/illumina/parser/MultiTileBclParser.java
+++ b/src/java/picard/illumina/parser/MultiTileBclParser.java
@@ -66,6 +66,12 @@ public class MultiTileBclParser extends BclParser {
     }
 
     @Override
+    protected CycleFilesParser<BclData> makeCycleFileParser(final List<File> files, final CycleFilesParser<BclData> cycleFilesParser) {
+        // NB: do not close the underlying reader like the parent does just yet.
+        return makeCycleFileParser(files);
+    }
+
+    @Override
     protected CycleFilesParser<BclData> makeCycleFileParser(final List<File> files) {
         if (cycleFileParser == null) {
             cycleFileParser = new MultiTileBclDataCycleFileParser(files, currentTile);
@@ -97,7 +103,7 @@ public class MultiTileBclParser extends BclParser {
 
         @Override
         public void close() {
-            //underlyingIterator.close();
+            underlyingIterator.close();
         }
 
         @Override


### PR DESCRIPTION
Please do not merge yet, as the real-world test case is in progress, but reviews are welcome (@jacarey).

### Description

When `PerTileCycleParser` seeks to a tile, it would call `close()` on the
underlying `cycleFilesParser`, which is fine if the parser parses only a
single tile.  When seeking to a new tile with `MultiTileBclParser`, we
want to re-use the underlying `cycleFileParser`, so the `close()` call on the
underlying iterator was commented out.  This leads to an error with "too
many open files", even when setting `ulimit` to 800K files.

The solution is to only call close on the underlying iterator if the
base class' (`PerTileCycleParser`) `close()` method was called, not when the
`seekToTile()` method is called.

### Checklist

- [x] Code compiles correctly
- [x] All tests passing
- [ ] Failing real-world test case now succeeds.