### PR TITLE
Cleanup - squid:S2142 - InterruptedException should not be ignored

### DIFF
--- a/src/java/picard/fingerprint/FingerprintChecker.java
+++ b/src/java/picard/fingerprint/FingerprintChecker.java
@@ -472,7 +472,10 @@ public class FingerprintChecker {
 
         executor.shutdown();
         try { executor.awaitTermination(waitTime, waitTimeUnit); }
-        catch (final InterruptedException ie) { log.warn(ie, "Interrupted while waiting for executor to terminate."); }
+        catch (final InterruptedException ie) {
+            log.warn(ie, "Interrupted while waiting for executor to terminate.");
+            Thread.currentThread().interrupt();
+        }
 
         return retval;
     }

--- a/src/java/picard/illumina/IlluminaBasecallsConverter.java
+++ b/src/java/picard/illumina/IlluminaBasecallsConverter.java
@@ -47,6 +47,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.Timer;
@@ -318,6 +319,7 @@ public class IlluminaBasecallsConverter<CLUSTER_OUTPUT_RECORD> {
                 tileReadAggregator.awaitWorkComplete();
             } catch (final InterruptedException e) {
                 log.error(e, "Failure encountered in worker thread; attempting to shut down remaining worker threads and terminate ...");
+                Thread.currentThread().interrupt();
                 throw new PicardException("Failure encountered in worker thread; see log for details.");
             } finally {
                 tileReadAggregator.shutdown();

--- a/src/java/picard/illumina/parser/OutputMapping.java
+++ b/src/java/picard/illumina/parser/OutputMapping.java
@@ -26,6 +26,8 @@ package picard.illumina.parser;
 import htsjdk.samtools.util.StringUtil;
 import picard.PicardException;
 
+import java.util.Objects;
+
 /**
  * In multiple locations we need to know what cycles are output, as of now we output all non-skip cycles, but rather than sprinkle
  * this knowledge throughout the parser code, instead OutputMapping provides all the data a client might want about the

--- a/src/java/picard/util/AsyncIterator.java
+++ b/src/java/picard/util/AsyncIterator.java
@@ -76,7 +76,10 @@ public class AsyncIterator<T> implements CloseableIterator<T> {
                 checkAndRethrow();
                 if (theNext != null) break;
             }
-        } catch (InterruptedException ie) { throw new RuntimeException("Interrupted queueing item for writing.", ie); }
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted queueing item for writing.", ie);
+        }
         checkAndRethrow();
     }
 
@@ -107,7 +110,10 @@ public class AsyncIterator<T> implements CloseableIterator<T> {
         this.isClosed.set(true);
 
         try { this.reader.join(); }
-        catch (InterruptedException ie) { throw new RuntimeException("Interrupted waiting on reader thread.", ie); }
+        catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted waiting on reader thread.", ie);
+        }
 
         underlyingIterator.close();
         checkAndRethrow();
@@ -156,7 +162,7 @@ public class AsyncIterator<T> implements CloseableIterator<T> {
                         }
                     }
                     catch (InterruptedException ie) {
-                        /* Do Nothing */
+                        Thread.currentThread().interrupt();
                     }
                 }
             }

--- a/src/java/picard/util/CircularByteBuffer.java
+++ b/src/java/picard/util/CircularByteBuffer.java
@@ -36,7 +36,10 @@ public class CircularByteBuffer {
         if (closed) throw new IllegalStateException("Cannot write to closed buffer.");
 
         try { if (this.bytesAvailableToWrite == 0) wait(); }
-        catch (final InterruptedException ie) {throw new PicardException("Interrupted while waiting to write to fifo.", ie); }
+        catch (final InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new PicardException("Interrupted while waiting to write to fifo.", ie);
+        }
 
         final int writePos      = this.nextWritePos;
         final int distanceToEnd = this.capacity - writePos;
@@ -60,7 +63,10 @@ public class CircularByteBuffer {
      */
     synchronized public int read(final byte[] bytes, final int start, final int size) {
         try { if (this.bytesAvailableToRead == 0 && !closed) wait(); }
-        catch (final InterruptedException ie) {throw new PicardException("Interrupted while waiting to read from fifo.", ie); }
+        catch (final InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new PicardException("Interrupted while waiting to read from fifo.", ie);
+        }
 
         final int readPos       = this.nextReadPos;
         final int distanceToEnd = this.capacity - readPos;

--- a/src/java/picard/util/FifoBuffer.java
+++ b/src/java/picard/util/FifoBuffer.java
@@ -139,7 +139,10 @@ public class FifoBuffer extends CommandLineProgram {
                             final double pct   = used / (double) capacity;
                             final String name = NAME == null ? "" : NAME + " ";
                             log.info("Fifo buffer ", name, "used ", iFmt.format(used), " / ", iFmt.format(capacity), " (", pFmt.format(pct), ").");
-                            try { Thread.sleep(DEBUG_FREQUENCY * 1000); } catch (final InterruptedException ie) { /* do nothing */ }
+                            try { Thread.sleep(DEBUG_FREQUENCY * 1000); }
+                            catch (final InterruptedException ie) {
+                                Thread.currentThread().interrupt();
+                            }
                         }
                     }
                 });
@@ -169,6 +172,7 @@ public class FifoBuffer extends CommandLineProgram {
             if (outputExceptionHandler.throwable != null) throw new PicardException("Exception on output thread.", outputExceptionHandler.throwable);
         }
         catch (final InterruptedException ie) {
+            Thread.currentThread().interrupt();
             throw new PicardException("Interrupted!", ie);
         }
 

--- a/src/java/picard/vcf/processor/VariantProcessor.java
+++ b/src/java/picard/vcf/processor/VariantProcessor.java
@@ -93,6 +93,7 @@ public class VariantProcessor<RESULT, ACCUMULATOR extends VariantProcessor.Accum
         try {
             executor.awaitCompletion();
         } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2142 - "InterruptedException" should not be ignored

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2142

Please let me know if you have any questions.

M-Ezzat