### PR TITLE
fixed number of bases in output (missing a + sign)

### DIFF
--- a/src/java/picard/util/IntervalListTools.java
+++ b/src/java/picard/util/IntervalListTools.java
@@ -268,7 +268,7 @@ public class IntervalListTools extends CommandLineProgram {
         long totalUniqueBaseCount = 0;
         long intervalCount = 0;
         for (final IntervalList finalInterval : resultIntervals) {
-            totalUniqueBaseCount = finalInterval.getUniqueBaseCount();
+            totalUniqueBaseCount += finalInterval.getUniqueBaseCount();
             intervalCount += finalInterval.size();    
         }
 


### PR DESCRIPTION
In the log message, in the end of the run, when scattering to multiple files, the total number of bases was actually the number of bases in the last intervalList.

There is no test for this since we rarely (if ever?) test the log output values. The CLP produced correct output, just incorrect log-message.