### PR TITLE
UMI Aware Mark Duplicates with rudimentary error correction

### DIFF
--- a/src/main/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigar.java
@@ -32,10 +32,7 @@ import htsjdk.samtools.SAMFileWriterFactory;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecordDuplicateComparator;
 import htsjdk.samtools.SAMTag;
-import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.IterableAdapter;
-import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.ProgressLogger;
+import htsjdk.samtools.util.*;
 import picard.PicardException;
 import picard.cmdline.CommandLineProgramProperties;
 import picard.cmdline.programgroups.Testing;
@@ -120,10 +117,7 @@ public class SimpleMarkDuplicatesWithMateCigar extends MarkDuplicates {
         final SAMRecordDuplicateComparator comparator = new SAMRecordDuplicateComparator(Collections.singletonList(headerAndIterator.header));
         comparator.setScoringStrategy(this.DUPLICATE_SCORING_STRATEGY);
 
-        final DuplicateSetIterator iterator = new DuplicateSetIterator(headerAndIterator.iterator,
-                headerAndIterator.header,
-                false,
-                comparator);
+        final CloseableIterator<DuplicateSet> iterator = getDuplicateSetIterator(headerAndIterator, comparator);
 
         // progress logger!
         final ProgressLogger progress = new ProgressLogger(log, (int) 1e6, "Read");
@@ -232,5 +226,12 @@ public class SimpleMarkDuplicatesWithMateCigar extends MarkDuplicates {
         finalizeAndWriteMetrics(libraryIdGenerator);
 
         return 0;
+    }
+
+    protected CloseableIterator<DuplicateSet> getDuplicateSetIterator(final SamHeaderAndIterator headerAndIterator, final SAMRecordDuplicateComparator comparator) {
+        return new DuplicateSetIterator(headerAndIterator.iterator,
+                    headerAndIterator.header,
+                    false,
+                    comparator);
     }
 }

