### PR TITLE
Added options to CollectOxoGMetrics and CollectSequencingArtifactMetrics to include/exclude non-PF reads.

### DIFF
--- a/src/main/java/picard/analysis/CollectOxoGMetrics.java
+++ b/src/main/java/picard/analysis/CollectOxoGMetrics.java
@@ -130,6 +130,9 @@ public class CollectOxoGMetrics extends CommandLineProgram {
             doc = "The maximum insert size for a read to be included in analysis. Set of 0 to allow unpaired reads.")
     public int MAXIMUM_INSERT_SIZE = 600;
 
+    @Option(shortName = "NON_PF", doc = "Whether or not to include non-PF reads.")
+    public boolean INCLUDE_NON_PF_READS = true;
+
     @Option(doc = "When available, use original quality scores for filtering.")
     public boolean USE_OQ = true;
 
@@ -284,6 +287,7 @@ public class CollectOxoGMetrics extends CommandLineProgram {
         }
         iterator.setEmitUncoveredLoci(false);
         iterator.setMappingQualityScoreCutoff(MINIMUM_MAPPING_QUALITY);
+        iterator.setIncludeNonPfReads(INCLUDE_NON_PF_READS);
 
         final List<SamRecordFilter> filters = new ArrayList<SamRecordFilter>();
         filters.add(new NotPrimaryAlignmentFilter());

--- a/src/main/java/picard/analysis/artifacts/CollectSequencingArtifactMetrics.java
+++ b/src/main/java/picard/analysis/artifacts/CollectSequencingArtifactMetrics.java
@@ -122,6 +122,9 @@ static final String USAGE_DETAILS = "<p>This tool examines two sources of sequen
     @Option(shortName = "DUPES", doc = "Include duplicate reads. If set to true then all reads flagged as duplicates will be included as well.")
     public boolean INCLUDE_DUPLICATES = false;
 
+    @Option(shortName = "NON_PF", doc = "Whether or not to include non-PF reads.")
+    public boolean INCLUDE_NON_PF_READS = false;
+
     @Option(shortName = "TANDEM", doc = "Set to true if mate pairs are being sequenced from the same strand, " +
             "i.e. they're expected to face the same direction.")
     public boolean TANDEM_READS = false;
@@ -211,7 +214,7 @@ static final String USAGE_DETAILS = "<p>This tool examines two sources of sequen
 
         // set record-level filters
         final List<SamRecordFilter> filters = new ArrayList<SamRecordFilter>();
-        filters.add(new FailsVendorReadQualityFilter());
+        if (!INCLUDE_NON_PF_READS) filters.add(new FailsVendorReadQualityFilter());
         filters.add(new NotPrimaryAlignmentFilter());
         if (!INCLUDE_DUPLICATES) filters.add(new DuplicateReadFilter());
         filters.add(new AlignedFilter(true)); // discard unmapped reads


### PR DESCRIPTION
I've been trying to tie out results between CollectOxoGMetrics and CollectSequencingArtifactMetrics, which I believe should produce near-identical values for a specific subset of metrics, if given the same inputs.  I was getting results that were different enough (off by Q=3-4 for several contexts) that I tracked down what was going on.  The difference is that CollectOxoGMetrics includes non-PF reads and CollectSequencingArtifactMetrics doesn't.  Neither exposed an option to control this.

I've added options to both, but retained the original behaviour of each by default.