### PR TITLE
Using predefined version of MQ (two different kinds) and SA.

### DIFF
--- a/src/main/java/picard/analysis/AlignmentSummaryMetricsCollector.java
+++ b/src/main/java/picard/analysis/AlignmentSummaryMetricsCollector.java
@@ -24,13 +24,7 @@
 
 package picard.analysis;
 
-import htsjdk.samtools.AlignmentBlock;
-import htsjdk.samtools.BAMRecord;
-import htsjdk.samtools.CigarElement;
-import htsjdk.samtools.CigarOperator;
-import htsjdk.samtools.ReservedTagConstants;
-import htsjdk.samtools.SAMReadGroupRecord;
-import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.*;
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.util.CoordMath;
@@ -253,7 +247,7 @@ public class AlignmentSummaryMetricsCollector extends SAMRecordAndReferenceMulti
                             metrics.READS_ALIGNED_IN_PAIRS++;
 
                             // Check that both ends have mapq > minimum
-                            final Integer mateMq = record.getIntegerAttribute("MQ");
+                            final Integer mateMq = record.getIntegerAttribute(SAMTag.MQ.toString());
                             if (mateMq == null || mateMq >= MAPPING_QUALITY_THRESOLD && record.getMappingQuality() >= MAPPING_QUALITY_THRESOLD) {
                                 ++this.chimerasDenominator;
 
@@ -267,7 +261,7 @@ public class AlignmentSummaryMetricsCollector extends SAMRecordAndReferenceMulti
                             // Consider chimeras that occur *within* the read using the SA tag
                             if (record.getMappingQuality() >= MAPPING_QUALITY_THRESOLD) {
                                 ++this.chimerasDenominator;
-                                if (record.getAttribute("SA") != null) ++this.chimeras;
+                                if (record.getAttribute(SAMTag.SA.toString()) != null) ++this.chimeras;
                             }
                         }
                     }

--- a/src/main/java/picard/analysis/ChimeraUtil.java
+++ b/src/main/java/picard/analysis/ChimeraUtil.java
@@ -25,6 +25,7 @@
 package picard.analysis;
 
 import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMTag;
 import htsjdk.samtools.SamPairUtil;
 import htsjdk.samtools.SamPairUtil.PairOrientation;
 
@@ -66,7 +67,7 @@ public class ChimeraUtil {
                 (Math.abs(r1.getInferredInsertSize()) > maxInsertSize ||            //    either far apart on the same contig
                         !r1.getReferenceIndex().equals(r2.getReferenceIndex()) ||   //    or on different contigs
                         !matchesExpectedOrientations(r1, expectedOrientations) ||   //    or in unexpected orientations
-                        r2.getAttribute("SA") != null);                             //      (another check for an unexpected orientation here)
+                        r2.getAttribute(SAMTag.SA.toString()) != null);                             //      (another check for an unexpected orientation here)
     }
 
     private static boolean isMappedPair(final SAMRecord rec) {
@@ -74,6 +75,6 @@ public class ChimeraUtil {
     }
 
     private static boolean matchesExpectedOrientations(final SAMRecord rec, final Set<PairOrientation> expectedOrientations) {
-        return expectedOrientations.contains(SamPairUtil.getPairOrientation(rec)) && rec.getAttribute("SA") == null;
+        return expectedOrientations.contains(SamPairUtil.getPairOrientation(rec)) && rec.getAttribute(SAMTag.SA.toString()) == null;
     }
 }

--- a/src/main/java/picard/analysis/CollectOxoGMetrics.java
+++ b/src/main/java/picard/analysis/CollectOxoGMetrics.java
@@ -60,6 +60,7 @@ import java.util.Set;
 import static htsjdk.samtools.util.CodeUtil.getOrElse;
 import static htsjdk.samtools.util.SequenceUtil.generateAllKmers;
 import static java.lang.Math.log10;
