### PR TITLE
Histogram of duplicate set sizes to be reported in the MarkDuplicates metrics file

### DIFF
--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -761,6 +761,8 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
                     if (TAG_DUPLICATE_SET_MEMBERS) {
                         addRepresentativeReadIndex(nextChunk);
                     }
+                } else if (nextChunk.size() == 1) {
+                    addSingletonToCount(libraryIdGenerator);
                 }
                 nextChunk.clear();
                 nextChunk.add(next);
@@ -772,6 +774,8 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
             if (TAG_DUPLICATE_SET_MEMBERS) {
                 addRepresentativeReadIndex(nextChunk);
             }
+        }  else if (nextChunk.size() == 1) {
+            addSingletonToCount(libraryIdGenerator);
         }
         this.pairSort.cleanup();
         this.pairSort = null;

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -756,27 +756,14 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
             if (firstOfNextChunk != null && areComparableForDuplicates(firstOfNextChunk, next, true, useBarcodes)) {
                 nextChunk.add(next);
             } else {
-                if (nextChunk.size() > 1) {
-                    markDuplicatePairs(nextChunk);
-                    if (TAG_DUPLICATE_SET_MEMBERS) {
-                        addRepresentativeReadIndex(nextChunk);
-                    }
-                } else if (nextChunk.size() == 1) {
-                    addSingletonToCount(libraryIdGenerator);
-                }
+                handleChunk(nextChunk);
                 nextChunk.clear();
                 nextChunk.add(next);
                 firstOfNextChunk = next;
             }
         }
-        if (nextChunk.size() > 1) {
-            markDuplicatePairs(nextChunk);
-            if (TAG_DUPLICATE_SET_MEMBERS) {
-                addRepresentativeReadIndex(nextChunk);
-            }
-        }  else if (nextChunk.size() == 1) {
-            addSingletonToCount(libraryIdGenerator);
-        }
+        handleChunk(nextChunk);
+
         this.pairSort.cleanup();
         this.pairSort = null;
 
@@ -814,6 +801,17 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
         }
         if (TAG_DUPLICATE_SET_MEMBERS) {
             this.representativeReadIndicesForDuplicates.doneAdding();
+        }
+    }
+
+    private void handleChunk(List<ReadEndsForMarkDuplicates> nextChunk) {
+        if (nextChunk.size() > 1) {
+            markDuplicatePairs(nextChunk);
+            if (TAG_DUPLICATE_SET_MEMBERS) {
+                addRepresentativeReadIndex(nextChunk);
+            }
+        } else if (nextChunk.size() == 1) {
+            addSingletonToCount(libraryIdGenerator);
         }
     }
 

