### PR TITLE
Allow sbt TestNG plugin to be resolved on systems that don't have it cached already

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ import com.typesafe.sbt.SbtGit._
 import de.johoop.testngplugin.TestNGPlugin._
 import sbt.Package.ManifestAttributes
 
+resolvers += Resolver.sbtPluginRepo("releases")
+
 name := "picard"
 
 version := "2.4.1"


### PR DESCRIPTION
I found this change necessary in order to do a successful sbt release.
See the discussion at https://github.com/sbt/sbt-testng-interface/issues/9