### PR TITLE
Fixing bug in GatherVcfs.

### DIFF
--- a/src/java/picard/vcf/GatherVcfs.java
+++ b/src/java/picard/vcf/GatherVcfs.java
@@ -210,7 +210,7 @@ public class GatherVcfs extends CommandLineProgram {
                     final BlockCompressedInputStream blockIn = new BlockCompressedInputStream(in, false);
                     boolean lastByteNewline = true;
 
-                    while (in.available() > 0) {
+                    while (blockIn.available() > 0) {
                         // Read a block - blockIn.available() is guaranteed to return the bytes remaining in the block that has been
                         // read, and since we haven't consumed any yet, that is the block size.
                         final int blockLength = blockIn.available();


### PR DESCRIPTION
If the VCF header spans multiple Gzip blocks and there are no variants,
then an Exception could be thrown:
- java.lang.IllegalStateException: Could not read available bytes from BlockCompressedInputStream

Not adding tests since the fix is obvious, and the issue breaks a production pipeline.  Thanks for reviewing: @yfarjoun @jacarey @ktibbett. 