### PR TITLE
creating a picard.jar when running ./gradlew

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,13 @@ As of version 2.0.1 (Nov. 2015) Picard requires Java 1.8 (jdk8u66). The last ver
 
 * The resulting jar will be in `build/libs`. To run it, the command is:
 ```
-    java -jar build/libs/picard-*-all.jar
-    // actual name of the jar will vary depending on the current Picard version
+    java -jar build/libs/picard.jar
+    
+    or
+    
+    java -jar build/libs/picard-<VERSION>-all.jar 
 ```    
+
     
 * To build a jar containing only Picard classes (without its dependencies), run:
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ group = 'com.github.broadinstitute'
 
 defaultTasks 'all'
 
-task all(dependsOn: ['jar', 'distZip', 'documentAll'])
+task all(dependsOn: ['jar', 'distZip', 'documentAll', 'shadowJar', 'currentJar'])
 
 jar {
     manifest {
@@ -84,6 +84,16 @@ if (JavaVersion.current().isJava8Compatible()) {
     tasks.withType(Javadoc) {
         options.addStringOption('Xdoclint:none', '-quiet')
     }
+}
+
+task currentJar(type: Copy){
+    from shadowJar
+    into new File(buildDir, "libs")
+    rename { string -> "picard.jar"}
+}
+
+shadowJar {
+    finalizedBy currentJar
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
I added a currentJar target which is invoked by default if you run `/.gradlew`

It copies the most recent shadowJar into build/libs/picard-current.jar

fixes #617 