### PR TITLE
Adding Paired Interval Filter to Filter Sam Reads

### DIFF
--- a/src/main/java/picard/sam/FilterSamReads.java
+++ b/src/main/java/picard/sam/FilterSamReads.java
@@ -50,6 +50,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -209,7 +210,12 @@ public class FilterSamReads extends CommandLineProgram {
             IOUtil.assertFileIsReadable(INPUT);
             IOUtil.assertFileIsWritable(OUTPUT);
             if (WRITE_READS_FILES) writeReadsFile(INPUT);
-            final List<Interval> intervalList = getIntervalList(INTERVAL_LIST);
+
+            List<Interval> intervalList;
+
+            if (INTERVAL_LIST != null) {
+                intervalList = getIntervalList(INTERVAL_LIST);
+            }
 
             final SamReader samReader = SamReaderFactory.makeDefault().referenceSequence(REFERENCE_SEQUENCE).open(INPUT);
             final FilteringSamIterator filteringIterator;

--- a/src/main/java/picard/sam/FilterSamReads.java
+++ b/src/main/java/picard/sam/FilterSamReads.java
@@ -211,7 +211,7 @@ public class FilterSamReads extends CommandLineProgram {
             IOUtil.assertFileIsWritable(OUTPUT);
             if (WRITE_READS_FILES) writeReadsFile(INPUT);
 
-            List<Interval> intervalList;
+            List<Interval> intervalList = new ArrayList<>();
 
             if (INTERVAL_LIST != null) {
                 intervalList = getIntervalList(INTERVAL_LIST);

--- a/src/test/java/picard/sam/FilterSamReadsTest.java
+++ b/src/test/java/picard/sam/FilterSamReadsTest.java
@@ -23,13 +23,12 @@
  */
 package picard.sam;
 
+import htsjdk.samtools.*;
 import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import htsjdk.samtools.SAMRecordIterator;
-import htsjdk.samtools.SamReader;
-import htsjdk.samtools.SamReaderFactory;
 import picard.cmdline.CommandLineProgramTest;
 
 import java.io.File;
@@ -40,11 +39,33 @@ public class FilterSamReadsTest extends CommandLineProgramTest {
         return FilterSamReads.class.getSimpleName();
     }
 
+    private static final int READ_LENGTH = 151;
+    private final SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
+    private final static File TEST_DIR = new File("testdata/picard/sam/FilterSamReads/");
+
+
+    @BeforeTest
+    public void setUp() {
+        builder.setReadLength(READ_LENGTH);
+        builder.addPair("mapped_pair_chr1", 0, 1, 151); //should be kept in first test, filtered out in third
+        builder.addPair("mapped_pair_chr2", 1, 1, 151); //should be filtered out for first test, and kept in third
+        builder.addPair("prove_one_of_pair", 0, 1000, 1000); //neither of these will be kept in any test
+        builder.addPair("one_of_pair", 0, 1, 1000); //first read should pass, second should not, but both will be kept in first test
+    }
+
     @DataProvider(name = "dataTestJsFilter")
     public Object[][] dataTestJsFilter() {
         return new Object[][]{
-                {"testdata/picard/sam/aligned.sam","testdata/picard/sam/FilterSamReads/filterOddStarts.js",3},
-                {"testdata/picard/sam/aligned.sam","testdata/picard/sam/FilterSamReads/filterReadsWithout5primeSoftClip.js", 0}
+                {"testdata/picard/sam/aligned.sam", "testdata/picard/sam/FilterSamReads/filterOddStarts.js",3},
+                {"testdata/picard/sam/aligned.sam", "testdata/picard/sam/FilterSamReads/filterReadsWithout5primeSoftClip.js", 0}
+        };
+    }
+
+    @DataProvider(name = "dataTestPairedIntervalFilter")
+    public Object[][] dataTestPairedIntervalFilter() {
+        return new Object[][]{
+                {"testdata/picard/sam/FilterSamReads/filter1.interval_list", 4},
+                {"testdata/picard/sam/FilterSamReads/filter2.interval_list", 0}
         };
     }
     
@@ -69,9 +90,49 @@ public class FilterSamReadsTest extends CommandLineProgramTest {
         final SamReader samReader = SamReaderFactory.makeDefault().open(program.OUTPUT);
         final SAMRecordIterator iter = samReader.iterator();
         int count = 0;
-        while(iter.hasNext()) { iter.next(); ++ count; }
+        while (iter.hasNext()) {
+            iter.next(); ++ count;
+        }
         iter.close();
         samReader.close();
         Assert.assertEquals(count, expectNumber);
-    	}
-	}
+    }
+
+    @Test(dataProvider = "dataTestPairedIntervalFilter")
+    public void testPairedIntervalFilter(final String intervalFilename, final int expectNumber) throws Exception {
+        // input as SAM file
+        final File inputSam = File.createTempFile("testSam", ".sam", TEST_DIR);
+        inputSam.deleteOnExit();
+
+        final SAMFileWriter writer = new SAMFileWriterFactory()
+                .setCreateIndex(true).makeBAMWriter(builder.getHeader(), false, inputSam);
+
+        for (final SAMRecord record : builder) {
+            writer.addAlignment(record);
+        }
+        writer.close();
+
+        final File intervalFile = new File(intervalFilename);
+
+        //loop over javascript filters
+        final FilterSamReads program = new FilterSamReads();
+        program.INPUT = inputSam;
+        program.OUTPUT = File.createTempFile("FilterSamReads.output.", ".sam");
+        program.OUTPUT.deleteOnExit();
+        program.FILTER = FilterSamReads.Filter.includePairedIntervals;
+        program.INTERVAL_LIST = intervalFile;
+        Assert.assertEquals(program.doWork(),0);
+
+        //count reads
+        final SamReader samReader = SamReaderFactory.makeDefault().open(program.OUTPUT);
+        final SAMRecordIterator iter = samReader.iterator();
+        int count = 0;
+        while (iter.hasNext()) {
+            iter.next(); ++ count;
+        }
+
+        iter.close();
+        samReader.close();
+        Assert.assertEquals(count, expectNumber);
+    }
+}

