### PR TITLE
Tag reads in duplicate sets with the representative read and the duplicate set size

### DIFF
--- a/src/java/picard/sam/markduplicates/util/ReadEndsForMarkDuplicates.java
+++ b/src/java/picard/sam/markduplicates/util/ReadEndsForMarkDuplicates.java
@@ -76,4 +76,5 @@ public class ReadEndsForMarkDuplicates extends ReadEnds implements Cloneable {
     public ReadEndsForMarkDuplicates clone() {
         return new ReadEndsForMarkDuplicates(this);
     }
+
 }

--- a/src/java/picard/sam/markduplicates/util/ReadEndsForMarkDuplicatesTagRepresentativeRead.java
+++ b/src/java/picard/sam/markduplicates/util/ReadEndsForMarkDuplicatesTagRepresentativeRead.java
@@ -1,0 +1,43 @@
+/*
+  * The MIT License
+  *
+  * Copyright (c) 2015 The Broad Institute
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in
+  * all copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  * THE SOFTWARE.
+  */
+
+package picard.sam.markduplicates.util;
+
+public class ReadEndsForMarkDuplicatesTagRepresentativeRead extends ReadEndsForMarkDuplicates {
+    public String firstEncounteredReadName = "Null";
+    public String representativeReadName = "Null";
+    public int duplicateSetSize = 0;
+
+    public ReadEndsForMarkDuplicatesTagRepresentativeRead() { }
+
+    public ReadEndsForMarkDuplicatesTagRepresentativeRead(final ReadEndsForMarkDuplicates read) {
+        super(read);
+    }
+
+    // one int: 32
+    // 2 read names, UTF-8: (2 x ~34 char x 8) + 4
+    public static int getSizeOf() {
+        return ReadEndsForMarkDuplicates.getSizeOf() + 32 + (2 * 8 * 34)+4;
+    }
+}

--- a/src/java/picard/sam/markduplicates/util/ReadEndsForMarkDuplicatesTagRepresentativeReadCodec.java
+++ b/src/java/picard/sam/markduplicates/util/ReadEndsForMarkDuplicatesTagRepresentativeReadCodec.java
@@ -1,0 +1,76 @@
+/*
+  * The MIT License
+  *
+  * Copyright (c) 2015 The Broad Institute
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in
+  * all copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  * THE SOFTWARE.
+  */
+
+package picard.sam.markduplicates.util;
+
+import htsjdk.samtools.util.SortingCollection;
+import picard.PicardException;
+
+import java.io.IOException;
+
+/**
+ * Created by hogstrom on 06/07/15.
+ */
+public class ReadEndsForMarkDuplicatesTagRepresentativeReadCodec extends ReadEndsForMarkDuplicatesCodec {
+
+    @Override
+    public SortingCollection.Codec<ReadEndsForMarkDuplicates> clone() {
+        return new ReadEndsForMarkDuplicatesTagRepresentativeReadCodec();
+    }
+
+    @Override
+    public void encode(final ReadEndsForMarkDuplicates read) {
+        if (!(read instanceof ReadEndsForMarkDuplicatesTagRepresentativeRead)) {
+            throw new PicardException("Read was not a ReadEndsForMarkDuplicatesTagRepresentativeRead");
+        }
+        super.encode(read);
+
+        try {
+            final ReadEndsForMarkDuplicatesTagRepresentativeRead val = (ReadEndsForMarkDuplicatesTagRepresentativeRead)read;
+            out.writeUTF(val.firstEncounteredReadName);
+            out.writeUTF(val.representativeReadName);
+            out.writeInt(val.duplicateSetSize);
+        } catch (final IOException ioe) {
+            throw new PicardException("Exception writing ReadEnds to file.", ioe);
+        }
+    }
+
+    @Override
+    public ReadEndsForMarkDuplicates decode() {
+        final ReadEndsForMarkDuplicates parentRead = super.decode();
+        if (null == parentRead) return null; // EOF
+        final ReadEndsForMarkDuplicatesTagRepresentativeRead read = new ReadEndsForMarkDuplicatesTagRepresentativeRead(parentRead);
+        try {
+            read.firstEncounteredReadName = in.readUTF();
+            read.representativeReadName = in.readUTF();
+            read.duplicateSetSize = in.readInt();
+            return read;
+        } catch (final IOException ioe) {
+            throw new PicardException("Exception writing ReadEnds to file.", ioe);
+        }
+    }
+
+}
+
+

