### PR TITLE
Modify documentation to add RNA-seq usage example of READ_NAME_REGEX=…

### DIFF
--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -86,10 +86,12 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
             "duplicate.  To do this, a new tag called the duplicate type (DT) tag was recently added as an optional output in  " +
             "the 'optional field' section of a SAM/BAM file.  Invoking the TAGGING_POLICY option," +
             " you can instruct the program to mark all the duplicates (All), only the optical duplicates (OpticalOnly), or no " +
-            "duplicates (DontTag).  This tool uses the READ_NAME_REGEX and the OPTICAL_DUPLICATE_PIXEL_DISTANCE options as the primary " +
-            "methods to identify and differentiate duplicate types. The records within the output of a SAM/BAM file will have values " +
-            "for the 'DT' tag (depending on the invoked TAGGING_POLICY), as either library/PCR-generated duplicates (LB), or " +
-            "sequencing-platform artifact duplicates (SQ).</p> "+
+            "duplicates (DontTag).  The records within the output of a SAM/BAM file will have values for the 'DT' tag (depending on the invoked " +
+            "TAGGING_POLICY), as either library/PCR-generated duplicates (LB), or sequencing-platform artifact duplicates (SQ).  " +
+            "This tool uses the READ_NAME_REGEX and the OPTICAL_DUPLICATE_PIXEL_DISTANCE options as the primary methods to identify " +
+            "and differentiate duplicate types.  Set READ_NAME_REGEX to null to skip optical duplicate detection, e.g. for RNA-seq " +
+            "or other data where duplicate sets are extremely large and estimating library complexity is not an aim.  " +
+            "Note that without optical duplicate counts, library size estimation will be inaccurate.</p> "+
 
             "<p>MarkDuplicates also produces a metrics file indicating the numbers of duplicates for both single- and paired-end reads.</p>  "+
 

--- a/src/main/java/picard/sam/markduplicates/util/AbstractOpticalDuplicateFinderCommandLineProgram.java
+++ b/src/main/java/picard/sam/markduplicates/util/AbstractOpticalDuplicateFinderCommandLineProgram.java
@@ -40,7 +40,9 @@ public abstract class AbstractOpticalDuplicateFinderCommandLineProgram extends C
     @Option(doc = "Regular expression that can be used to parse read names in the incoming SAM file. Read names are " +
             "parsed to extract three variables: tile/region, x coordinate and y coordinate. These values are used " +
             "to estimate the rate of optical duplication in order to give a more accurate estimated library size. " +
-            "Set this option to null to disable optical duplicate detection. " +
+            "Set this option to null to disable optical duplicate detection, e.g. for RNA-seq " +
+            "or other data where duplicate sets are extremely large and estimating library complexity is not an aim. " +
+            "Note that without optical duplicate counts, library size estimation will be inaccurate. " +
             "The regular expression should contain three capture groups for the three variables, in order. " +
             "It must match the entire read name. " +
             "Note that if the default regex is specified, a regex match is not actually done, but instead the read name " +


### PR DESCRIPTION
…null to skip optical duplicate detection.