--- a/src/test/java/picard/sam/FilterSamReadsTest.java
+++ b/src/test/java/picard/sam/FilterSamReadsTest.java
@@ -98,6 +98,9 @@ public class FilterSamReadsTest extends CommandLineProgramTest {
         Assert.assertEquals(count, expectNumber);
     }
 
+    /**
+     * filters a SAM using an interval filter
+     */
     @Test(dataProvider = "dataTestPairedIntervalFilter")
     public void testPairedIntervalFilter(final String intervalFilename, final int expectNumber) throws Exception {
         // input as SAM file
@@ -114,7 +117,6 @@ public class FilterSamReadsTest extends CommandLineProgramTest {
 
         final File intervalFile = new File(intervalFilename);
 
-        //loop over javascript filters
         final FilterSamReads program = new FilterSamReads();
         program.INPUT = inputSam;
         program.OUTPUT = File.createTempFile("FilterSamReads.output.", ".sam");

--- a/testdata/picard/sam/FilterSamReads/filter1.interval_list
+++ b/testdata/picard/sam/FilterSamReads/filter1.interval_list
@@ -1,0 +1,12 @@
+@HD	VN:1.5	SO:coordinate
+@SQ	SN:chr1	LN:101
+@SQ	SN:chr2	LN:101
+@SQ	SN:chr3	LN:101
+@SQ	SN:chr4	LN:101
+@SQ	SN:chr5	LN:101
+@SQ	SN:chr6	LN:101
+@SQ	SN:chr7	LN:404
+@SQ	SN:chr8	LN:202
+@RG	ID:0	SM:Hi,Mom!	PL:ILLUMINA
+@PG	ID:1	PN:Hey!	VN:2.0
+chr1	1	999	+	.

--- a/testdata/picard/sam/FilterSamReads/filter2.interval_list
+++ b/testdata/picard/sam/FilterSamReads/filter2.interval_list
@@ -1,0 +1,12 @@
+@HD	VN:1.5	SO:coordinate
+@SQ	SN:chr1	LN:101
+@SQ	SN:chr2	LN:101
+@SQ	SN:chr3	LN:101
+@SQ	SN:chr4	LN:101
+@SQ	SN:chr5	LN:101
+@SQ	SN:chr6	LN:101
+@SQ	SN:chr7	LN:404
+@SQ	SN:chr8	LN:202
+@RG	ID:0	SM:Hi,Mom!	PL:ILLUMINA
+@PG	ID:1	PN:Hey!	VN:2.0
+chr3	1	2	+	.


### PR DESCRIPTION
Adds an interval filter to filter sam reads that filters over intervals while keeping paired reads together.