### PR TITLE
squid:S1640 - Maps with keys that are enum values should be replaced …

### DIFF
--- a/src/java/picard/analysis/artifacts/ArtifactCounter.java
+++ b/src/java/picard/analysis/artifacts/ArtifactCounter.java
@@ -8,6 +8,7 @@ import picard.PicardException;
 import picard.analysis.artifacts.SequencingArtifactMetrics.*;
 
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -135,7 +136,7 @@ class ArtifactCounter {
      *
      */
     private Map<Transition, SummaryPair> getSummaryMetrics() {
-        final Map<Transition, SummaryPair> summaryMetricsMap = new HashMap<Transition, SummaryPair>();
+        final Map<Transition, SummaryPair> summaryMetricsMap = new EnumMap<Transition, SummaryPair>(Transition.class);
 
         // extract the detail metrics from each accumulator
         final ListMap<Transition, DetailPair> fullMetrics = this.fullContextAccumulator.calculateMetrics(sampleAlias, library);

--- a/src/java/picard/illumina/parser/IlluminaDataProviderFactory.java
+++ b/src/java/picard/illumina/parser/IlluminaDataProviderFactory.java
@@ -34,6 +34,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -67,7 +68,7 @@ public class IlluminaDataProviderFactory {
      * We try to prefer data types that will be the fastest to parse/smallest in memory
      * NOTE: In the code below, if Qseq is chosen to provide for ANY data type then it is used for ALL its data types (since we'll have to parse the entire line for each Qseq anyways)
      */
-    private static final Map<IlluminaDataType, List<SupportedIlluminaFormat>> DATA_TYPE_TO_PREFERRED_FORMATS = new HashMap<IlluminaDataType, List<SupportedIlluminaFormat>>();
+    private static final Map<IlluminaDataType, List<SupportedIlluminaFormat>> DATA_TYPE_TO_PREFERRED_FORMATS = new EnumMap<IlluminaDataType, List<SupportedIlluminaFormat>>(IlluminaDataType.class);
 
     static {
         /** For types found in Qseq, we prefer the NON-Qseq file formats first.  However, if we end up using Qseqs then we use Qseqs for EVERY type it provides,
@@ -266,8 +267,8 @@ public class IlluminaDataProviderFactory {
     public static Map<SupportedIlluminaFormat, Set<IlluminaDataType>> determineFormats(final Set<IlluminaDataType> requestedDataTypes, final IlluminaFileUtil fileUtil) {
         //For predictable ordering and uniqueness only, put the requestedDataTypes into a treeSet
         final SortedSet<IlluminaDataType> toSupport = new TreeSet<IlluminaDataType>(requestedDataTypes);
-        final Map<SupportedIlluminaFormat, Set<IlluminaDataType>> fileTypeToDataTypes = new HashMap<SupportedIlluminaFormat, Set<IlluminaDataType>>();
-        final Map<IlluminaDataType, SupportedIlluminaFormat> dataTypeToFormat = new HashMap<IlluminaDataType, SupportedIlluminaFormat>();
+        final Map<SupportedIlluminaFormat, Set<IlluminaDataType>> fileTypeToDataTypes = new EnumMap<SupportedIlluminaFormat, Set<IlluminaDataType>>(SupportedIlluminaFormat.class);
+        final Map<IlluminaDataType, SupportedIlluminaFormat> dataTypeToFormat = new EnumMap<IlluminaDataType, SupportedIlluminaFormat>(IlluminaDataType.class);
 
         for (final IlluminaDataType ts : toSupport) {
             final SupportedIlluminaFormat preferredFormat = findPreferredAvailableFormat(ts, fileUtil);

--- a/src/java/picard/illumina/parser/IlluminaFileUtil.java
+++ b/src/java/picard/illumina/parser/IlluminaFileUtil.java
@@ -36,6 +36,7 @@ import picard.illumina.parser.readers.TileMetricsOutReader;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -76,7 +77,7 @@ public class IlluminaFileUtil {
     private final int lane;
 
     private final File tileMetricsOut;
-    private final Map<SupportedIlluminaFormat, ParameterizedFileUtil> utils = new HashMap<SupportedIlluminaFormat, ParameterizedFileUtil>();
+    private final Map<SupportedIlluminaFormat, ParameterizedFileUtil> utils = new EnumMap<SupportedIlluminaFormat, ParameterizedFileUtil>(SupportedIlluminaFormat.class);
 
     public IlluminaFileUtil(final File basecallDir, final int lane) {
 		this(basecallDir, null, lane);

--- a/src/java/picard/illumina/parser/Tile.java
+++ b/src/java/picard/illumina/parser/Tile.java
@@ -29,6 +29,7 @@ import htsjdk.samtools.util.CollectionUtil;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -58,8 +59,8 @@ public class Tile {
 
         final Collection<TilePhasingValue> phasingValues = ensureSoleTilePhasingValuesPerRead(Arrays.asList(tilePhasingValues));
 
-        final Map<TileTemplateRead, Float> phasingMap = new HashMap<TileTemplateRead, Float>();
-        final Map<TileTemplateRead, Float> prePhasingMap = new HashMap<TileTemplateRead, Float>();
+        final Map<TileTemplateRead, Float> phasingMap = new EnumMap<TileTemplateRead, Float>(TileTemplateRead.class);
+        final Map<TileTemplateRead, Float> prePhasingMap = new EnumMap<TileTemplateRead, Float>(TileTemplateRead.class);
 
         /** For each of the TileReads, assign their phasing & prephasing values to the respective maps, which we will
          * use later to calculate the medians

--- a/src/java/picard/vcf/GenotypeConcordanceCounts.java
+++ b/src/java/picard/vcf/GenotypeConcordanceCounts.java
@@ -2,6 +2,7 @@ package picard.vcf;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -282,7 +283,7 @@ public class GenotypeConcordanceCounts {
     public Map<ContingencyState, Long> getContingencyStateCounts(final GenotypeConcordanceScheme scheme) {
         scheme.validateScheme();
 
-        final Map<ContingencyState, Long> counts = new HashMap<ContingencyState, Long>();
+        final Map<ContingencyState, Long> counts = new EnumMap<ContingencyState, Long>(ContingencyState.class);
         for (final ContingencyState contingencyState : ContingencyState.values()) {
             counts.put(contingencyState, 0L);
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1640 - Maps with keys that are enum values should be replaced with EnumMap

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1640

Please let me know if you have any questions.

M-Ezzat