### PR TITLE
DuplicationMetrics are now mergeable.

### DIFF
--- a/src/main/java/picard/analysis/MergeableMetricBase.java
+++ b/src/main/java/picard/analysis/MergeableMetricBase.java
@@ -20,8 +20,9 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
+ *
  */
-package picard.analysis.replicates;
+package picard.analysis;
 
 import htsjdk.samtools.metrics.MetricBase;
 

--- a/src/main/java/picard/analysis/replicates/IndependentReplicateMetric.java
+++ b/src/main/java/picard/analysis/replicates/IndependentReplicateMetric.java
@@ -24,6 +24,8 @@
 
 package picard.analysis.replicates;
 
+import picard.analysis.MergeableMetricBase;
+
 /**
  * A class to store information relevant for biological rate estimation
  *

--- a/src/main/java/picard/sam/markduplicates/EstimateLibraryComplexity.java
+++ b/src/main/java/picard/sam/markduplicates/EstimateLibraryComplexity.java
@@ -588,7 +588,7 @@ public class EstimateLibraryComplexity extends AbstractOpticalDuplicateFinderCom
                 }
             }
 
-            metrics.calculateDerivedMetrics();
+            metrics.calculateDerivedFields();
             file.addMetric(metrics);
             file.addHistogram(duplicationHisto);
 

--- a/src/main/java/picard/sam/markduplicates/util/AbstractMarkDuplicatesCommandLineProgram.java
+++ b/src/main/java/picard/sam/markduplicates/util/AbstractMarkDuplicatesCommandLineProgram.java
@@ -176,7 +176,7 @@ public abstract class AbstractMarkDuplicatesCommandLineProgram extends AbstractO
                     metrics.READ_PAIR_OPTICAL_DUPLICATES = (long) bin.getValue();
                 }
             }
-            metrics.calculateDerivedMetrics();
+            metrics.calculateDerivedFields();
             file.addMetric(metrics);
         }
 

--- a/src/test/java/picard/analysis/MergeableMetricBaseTest.java
+++ b/src/test/java/picard/analysis/MergeableMetricBaseTest.java
@@ -1,4 +1,29 @@
-package picard.analysis.replicates;
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Fulcrum Genomics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package picard.analysis;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/src/test/java/picard/sam/DuplicationMetricsTest.java
+++ b/src/test/java/picard/sam/DuplicationMetricsTest.java
@@ -1,0 +1,91 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Nils Homer
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for DuplicationMetrics.
+ */
+public class DuplicationMetricsTest {
+
+    private DuplicationMetrics emptyMetrics() {
+        final DuplicationMetrics metric       = new DuplicationMetrics();
+        metric.LIBRARY                        = "LIBRARY";
+        metric.UNPAIRED_READS_EXAMINED        = 0;
+        metric.READ_PAIRS_EXAMINED            = 0;
+        metric.SECONDARY_OR_SUPPLEMENTARY_RDS = 0;
+        metric.UNMAPPED_READS                 = 0;
+        metric.UNPAIRED_READ_DUPLICATES       = 0;
+        metric.READ_PAIR_DUPLICATES           = 0;
+        metric.READ_PAIR_OPTICAL_DUPLICATES   = 0;
+        metric.calculateDerivedFields();
+        return metric;
+    }
+    
+    private DuplicationMetrics nonEmptyMetrics(final int scale) {
+        final DuplicationMetrics metric       = new DuplicationMetrics();
+        metric.LIBRARY                        = "LIBRARY";
+        metric.UNPAIRED_READS_EXAMINED        = 1000 * scale;
+        metric.READ_PAIRS_EXAMINED            = 1000 * scale;
+        metric.SECONDARY_OR_SUPPLEMENTARY_RDS = scale;
+        metric.UNMAPPED_READS                 = 10 * scale;
+        metric.UNPAIRED_READ_DUPLICATES       = 100 * scale;
+        metric.READ_PAIR_DUPLICATES           = 110 * scale;
+        metric.READ_PAIR_OPTICAL_DUPLICATES   = 10 * scale;
+        metric.calculateDerivedFields();
+        return metric;
+    }
+
+    @Test(dataProvider="testMergeDataProvider")
+    public void testMerge(final DuplicationMetrics left, final DuplicationMetrics right, final DuplicationMetrics expected) {
+        left.merge(right);
+        left.calculateDerivedFields();
+
+        Assert.assertEquals(left.LIBRARY,                        expected.LIBRARY);
+        Assert.assertEquals(left.UNPAIRED_READS_EXAMINED,        expected.UNPAIRED_READS_EXAMINED);
+        Assert.assertEquals(left.READ_PAIRS_EXAMINED,            expected.READ_PAIRS_EXAMINED);
+        Assert.assertEquals(left.SECONDARY_OR_SUPPLEMENTARY_RDS, expected.SECONDARY_OR_SUPPLEMENTARY_RDS);
+        Assert.assertEquals(left.UNMAPPED_READS,                 expected.UNMAPPED_READS);
+        Assert.assertEquals(left.UNPAIRED_READ_DUPLICATES,       expected.UNPAIRED_READ_DUPLICATES);
+        Assert.assertEquals(left.READ_PAIR_DUPLICATES,           expected.READ_PAIR_DUPLICATES);
+        Assert.assertEquals(left.READ_PAIR_OPTICAL_DUPLICATES,   expected.READ_PAIR_OPTICAL_DUPLICATES);
+        Assert.assertEquals(left.PERCENT_DUPLICATION,            expected.PERCENT_DUPLICATION);
+        Assert.assertEquals(left.ESTIMATED_LIBRARY_SIZE,         expected.ESTIMATED_LIBRARY_SIZE);
+    }
+    
+    @DataProvider(name="testMergeDataProvider")
+    public Object[][] testMergeDataProvider() {
+        return new Object[][] {
+                {emptyMetrics(),     emptyMetrics(),     emptyMetrics()},
+                {emptyMetrics(),     nonEmptyMetrics(1), nonEmptyMetrics(1)},
+                {nonEmptyMetrics(1), emptyMetrics(),     nonEmptyMetrics(1)},
+                {nonEmptyMetrics(1), nonEmptyMetrics(1), nonEmptyMetrics(2)},
+                {nonEmptyMetrics(1), nonEmptyMetrics(2), nonEmptyMetrics(3)}
+        };
+    }
+}

--- a/src/test/java/picard/sam/markduplicates/AbstractMarkDuplicatesCommandLineProgramTester.java
+++ b/src/test/java/picard/sam/markduplicates/AbstractMarkDuplicatesCommandLineProgramTester.java
@@ -112,7 +112,7 @@ abstract public class AbstractMarkDuplicatesCommandLineProgramTester extends Sam
         }
         expectedMetrics.READ_PAIR_DUPLICATES = expectedMetrics.READ_PAIR_DUPLICATES / 2;
         expectedMetrics.READ_PAIRS_EXAMINED = expectedMetrics.READ_PAIRS_EXAMINED / 2;
-        expectedMetrics.calculateDerivedMetrics();
+        expectedMetrics.calculateDerivedFields();
 
         // Have to run this Double value through the same format/parsing operations as during a file write/read
         expectedMetrics.PERCENT_DUPLICATION = formatter.parseDouble(formatter.format(expectedMetrics.PERCENT_DUPLICATION));


### PR DESCRIPTION
@yfarjoun want to take a look since you wrote `MergeableMetricBase`? 

Also, I am not sure if it is too late, but the metric names in `IndependentReplicateMetric` (the first class to use `MergeableMetricBase`) are camel-case rather than upper-case+underscore, with the latter being the convention of all other picard metrics that I know of.