### PR TITLE
squid:S2063 - Comparators should be Serializable

### DIFF
--- a/src/main/java/picard/cmdline/CommandLineParser.java
+++ b/src/main/java/picard/cmdline/CommandLineParser.java
@@ -34,6 +34,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -1145,7 +1146,8 @@ public class CommandLineParser {
         String getHelpDoc();
     }
 
-    protected static class OptionDefinitionByPrintOrderComparator implements Comparator<OptionDefinition> {
+    protected static class OptionDefinitionByPrintOrderComparator implements Comparator<OptionDefinition>, Serializable {
+        private static final long serialVersionUID = 6476036013963135375L;
 
         @Override
         public int compare(OptionDefinition o1, OptionDefinition o2) {

--- a/src/main/java/picard/cmdline/PicardCommandLine.java
+++ b/src/main/java/picard/cmdline/PicardCommandLine.java
@@ -4,6 +4,7 @@ import htsjdk.samtools.Defaults;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.StringUtil;
 
+import java.io.Serializable;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -169,7 +170,9 @@ public class PicardCommandLine {
         return (CommandLineProgramProperties)clazz.getAnnotation(CommandLineProgramProperties.class);
     }
 
-    private static class SimpleNameComparator implements Comparator<Class> {
+    private static class SimpleNameComparator implements Comparator<Class>, Serializable {
+        private static final long serialVersionUID = -1201103996188234064L;
+
         @Override
         public int compare(final Class aClass, final Class bClass) {
             return aClass.getSimpleName().compareTo(bClass.getSimpleName());

--- a/src/main/java/picard/illumina/IlluminaBasecallsToSam.java
+++ b/src/main/java/picard/illumina/IlluminaBasecallsToSam.java
@@ -53,6 +53,7 @@ import picard.util.TabbedTextFileWithHeaderParser;
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -529,7 +530,9 @@ public class IlluminaBasecallsToSam extends CommandLineProgram {
         }
     }
 
-    static class QueryNameComparator implements Comparator<SAMRecordsForCluster> {
+    static class QueryNameComparator implements Comparator<SAMRecordsForCluster>, Serializable {
+        private static final long serialVersionUID = -250586611537988409L;
+
         private final SAMRecordQueryNameComparator comparator = new SAMRecordQueryNameComparator();
         @Override
         public int compare(final SAMRecordsForCluster s1, final SAMRecordsForCluster s2) {

--- a/src/main/java/picard/sam/BestEndMapqPrimaryAlignmentStrategy.java
+++ b/src/main/java/picard/sam/BestEndMapqPrimaryAlignmentStrategy.java
@@ -26,6 +26,7 @@ package picard.sam;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMUtils;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -89,7 +90,9 @@ public class BestEndMapqPrimaryAlignmentStrategy implements PrimaryAlignmentSele
     }
 
     // Sorts in descending order, but 255 is considered > 0 but < 1, and unmapped is worst of all
-    private static class MapqComparator implements Comparator<SAMRecord> {
+    private static class MapqComparator implements Comparator<SAMRecord>, Serializable {
+        private static final long serialVersionUID = 4860599725217322884L;
+
         public int compare(final SAMRecord rec1, final SAMRecord rec2) {
             if (rec1.getReadUnmappedFlag()) {
                 if (rec2.getReadUnmappedFlag()) return 0;

--- a/src/main/java/picard/sam/HitsForInsert.java
+++ b/src/main/java/picard/sam/HitsForInsert.java
@@ -26,6 +26,7 @@ package picard.sam;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMTag;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -258,7 +259,9 @@ class HitsForInsert {
     }
 
     // null HI tag sorts after any non-null.
-    private static class HitIndexComparator implements Comparator<SAMRecord> {
+    private static class HitIndexComparator implements Comparator<SAMRecord>, Serializable {
+        private static final long serialVersionUID = -4183102695000550873L;
+
         public int compare(final SAMRecord rec1, final SAMRecord rec2) {
             final Integer hi1 = rec1.getIntegerAttribute(SAMTag.HI.name());
             final Integer hi2 = rec2.getIntegerAttribute(SAMTag.HI.name());

--- a/src/main/java/picard/sam/markduplicates/EstimateLibraryComplexity.java
+++ b/src/main/java/picard/sam/markduplicates/EstimateLibraryComplexity.java
@@ -56,6 +56,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -343,7 +344,9 @@ public class EstimateLibraryComplexity extends AbstractOpticalDuplicateFinderCom
      * Comparator that orders read pairs on the first N bases of both reads.
      * There is no tie-breaking, so any sort is stable, not total.
      */
-    private class PairedReadComparator implements Comparator<PairedReadSequence> {
+    private class PairedReadComparator implements Comparator<PairedReadSequence>, Serializable {
+        private static final long serialVersionUID = 2467976276921568474L;
+
         final int BASES = EstimateLibraryComplexity.this.MIN_IDENTICAL_BASES;
 
         public int compare(final PairedReadSequence lhs, final PairedReadSequence rhs) {

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -765,7 +765,8 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
     }
 
     /** Comparator for ReadEndsForMarkDuplicates that orders by read1 position then pair orientation then read2 position. */
-    static class ReadEndsMDComparator implements Comparator<ReadEndsForMarkDuplicates> {
+    static class ReadEndsMDComparator implements Comparator<ReadEndsForMarkDuplicates>, Serializable {
+        private static final long serialVersionUID = -8835633629108383865L;
 
         final boolean useBarcodes;
 

--- a/src/main/java/picard/sam/markduplicates/util/MarkQueue.java
+++ b/src/main/java/picard/sam/markduplicates/util/MarkQueue.java
@@ -33,6 +33,7 @@ import picard.PicardException;
 import picard.sam.DuplicationMetrics;
 import htsjdk.samtools.DuplicateScoringStrategy.ScoringStrategy;
 
+import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Set;
 import java.util.SortedSet;
@@ -51,7 +52,9 @@ public class MarkQueue {
      * Comparator to order the mark queue nonDuplicateReadEndsSet.  The nonDuplicateReadEndsSet of all the read ends that are compared to be the same should
      * be used for duplicate marking.
      */
-    private class MarkQueueComparator implements Comparator<ReadEndsForMateCigar> {
+    private class MarkQueueComparator implements Comparator<ReadEndsForMateCigar>, Serializable {
+        private static final long serialVersionUID = -6956889883827037267L;
+
         public int compare(final ReadEndsForMateCigar lhs, final ReadEndsForMateCigar rhs) {
             int retval = lhs.libraryId - rhs.libraryId;
             if (retval == 0) retval = lhs.read1ReferenceIndex - rhs.read1ReferenceIndex;
@@ -67,7 +70,9 @@ public class MarkQueue {
      * Comparator for ReadEndsForMateCigar that orders by read1 position then pair orientation then read2 position.
      * This is the main comparator to choose the best representative read and end to store as the non-duplicate.
      */
-    class ReadEndsMCComparator implements Comparator<ReadEndsForMateCigar> {
+    class ReadEndsMCComparator implements Comparator<ReadEndsForMateCigar>, Serializable {
+        private static final long serialVersionUID = 2538562381318322869L;
+
         private final ScoringStrategy duplicateScoringStrategy;
 
         public ReadEndsMCComparator(final ScoringStrategy duplicateScoringStrategy) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2063 - Comparators should be "Serializable"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2063

Please let me know if you have any questions.

M-Ezzat