--- a/src/java/picard/sam/markduplicates/util/RepresentativeReadCodec.java
+++ b/src/java/picard/sam/markduplicates/util/RepresentativeReadCodec.java
@@ -1,0 +1,80 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package picard.sam.markduplicates.util;
+
+import htsjdk.samtools.util.SortingCollection;
+import picard.PicardException;
+import picard.sam.util.RepresentativeReadName;
+
+import java.io.*;
+
+/** Codec for read names and integers that outputs the primitive fields and reads them back. */
+public class RepresentativeReadCodec implements SortingCollection.Codec<RepresentativeReadName> {
+    protected DataInputStream in;
+    protected DataOutputStream out;
+
+
+    public SortingCollection.Codec<RepresentativeReadName> clone() {
+        return new RepresentativeReadCodec();
+    }
+
+    public void setOutputStream(final OutputStream os) { this.out = new DataOutputStream(os); }
+
+    public void setInputStream(final InputStream is) { this.in = new DataInputStream(is); }
+
+    public DataInputStream getInputStream() {
+        return in;
+    }
+
+    public DataOutputStream getOutputStream() {
+        return out;
+    }
+
+    public void encode(final RepresentativeReadName rni) {
+        try {
+            this.out.writeInt(rni.readIndexInFile);
+            this.out.writeInt(rni.setSize);
+            this.out.writeUTF(rni.readname);
+        } catch (final IOException ioe) {
+            throw new PicardException("Exception writing ReadEnds to file.", ioe);
+        }
+    }
+
+    public RepresentativeReadName decode() {
+        final RepresentativeReadName rni = new RepresentativeReadName();
+        try {
+            // If the first read results in an EOF we've exhausted the stream
+            try {
+                rni.readIndexInFile = this.in.readInt();
+            } catch (final EOFException eof) {
+                return null;
+            }
+            rni.setSize = this.in.readInt();
+            rni.readname = this.in.readUTF();
+            return rni;
+        } catch (final IOException ioe) {
+            throw new PicardException("Exception writing ReadEnds to file.", ioe);
+        }
+    }
+}

--- a/src/java/picard/sam/markduplicates/util/StringCodec.java
+++ b/src/java/picard/sam/markduplicates/util/StringCodec.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package picard.sam.markduplicates.util;
+
+import htsjdk.samtools.util.SortingCollection;
+import picard.PicardException;
+
+import java.io.*;
+
+/** Codec for a string. */
+public class StringCodec implements SortingCollection.Codec<String> {
+    protected DataInputStream in;
+    protected DataOutputStream out;
+
+
+    public SortingCollection.Codec<String> clone() {
+        return new StringCodec();
+    }
+
+    public void setOutputStream(final OutputStream os) { this.out = new DataOutputStream(os); }
+
+    public void setInputStream(final InputStream is) { this.in = new DataInputStream(is); }
+
+    public DataInputStream getInputStream() {
+        return in;
+    }
+
+    public DataOutputStream getOutputStream() {
+        return out;
+    }
+
+    public void encode(final String str) {
+        try {
+            this.out.writeBytes(str);
+        } catch (final IOException ioe) {
+            throw new PicardException("Exception writing ReadEnds to file.", ioe);
+        }
+    }
+
+    public String decode() {
+        final String str;
+        try {
+            str = in.readUTF();
+            return str;
+        } catch (final IOException ioe) {
+            throw new PicardException("Exception writing ReadEnds to file.", ioe);
+        }
+    }
+}

--- a/src/java/picard/sam/util/RepresentativeReadName.java
+++ b/src/java/picard/sam/util/RepresentativeReadName.java
@@ -1,0 +1,19 @@
+package picard.sam.util;
+
+/**
+ * Little struct-like class to hold read name information, record index, and duplicate set size information.
+ */
+
+public class RepresentativeReadName {
+
+    public int readIndexInFile = -1;
+
+    public int setSize = -1;
+
+    public String readname = null;
+
+    public String getReadName() {return readname;};
+
+    public void setReadName(final String name) { this.readname = name; }
+
+}

--- a/src/tests/java/picard/sam/markduplicates/AbstractMarkDuplicatesCommandLineProgramTest.java
+++ b/src/tests/java/picard/sam/markduplicates/AbstractMarkDuplicatesCommandLineProgramTest.java
@@ -598,5 +598,4 @@ public abstract class AbstractMarkDuplicatesCommandLineProgramTest {
         tester.addMappedFragment(fragLikeFirst ? "RUNID:1:1:15993:13361" : "RUNID:1:1:16020:13352", 1, 400, markSecondaryAndSupplementaryRecordsLikeTheCanonical() && !fragLikeFirst, null, null, additionalFragSecondary, additionalFragSupplementary, DEFAULT_BASE_QUALITY);
         tester.runTest();
     }