--- a/src/main/java/picard/sam/markduplicates/util/AbstractMarkDuplicatesCommandLineProgram.java
+++ b/src/main/java/picard/sam/markduplicates/util/AbstractMarkDuplicatesCommandLineProgram.java
@@ -297,9 +297,7 @@ public abstract class AbstractMarkDuplicatesCommandLineProgram extends AbstractO
         }
         trackDuplicateCounts(ends.size(),
                 nOpticalDup,
-                libraryIdGenerator.getDuplicateCountHist(),
-                libraryIdGenerator.getNonOpticalDuplicateCountHist(),
-                libraryIdGenerator.getOpticalDuplicateCountHist());
+                libraryIdGenerator);
     }
 
     public static void addSingletonToCount(final LibraryIdGenerator libraryIdGenerator) {
@@ -339,9 +337,12 @@ public abstract class AbstractMarkDuplicatesCommandLineProgram extends AbstractO
 
     private static void trackDuplicateCounts(final int listSize,
                                              final int optDupCnt,
-                                             final Histogram<Double> duplicatesCountHist,
-                                             final Histogram<Double> nonOpticalDuplicatesCountHist,
-                                             final Histogram<Double> opticalDuplicatesCountHist) {
+                                             final LibraryIdGenerator libraryIdGenerator) {
+
+        final Histogram<Double> duplicatesCountHist = libraryIdGenerator.getDuplicateCountHist();
+        final Histogram<Double> nonOpticalDuplicatesCountHist = libraryIdGenerator.getNonOpticalDuplicateCountHist();
+        final Histogram<Double> opticalDuplicatesCountHist = libraryIdGenerator.getOpticalDuplicateCountHist();
+
         duplicatesCountHist.increment((double) listSize);
         if ((listSize - optDupCnt) > 0) {
             nonOpticalDuplicatesCountHist.increment((double) (listSize - optDupCnt));

--- a/src/main/java/picard/sam/markduplicates/util/AbstractMarkDuplicatesCommandLineProgram.java
+++ b/src/main/java/picard/sam/markduplicates/util/AbstractMarkDuplicatesCommandLineProgram.java
@@ -265,6 +265,7 @@ public abstract class AbstractMarkDuplicatesCommandLineProgram extends AbstractO
         }
 
         // Check if we need to partition since the orientations could have changed
+        final int nOpticalDup;
         if (hasFR && hasRF) { // need to track them independently
             // Variables used for optical duplicate detection and tracking
             final List<ReadEnds> trackOpticalDuplicatesF = new ArrayList<>();
@@ -290,19 +291,15 @@ public abstract class AbstractMarkDuplicatesCommandLineProgram extends AbstractO
                     keeper,
                     opticalDuplicateFinder,
                     libraryIdGenerator.getOpticalDuplicatesByLibraryIdMap());
-            trackDuplicateCounts(ends.size(),
-                    nOpticalDupF + nOpticalDupR,
-                    libraryIdGenerator.getDuplicateCountHist(),
-                    libraryIdGenerator.getNonOpticalDuplicateCountHist(),
-                    libraryIdGenerator.getOpticalDuplicateCountHist());
+            nOpticalDup = nOpticalDupF + nOpticalDupR;
         } else { // No need to partition
-            final int nOpticalDup = trackOpticalDuplicates(ends, keeper, opticalDuplicateFinder, libraryIdGenerator.getOpticalDuplicatesByLibraryIdMap());
-            trackDuplicateCounts(ends.size(),
-                    nOpticalDup,
-                    libraryIdGenerator.getDuplicateCountHist(),
-                    libraryIdGenerator.getNonOpticalDuplicateCountHist(),
-                    libraryIdGenerator.getOpticalDuplicateCountHist());
+            nOpticalDup = trackOpticalDuplicates(ends, keeper, opticalDuplicateFinder, libraryIdGenerator.getOpticalDuplicatesByLibraryIdMap());
         }
+        trackDuplicateCounts(ends.size(),
+                nOpticalDup,
+                libraryIdGenerator.getDuplicateCountHist(),
+                libraryIdGenerator.getNonOpticalDuplicateCountHist(),
+                libraryIdGenerator.getOpticalDuplicateCountHist());
     }
 
     public static void addSingletonToCount(final LibraryIdGenerator libraryIdGenerator) {

--- a/src/main/java/picard/sam/markduplicates/util/AbstractMarkDuplicatesCommandLineProgram.java
+++ b/src/main/java/picard/sam/markduplicates/util/AbstractMarkDuplicatesCommandLineProgram.java
@@ -161,7 +161,6 @@ public abstract class AbstractMarkDuplicatesCommandLineProgram extends AbstractO
     protected void finalizeAndWriteMetrics(final LibraryIdGenerator libraryIdGenerator) {
         final Map<String, DuplicationMetrics> metricsByLibrary = libraryIdGenerator.getMetricsByLibraryMap();
         final Histogram<Short> opticalDuplicatesByLibraryId = libraryIdGenerator.getOpticalDuplicatesByLibraryIdMap();
-
         final Map<String, Short> libraryIds = libraryIdGenerator.getLibraryIdsMap();
 
         // Write out the metrics
@@ -284,13 +283,13 @@ public abstract class AbstractMarkDuplicatesCommandLineProgram extends AbstractO
 
             // track the duplicates
             final int nOpticalDupF = trackOpticalDuplicates(trackOpticalDuplicatesF,
-                                                    keeper,
-                                                    opticalDuplicateFinder,
-                                                    libraryIdGenerator.getOpticalDuplicatesByLibraryIdMap());
+                    keeper,
+                    opticalDuplicateFinder,
+                    libraryIdGenerator.getOpticalDuplicatesByLibraryIdMap());
             final int nOpticalDupR = trackOpticalDuplicates(trackOpticalDuplicatesR,
-                                                    keeper,
-                                                    opticalDuplicateFinder,
-                                                    libraryIdGenerator.getOpticalDuplicatesByLibraryIdMap());
+                    keeper,
+                    opticalDuplicateFinder,
+                    libraryIdGenerator.getOpticalDuplicatesByLibraryIdMap());
             trackDuplicateCounts(ends.size(),
                     nOpticalDupF + nOpticalDupR,
                     libraryIdGenerator.getDuplicateCountHist(),
@@ -346,7 +345,7 @@ public abstract class AbstractMarkDuplicatesCommandLineProgram extends AbstractO
                                              final Histogram<Double> duplicatesCountHist,
                                              final Histogram<Double> nonOpticalDuplicatesCountHist,
                                              final Histogram<Double> opticalDuplicatesCountHist) {
-        duplicatesCountHist.increment((double)(listSize));
+        duplicatesCountHist.increment((double) listSize);
         if ((listSize - optDupCnt) > 0) {
             nonOpticalDuplicatesCountHist.increment((double) (listSize - optDupCnt));
         }

--- a/src/main/java/picard/sam/markduplicates/util/AbstractMarkDuplicatesCommandLineProgram.java
+++ b/src/main/java/picard/sam/markduplicates/util/AbstractMarkDuplicatesCommandLineProgram.java
@@ -301,8 +301,8 @@ public abstract class AbstractMarkDuplicatesCommandLineProgram extends AbstractO
     }
 
     public static void addSingletonToCount(final LibraryIdGenerator libraryIdGenerator) {
-        addSingletonToCount(libraryIdGenerator.getDuplicateCountHist(),
-                libraryIdGenerator.getNonOpticalDuplicateCountHist());
+        libraryIdGenerator.getDuplicateCountHist().increment(1.0);
+        libraryIdGenerator.getNonOpticalDuplicateCountHist().increment(1.0);
     }
 
     /**
@@ -351,11 +351,4 @@ public abstract class AbstractMarkDuplicatesCommandLineProgram extends AbstractO
             opticalDuplicatesCountHist.increment((double) (optDupCnt + 1.0));
         }
     }
-
-    private static void addSingletonToCount(final Histogram<Double> duplicatesCountHist,
-                                            final Histogram<Double> nonOpticalDuplicatesCountHist) {
-        duplicatesCountHist.increment(1.0);
-        nonOpticalDuplicatesCountHist.increment(1.0);
-    }
-
 }

--- a/src/main/java/picard/sam/markduplicates/util/LibraryIdGenerator.java
+++ b/src/main/java/picard/sam/markduplicates/util/LibraryIdGenerator.java
@@ -49,7 +49,9 @@ public class LibraryIdGenerator {
     private short nextLibraryId = 1;
     private final Map<String, DuplicationMetrics> metricsByLibrary = new HashMap<String, DuplicationMetrics>();
     private final Histogram<Short> opticalDuplicatesByLibraryId = new Histogram<Short>();
-
+    public final Histogram<Double> duplicateCountHist = new Histogram<Double>("set_size", "all_sets");
+    public final Histogram<Double> nonOpticalDuplicateCountHist = new Histogram<Double>("set_size", "non_optical_sets");
+    public final Histogram<Double> opticalDuplicateCountHist = new Histogram<Double>("set_size", "optical_sets");
 
     public LibraryIdGenerator(final SAMFileHeader header) {
         this.header = header;
@@ -65,13 +67,31 @@ public class LibraryIdGenerator {
         }
     }
 
-    public Map<String, Short> getLibraryIdsMap() { return this.libraryIds; }
+    public Map<String, Short> getLibraryIdsMap() {
+        return this.libraryIds;
+    }
 
-    public Map<String, DuplicationMetrics> getMetricsByLibraryMap() { return this.metricsByLibrary; }
+    public Map<String, DuplicationMetrics> getMetricsByLibraryMap() {
+        return this.metricsByLibrary;
+    }
 
-    public Histogram<Short> getOpticalDuplicatesByLibraryIdMap() { return this.opticalDuplicatesByLibraryId; }
+    public Histogram<Short> getOpticalDuplicatesByLibraryIdMap() {
+        return this.opticalDuplicatesByLibraryId;
+    }
 
-	public static String getReadGroupLibraryName(SAMReadGroupRecord readGroup) {
+    public Histogram<Double> getDuplicateCountHist() {
+        return this.duplicateCountHist;
+    }
+
+    public Histogram<Double> getNonOpticalDuplicateCountHist() {
+        return this.nonOpticalDuplicateCountHist;
+    }
+
+    public Histogram<Double> getOpticalDuplicateCountHist() {
+        return this.opticalDuplicateCountHist;
+    }
+
+    public static String getReadGroupLibraryName(final SAMReadGroupRecord readGroup) {
 		return Optional.ofNullable(readGroup.getLibrary())
 				.orElse(UNKNOWN_LIBRARY);
 	}

--- a/src/main/java/picard/sam/markduplicates/util/LibraryIdGenerator.java
+++ b/src/main/java/picard/sam/markduplicates/util/LibraryIdGenerator.java
@@ -47,11 +47,11 @@ public class LibraryIdGenerator {
     private final SAMFileHeader header;
     private final Map<String, Short> libraryIds = new HashMap<String, Short>(); // from library string to library id
     private short nextLibraryId = 1;
-    private final Map<String, DuplicationMetrics> metricsByLibrary = new HashMap<String, DuplicationMetrics>();
-    private final Histogram<Short> opticalDuplicatesByLibraryId = new Histogram<Short>();
-    public final Histogram<Double> duplicateCountHist = new Histogram<Double>("set_size", "all_sets");
-    public final Histogram<Double> nonOpticalDuplicateCountHist = new Histogram<Double>("set_size", "non_optical_sets");
-    public final Histogram<Double> opticalDuplicateCountHist = new Histogram<Double>("set_size", "optical_sets");
+    private final Map<String, DuplicationMetrics> metricsByLibrary = new HashMap<>();
+    private final Histogram<Short> opticalDuplicatesByLibraryId = new Histogram<>();
+    private final Histogram<Double> duplicateCountHist = new Histogram<>("set_size", "all_sets");
+    private final Histogram<Double> nonOpticalDuplicateCountHist = new Histogram<>("set_size", "non_optical_sets");
+    private final Histogram<Double> opticalDuplicateCountHist = new Histogram<>("set_size", "optical_sets");
 
     public LibraryIdGenerator(final SAMFileHeader header) {
         this.header = header;

--- a/src/test/java/picard/sam/markduplicates/AbstractMarkDuplicatesCommandLineProgramTester.java
+++ b/src/test/java/picard/sam/markduplicates/AbstractMarkDuplicatesCommandLineProgramTester.java
@@ -155,17 +155,11 @@ abstract public class AbstractMarkDuplicatesCommandLineProgramTester extends Sam
                 for (final SAMRecord record : reader) {
                     outputRecords++;
                     final String key = samRecordToDuplicatesFlagsKey(record);
-                    if (!this.duplicateFlags.containsKey(key)) {
-                        System.err.println("DOES NOT CONTAIN KEY: " + key);
-                    }
+
                     Assert.assertTrue(this.duplicateFlags.containsKey(key));
                     final boolean value = this.duplicateFlags.get(key);
                     this.duplicateFlags.remove(key);
-                    if (value != record.getDuplicateReadFlag()) {
-                        System.err.println("Mismatching read:");
-                        System.err.print(record.getSAMString());
-                    }
-                    Assert.assertEquals(record.getDuplicateReadFlag(), value);
+                    Assert.assertEquals(record.getDuplicateReadFlag(), value, "Mismatching read: " + record.getSAMString());
                     if (testOpticalDuplicateDTTag && MarkDuplicates.DUPLICATE_TYPE_SEQUENCING.equals(record.getAttribute("DT"))) {
                         sequencingDTErrorsSeen.add(record.getReadName());
                     }

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesSetSizeHistogramTest.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesSetSizeHistogramTest.java
@@ -29,7 +29,8 @@ import org.testng.annotations.Test;
 import java.util.Arrays;
 
 /**
- * This class defines the individual test cases to check the duplicate set histograms. 
+ * This class defines the individual test cases to check the duplicate set histograms.
+ *
  * @author hogstrom@broadinstitute.org
  */
 public class MarkDuplicatesSetSizeHistogramTest extends AbstractMarkDuplicatesCommandLineProgramTest {
@@ -40,25 +41,25 @@ public class MarkDuplicatesSetSizeHistogramTest extends AbstractMarkDuplicatesCo
 
     @Test
     public void TestSingleSet() {
-    // This tests checks that if I add two read pairs with the same alignment start, a duplicate
-    // set size entry of 2 is put into the histogram. The pair is an optical dup, so a 2 entry for
-    // the 'optical_sets' should also be marked
+        // This tests checks that if I add two read pairs with the same alignment start, a duplicate
+        // set size entry of 2 is put into the histogram. The pair is an optical dup, so a 2 entry for
+        // the 'optical_sets' should also be marked
         final MarkDuplicatesSetSizeHistogramTester tester = getTester();
         tester.setExpectedOpticalDuplicate(1);
         String representativeReadName = "RUNID:1:1:16020:13352";
         tester.addMatePair(representativeReadName, 1, 485253, 485253, false, false, false, false, "45M", "45M", false, true, false, false, false, DEFAULT_BASE_QUALITY);
         tester.addMatePair("RUNID:1:1:15993:13361", 1, 485253, 485253, false, false, true, true, "44M1S", "44M1S", false, true, false, false, false, DEFAULT_BASE_QUALITY);
         // set expected counts in hashmap that takes the form: key=(Histogram Label, histogram bin), value=histogram entry
-        tester.expectedSetSizeMap.put(Arrays.asList("all_sets","2.0"),1.0);
-        tester.expectedSetSizeMap.put(Arrays.asList("optical_sets","2.0"),1.0);
+        tester.expectedSetSizeMap.put(Arrays.asList("all_sets", "2.0"), 1.0);
+        tester.expectedSetSizeMap.put(Arrays.asList("optical_sets", "2.0"), 1.0);
         tester.runTest();
     }
 
     @Test
     public void testOpticalAndNonOpticalSet() {
-    // This tests checks that if I have two optical dups and one non-optical in the same dup set that the correct histogram entries
-    // are specified
-    final MarkDuplicatesSetSizeHistogramTester tester = getTester();
+        // This tests checks that if I have two optical dups and one non-optical in the same dup set that the correct histogram entries
+        // are specified
+        final MarkDuplicatesSetSizeHistogramTester tester = getTester();
         tester.setExpectedOpticalDuplicate(2);
         String representativeReadName = "RUNID:1:1:16020:13352";
         tester.addMatePair(representativeReadName, 1, 485253, 485253, false, false, false, false, "45M", "45M", false, true, false, false, false, DEFAULT_BASE_QUALITY);
@@ -66,41 +67,41 @@ public class MarkDuplicatesSetSizeHistogramTest extends AbstractMarkDuplicatesCo
         tester.addMatePair("RUNID:1:1:15994:13364", 1, 485253, 485253, false, false, true, true, "44M1S", "44M1S", false, true, false, false, false, DEFAULT_BASE_QUALITY);
         // add one non-optical duplicate
         tester.addMatePair("RUNID:1:1:25993:23361", 1, 485253, 485253, false, false, true, true, "44M1S", "44M1S", false, true, false, false, false, DEFAULT_BASE_QUALITY);
-        tester.expectedSetSizeMap.put(Arrays.asList("all_sets","4.0"),1.0);
-        tester.expectedSetSizeMap.put(Arrays.asList("optical_sets","3.0"),1.0);
+        tester.expectedSetSizeMap.put(Arrays.asList("all_sets", "4.0"), 1.0);
+        tester.expectedSetSizeMap.put(Arrays.asList("optical_sets", "3.0"), 1.0);
         tester.runTest();
     }
 
     @Test
     public void testSingleton() {
         // This tests checks if having a read pair that is not duplicated, the correct histogram entry is updated
-    final MarkDuplicatesSetSizeHistogramTester tester = getTester();
+        final MarkDuplicatesSetSizeHistogramTester tester = getTester();
         tester.setExpectedOpticalDuplicate(0);
         // Add non-duplicate read
         tester.addMatePair("RUNID:1:1:15993:13375", 1, 485255, 485255, false, false, false, false, "43M2S", "43M2S", false, true, false, false, false, DEFAULT_BASE_QUALITY);
-        tester.expectedSetSizeMap.put(Arrays.asList("all_sets","1.0"),1.0);
+        tester.expectedSetSizeMap.put(Arrays.asList("all_sets", "1.0"), 1.0);
         tester.runTest();
     }
 
     @Test
     public void testMultiRepresentativeReadTags() {
         // This tests checks multiple different duplicate sets of varying sizes
-    final MarkDuplicatesSetSizeHistogramTester tester = getTester();
+        final MarkDuplicatesSetSizeHistogramTester tester = getTester();
         tester.setExpectedOpticalDuplicate(3);
         // Duplicate set: size 2 - all optical
         String representativeReadName1 = "RUNID:1:1:16020:13352";
         tester.addMatePair(representativeReadName1, 1, 485253, 485253, false, false, false, false, "45M", "45M", false, true, false, false, false, DEFAULT_BASE_QUALITY);
         tester.addMatePair("RUNID:1:1:15993:13361", 1, 485253, 485253, false, false, true, true, "44M1S", "44M1S", false, true, false, false, false, DEFAULT_BASE_QUALITY);
-        tester.expectedSetSizeMap.put(Arrays.asList("all_sets","3.0"),1.0);
-        tester.expectedSetSizeMap.put(Arrays.asList("optical_sets","3.0"),1.0);
+        tester.expectedSetSizeMap.put(Arrays.asList("all_sets", "3.0"), 1.0);
+        tester.expectedSetSizeMap.put(Arrays.asList("optical_sets", "3.0"), 1.0);
 
         // Duplicate set: size 3 - all optical
         String representativeReadName2 = "RUNID:1:1:15993:13360";
         tester.addMatePair(representativeReadName2, 1, 485299, 485299, false, false, false, false, "45M", "45M", false, true, false, false, false, DEFAULT_BASE_QUALITY);
         tester.addMatePair("RUNID:1:1:15993:13365", 1, 485299, 485299, false, false, true, true, "44M1S", "44M1S", false, true, false, false, false, DEFAULT_BASE_QUALITY);
         tester.addMatePair("RUNID:1:1:15993:13370", 1, 485299, 485299, false, false, true, true, "43M2S", "43M2S", false, true, false, false, false, DEFAULT_BASE_QUALITY);
-        tester.expectedSetSizeMap.put(Arrays.asList("all_sets","4.0"),1.0);
-        tester.expectedSetSizeMap.put(Arrays.asList("optical_sets","4.0"),1.0);
+        tester.expectedSetSizeMap.put(Arrays.asList("all_sets", "4.0"), 1.0);
+        tester.expectedSetSizeMap.put(Arrays.asList("optical_sets", "4.0"), 1.0);
 
         // Add non-duplicate read
         tester.addMatePair("RUNID:1:1:15993:13375", 1, 485255, 485255, false, false, false, false, "43M2S", "43M2S", false, true, false, false, false, DEFAULT_BASE_QUALITY);

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesSetSizeHistogramTest.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesSetSizeHistogramTest.java
@@ -1,0 +1,112 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam.markduplicates;
+
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+/**
+ * This class defines the individual test cases to check the duplicate set histograms. 
+ * @author hogstrom@broadinstitute.org
+ */
+public class MarkDuplicatesSetSizeHistogramTest extends AbstractMarkDuplicatesCommandLineProgramTest {
+    @Override
+    protected MarkDuplicatesSetSizeHistogramTester getTester() {
+        return new MarkDuplicatesSetSizeHistogramTester();
+    }
+
+    @Test
+    public void TestSingleSet() {
+    // This tests checks that if I add two read pairs with the same alignment start, a duplicate
+    // set size entry of 2 is put into the histogram. The pair is an optical dup, so a 2 entry for
+    // the 'optical_sets' should also be marked
+        final MarkDuplicatesSetSizeHistogramTester tester = getTester();
+        tester.setExpectedOpticalDuplicate(1);
+        String representativeReadName = "RUNID:1:1:16020:13352";
+        tester.addMatePair(representativeReadName, 1, 485253, 485253, false, false, false, false, "45M", "45M", false, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.addMatePair("RUNID:1:1:15993:13361", 1, 485253, 485253, false, false, true, true, "44M1S", "44M1S", false, true, false, false, false, DEFAULT_BASE_QUALITY);
+        // set expected counts in hashmap that takes the form: key=(Histogram Label, histogram bin), value=histogram entry
+        tester.expectedSetSizeMap.put(Arrays.asList("all_sets","2.0"),1.0);
+        tester.expectedSetSizeMap.put(Arrays.asList("optical_sets","2.0"),1.0);
+        tester.runTest();
+    }
+
+    @Test
+    public void testOpticalAndNonOpticalSet() {
+    // This tests checks that if I have two optical dups and one non-optical in the same dup set that the correct histogram entries
+    // are specified
+    final MarkDuplicatesSetSizeHistogramTester tester = getTester();
+        tester.setExpectedOpticalDuplicate(2);
+        String representativeReadName = "RUNID:1:1:16020:13352";
+        tester.addMatePair(representativeReadName, 1, 485253, 485253, false, false, false, false, "45M", "45M", false, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.addMatePair("RUNID:1:1:15993:13361", 1, 485253, 485253, false, false, true, true, "44M1S", "44M1S", false, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.addMatePair("RUNID:1:1:15994:13364", 1, 485253, 485253, false, false, true, true, "44M1S", "44M1S", false, true, false, false, false, DEFAULT_BASE_QUALITY);
+        // add one non-optical duplicate
+        tester.addMatePair("RUNID:1:1:25993:23361", 1, 485253, 485253, false, false, true, true, "44M1S", "44M1S", false, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.expectedSetSizeMap.put(Arrays.asList("all_sets","4.0"),1.0);
+        tester.expectedSetSizeMap.put(Arrays.asList("optical_sets","3.0"),1.0);
+        tester.runTest();
+    }
+
+    @Test
+    public void testSingleton() {
+        // This tests checks if having a read pair that is not duplicated, the correct histogram entry is updated
+    final MarkDuplicatesSetSizeHistogramTester tester = getTester();
+        tester.setExpectedOpticalDuplicate(0);
+        // Add non-duplicate read
+        tester.addMatePair("RUNID:1:1:15993:13375", 1, 485255, 485255, false, false, false, false, "43M2S", "43M2S", false, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.expectedSetSizeMap.put(Arrays.asList("all_sets","1.0"),1.0);
+        tester.runTest();
+    }
+
+    @Test
+    public void testMultiRepresentativeReadTags() {
+        // This tests checks multiple different duplicate sets of varying sizes
+    final MarkDuplicatesSetSizeHistogramTester tester = getTester();
+        tester.setExpectedOpticalDuplicate(3);
+        // Duplicate set: size 2 - all optical
+        String representativeReadName1 = "RUNID:1:1:16020:13352";
+        tester.addMatePair(representativeReadName1, 1, 485253, 485253, false, false, false, false, "45M", "45M", false, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.addMatePair("RUNID:1:1:15993:13361", 1, 485253, 485253, false, false, true, true, "44M1S", "44M1S", false, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.expectedSetSizeMap.put(Arrays.asList("all_sets","3.0"),1.0);
+        tester.expectedSetSizeMap.put(Arrays.asList("optical_sets","3.0"),1.0);
+
+        // Duplicate set: size 3 - all optical
+        String representativeReadName2 = "RUNID:1:1:15993:13360";
+        tester.addMatePair(representativeReadName2, 1, 485299, 485299, false, false, false, false, "45M", "45M", false, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.addMatePair("RUNID:1:1:15993:13365", 1, 485299, 485299, false, false, true, true, "44M1S", "44M1S", false, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.addMatePair("RUNID:1:1:15993:13370", 1, 485299, 485299, false, false, true, true, "43M2S", "43M2S", false, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.expectedSetSizeMap.put(Arrays.asList("all_sets","4.0"),1.0);
+        tester.expectedSetSizeMap.put(Arrays.asList("optical_sets","4.0"),1.0);
+
+        // Add non-duplicate read
+        tester.addMatePair("RUNID:1:1:15993:13375", 1, 485255, 485255, false, false, false, false, "43M2S", "43M2S", false, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.expectedSetSizeMap.put(Arrays.asList("all_sets", "1.0"), 1.0);
+
+        tester.runTest();
+    }
+
+}

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesSetSizeHistogramTester.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesSetSizeHistogramTester.java
@@ -1,0 +1,128 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam.markduplicates;
+
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.metrics.MetricsFile;
+import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.Histogram;
+import htsjdk.samtools.util.TestUtil;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import picard.cmdline.CommandLineProgram;
+import picard.sam.DuplicationMetrics;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * This class is an extension of AbstractMarkDuplicatesCommandLineProgramTester used to test MarkDuplicatesWithMateCigar with SAM files generated on the fly.
+ * This performs the underlying tests defined by classes such as see AbstractMarkDuplicatesCommandLineProgramTest and MarkDuplicatesWithMateCigarTest.
+ */
+public class MarkDuplicatesSetSizeHistogramTester extends AbstractMarkDuplicatesCommandLineProgramTester {
+
+    final public Map<List<String>, Double> expectedSetSizeMap = new HashMap<>(); // key=(Histogram Label, histogram bin), value=histogram entry
+
+    @Override
+    protected CommandLineProgram getProgram() {
+        return new MarkDuplicates();
+    }
+
+    @Override
+    public void test() throws IOException {
+        updateExpectedDuplicationMetrics();
+
+        // Read the output and check the duplicate flag
+        int outputRecords = 0;
+
+        try (SamReader reader = SamReaderFactory.makeDefault().open(getOutput())) {
+            for (final SAMRecord record : reader) {
+                outputRecords++;
+                final String key = samRecordToDuplicatesFlagsKey(record);
+                if (!this.duplicateFlags.containsKey(key)) {
+                    System.err.println("DOES NOT CONTAIN KEY: " + key);
+                }
+                Assert.assertTrue(this.duplicateFlags.containsKey(key));
+                final boolean value = this.duplicateFlags.get(key);
+                this.duplicateFlags.remove(key);
+                if (value != record.getDuplicateReadFlag()) {
+
+                    System.err.println("Mismatching read:");
+                    System.err.println(record.getSAMString());
+                }
+                Assert.assertEquals(record.getDuplicateReadFlag(), value);
+            }
+        }
+
+        // Ensure the program output the same number of records as were read in
+        Assert.assertEquals(outputRecords, this.getNumberOfRecords(), ("saw " + outputRecords + " output records, vs. " + this.getNumberOfRecords() + " input records"));
+
+        // Check the values written to metrics.txt against our input expectations
+        final MetricsFile<DuplicationMetrics, Double> metricsOutput = new MetricsFile<DuplicationMetrics, Double>();
+        try {
+            metricsOutput.read(new FileReader(metricsFile));
+        } catch (final FileNotFoundException ex) {
+            System.err.println("Metrics file not found: " + ex);
+        }
+        Assert.assertEquals(metricsOutput.getMetrics().size(), 1);
+        final DuplicationMetrics observedMetrics = metricsOutput.getMetrics().get(0);
+        Assert.assertEquals(observedMetrics.UNPAIRED_READS_EXAMINED, expectedMetrics.UNPAIRED_READS_EXAMINED, "UNPAIRED_READS_EXAMINED does not match expected");
+        Assert.assertEquals(observedMetrics.READ_PAIRS_EXAMINED, expectedMetrics.READ_PAIRS_EXAMINED, "READ_PAIRS_EXAMINED does not match expected");
+        Assert.assertEquals(observedMetrics.UNMAPPED_READS, expectedMetrics.UNMAPPED_READS, "UNMAPPED_READS does not match expected");
+        Assert.assertEquals(observedMetrics.UNPAIRED_READ_DUPLICATES, expectedMetrics.UNPAIRED_READ_DUPLICATES, "UNPAIRED_READ_DUPLICATES does not match expected");
+        Assert.assertEquals(observedMetrics.READ_PAIR_DUPLICATES, expectedMetrics.READ_PAIR_DUPLICATES, "READ_PAIR_DUPLICATES does not match expected");
+        Assert.assertEquals(observedMetrics.READ_PAIR_OPTICAL_DUPLICATES, expectedMetrics.READ_PAIR_OPTICAL_DUPLICATES, "READ_PAIR_OPTICAL_DUPLICATES does not match expected");
+        Assert.assertEquals(observedMetrics.PERCENT_DUPLICATION, expectedMetrics.PERCENT_DUPLICATION, "PERCENT_DUPLICATION does not match expected");
+        Assert.assertEquals(observedMetrics.ESTIMATED_LIBRARY_SIZE, expectedMetrics.ESTIMATED_LIBRARY_SIZE, "ESTIMATED_LIBRARY_SIZE does not match expected");
+        Assert.assertEquals(observedMetrics.SECONDARY_OR_SUPPLEMENTARY_RDS, expectedMetrics.SECONDARY_OR_SUPPLEMENTARY_RDS, "SECONDARY_OR_SUPPLEMENTARY_RDS does not match expected");
+
+
+        // Check contents of set size bin against expected values //
+        for (final Histogram<Double> histo : metricsOutput.getAllHistograms()) {
+            final String label = histo.getValueLabel();
+            for (final Double bin : histo.keySet()) {
+                final String binStr = String.valueOf(bin);
+                final List<String> labelBinStr = Arrays.asList(label, binStr);
+                if (expectedSetSizeMap.containsKey(labelBinStr)) {
+                    Histogram.Bin<Double> binValue = histo.get(bin);
+                    final double actual = binValue.getValue();
+                    final double expected = expectedSetSizeMap.get(labelBinStr);
+                    Assert.assertEquals(actual, expected);
+                }
+            }
+        }
+    }
+
+    @AfterClass
+    public void afterTest() {
+        TestUtil.recursiveDelete(getOutputDir());
+    }
+
+}

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesSetSizeHistogramTester.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesSetSizeHistogramTester.java
@@ -89,7 +89,8 @@ public class MarkDuplicatesSetSizeHistogramTester extends AbstractMarkDuplicates
         try {
             metricsOutput.read(new FileReader(metricsFile));
         } catch (final FileNotFoundException ex) {
-            System.err.println("Metrics file not found: " + ex);
+            // Rethrows as unchecked exception to avoid having to change existing tests
+            throw new RuntimeException(ex);
         }
         Assert.assertEquals(metricsOutput.getMetrics().size(), 1);
         final DuplicationMetrics observedMetrics = metricsOutput.getMetrics().get(0);

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesSetSizeHistogramTester.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesSetSizeHistogramTester.java
@@ -82,7 +82,7 @@ public class MarkDuplicatesSetSizeHistogramTester extends AbstractMarkDuplicates
         }
 
         // Ensure the program output the same number of records as were read in
-        Assert.assertEquals(outputRecords, this.getNumberOfRecords(), ("saw " + outputRecords + " output records, vs. " + this.getNumberOfRecords() + " input records"));
+        Assert.assertEquals(outputRecords, this.getNumberOfRecords());
 
         // Check the values written to metrics.txt against our input expectations
         final MetricsFile<DuplicationMetrics, Double> metricsOutput = new MetricsFile<DuplicationMetrics, Double>();

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesSetSizeHistogramTester.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesSetSizeHistogramTester.java
@@ -24,22 +24,14 @@
 
 package picard.sam.markduplicates;
 
-import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.SamReader;
-import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.metrics.MetricsFile;
-import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.Histogram;
 import htsjdk.samtools.util.TestUtil;
-import org.apache.commons.jexl2.UnifiedJEXL;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import picard.cmdline.CommandLineProgram;
 import picard.sam.DuplicationMetrics;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
 import java.util.*;
 
@@ -58,52 +50,7 @@ public class MarkDuplicatesSetSizeHistogramTester extends AbstractMarkDuplicates
 
     @Override
     public void test() throws IOException {
-        updateExpectedDuplicationMetrics();
-
-        // Read the output and check the duplicate flag
-        int outputRecords = 0;
-
-        try (SamReader reader = SamReaderFactory.makeDefault().open(getOutput())) {
-            for (final SAMRecord record : reader) {
-                outputRecords++;
-                final String key = samRecordToDuplicatesFlagsKey(record);
-                if (!this.duplicateFlags.containsKey(key)) {
-                    System.err.println("DOES NOT CONTAIN KEY: " + key);
-                }
-                Assert.assertTrue(this.duplicateFlags.containsKey(key));
-                final boolean value = this.duplicateFlags.get(key);
-                this.duplicateFlags.remove(key);
-                if (value != record.getDuplicateReadFlag()) {
-
-                    System.err.println("Mismatching read:");
-                    System.err.println(record.getSAMString());
-                }
-                Assert.assertEquals(record.getDuplicateReadFlag(), value);
-            }
-        }
-
-        // Ensure the program output the same number of records as were read in
-        Assert.assertEquals(outputRecords, this.getNumberOfRecords());
-
-        // Check the values written to metrics.txt against our input expectations
-        final MetricsFile<DuplicationMetrics, Double> metricsOutput = new MetricsFile<DuplicationMetrics, Double>();
-        try {
-            metricsOutput.read(new FileReader(metricsFile));
-        } catch (final FileNotFoundException ex) {
-            // Rethrows as unchecked exception to avoid having to change existing tests
-            throw new RuntimeException(ex);
-        }
-        Assert.assertEquals(metricsOutput.getMetrics().size(), 1);
-        final DuplicationMetrics observedMetrics = metricsOutput.getMetrics().get(0);
-        Assert.assertEquals(observedMetrics.UNPAIRED_READS_EXAMINED, expectedMetrics.UNPAIRED_READS_EXAMINED, "UNPAIRED_READS_EXAMINED does not match expected");
-        Assert.assertEquals(observedMetrics.READ_PAIRS_EXAMINED, expectedMetrics.READ_PAIRS_EXAMINED, "READ_PAIRS_EXAMINED does not match expected");
-        Assert.assertEquals(observedMetrics.UNMAPPED_READS, expectedMetrics.UNMAPPED_READS, "UNMAPPED_READS does not match expected");
-        Assert.assertEquals(observedMetrics.UNPAIRED_READ_DUPLICATES, expectedMetrics.UNPAIRED_READ_DUPLICATES, "UNPAIRED_READ_DUPLICATES does not match expected");
-        Assert.assertEquals(observedMetrics.READ_PAIR_DUPLICATES, expectedMetrics.READ_PAIR_DUPLICATES, "READ_PAIR_DUPLICATES does not match expected");
-        Assert.assertEquals(observedMetrics.READ_PAIR_OPTICAL_DUPLICATES, expectedMetrics.READ_PAIR_OPTICAL_DUPLICATES, "READ_PAIR_OPTICAL_DUPLICATES does not match expected");
-        Assert.assertEquals(observedMetrics.PERCENT_DUPLICATION, expectedMetrics.PERCENT_DUPLICATION, "PERCENT_DUPLICATION does not match expected");
-        Assert.assertEquals(observedMetrics.ESTIMATED_LIBRARY_SIZE, expectedMetrics.ESTIMATED_LIBRARY_SIZE, "ESTIMATED_LIBRARY_SIZE does not match expected");
-        Assert.assertEquals(observedMetrics.SECONDARY_OR_SUPPLEMENTARY_RDS, expectedMetrics.SECONDARY_OR_SUPPLEMENTARY_RDS, "SECONDARY_OR_SUPPLEMENTARY_RDS does not match expected");
+        final MetricsFile<DuplicationMetrics, Double> metricsOutput = testMetrics();
 
         // Check contents of set size bin against expected values
         if (!expectedSetSizeMap.isEmpty()) {
@@ -123,7 +70,7 @@ public class MarkDuplicatesSetSizeHistogramTester extends AbstractMarkDuplicates
                 }
             }
             if (!checked) {
-                throw new RuntimeException("Could not not find matching entry for expectedSetSizeMap in metrics.");
+                Assert.fail("Could not not find matching entry for expectedSetSizeMap in metrics.");
             }
         }
     }

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
@@ -232,7 +232,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
         try {
             super.test();
         } catch (IOException ex) {
-            Assert.fail("Could not open metrics file: " + ex.getMessage());
+            Assert.fail("Could not open metrics file: " + ex);
         }
     }
 

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
@@ -35,6 +35,7 @@ import picard.cmdline.CommandLineProgram;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -228,7 +229,11 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
         }
 
         // Also do tests from AbstractMarkDuplicatesCommandLineProgramTester
-        super.test();
+        try {
+            super.test();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     @Override

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
@@ -232,8 +232,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
         try {
             super.test();
         } catch (IOException ex) {
-            // Rethrows as unchecked exception to avoid having to change existing tests
-            throw new RuntimeException(ex);
+            Assert.fail("Could not open metrics file: " + ex.getMessage());
         }
     }
 

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
@@ -231,8 +231,9 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
         // Also do tests from AbstractMarkDuplicatesCommandLineProgramTester
         try {
             super.test();
-        } catch (IOException e) {
-            e.printStackTrace();
+        } catch (IOException ex) {
+            // Rethrows as unchecked exception to avoid having to change existing tests
+            throw new RuntimeException(ex);
         }
     }
 

--- a/src/test/java/picard/sam/testers/SamFileTester.java
+++ b/src/test/java/picard/sam/testers/SamFileTester.java
@@ -359,7 +359,8 @@ public abstract class SamFileTester extends CommandLineProgramTest {
             Assert.assertEquals(runPicardCommandLine(args), 0);
             test();
         } catch (IOException ex) {
-            ex.printStackTrace();
+            // Rethrows as unchecked exception to avoid having to change existing tests
+            throw new RuntimeException(ex);
         }
     }
 

--- a/src/test/java/picard/sam/testers/SamFileTester.java
+++ b/src/test/java/picard/sam/testers/SamFileTester.java
@@ -13,6 +13,7 @@ import org.testng.Assert;
 import picard.cmdline.CommandLineProgramTest;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -343,19 +344,23 @@ public abstract class SamFileTester extends CommandLineProgramTest {
                 isDuplicate1, isDuplicate2, cigar1, cigar2, strand1, strand2, firstOnly, record1NonPrimary, record2NonPrimary, defaultQuality);
     }
 
-    protected abstract void test();
+    protected abstract void test() throws IOException;
 
     /**
      * Sets up the basic command line arguments for input and output and runs instanceMain.
      */
     public void runTest() {
-        final File input = createInputFile();
+        try {
+            final File input = createInputFile();
 
-        output = new File(outputDir, "output.sam");
-        args.add("INPUT=" + input.getAbsoluteFile());
-        args.add("OUTPUT=" + output.getAbsoluteFile());
-        Assert.assertEquals(runPicardCommandLine(args), 0);
-        test();
+            output = new File(outputDir, "output.sam");
+            args.add("INPUT=" + input.getAbsoluteFile());
+            args.add("OUTPUT=" + output.getAbsoluteFile());
+            Assert.assertEquals(runPicardCommandLine(args), 0);
+            test();
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
     }
 
     private File createInputFile() {


### PR DESCRIPTION
This change tracks the size of read pairs sets that are found by MarkDuplicates to be mapped to the same location. The feature performs as follows:
- only sets of mapped read pairs are counted in the histogram
- a set size of 1 indicates a read pair was not a duplicate
- set size of 2 indicates two read pairs were mapped to the same location
- set size of 3 indicates three read pairs were mapped to the same location... and so on

Design choices where I'd welcome feedback:
- optional flag to write the set size counts: I could add this if need be. 
- addSingletonToCount: this function directly counts each read pair that does not appear as duplicate. The overall count of these non-duplicate pairs could also be inferred from READ_PAIRS_EXAMINED - READ_PAIR_DUPLICATES. In one sense, I see it as preferable to count them directly, but I could also see the argument for inferring the count of non-duplicate entries to reduce overhead. 
- The structure of the output file is not ideal. The set size counts are printed on adjacent columns to the ROI metric. This follows the convention of 'addHistogram()' to a metrics file, but I see two problems doing this. First, I find this slightly confusing as the single 'BIN' column is used to represent two different things (set size and ROI multiple). Second, values of the duplicate set histogram will always take on integer values and that doesn't have to be the case for ROI sequencing multiples. 

Here are three options regarding this last issue 1) Leave the output as it appears in this pull request (ROI output and set sizes printed together) being careful to explain in the documentation that both are represented in the ## HISTOGRAM entry. 2) Change the metrics file to allow histograms to be printed on multiple lines (possible, but probably out of scope for this pull request). 3) Print the set size histograms to an entirely new file. 
