### PR TITLE
Converted VariantCallingMetrics to using mergableMetricsBase 

### DIFF
--- a/src/main/java/picard/analysis/MergeableMetricBase.java
+++ b/src/main/java/picard/analysis/MergeableMetricBase.java
@@ -219,9 +219,9 @@ abstract public class MergeableMetricBase extends MetricBase {
     }
 
     private static List<Field> getAllFields(Class clazz){
-        List<Field> fields = new ArrayList<>();
+        final List<Field> fields = new ArrayList<>();
         fields.addAll(Arrays.asList(clazz.getDeclaredFields()));
-        Class superClass = clazz.getSuperclass();
+        final Class superClass = clazz.getSuperclass();
 
         if (superClass != null) fields.addAll(getAllFields(superClass));
 

--- a/src/main/java/picard/sam/MergeBamAlignment.java
+++ b/src/main/java/picard/sam/MergeBamAlignment.java
@@ -134,7 +134,7 @@ public class MergeBamAlignment extends CommandLineProgram {
     @Option(doc = "Whether to clip adapters where identified.")
     public boolean CLIP_ADAPTERS = true;
 
-    @Option(doc = "Whether the lane is bisulfite sequence (used when caculating the NM tag).")
+    @Option(doc = "Whether the lane is bisulfite sequence (used when calculating the NM tag).")
     public boolean IS_BISULFITE_SEQUENCE = false;
 
     @Option(doc = "Whether to output only aligned reads.  ")
@@ -148,11 +148,11 @@ public class MergeBamAlignment extends CommandLineProgram {
 
     @Option(doc = "Reserved alignment attributes (tags starting with X, Y, or Z) that should be " +
             "brought over from the alignment data when merging.")
-    public List<String> ATTRIBUTES_TO_RETAIN = new ArrayList<String>();
+    public List<String> ATTRIBUTES_TO_RETAIN = new ArrayList<>();
 
     @Option(doc = "Attributes from the alignment record that should be removed when merging." +
             "  This overrides ATTRIBUTES_TO_RETAIN if they share common tags.")
-    public List<String> ATTRIBUTES_TO_REMOVE = new ArrayList<String>();
+    public List<String> ATTRIBUTES_TO_REMOVE = new ArrayList<>();
 
     @Option(shortName="RV", doc="Attributes on negative strand reads that need to be reversed.")
     public Set<String> ATTRIBUTES_TO_REVERSE = new TreeSet<>(SAMRecord.TAGS_TO_REVERSE);

--- a/src/main/java/picard/vcf/CallingMetricAccumulator.java
+++ b/src/main/java/picard/vcf/CallingMetricAccumulator.java
@@ -76,10 +76,12 @@ public class CallingMetricAccumulator implements VariantProcessor.Accumulator<Ca
                 final VariantCallingDetailMetrics collapsed = new VariantCallingDetailMetrics();
                 VariantCallingDetailMetrics.foldInto(collapsed, sampleDetails);
                 collapsedDetails.add(collapsed);
+                collapsed.calculateDerivedFields();
             });
 
             final VariantCallingSummaryMetrics collapsedSummary = new VariantCallingSummaryMetrics();
             VariantCallingSummaryMetrics.foldInto(collapsedSummary, summaries);
+            collapsedSummary.calculateDerivedFields();
 
             return new Result(collapsedSummary, collapsedDetails);
         }

--- a/src/main/java/picard/vcf/CallingMetricAccumulator.java
+++ b/src/main/java/picard/vcf/CallingMetricAccumulator.java
@@ -157,9 +157,9 @@ public class CallingMetricAccumulator implements VariantProcessor.Accumulator<Ca
 
     public Result result() {
         final Collection<VariantCallingDetailMetrics> values = sampleMetricsMap.values();
-        values.forEach(CollectVariantCallingMetrics.VariantCallingDetailMetrics::updateDerivedValuesInPlace);
+        values.forEach(CollectVariantCallingMetrics.VariantCallingDetailMetrics::calculateDerivedFields);
 
-        summaryMetric.updateDerivedValuesInPlace();
+        summaryMetric.calculateDerivedFields();
         return new Result(summaryMetric, values);
     }
 

--- a/src/main/java/picard/vcf/CollectVariantCallingMetrics.java
+++ b/src/main/java/picard/vcf/CollectVariantCallingMetrics.java
@@ -251,7 +251,6 @@ public class CollectVariantCallingMetrics extends CommandLineProgram {
 
         public static <T extends VariantCallingSummaryMetrics> void foldInto(final T target, final Collection<T> metrics) {
             metrics.forEach(target::merge);
-            target.calculateDerivedFields();
         }
     }
 

