### PR TITLE
adding settings.gradle file

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name =	"picard"


### PR DESCRIPTION
this sets the project name so that jars will have consistent names
without the settings.gradle file, the project name is taken from the folder name which is not ideal