+import static picard.cmdline.StandardOptionDefinitions.MINIMUM_MAPPING_QUALITY_SHORT_NAME;
 
 /**
  * Class for trying to quantify the CpCG->CpCA error rate.
@@ -117,7 +118,7 @@ public class CollectOxoGMetrics extends CommandLineProgram {
             doc = "The minimum base quality score for a base to be included in analysis.")
     public int MINIMUM_QUALITY_SCORE = 20;
 
-    @Option(shortName = "MQ",
+    @Option(shortName = MINIMUM_MAPPING_QUALITY_SHORT_NAME,
             doc = "The minimum mapping quality score for a base to be included in analysis.")
     public int MINIMUM_MAPPING_QUALITY = 30;
 

--- a/src/main/java/picard/analysis/CollectRawWgsMetrics.java
+++ b/src/main/java/picard/analysis/CollectRawWgsMetrics.java
@@ -28,6 +28,8 @@ import picard.cmdline.CommandLineProgramProperties;
 import picard.cmdline.Option;
 import picard.cmdline.programgroups.Metrics;
 
+import static picard.cmdline.StandardOptionDefinitions.MINIMUM_MAPPING_QUALITY_SHORT_NAME;
+
 /**
  * Computes a number of metrics that are useful for evaluating coverage and performance of whole genome sequencing
  * experiments, same implementation as CollectWgsMetrics, with different defaults: lacks baseQ and mappingQ filters
@@ -71,7 +73,7 @@ public class CollectRawWgsMetrics extends CollectWgsMetrics{
             "<a href='https://broadinstitute.github.io/picard/picard-metric-definitions.html#CollectWgsMetrics.WgsMetrics'>" +
             "the WgsMetrics documentation</a> for detailed explanations of the output metrics." +
             "<hr />";
-    @Option(shortName="MQ", doc="Minimum mapping quality for a read to contribute coverage.")
+    @Option(shortName=MINIMUM_MAPPING_QUALITY_SHORT_NAME, doc="Minimum mapping quality for a read to contribute coverage.")
     public int MINIMUM_MAPPING_QUALITY = 0;
 
     @Option(shortName="Q", doc="Minimum base quality for a base to contribute coverage.")

--- a/src/main/java/picard/analysis/CollectWgsMetrics.java
+++ b/src/main/java/picard/analysis/CollectWgsMetrics.java
@@ -57,6 +57,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import static picard.cmdline.StandardOptionDefinitions.MINIMUM_MAPPING_QUALITY_SHORT_NAME;
+
 /**
  * Computes a number of metrics that are useful for evaluating coverage and performance of whole genome sequencing experiments.
  *
@@ -96,7 +98,7 @@ static final String USAGE_DETAILS = "<p>This tool collects metrics about the fra
     @Option(shortName = StandardOptionDefinitions.REFERENCE_SHORT_NAME, doc = "The reference sequence fasta aligned to.")
     public File REFERENCE_SEQUENCE;
 
-    @Option(shortName = "MQ", doc = "Minimum mapping quality for a read to contribute coverage.", overridable = true)
+    @Option(shortName = MINIMUM_MAPPING_QUALITY_SHORT_NAME, doc = "Minimum mapping quality for a read to contribute coverage.", overridable = true)
     public int MINIMUM_MAPPING_QUALITY = 20;
 
     @Option(shortName = "Q", doc = "Minimum base quality for a base to contribute coverage. N bases will be treated as having a base quality " +

--- a/src/main/java/picard/analysis/artifacts/CollectSequencingArtifactMetrics.java
+++ b/src/main/java/picard/analysis/artifacts/CollectSequencingArtifactMetrics.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static htsjdk.samtools.util.CodeUtil.getOrElse;
+import static picard.cmdline.StandardOptionDefinitions.MINIMUM_MAPPING_QUALITY_SHORT_NAME;
 
 /**
  * Quantify substitution errors caused by mismatched base pairings during various
@@ -105,7 +106,7 @@ static final String USAGE_DETAILS = "<p>This tool examines two sources of sequen
     @Option(shortName = "Q", doc = "The minimum base quality score for a base to be included in analysis.")
     public int MINIMUM_QUALITY_SCORE = 20;
 
-    @Option(shortName = "MQ", doc = "The minimum mapping quality score for a base to be included in analysis.")
+    @Option(shortName = MINIMUM_MAPPING_QUALITY_SHORT_NAME, doc = "The minimum mapping quality score for a base to be included in analysis.")
     public int MINIMUM_MAPPING_QUALITY = 30;
 
     @Option(shortName = "MIN_INS", doc = "The minimum insert size for a read to be included in analysis.")

--- a/src/main/java/picard/analysis/directed/CalculateHsMetrics.java
+++ b/src/main/java/picard/analysis/directed/CalculateHsMetrics.java
@@ -28,6 +28,8 @@ import picard.cmdline.CommandLineProgramProperties;
 import picard.cmdline.Option;
 import picard.cmdline.programgroups.Metrics;
 
+import static picard.cmdline.StandardOptionDefinitions.MINIMUM_MAPPING_QUALITY_SHORT_NAME;
+
 /**
  * Calculates a set of HS metrics from a sam or bam file.  See HsMetricsCollector and CollectTargetedMetrics for more details.
  *
@@ -45,7 +47,7 @@ import picard.cmdline.programgroups.Metrics;
 @Deprecated
 public class CalculateHsMetrics extends CollectHsMetrics {
 
-    @Option(shortName = "MQ", doc = "Minimum mapping quality for a read to contribute coverage.", overridable = true)
+    @Option(shortName = MINIMUM_MAPPING_QUALITY_SHORT_NAME, doc = "Minimum mapping quality for a read to contribute coverage.", overridable = true)
     public int MINIMUM_MAPPING_QUALITY = 1;
 
     @Option(shortName = "Q", doc = "Minimum base quality for a base to contribute coverage.", overridable = true)

--- a/src/main/java/picard/analysis/directed/CollectHsMetrics.java
+++ b/src/main/java/picard/analysis/directed/CollectHsMetrics.java
@@ -39,6 +39,8 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import static picard.cmdline.StandardOptionDefinitions.MINIMUM_MAPPING_QUALITY_SHORT_NAME;
+
 /**
  * Collects a set of HS metrics from a sam or bam file.  See HsMetricsCollector and CollectTargetedMetrics for more details.
  *
@@ -94,7 +96,7 @@ static final String USAGE_DETAILS = "This tool takes a SAM/BAM file input and co
     @Option(shortName = "N", doc = "Bait set name. If not provided it is inferred from the filename of the bait intervals.", optional = true)
     public String BAIT_SET_NAME;
 
-    @Option(shortName = "MQ", doc = "Minimum mapping quality for a read to contribute coverage.", overridable = true)
+    @Option(shortName = MINIMUM_MAPPING_QUALITY_SHORT_NAME, doc = "Minimum mapping quality for a read to contribute coverage.", overridable = true)
     public int MINIMUM_MAPPING_QUALITY = 20;
 
     @Option(shortName = "Q", doc = "Minimum base quality for a base to contribute coverage.", overridable = true)

--- a/src/main/java/picard/analysis/directed/CollectTargetedMetrics.java
+++ b/src/main/java/picard/analysis/directed/CollectTargetedMetrics.java
@@ -25,6 +25,8 @@ import java.io.File;
 import java.util.List;
 import java.util.Set;
 
+import static picard.cmdline.StandardOptionDefinitions.MINIMUM_MAPPING_QUALITY_SHORT_NAME;
+
 /**
  * <p>Both CollectTargetedPCRMetrics and CollectHsSelection share virtually identical program structures except
  * for the name of their targeting mechanisms (e.g. bait set or amplicon set).  The shared behavior of these programs
@@ -82,7 +84,7 @@ public abstract class CollectTargetedMetrics<METRIC extends MultilevelMetrics, C
             "considered 'near probe' and included in percent selected.")
     public int NEAR_DISTANCE = TargetedPcrMetricsCollector.NEAR_PROBE_DISTANCE_DEFAULT;
 
-    @Option(shortName = "MQ", doc = "Minimum mapping quality for a read to contribute coverage.", overridable = true)
+    @Option(shortName = MINIMUM_MAPPING_QUALITY_SHORT_NAME, doc = "Minimum mapping quality for a read to contribute coverage.", overridable = true)
     public int MINIMUM_MAPPING_QUALITY = 1;
 
     @Option(shortName = "Q", doc = "Minimum base quality for a base to contribute coverage.", overridable = true)

--- a/src/main/java/picard/analysis/replicates/CollectIndependentReplicateMetrics.java
+++ b/src/main/java/picard/analysis/replicates/CollectIndependentReplicateMetrics.java
@@ -74,6 +74,8 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static picard.cmdline.StandardOptionDefinitions.MINIMUM_MAPPING_QUALITY_SHORT_NAME;
+
 /**
  * A CLP that, given a BAM and a VCF with genotypes of the same sample, estimates the rate of independent replication of reads within the bam.
  * That is, it estimates the fraction of the reads which look like duplicates (in the MarkDuplicates sense of the word) but are actually
@@ -124,7 +126,7 @@ public class CollectIndependentReplicateMetrics extends CommandLineProgram {
     @Option(shortName = "GQ", doc = "minimal value for the GQ field in the VCF to use variant site.", optional = true)
     public Integer MINIMUM_GQ = 90;
 
-    @Option(shortName = "MQ", doc = "minimal value for the mapping quality of the reads to be used in the estimation.", optional = true)
+    @Option(shortName = MINIMUM_MAPPING_QUALITY_SHORT_NAME, doc = "minimal value for the mapping quality of the reads to be used in the estimation.", optional = true)
     public Integer MINIMUM_MQ = 40;
 
     @Option(shortName = "BQ", doc = "minimal value for the base quality of a base to be used in the estimation.", optional = true)

--- a/src/test/java/picard/sam/RevertSamTest.java
+++ b/src/test/java/picard/sam/RevertSamTest.java
@@ -250,7 +250,7 @@ public class RevertSamTest extends CommandLineProgramTest {
 
             for (final SAMRecord.SAMTagAndValue attr : rec.getAttributes()) {
                 if (removeAlignmentInfo || (!attr.tag.equals("PG") && !attr.tag.equals("NM")
-                        && !attr.tag.equals("MQ"))) {
+                        && !attr.tag.equals(SAMTag.MQ.toString()))) {
                     Assert.assertFalse(reverter.ATTRIBUTE_TO_CLEAR.contains(attr.tag),
                             attr.tag + " should have been cleared.");
                 }


### PR DESCRIPTION
A small PR that makes use of predefined strings rather than using "SA" and "MQ". 

Aesthetic only. Has no performance effects.