--- a/src/test/java/picard/analysis/MergeableMetricBaseTest.java
+++ b/src/test/java/picard/analysis/MergeableMetricBaseTest.java
@@ -32,52 +32,99 @@ public class MergeableMetricBaseTest {
 
     class TestMergeableMetric extends MergeableMetricBase {
         @MergeByAdding
-        Integer boxedInt = 1;
+        public Integer boxedInt = 1;
         @MergeByAdding
-        int unboxedInt = 2;
+        public int unboxedInt = 2;
 
         @MergeByAdding
-        Double boxedDouble = 3D;
+        public Double boxedDouble = 3D;
         @MergeByAdding
-        double unboxedDouble = 4D;
+        public double unboxedDouble = 4D;
 
         @MergeByAdding
-        Long boxedLong = 5L;
+        public Long boxedLong = 5L;
         @MergeByAdding
-        long unboxedLong = 6L;
+        public long unboxedLong = 6L;
 
         @MergeByAdding
-        Float boxedFloat = 7F;
+        public Float boxedFloat = 7F;
         @MergeByAdding
-        float unboxedFloat = 8F;
+        public float unboxedFloat = 8F;
 
         @MergeByAdding
-        Short boxedShort = 9;
+        public Short boxedShort = 9;
         @MergeByAdding
-        short unboxedShort = 10;
+        public short unboxedShort = 10;
 
         @MergeByAdding
-        Byte boxedByte = 11;
+        public Byte boxedByte = 11;
         @MergeByAdding
-        byte unboxedByte = 12;
-
-        @MergeByAssertEquals
-        String mustBeEqualString = "hello";
+        public byte unboxedByte = 12;
 
         @MergeByAssertEquals
-        Double mustBeEqualDouble = 0.5;
+        public String mustBeEqualString = "hello";
 
         @MergeByAssertEquals
-        boolean mustBeEqualUnboxedBoolean = false;
+        public Double mustBeEqualDouble = 0.5;
+
+        @MergeByAssertEquals
+        public boolean mustBeEqualUnboxedBoolean = false;
+
+        @MergeByAdding
+        protected Integer protectedIntBase = 1;
+
+        @MergeByAdding
+        private Integer privateIntBase = 1;
 
         @NoMergingIsDerived
-        double ratioIntValues;
+        protected double ratioIntValues;
 
         @Override
         public void calculateDerivedFields() {
             ratioIntValues = boxedInt / (double) unboxedInt;
         }
     }
+
+     class TestMergeableMetricWithRestrictedMembers extends TestMergeableMetric {
+
+        @MergeByAdding
+        private Integer privateIntDerived = 1;
+
+        @MergeByAdding
+        protected Integer protectedIntDerived = 1;
+
+        @MergeByAssertEquals
+        private String privateString = "hi!";
+
+        @Override
+        public void calculateDerivedFields() {}
+    }
+
+    @Test
+    public void testMergingWithRestrictedMembers() {
+        final TestMergeableMetricWithRestrictedMembers metric1 = new TestMergeableMetricWithRestrictedMembers(), metric2 = new TestMergeableMetricWithRestrictedMembers();
+        metric1.merge(metric2);
+
+        Assert.assertEquals(metric1.boxedInt, (Integer) 2);
+        Assert.assertEquals(metric1.unboxedInt, 4);
+        Assert.assertEquals(metric1.privateIntDerived, (Integer) 2);
+        Assert.assertEquals(metric1.protectedIntDerived, (Integer) 2);
+        Assert.assertEquals(metric1.protectedIntBase, (Integer) 2);
+        Assert.assertEquals(((TestMergeableMetric)metric1).privateIntBase, (Integer) 2);
+        Assert.assertEquals(metric1.privateString, "hi!");
+    }
+
+    @Test
+    public void testMergingWithRestrictedMembersUsingBaseClass() {
+        final MergeableMetricBase metric1 = new TestMergeableMetricWithRestrictedMembers(), metric2 = new TestMergeableMetricWithRestrictedMembers();
+        metric1.merge(metric2);
+
+        Assert.assertEquals(((TestMergeableMetricWithRestrictedMembers)metric1).boxedInt, (Integer) 2);
+        Assert.assertEquals(((TestMergeableMetricWithRestrictedMembers)metric1).unboxedInt, 4);
+        Assert.assertEquals(((TestMergeableMetricWithRestrictedMembers)metric1).privateIntDerived, (Integer) 2);
+        Assert.assertEquals(((TestMergeableMetricWithRestrictedMembers)metric1).privateString, "hi!");
+    }
+
 
     @Test
     public void testMerging() {
@@ -158,13 +205,16 @@ public class MergeableMetricBaseTest {
         metric1.merge(metric2);
     }
 
-    private class TestMergeableMericIllegal extends MergeableMetricBase {
+    private class TestMergeableMetricIllegal extends MergeableMetricBase {
         Integer undecorated = 0;
+
+        @Override
+        public void calculateDerivedFields() {}
     }
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testIllegalClass() {
-        final TestMergeableMericIllegal illegal1 = new TestMergeableMericIllegal(), illegal2 = new TestMergeableMericIllegal();
+        final TestMergeableMetricIllegal illegal1 = new TestMergeableMetricIllegal(), illegal2 = new TestMergeableMetricIllegal();
 
         illegal1.merge(illegal2);
     }
@@ -193,9 +243,9 @@ public class MergeableMetricBaseTest {
     @Test
     public void TestCanMerge() {
         final TestMergeableMetric instance1 = new TestMergeableMetric();
-        instance1.unboxedInt=1;
+        instance1.unboxedInt = 1;
         final TestDerivedMergableMetric instance2 = new TestDerivedMergableMetric();
-        instance2.unboxedInt=2;
+        instance2.unboxedInt = 2;
 
         instance1.merge(instance2);
         Assert.assertEquals(instance1.unboxedInt, 3);

--- a/src/test/java/picard/vcf/CollectVariantCallingMetricsTest.java
+++ b/src/test/java/picard/vcf/CollectVariantCallingMetricsTest.java
@@ -115,7 +115,6 @@ public class CollectVariantCallingMetricsTest {
         Assert.assertEquals(detailMetrics.size(), 50, "Did not parse the desired number of detail metrics.");
     }
 
-
     @Test
     public void testMetricsTinyGVCF() throws IOException {
         final File dbSnpFile = new File(TEST_DATA_DIR, "mini.dbsnp.vcf");


### PR DESCRIPTION
- converting VariantCallingMetircs to mergable metrics
- added tests
- extended MergableMetricsBase so that it can deal with private and protected members of the superclass
- cleaned up alignment/typos in FilterVcf and MergeBamAlignment (unrelated)

@nh13 you has said that you'd like to see this framework used for something other than IndependentReplicates...so, here's your chance!  😄 
