### PR TITLE
adding the broad artifactory as a repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
+import org.gradle.internal.os.OperatingSystem
+
 import javax.tools.ToolProvider
-import org.ajoberstar.grgit.*
 
 buildscript {
     repositories {
@@ -25,6 +26,9 @@ mainClassName = "picard.cmdline.PicardCommandLine"
 repositories {
     mavenLocal()
     mavenCentral()
+    maven {
+        url "https://artifactory.broadinstitute.org/artifactory/libs-snapshot/" //for htsjdk snapshots
+    }
 }
 
 jacocoTestReport {
@@ -73,9 +77,6 @@ jar {
                 'Implementation-Version': version
     }
 }
-
-import org.gradle.internal.os.OperatingSystem;
-
 // This is a hack to disable the java 8 default javadoc lint until we fix the html formatting
 if (JavaVersion.current().isJava8Compatible()) {
     tasks.withType(Javadoc) {

--- a/build.gradle
+++ b/build.gradle
@@ -47,9 +47,11 @@ jacoco {
     toolVersion = "0.7.5.201505241946"
 }
 
+final htsjdkVersion = System.getProperty('htsjdk.version', '2.5.0')
+
 dependencies {
     compile 'com.google.guava:guava:15.0'
-    compile ('com.github.samtools:htsjdk:2.5.0')
+    compile 'com.github.samtools:htsjdk:' + htsjdkVersion
     //tools dependency for doclet requires sdk devel
     compile(files(((URLClassLoader) ToolProvider.getSystemToolClassLoader()).getURLs()))
     testCompile 'org.testng:testng:6.9.10'


### PR DESCRIPTION
this lets picard be built against artifactory snapshots of htsjdk
picard MUST NOT be released if using an artifactory snapshot (and probably cannot be)

also letting htsjdk version be specified on the command line (fixes #611 )

ex:
```
./gradlew test -Dhtsjdk.version=2.6.0
```