### PR TITLE
Cleanup - squid:S2162 - equals methods should be symmetric and work f…

### DIFF
--- a/src/main/java/picard/annotation/Gene.java
+++ b/src/main/java/picard/annotation/Gene.java
@@ -64,7 +64,9 @@ public class Gene extends Interval implements Iterable<Gene.Transcript>  {
     }
 
     public boolean equals(final Object other) {
-        if (!(other instanceof Gene)) return false;
+        if (this == other) return true;
+        if (other == null) return false;
+        if (this.getClass() != other.getClass()) return false;
         else if (this == other) return true;
         else {
             final Gene that = (Gene)other;

--- a/src/main/java/picard/fingerprint/Snp.java
+++ b/src/main/java/picard/fingerprint/Snp.java
@@ -103,7 +103,16 @@ public class Snp implements Comparable<Snp> {
 
     @Override
     public boolean equals(final Object o) {
-        return (this == o) || ((o instanceof Snp) && compareTo((Snp) o) == 0);
+        if (this == o) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
+        if (this.getClass() == o.getClass()) {
+            return compareTo((Snp) o) == 0;   
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/picard/illumina/IlluminaBasecallsConverter.java
+++ b/src/main/java/picard/illumina/IlluminaBasecallsConverter.java
@@ -359,7 +359,16 @@ public class IlluminaBasecallsConverter<CLUSTER_OUTPUT_RECORD> {
 
         @Override
         public boolean equals(final Object o) {
-            return o instanceof Tile && this.getNumber() == ((Tile) o).getNumber();
+            if (this == o) {
+                return true;
+            }
+            if (o == null) {
+                return false;
+            }
+            if (this.getClass() == o.getClass()) {
+                return this.getNumber() == ((Tile) o).getNumber();
+            }
+            return false;
         }
 
         @Override

--- a/src/main/java/picard/illumina/parser/OutputMapping.java
+++ b/src/main/java/picard/illumina/parser/OutputMapping.java
@@ -137,12 +137,17 @@ public class OutputMapping {
 
         @Override
         public boolean equals(final Object thatObj) {
-            if(thatObj == null || !(thatObj instanceof TwoDIndex)) {
+            if (this == thatObj) {
+                return true;
+            }
+            if (thatObj == null) {
                 return false;
             }
-
-            final TwoDIndex that = (TwoDIndex) thatObj;
-            return this.majorIndex == that.majorIndex && this.minorIndex == that.minorIndex;
+            if (this.getClass() == thatObj.getClass()) {
+                final TwoDIndex that = (TwoDIndex) thatObj;
+                return this.majorIndex == that.majorIndex && this.minorIndex == that.minorIndex;
+            }
+            return false;
         }
     }
 

--- a/src/main/java/picard/illumina/parser/Range.java
+++ b/src/main/java/picard/illumina/parser/Range.java
@@ -45,12 +45,17 @@ public class Range {
 
     @Override
     public boolean equals(final Object object) {
-        if(object == null || !(object instanceof Range)) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null) {
             return false;
         }
-
-        final Range that = (Range) object;
-        return that.start == this.start && that.end == this.end;
+        if (this.getClass() == object.getClass()) {
+            final Range that = (Range) object;
+            return that.start == this.start && that.end == this.end;
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/picard/illumina/parser/readers/TileMetricsOutReader.java
+++ b/src/main/java/picard/illumina/parser/readers/TileMetricsOutReader.java
@@ -108,7 +108,13 @@ public class TileMetricsOutReader implements Iterator<TileMetricsOutReader.Illum
 
         @Override
         public boolean equals(final Object o) {
-            if (o instanceof IlluminaTileMetrics) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null) {
+                return false;
+            }
+            if (this.getClass() == o.getClass()) {
                 final IlluminaTileMetrics that = (IlluminaTileMetrics) o;
                 return laneTileCode == that.laneTileCode && metricValue == that.metricValue; // Identical tile data should render exactly the same float.
             } else {
@@ -148,7 +154,13 @@ public class TileMetricsOutReader implements Iterator<TileMetricsOutReader.Illum
 
         @Override
         public boolean equals(final Object o) {
-            if (o instanceof IlluminaLaneTileCode) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null) {
+                return false;
+            }
+            if (this.getClass() == o.getClass()) {
                 final IlluminaLaneTileCode that = (IlluminaLaneTileCode) o;
                 return laneNumber == that.laneNumber && tileNumber == that.tileNumber && metricCode == that.metricCode;
             } else {

--- a/src/main/java/picard/sam/markduplicates/util/PhysicalLocationForMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/util/PhysicalLocationForMateCigar.java
@@ -60,7 +60,13 @@ public class PhysicalLocationForMateCigar extends PhysicalLocationShort {
 
     @Override
     public boolean equals(Object other) {
-        if (other instanceof PhysicalLocationForMateCigar) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null) {
+            return false;
+        }
+        if (this.getClass() == other.getClass()) {
             int cmp;
             PhysicalLocationForMateCigar loc = (PhysicalLocationForMateCigar) other;
             cmp = getLibraryId() - loc.getLibraryId();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2162 - "equals" methods should be symmetric and work for subclasses

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2162

Please let me know if you have any questions.

M-Ezzat