--- a/src/main/java/picard/sam/markduplicates/UmiAwareDuplicateSetIterator.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareDuplicateSetIterator.java
@@ -1,0 +1,249 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam.markduplicates;
+
+import htsjdk.samtools.DuplicateSet;
+import htsjdk.samtools.DuplicateSetIterator;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.util.CloseableIterator;
+import picard.PicardException;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.counting;
+
+/**
+ * Created by fleharty on 5/23/16.
+ */
+public class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
+    private final DuplicateSetIterator wrappedIterator;
+    private Iterator<DuplicateSet> nextSetsIterator;
+    private final int editDistanceToJoin;
+    private final boolean addInferredUmi;
+    private final String umiTag;
+    private final String inferredUmiTag;
+
+    public UmiAwareDuplicateSetIterator(final DuplicateSetIterator wrappedIterator, final int editDistanceToJoin, final boolean addInferredUmi, final String umiTag, final String inferredUmiTag) {
+        this.wrappedIterator = wrappedIterator;
+        this.editDistanceToJoin = editDistanceToJoin;
+        this.addInferredUmi = addInferredUmi;
+        this.umiTag = umiTag;
+        this.inferredUmiTag = inferredUmiTag;
+        nextSetsIterator = Collections.emptyIterator();
+    }
+
+    @Override
+    public void close() {
+        wrappedIterator.close();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return nextSetsIterator.hasNext() || wrappedIterator.hasNext();
+    }
+
+    @Override
+    public DuplicateSet next() {
+        if(!nextSetsIterator.hasNext())
+            process(wrappedIterator.next());
+
+        return nextSetsIterator.next();
+    }
+
+    // Takes a duplicate set and breaks it up into possible smaller sets according to the UMI,
+    // and updates nextSetsIterator to be an iterator on that set of DuplicateSets.
+    private void process(final DuplicateSet set) {
+
+        List<SAMRecord> records = set.getRecords();
+
+        // If any records are missing the UMI_TAG proceed as if there were no UMIs
+        // and return nextSetsIterator without breaking it up into smaller sets.
+        for(SAMRecord rec : records) {
+            if(rec.getStringAttribute(umiTag) == null) {
+                nextSetsIterator = Collections.singleton(set).iterator();
+                return;
+            }
+        }
+
+        // Count all the uniquely observed UMI sequences
+        Map<String, Long> umiFrequencies = records.stream()
+                        .collect(Collectors.groupingBy(p -> p.getStringAttribute(umiTag),
+                                counting()));
+
+        UmiGraph umiGraph = new UmiGraph();
+
+        // Add each of the uniquely observed UMI sequences to the graph
+        int firstGroup = 0;
+        for (Map.Entry<String, Long> umiFrequency : umiFrequencies.entrySet()) {
+            umiGraph.addNode(new UmiSequence(umiFrequency.getKey(), umiFrequency.getValue()));
+        }
+        umiGraph.processNodes();
+
+        Map<Integer, List<UmiSequence>> umisByDuplicateSet = umiGraph.getUmisByDuplicateSet();
+
+        // Construct DuplicateSetList
+        List<DuplicateSet> duplicateSetList = new ArrayList<>();
+        for(int i = 0;i < umiGraph.duplicateSetCounter;i++) {
+            DuplicateSet e = new DuplicateSet();
+            duplicateSetList.add(e);
+        }
+
+        for(SAMRecord rec : records) {
+            String umi = records.get(records.indexOf(rec)).getStringAttribute(umiTag);
+
+            // Figure out which group this belongs to
+            int recordGroup = umiGraph.node.get(umi).duplicateSet;
+            duplicateSetList.get(recordGroup).add(records.get(records.indexOf(rec)));
+        }
+
+        // Optionally add the inferred Umi
+        if(addInferredUmi) {
+            for(DuplicateSet ds : duplicateSetList) {
+                // For each duplicate set identify the most common UMI
+                List<SAMRecord> recordsFromDuplicateSet = ds.getRecords();
+
+                // Assign the inferred UMI to all reads in the current group
+                for(SAMRecord record : recordsFromDuplicateSet) {
+                    record.setAttribute(inferredUmiTag, umiGraph.getInferredUmiFromOriginalSequence(record.getStringAttribute(umiTag)));
+                }
+            }
+        }
+
+        nextSetsIterator = duplicateSetList.iterator();
+    }
+
+    private int getEditDistance(final String s1, final String s2) {
+        if(s1 == null || s2 == null) {
+            throw new PicardException("Attempt to compare two incomparable UMIs.  At least one of the UMIs was null.");
+        }
+        if(s1.length() != s2.length()) {
+            throw new PicardException("Barcode " + s1 + " and " + s2 + " do not have matching lengths.");
+        }
+        int count = 0;
+        for(int i = 0;i < s1.length();i++) {
+            if(s1.charAt(i) != s2.charAt(i)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private class UmiSequence {
+        private final String sequence;
+        private String inferredSequence;
+        private final Long occupancy;
+        private Integer duplicateSet;
+
+        UmiSequence(final String sequence, final Long occupancy) {
+            this.sequence = sequence;
+            this.occupancy = occupancy;
+        }
+    }
+
+    private class UmiGraph {
+        int duplicateSetCounter = 0;
+        private final Map<String, UmiSequence> node = new HashMap<>();
+
+        void addNode(final UmiSequence umi) {
+            node.put(umi.sequence, umi);
+        }
+
+        void processNodes() {
+            boolean isFirstEntry = true;
+            for(Map.Entry<String, UmiSequence> umi1 : node.entrySet()) {
+
+                if(isFirstEntry) {
+                    isFirstEntry = false;
+                    umi1.getValue().duplicateSet = duplicateSetCounter;
+                    duplicateSetCounter++;
+                }
+                // Test to see if this is similar to something I've seen before (that has been assigned to a duplicate set)
+                for (Map.Entry<String, UmiSequence> umi2 : node.entrySet()) {
+                    // If it is similar (within edit distance editDistanceToJoin) and not the same umi
+                    // join it to the appropriate existing duplicate set
+                    if (getEditDistance(umi1.getKey(), umi2.getKey()) <= editDistanceToJoin) {
+                        // Since it is similar to something we have seen before we
+                        // assign it to it's appropriate duplicateSet
+                        if(umi1.getValue().duplicateSet != null) {
+                            umi2.getValue().duplicateSet = umi1.getValue().duplicateSet;
+                        } else if(umi2.getValue().duplicateSet != null) {
+                            umi1.getValue().duplicateSet = umi2.getValue().duplicateSet;
+                        }
+                    }
+                }
+                // If we haven't added the UMI sequence to a duplicate set yet, then we need to put it in a
+                // in its own duplicate set.
+                if (umi1.getValue().duplicateSet == null) {
+                    // If we haven't seen a similar UMI before, we add it, and create a
+                    // new duplicate set for it.
+                    umi1.getValue().duplicateSet = duplicateSetCounter;
+                    //node.put(umi1.getValue().sequence, umi1.getValue());
+                    duplicateSetCounter++;
+                }
+            }
+        }
+
+        private String getInferredUmiFromOriginalSequence(String seq) {
+            return node.get(seq).inferredSequence;
+        }
+
+        Map<Integer, List<UmiSequence>> getUmisByDuplicateSet() {
+            Map<Integer, List<UmiSequence>> umisByDuplicateSet = new HashMap<>();
+
+            // Create UmiSequence Lists for each group that exists
+            for(int i = 0;i < duplicateSetCounter;i++) {
+                umisByDuplicateSet.put(i, new ArrayList<>());
+            }
+
+            // Assign each UmiSequence to a Duplicate set
+            for(Map.Entry<String, UmiSequence> s : node.entrySet()) {
+                umisByDuplicateSet.get(s.getValue().duplicateSet).add(s.getValue());
+            }
+
+            // Infer the Umi from each duplicate set
+            for(Map.Entry<Integer, List<UmiSequence>> s : umisByDuplicateSet.entrySet())  {
+
+                // Find most common UMI sequence in this duplicate set
+                Long maxOccupancy = new Long(0);
+                String mostCommonUmiSequence = null;
+                for(UmiSequence seq : s.getValue()) {
+                    if(seq.occupancy > maxOccupancy) {
+                        maxOccupancy = seq.occupancy;
+                        mostCommonUmiSequence = seq.sequence;
+                    }
+                }
+
+                // Set the most common UMI sequence to the inferred UMI for all UmiSequences
+                // in this duplicate set
+                for(UmiSequence seq : s.getValue()) {
+                    seq.inferredSequence = mostCommonUmiSequence;
+                }
+            }
+            return umisByDuplicateSet;
+        }
+    }
+}
+

--- a/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
@@ -1,0 +1,87 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam.markduplicates;
+
+import htsjdk.samtools.DuplicateSet;
+import htsjdk.samtools.DuplicateSetIterator;
+import htsjdk.samtools.SAMRecordDuplicateComparator;
+import htsjdk.samtools.util.*;
+import picard.cmdline.CommandLineProgramProperties;
+import picard.cmdline.Option;
+import picard.cmdline.programgroups.Alpha;
+
+/**
+ * This is a simple tool to mark duplicates using the UmiAwareDuplicateSetIterator, DuplicateSet, and SAMRecordDuplicateComparator.
+ *
+ * It makes use of the UmiAwareDuplicateSetIterator which is a wrapper around the DuplicateSetIterator.  It makes use
+ * of the fact that duplicate sets with UMIs can be broken up into subsets based on information contained in the UMI.
+ *
+ * Users should continue to use MarkDuplicates in general, the main motivation for this tool is to provide a way to
+ * mark duplicates using information from UMIs.
+ *
+ * @author fleharty
+ */
+@CommandLineProgramProperties(
+        usage = "Examines aligned records in the supplied SAM or BAM file to locate duplicate molecules. " +
+                "All records are then written to the output file with the duplicate records flagged.",
+        usageShort = "Examines aligned records in the supplied SAM or BAM file to locate duplicate molecules.",
+        programGroup = Alpha.class
+)
+
+public class UmiAwareMarkDuplicatesWithMateCigar extends SimpleMarkDuplicatesWithMateCigar {
+
+    @Option(shortName = "EDIT_DISTANCE_TO_JOIN",
+            doc = "This option specifies the edit distance of UMIs to join", optional = true)
+    public int EDIT_DISTANCE_TO_JOIN = 1;
+
+
+    @Option(shortName = "ADD_INFERRED_UMI",
+            doc = "This option adds the inferred UMI to the bam in the inferred UMI tag (by default this tag is RI).", optional = true)
+    public boolean ADD_INFERRED_UMI = false;
+
+    @Option(shortName = "UMI_TAG_NAME",
+            doc = "Tag name to use for UMI (default is RX)", optional = true)
+    public String UMI_TAG_NAME = "RX";
+
+    @Option(shortName = "INFERRED_UMI_TAG_NAME",
+            doc = "Tag name to use for inferred UMI (default is RI)", optional = true)
+    public String INFERRED_UMI_TAG_NAME = "RI";
+
+    private final Log log = Log.getInstance(UmiAwareMarkDuplicatesWithMateCigar.class);
+
+    /** Stock main method. */
+    public static void main(final String[] args) {
+        new UmiAwareMarkDuplicatesWithMateCigar().instanceMainWithExit(args);
+    }
+
+    @Override
+    protected CloseableIterator<DuplicateSet> getDuplicateSetIterator(final SamHeaderAndIterator headerAndIterator, final SAMRecordDuplicateComparator comparator) {
+        return new UmiAwareDuplicateSetIterator(
+                    new DuplicateSetIterator(headerAndIterator.iterator,
+                    headerAndIterator.header,
+                    false,
+                    comparator), EDIT_DISTANCE_TO_JOIN, ADD_INFERRED_UMI, UMI_TAG_NAME, INFERRED_UMI_TAG_NAME);
+    }
+}

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
@@ -1,0 +1,155 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam.markduplicates;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import java.util.*;
+import picard.PicardException;
+
+/**
+ * This class defines the individual test cases to run. The actual running of the test is done
+ * by UmiAwareMarkDuplicatesWithMateCigarTester (see getTester).
+ * @author fleharty
+ */
+public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicatesWithMateCigarTest {
+
+    protected UmiAwareMarkDuplicatesWithMateCigarTester getTester() {
+        return new UmiAwareMarkDuplicatesWithMateCigarTester();
+    }
+
+    @DataProvider(name = "testUmiSetsDataProvider")
+    private Object[][] testUmiSetsDataProvider() {
+        return new Object[][]{
+                {
+                        // Test basic error correction using edit distance of 1
+                        Arrays.asList(new String[] {"AAAA", "AAAA", "ATTA", "AAAA", "AAAT"}), // Observed UMI
+                        Arrays.asList(new String[] {"AAAA", "AAAA", "ATTA", "AAAA", "AAAA"}), // Expected inferred UMI
+                        Arrays.asList(new Boolean[] {false, true, false, true, true}), // Should it be marked as duplicate?
+                        1 // Edit Distance to Join
+                },
+                {
+                        // Test basic error correction using edit distance of 2
+                        Arrays.asList(new String[] {"AAAA", "AAAA", "ATTA", "AAAA", "AAAT"}),
+                        Arrays.asList(new String[] {"AAAA", "AAAA", "AAAA", "AAAA", "AAAA"}),
+                        Arrays.asList(new Boolean[] {false, true, true, true, true}),
+                        2
+                },
+                {
+                        // Test basic error correction using edit distance of 1 where UMIs
+                        // form a chain in edit distance space so that a UMI with large
+                        // edit distance will get error corrected to a distant but linked (in edit space) UMI
+                        Arrays.asList(new String[] {"AAAA", "AAAA", "AAAT", "AAGT", "ACGT", "TCGT", "CCCC"}),
+                        Arrays.asList(new String[] {"AAAA", "AAAA", "AAAA", "AAAA", "AAAA", "AAAA", "CCCC"}),
+                        Arrays.asList(new Boolean[] {false, true, true, true, true, true, false}),
+                        1
+                },
+                {
+                        // Test short UMIs
+                        Arrays.asList(new String[] {"A", "A", "T", "G", "G", "C", "C", "A"}),
+                        Arrays.asList(new String[] {"A", "A", "A", "A", "A", "A", "A", "A"}), // All UMIs should get corrected to A
+                        Arrays.asList(new Boolean[] {false, true, true, true, true, true, true, true}), // All mate pairs should be duplicates except the first
+                        1
+                },
+                {
+                        // Test short UMIs with no allowance for errors
+                        Arrays.asList(new String[] {"A", "A", "T", "G", "G", "C", "C", "A"}),
+                        Arrays.asList(new String[] {"A", "A", "T", "G", "G", "C", "C", "A"}), // No UMIs should get corrected
+                        Arrays.asList(new Boolean[] {false, true, false, false, true, false, true, true}), // Only exactly duplicated UMIs will give rise to a new duplicate set
+                        0
+                },
+                {
+                        // Test longish UMIs with relatively large allowance for error
+                        // UMIs "TTGACATCCA", "ATGCCATCGA", "AAGTCACCGT" should belong to the same duplicate set since
+                        // they are within edit distance of 4 of each other.  TTGACATCCA should be chosen as the inferred
+                        // UMI even though it only occurs once.  Since all UMIs only occur once, we choose the UMI that
+                        // is not marked as duplicate to be the inferred UMI.
+                        Arrays.asList(new String[] {"TTGACATCCA", "ATGCCATCGA", "AAGTCACCGT"}),
+                        Arrays.asList(new String[] {"TTGACATCCA", "TTGACATCCA", "TTGACATCCA"}), // All UMIs should get corrected to TTGACATCCA
+                        Arrays.asList(new Boolean[] {false, true, true}), // All mate pairs should be duplicates except the first
+                        4
+                },
+                {
+                        // Test to make sure that if any reads don't have a UMI, we treat things as if there were no
+                        // UMIs at all
+                        Arrays.asList(new String[] {"TTGACATCCA", null, null}),
+                        Arrays.asList(new String[] {null, null, null}), // Since we had missing UMIs, no UMIs should be inferred
+                        Arrays.asList(new Boolean[] {false, true, true}), // All mate pairs should be duplicates except the first
+                        4
+                }
+
+        };
+    }
+
+    @DataProvider(name = "testBadUmiSetsDataProvider")
+    private Object[][] testBadUmiSetsDataProvider() {
+        return new Object[][]{
+                {
+                        // The code should not support variable length UMIs, if we observe variable length UMIs
+                        // ensure that an exception is thrown.
+                        Arrays.asList(new String[] {"AAAA", "A"}),
+                        Arrays.asList(new String[] {"AAAA", "A"}),
+                        Arrays.asList(new Boolean[] {false, false}),
+                        4
+                },
+                {
+                        // The code should not support variable length UMIs, if we observe variable length UMIs
+                        // ensure that an exception is thrown.
+                        Arrays.asList(new String[] {"T", "GG"}),
+                        Arrays.asList(new String[] {"T", "GG"}),
+                        Arrays.asList(new Boolean[] {false, false}),
+                        1
+                }
+        };
+    }
+
+    @Test(dataProvider = "testUmiSetsDataProvider")
+    public void testUmi(List<String> umis, List<String> inferredUmi, final List<Boolean> isDuplicate, final int editDistanceToJoin) {
+        UmiAwareMarkDuplicatesWithMateCigarTester tester = getTester();
+        tester.addArg("EDIT_DISTANCE_TO_JOIN=" + editDistanceToJoin);
+        tester.addArg("ADD_INFERRED_UMI=TRUE");
+
+        for(int i = 0;i < umis.size();i++) {
+            tester.addMatePairWithUmi(umis.get(i), inferredUmi.get(i), isDuplicate.get(i), isDuplicate.get(i));
+        }
+        tester.setExpectedInferredUmis(inferredUmi);
+        tester.runTest();
+    }
+
+
+    @Test(dataProvider = "testBadUmiSetsDataProvider", expectedExceptions = PicardException.class)
+    public void testBadUmi(List<String> umis, List<String> inferredUmi, final List<Boolean> isDuplicate, final int editDistanceToJoin) {
+        UmiAwareMarkDuplicatesWithMateCigarTester tester = getTester();
+        tester.addArg("EDIT_DISTANCE_TO_JOIN=" + editDistanceToJoin);
+        tester.addArg("ADD_INFERRED_UMI=TRUE");
+
+        for(int i = 0;i < umis.size();i++) {
+            tester.addMatePairWithUmi(umis.get(i), inferredUmi.get(i), isDuplicate.get(i), isDuplicate.get(i));
+        }
+        tester.setExpectedInferredUmis(inferredUmi);
+        tester.runTest();
+    }
+
+}

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
@@ -1,0 +1,145 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam.markduplicates;
+
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
+import org.testng.Assert;
+import picard.cmdline.CommandLineProgram;
+
+import java.util.List;
+
+/**
+ * This class is an extension of AbstractMarkDuplicatesCommandLineProgramTester used to test
+ * AbstractMarkDuplicatesCommandLineProgram's with SAM files generated on the fly.  This performs the underlying tests
+ * defined by classes such as AbstractMarkDuplicatesCommandLineProgramTest.
+ * @author fleharty
+ */
+
+public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDuplicatesCommandLineProgramTester {
+    private int readNameCounter = 0;
+    private List<String> expectedInferredUmis;
+
+    public void addMatePairWithUmi(final String umi, final String inferredUmi, final boolean isDuplicate1, final boolean isDuplicate2) {
+
+        String readName = "READ" + readNameCounter++;
+        String cigar1 = null;
+        String cigar2 = null;
+        boolean strand1 = false;
+        boolean strand2 = true;
+
+        int referenceSequenceIndex1 = 0;
+        int referenceSequenceIndex2 = 0;
+        int alignmentStart1 = 20;
+        int alignmentStart2 = 20;
+
+        boolean record1Unmapped = false;
+        boolean record2Unmapped = false;
+
+        boolean firstOnly = false;
+        boolean record1NonPrimary = false;
+        boolean record2NonPrimary = false;
+
+        int defaultQuality = 10;
+
+        addMatePairWithUmi(readName, referenceSequenceIndex1, referenceSequenceIndex2, alignmentStart1, alignmentStart2, record1Unmapped,
+                record2Unmapped, isDuplicate1, isDuplicate2, cigar1, cigar2, strand1, strand2, firstOnly, record1NonPrimary, record2NonPrimary,
+                defaultQuality, umi, inferredUmi);
+
+    }
+
+    public void addMatePairWithUmi(final String readName,
+                            final int referenceSequenceIndex1,
+                            final int referenceSequenceIndex2,
+                            final int alignmentStart1,
+                            final int alignmentStart2,
+                            final boolean record1Unmapped,
+                            final boolean record2Unmapped,
+                            final boolean isDuplicate1,
+                            final boolean isDuplicate2,
+                            final String cigar1,
+                            final String cigar2,
+                            final boolean strand1,
+                            final boolean strand2,
+                            final boolean firstOnly,
+                            final boolean record1NonPrimary,
+                            final boolean record2NonPrimary,
+                            final int defaultQuality,
+                            final String umi,
+                            final String inferredUmi) {
+        final List<SAMRecord> samRecordList = samRecordSetBuilder.addPair(readName, referenceSequenceIndex1, referenceSequenceIndex2, alignmentStart1, alignmentStart2,
+                record1Unmapped, record2Unmapped, cigar1, cigar2, strand1, strand2, record1NonPrimary, record2NonPrimary, defaultQuality);
+
+        final SAMRecord record1 = samRecordList.get(0);
+        final SAMRecord record2 = samRecordList.get(1);
+
+        if (this.noMateCigars) {
+            record1.setAttribute("MC", null);
+            record2.setAttribute("MC", null);
+        }
+
+        if (firstOnly) {
+            samRecordSetBuilder.getRecords().remove(record2);
+        }
+
+        final String key1 = samRecordToDuplicatesFlagsKey(record1);
+        Assert.assertFalse(this.duplicateFlags.containsKey(key1));
+        this.duplicateFlags.put(key1, isDuplicate1);
+
+        final String key2 = samRecordToDuplicatesFlagsKey(record2);
+        Assert.assertFalse(this.duplicateFlags.containsKey(key2));
+        this.duplicateFlags.put(key2, isDuplicate2);
+
+        if(umi != null) {
+            record1.setAttribute("RX", umi);
+            record2.setAttribute("RX", umi);
+        }
+        if(inferredUmi != null) {
+            record1.setAttribute("RE", inferredUmi);
+            record2.setAttribute("RE", inferredUmi);
+        }
+    }
+
+    public void setExpectedInferredUmis(final List<String> expectedInferredUmis) {
+        this.expectedInferredUmis = expectedInferredUmis;
+    }
+
+    @Override
+    public void test() {
+        final SamReader reader = SamReaderFactory.makeDefault().open(getOutput());
+        for (final SAMRecord record : reader) {
+            // If there are expected inferred UMIs, check to make sure they match
+            if (expectedInferredUmis != null) {
+                Assert.assertEquals(record.getAttribute("RI"), record.getAttribute("RE"));
+            }
+        }
+        // Also do tests from AbstractMarkDuplicatesCommandLineProgramTester
+        super.test();
+    }
+
+    @Override
+    protected CommandLineProgram getProgram() { return new UmiAwareMarkDuplicatesWithMateCigar(); }
+}

--- a/src/test/java/picard/sam/testers/SamFileTester.java
+++ b/src/test/java/picard/sam/testers/SamFileTester.java
@@ -23,12 +23,12 @@ import java.util.Map;
  */
 public abstract class SamFileTester extends CommandLineProgramTest {
 
-    private final SAMRecordSetBuilder samRecordSetBuilder;
+    protected final SAMRecordSetBuilder samRecordSetBuilder;
     protected final Map<String, Boolean> duplicateFlags = new HashMap<>();
     private File outputDir;
     private File output;
     private int readNameCounter = 0;
-    private boolean noMateCigars = false;
+    protected boolean noMateCigars = false;
     private boolean deleteOnExit = true;
     private final ArrayList<String> args = new ArrayList<>();
 


### PR DESCRIPTION
This is a tool for performing MarkDuplicates in a UMI aware manner.  It uses a simple graph based algorithm to group UMIs into duplicate sets.  The error correction model is a bit naive, but this is intended to be a first iteration, and a more sophisticated algorithm will be submitted in the near future.