### PR TITLE
findbugs:DM_BOOLEAN_CTOR, findbugs:DM_NUMBER_CTOR - Performance - Met…

### DIFF
--- a/src/java/picard/cmdline/CommandLineDefaults.java
+++ b/src/java/picard/cmdline/CommandLineDefaults.java
@@ -28,13 +28,13 @@ public class CommandLineDefaults {
 
     /** Gets a boolean system property, prefixed with "picard.cmdline." using the default if the property does not exist. */
     private static boolean getBooleanProperty(final String name, final boolean def) {
-        final String value = getStringProperty(name, new Boolean(def).toString());
+        final String value = getStringProperty(name, String.valueOf(def));
         return Boolean.parseBoolean(value);
     }
 
     /** Gets an int system property, prefixed with "picard.cmdline." using the default if the property does not exist. */
     private static int getIntProperty(final String name, final int def) {
-        final String value = getStringProperty(name, new Integer(def).toString());
+        final String value = getStringProperty(name, String.valueOf(def));
         return Integer.parseInt(value);
     }
 

--- a/src/java/picard/pedigree/PedFile.java
+++ b/src/java/picard/pedigree/PedFile.java
@@ -26,7 +26,7 @@ public class PedFile extends TreeMap<String, PedFile.PedTrio> {
     private final String delimiterString; // A textual representation of the delimiter, for output purposes
 
     // These two are really for PedTrio, but they can't be static in there and need to be accessed outside of PedFile
-    public static final Number NO_PHENO = new Integer(-9);
+    public static final Number NO_PHENO = Integer.valueOf(-9);
     public static final Sex UNKNOWN_SEX = Sex.Unknown;
 
     public PedFile(final boolean isTabMode) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules findbugs:DM_NUMBER_CTOR - Performance - Method invokes inefficient Number constructor; use static valueOf instead
findbugs:DM_BOOLEAN_CTOR - Performance - Method invokes inefficient Boolean constructor; use Boolean.valueOf(...) instead

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=findbugs:DM_NUMBER_CTOR
https://dev.eclipse.org/sonar/coding_rules#q=findbugs:DM_BOOLEAN_CTOR

Please let me know if you have any questions.

M-Ezzat