-
 }

--- a/src/tests/java/picard/sam/markduplicates/MarkDuplicatesTagRepresentativeReadTest.java
+++ b/src/tests/java/picard/sam/markduplicates/MarkDuplicatesTagRepresentativeReadTest.java
@@ -1,0 +1,88 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam.markduplicates;
+
+import org.testng.annotations.Test;
+
+/**
+ * This class defines the individual test cases to run. The actual running of the test is done
+ * by MarkDuplicatesWithMateCigarTester (see getTester).
+ * @author nhomer@broadinstitute.org
+ */
+public class MarkDuplicatesTagRepresentativeReadTest extends AbstractMarkDuplicatesCommandLineProgramTest {
+    protected MarkDuplicatesTagRepresentativeReadTester getTester() {
+        return new MarkDuplicatesTagRepresentativeReadTester();
+    }
+
+    @Test
+    public void testRepresentativeReadTag() {
+        final MarkDuplicatesTagRepresentativeReadTester tester = getTester();
+        tester.testRepresentativeReads = true;
+        tester.setExpectedOpticalDuplicate(1);
+        String representativeReadName = "RUNID:1:1:16020:13352";
+        tester.addMatePair(representativeReadName, 1, 485253, 485253, false, false, false, false, "45M", "45M", false, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.readToRepReadMap.put(representativeReadName, representativeReadName);
+        tester.expectedSetSizeMap.put(representativeReadName,2);
+        tester.addMatePair("RUNID:1:1:15993:13361", 1, 485253, 485253, false, false, true, true, "44M1S", "44M1S", false, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.readToRepReadMap.put("RUNID:1:1:15993:13361", representativeReadName);
+        tester.expectedSetSizeMap.put("RUNID:1:1:15993:13361",2);
+        tester.runTest();
+    }
+
+    @Test
+    public void testMultiRepresentativeReadTags() {
+        final MarkDuplicatesTagRepresentativeReadTester tester = getTester();
+        tester.testRepresentativeReads = true;
+        tester.setExpectedOpticalDuplicate(3);
+        // Duplicate set: size 2 - all optical
+        String representativeReadName1 = "RUNID:1:1:16020:13352";
+        tester.addMatePair(representativeReadName1, 1, 485253, 485253, false, false, false, false, "45M", "45M", false, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.readToRepReadMap.put(representativeReadName1, representativeReadName1);
+        tester.expectedSetSizeMap.put(representativeReadName1,2);
+        tester.addMatePair("RUNID:1:1:15993:13361", 1, 485253, 485253, false, false, true, true, "44M1S", "44M1S", false, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.readToRepReadMap.put("RUNID:1:1:15993:13361", representativeReadName1);
+        tester.expectedSetSizeMap.put("RUNID:1:1:15993:13361",2);
+
+        // Duplicate set: size 3 - all optical
+        String representativeReadName2 = "RUNID:1:1:15993:13360";
+        tester.addMatePair(representativeReadName2, 1, 485299, 485299, false, false, false, false, "45M", "45M", false, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.readToRepReadMap.put(representativeReadName2, representativeReadName2);
+        tester.expectedSetSizeMap.put(representativeReadName2,3);
+        tester.addMatePair("RUNID:1:1:15993:13365", 1, 485299, 485299, false, false, true, true, "44M1S", "44M1S", false, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.readToRepReadMap.put("RUNID:1:1:15993:13365", representativeReadName2);
+        tester.expectedSetSizeMap.put("RUNID:1:1:15993:13365",3);
+        tester.addMatePair("RUNID:1:1:15993:13370", 1, 485299, 485299, false, false, true, true, "43M2S", "43M2S", false, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.readToRepReadMap.put("RUNID:1:1:15993:13370", representativeReadName2);
+        tester.expectedSetSizeMap.put("RUNID:1:1:15993:13370",3);
+
+        // Add non-duplicate read
+        tester.addMatePair("RUNID:1:1:15993:13375", 1, 485255, 485255, false, false, false, false, "43M2S", "43M2S", false, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.readToRepReadMap.put("RUNID:1:1:15993:13375", null);
+        tester.expectedSetSizeMap.put("RUNID:1:1:15993:13375",null);
+
+        tester.runTest();
+    }
+
+}

--- a/src/tests/java/picard/sam/markduplicates/MarkDuplicatesTagRepresentativeReadTester.java
+++ b/src/tests/java/picard/sam/markduplicates/MarkDuplicatesTagRepresentativeReadTester.java
@@ -24,103 +24,41 @@
 
 package picard.sam.markduplicates;
 
+import htsjdk.samtools.DuplicateScoringStrategy;
 import htsjdk.samtools.DuplicateScoringStrategy.ScoringStrategy;
-import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.SAMRecordSetBuilder;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.metrics.MetricsFile;
-import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.CloserUtil;
-import htsjdk.samtools.util.FormatUtil;
 import htsjdk.samtools.util.TestUtil;
 import org.testng.Assert;
 import picard.cmdline.CommandLineProgram;
 import picard.sam.DuplicationMetrics;
-import picard.sam.testers.SamFileTester;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
- * This class is an extension of SamFileTester used to test AbstractMarkDuplicatesCommandLineProgram's with SAM files generated on the fly.
- * This performs the underlying tests defined by classes such as AbstractMarkDuplicatesCommandLineProgramTest.
+ * This class is an extension of AbstractMarkDuplicatesCommandLineProgramTester used to test MarkDuplicatesWithMateCigar with SAM files generated on the fly.
+ * This performs the underlying tests defined by classes such as see AbstractMarkDuplicatesCommandLineProgramTest and MarkDuplicatesWithMateCigarTest.
  */
-abstract public class AbstractMarkDuplicatesCommandLineProgramTester extends SamFileTester {
+public class MarkDuplicatesTagRepresentativeReadTester extends AbstractMarkDuplicatesCommandLineProgramTester {
 
-    final File metricsFile;
-    final DuplicationMetrics expectedMetrics;
+    final public Map<String, String> readToRepReadMap = new HashMap<>(); // map to contain representative read names for each record
+    final public Map<String, Integer> expectedSetSizeMap = new HashMap<>();
+    public boolean testRepresentativeReads = false;
 
-    public AbstractMarkDuplicatesCommandLineProgramTester(final ScoringStrategy duplicateScoringStrategy, SAMFileHeader.SortOrder sortOrder) {
-        this(duplicateScoringStrategy, sortOrder, true);
-    }
+    public MarkDuplicatesTagRepresentativeReadTester() {
 
-    public AbstractMarkDuplicatesCommandLineProgramTester(final ScoringStrategy duplicateScoringStrategy, SAMFileHeader.SortOrder sortOrder, boolean recordNeedSorting) {
-        super(50, true, SAMRecordSetBuilder.DEFAULT_CHROMOSOME_LENGTH, duplicateScoringStrategy, sortOrder, recordNeedSorting);
-
-        expectedMetrics = new DuplicationMetrics();
-        expectedMetrics.READ_PAIR_OPTICAL_DUPLICATES = 0;
-
-        metricsFile = new File(getOutputDir(), "metrics.txt");
-        addArg("METRICS_FILE=" + metricsFile);
-        addArg("DUPLICATE_SCORING_STRATEGY=" + duplicateScoringStrategy.name());
-    }
-
-    public AbstractMarkDuplicatesCommandLineProgramTester(final ScoringStrategy duplicateScoringStrategy) {
-        this(duplicateScoringStrategy, SAMFileHeader.SortOrder.coordinate);
-    }
-
-    public AbstractMarkDuplicatesCommandLineProgramTester() {
-        this(SAMRecordSetBuilder.DEFAULT_DUPLICATE_SCORING_STRATEGY);
+        addArg("TAGGING_POLICY=All");
+        addArg("TAG_REPRESENTATIVE_READ=true");
     }
 
     @Override
-    public String getCommandLineProgramName() { return getProgram().getClass().getSimpleName(); }
-
-    /**
-     * Fill in expected duplication metrics directly from the input records given to this tester
-     */
-    public void updateExpectedDuplicationMetrics() {
-
-        final FormatUtil formatter = new FormatUtil();
-
-        final CloseableIterator<SAMRecord> inputRecordIterator = this.getRecordIterator();
-        while (inputRecordIterator.hasNext()) {
-            final SAMRecord record = inputRecordIterator.next();
-            if (record.isSecondaryOrSupplementary()) {
-                ++expectedMetrics.SECONDARY_OR_SUPPLEMENTARY_RDS;
-            } else {
-                final String key = samRecordToDuplicatesFlagsKey(record);
-                if (!this.duplicateFlags.containsKey(key)) {
-                    System.err.println("DOES NOT CONTAIN KEY: " + key);
-                }
-                final boolean isDuplicate = this.duplicateFlags.get(key);
-
-                // First bring the simple metricsFile up to date
-                if (record.getReadUnmappedFlag()) {
-                    ++expectedMetrics.UNMAPPED_READS;
-                } else if (!record.getReadPairedFlag() || record.getMateUnmappedFlag()) {
-                    ++expectedMetrics.UNPAIRED_READS_EXAMINED;
-                    if (isDuplicate) ++expectedMetrics.UNPAIRED_READ_DUPLICATES;
-                } else {
-                    ++expectedMetrics.READ_PAIRS_EXAMINED; // will need to be divided by 2 at the end
-                    if (isDuplicate) ++expectedMetrics.READ_PAIR_DUPLICATES; // will need to be divided by 2 at the end
-                }
-            }
-        }
-        expectedMetrics.READ_PAIR_DUPLICATES = expectedMetrics.READ_PAIR_DUPLICATES / 2;
-        expectedMetrics.READ_PAIRS_EXAMINED = expectedMetrics.READ_PAIRS_EXAMINED / 2;
-        expectedMetrics.calculateDerivedMetrics();
-
-        // Have to run this Double value through the same format/parsing operations as during a file write/read
-        expectedMetrics.PERCENT_DUPLICATION = formatter.parseDouble(formatter.format(expectedMetrics.PERCENT_DUPLICATION));
-    }
-
-    public void setExpectedOpticalDuplicate(final int expectedOpticalDuplicatePairs) {
-        expectedMetrics.READ_PAIR_OPTICAL_DUPLICATES = expectedOpticalDuplicatePairs;
-    }
+    protected CommandLineProgram getProgram() { return new MarkDuplicates(); }
 
     @Override
     public void test() {
@@ -130,6 +68,7 @@ abstract public class AbstractMarkDuplicatesCommandLineProgramTester extends Sam
             // Read the output and check the duplicate flag
             int outputRecords = 0;
             final SamReader reader = SamReaderFactory.makeDefault().open(getOutput());
+            System.out.println(getOutput().getAbsolutePath());
             for (final SAMRecord record : reader) {
                 outputRecords++;
                 final String key = samRecordToDuplicatesFlagsKey(record);
@@ -144,6 +83,10 @@ abstract public class AbstractMarkDuplicatesCommandLineProgramTester extends Sam
                     System.err.print(record.getSAMString());
                 }
                 Assert.assertEquals(record.getDuplicateReadFlag(), value);
+                if (testRepresentativeReads) {
+                    Assert.assertEquals(record.getAttribute("RR"), readToRepReadMap.get(record.getReadName()));
+                    Assert.assertEquals(record.getAttribute("DS"), expectedSetSizeMap.get(record.getReadName()));
+                }
             }
             CloserUtil.close(reader);
 
@@ -170,9 +113,8 @@ abstract public class AbstractMarkDuplicatesCommandLineProgramTester extends Sam
             Assert.assertEquals(observedMetrics.ESTIMATED_LIBRARY_SIZE, expectedMetrics.ESTIMATED_LIBRARY_SIZE, "ESTIMATED_LIBRARY_SIZE does not match expected");
             Assert.assertEquals(observedMetrics.SECONDARY_OR_SUPPLEMENTARY_RDS, expectedMetrics.SECONDARY_OR_SUPPLEMENTARY_RDS, "SECONDARY_OR_SUPPLEMENTARY_RDS does not match expected");
         } finally {
-            TestUtil.recursiveDelete(getOutputDir());
+            //TestUtil.recursiveDelete(getOutputDir());
         }
     }
 
-    abstract protected CommandLineProgram getProgram();
 }


### PR DESCRIPTION
Optional flag added to MarkDuplicates. If true, each record that is part of a duplicate set is tagged with the representative read that is chosen by MarkDuplicates. This is accomplished with the ReadEndsForMarkDuplicatesTagRepresentativeRead class that retains read name information for each read pair examined. The RepresentativeReadName class stores the representative read name and set size for each duplicate set, spilling to disk if necessary. This functionality is tested by MarkDuplicatesTagRepresentativeReadTest that also executes the tests in AbstractMarkDuplicatesCommandLineProgramTest.