### PR TITLE
Added in an summary error rate by substitution type to CollectSequencingArtifactMetrics

### DIFF
--- a/src/main/java/picard/analysis/artifacts/ErrorSummaryMetrics.java
+++ b/src/main/java/picard/analysis/artifacts/ErrorSummaryMetrics.java
@@ -1,0 +1,36 @@
+package picard.analysis.artifacts;
+
+import picard.analysis.MergeableMetricBase;
+
+/**
+ * Summary metrics produced by {@link CollectSequencingArtifactMetrics} as a roll up of the
+ * context-specific error rates, to provide global error rates per type of base substitution.
+ *
+ * Errors are normalized to the lexically lower reference base and summarized together. E.g.
+ * G>T is converted to C>A and merged with data from C>A for reporting.
+ */
+public class ErrorSummaryMetrics extends MergeableMetricBase {
+    /** The reference base (or it's complement). */
+    @MergeByAssertEquals public char REF_BASE;
+
+    /** The alternative base (or it's complement). */
+    @MergeByAssertEquals public char ALT_BASE;
+
+    /** A single string representing the substition from REF_BASE to ALT_BASE for convenience. */
+    @MergeByAssertEquals public String SUBSTITUTION;
+
+    /** The number of reference bases observed. */
+    @MergeByAdding public long REF_COUNT;
+
+    /** The number of alt bases observed. */
+    @MergeByAdding public long ALT_COUNT;
+
+    /** The rate of the substitution in question. */
+    @NoMergingIsDerived public double SUBSTITUTION_RATE;
+
+    @Override
+    public void calculateDerivedFields() {
+        final double total = REF_COUNT + ALT_COUNT;
+        this.SUBSTITUTION_RATE = (total == 0) ? 0 : ALT_COUNT / total;
+    }
+}

--- a/src/main/java/picard/analysis/artifacts/SequencingArtifactMetrics.java
+++ b/src/main/java/picard/analysis/artifacts/SequencingArtifactMetrics.java
@@ -8,8 +8,9 @@ import java.util.Comparator;
 public class SequencingArtifactMetrics {
     public static final String PRE_ADAPTER_SUMMARY_EXT = ".pre_adapter_summary_metrics";
     public static final String PRE_ADAPTER_DETAILS_EXT = ".pre_adapter_detail_metrics";
-    public static final String BAIT_BIAS_SUMMARY_EXT = ".bait_bias_summary_metrics";
-    public static final String BAIT_BIAS_DETAILS_EXT = ".bait_bias_detail_metrics";
+    public static final String BAIT_BIAS_SUMMARY_EXT   = ".bait_bias_summary_metrics";
+    public static final String BAIT_BIAS_DETAILS_EXT   = ".bait_bias_detail_metrics";
+    public static final String ERROR_SUMMARY_EXT       = ".error_summary_metrics";
 
     private static final double MIN_ERROR = 1e-10; // minimum error rate to report
 

--- a/src/test/java/picard/analysis/artifacts/CollectSequencingArtifactMetricsTest.java
+++ b/src/test/java/picard/analysis/artifacts/CollectSequencingArtifactMetricsTest.java
@@ -72,6 +72,7 @@ public class CollectSequencingArtifactMetricsTest extends CommandLineProgramTest
         Assert.assertTrue(areMetricsEqual(expectedBase, actualBase, SequencingArtifactMetrics.PRE_ADAPTER_DETAILS_EXT),"Pre-Adapter details files differ.");
         Assert.assertTrue(areMetricsEqual(expectedBase, actualBase, SequencingArtifactMetrics.BAIT_BIAS_SUMMARY_EXT), "Bait-Bias summary files differ.");
         Assert.assertTrue(areMetricsEqual(expectedBase, actualBase, SequencingArtifactMetrics.BAIT_BIAS_DETAILS_EXT), "Bait-bias details files differ.");
+        Assert.assertTrue(areMetricsEqual(expectedBase, actualBase, SequencingArtifactMetrics.ERROR_SUMMARY_EXT), "Error-summary files differ.");
     }
 
     private boolean areMetricsEqual(final File expectedBase, final File actualBase, final String extension) {

--- a/testdata/picard/analysis/artifacts/CollectSequencingArtifactMetrics/ExpectedMetricsOutput/no_bq_cutoff.error_summary_metrics
+++ b/testdata/picard/analysis/artifacts/CollectSequencingArtifactMetrics/ExpectedMetricsOutput/no_bq_cutoff.error_summary_metrics
@@ -1,0 +1,15 @@
+## htsjdk.samtools.metrics.StringHeader
+# picard.analysis.artifacts.SummarizeErrors INPUT=no_bq_cutoff.pre_adapter_detail_metrics OUTPUT=no_bq_cutoff.error_summary_metrics    VERBOSITY=INFO QUIET=false VALIDATION_STRINGENCY=STRICT COMPRESSION_LEVEL=5 MAX_RECORDS_IN_RAM=500000 CREATE_INDEX=false CREATE_MD5_FILE=false GA4GH_CLIENT_SECRETS=client_secrets.json
+## htsjdk.samtools.metrics.StringHeader
+# Started on: Mon Oct 24 14:13:59 EDT 2016
+
+## METRICS CLASS	picard.analysis.artifacts.ErrorSummaryMetrics
+REF_BASE	ALT_BASE	SUBSTITUTION	REF_COUNT	ALT_COUNT	SUBSTITUTION_RATE
+A	C	A>C	134	0	0
+A	G	A>G	134	0	0
+A	T	A>T	134	0	0
+C	A	C>A	92	22	0.192982
+C	G	C>G	92	0	0
+C	T	C>T	92	32	0.258065
+
+

--- a/testdata/picard/analysis/artifacts/CollectSequencingArtifactMetrics/ExpectedMetricsOutput/no_mq_cutoff.error_summary_metrics
+++ b/testdata/picard/analysis/artifacts/CollectSequencingArtifactMetrics/ExpectedMetricsOutput/no_mq_cutoff.error_summary_metrics
@@ -1,0 +1,15 @@
+## htsjdk.samtools.metrics.StringHeader
+# picard.analysis.artifacts.SummarizeErrors INPUT=no_mq_cutoff.pre_adapter_detail_metrics OUTPUT=no_mq_cutoff.error_summary_metrics    VERBOSITY=INFO QUIET=false VALIDATION_STRINGENCY=STRICT COMPRESSION_LEVEL=5 MAX_RECORDS_IN_RAM=500000 CREATE_INDEX=false CREATE_MD5_FILE=false GA4GH_CLIENT_SECRETS=client_secrets.json
+## htsjdk.samtools.metrics.StringHeader
+# Started on: Mon Oct 24 14:14:00 EDT 2016
+
+## METRICS CLASS	picard.analysis.artifacts.ErrorSummaryMetrics
+REF_BASE	ALT_BASE	SUBSTITUTION	REF_COUNT	ALT_COUNT	SUBSTITUTION_RATE
+A	C	A>C	136	0	0
+A	G	A>G	136	0	0
+A	T	A>T	136	0	0
+C	A	C>A	100	22	0.180328
+C	G	C>G	100	0	0
+C	T	C>T	100	32	0.242424
+
+

--- a/testdata/picard/analysis/artifacts/CollectSequencingArtifactMetrics/ExpectedMetricsOutput/unmapped_mate.error_summary_metrics
+++ b/testdata/picard/analysis/artifacts/CollectSequencingArtifactMetrics/ExpectedMetricsOutput/unmapped_mate.error_summary_metrics
@@ -1,0 +1,15 @@
+## htsjdk.samtools.metrics.StringHeader
+# picard.analysis.artifacts.SummarizeErrors INPUT=unmapped_mate.pre_adapter_detail_metrics OUTPUT=unmapped_mate.error_summary_metrics    VERBOSITY=INFO QUIET=false VALIDATION_STRINGENCY=STRICT COMPRESSION_LEVEL=5 MAX_RECORDS_IN_RAM=500000 CREATE_INDEX=false CREATE_MD5_FILE=false GA4GH_CLIENT_SECRETS=client_secrets.json
+## htsjdk.samtools.metrics.StringHeader
+# Started on: Mon Oct 24 14:14:00 EDT 2016
+
+## METRICS CLASS	picard.analysis.artifacts.ErrorSummaryMetrics
+REF_BASE	ALT_BASE	SUBSTITUTION	REF_COUNT	ALT_COUNT	SUBSTITUTION_RATE
+A	C	A>C	138	0	0
+A	G	A>G	138	0	0
+A	T	A>T	138	0	0
+C	A	C>A	98	22	0.183333
+C	G	C>G	98	0	0
+C	T	C>T	98	32	0.246154
+
+

--- a/testdata/picard/analysis/artifacts/CollectSequencingArtifactMetrics/ExpectedMetricsOutput/with_context.error_summary_metrics
+++ b/testdata/picard/analysis/artifacts/CollectSequencingArtifactMetrics/ExpectedMetricsOutput/with_context.error_summary_metrics
@@ -1,0 +1,15 @@
+## htsjdk.samtools.metrics.StringHeader
+# picard.analysis.artifacts.SummarizeErrors INPUT=with_context.pre_adapter_detail_metrics OUTPUT=with_context.error_summary_metrics    VERBOSITY=INFO QUIET=false VALIDATION_STRINGENCY=STRICT COMPRESSION_LEVEL=5 MAX_RECORDS_IN_RAM=500000 CREATE_INDEX=false CREATE_MD5_FILE=false GA4GH_CLIENT_SECRETS=client_secrets.json
+## htsjdk.samtools.metrics.StringHeader
+# Started on: Mon Oct 24 14:14:01 EDT 2016
+
+## METRICS CLASS	picard.analysis.artifacts.ErrorSummaryMetrics
+REF_BASE	ALT_BASE	SUBSTITUTION	REF_COUNT	ALT_COUNT	SUBSTITUTION_RATE
+A	C	A>C	116	0	0
+A	G	A>G	116	0	0
+A	T	A>T	116	0	0
+C	A	C>A	86	22	0.203704
+C	G	C>G	86	0	0
+C	T	C>T	86	32	0.271186
+
+

--- a/testdata/picard/analysis/artifacts/CollectSequencingArtifactMetrics/ExpectedMetricsOutput/with_dbsnp.error_summary_metrics
+++ b/testdata/picard/analysis/artifacts/CollectSequencingArtifactMetrics/ExpectedMetricsOutput/with_dbsnp.error_summary_metrics
@@ -1,0 +1,15 @@
+## htsjdk.samtools.metrics.StringHeader
+# picard.analysis.artifacts.SummarizeErrors INPUT=with_dbsnp.pre_adapter_detail_metrics OUTPUT=with_dbsnp.error_summary_metrics    VERBOSITY=INFO QUIET=false VALIDATION_STRINGENCY=STRICT COMPRESSION_LEVEL=5 MAX_RECORDS_IN_RAM=500000 CREATE_INDEX=false CREATE_MD5_FILE=false GA4GH_CLIENT_SECRETS=client_secrets.json
+## htsjdk.samtools.metrics.StringHeader
+# Started on: Mon Oct 24 14:14:01 EDT 2016
+
+## METRICS CLASS	picard.analysis.artifacts.ErrorSummaryMetrics
+REF_BASE	ALT_BASE	SUBSTITUTION	REF_COUNT	ALT_COUNT	SUBSTITUTION_RATE
+A	C	A>C	126	0	0
+A	G	A>G	126	0	0
+A	T	A>T	126	0	0
+C	A	C>A	80	18	0.183673
+C	G	C>G	80	0	0
+C	T	C>T	80	24	0.230769
+
+

--- a/testdata/picard/analysis/artifacts/CollectSequencingArtifactMetrics/ExpectedMetricsOutput/with_intervals.error_summary_metrics
+++ b/testdata/picard/analysis/artifacts/CollectSequencingArtifactMetrics/ExpectedMetricsOutput/with_intervals.error_summary_metrics
@@ -1,0 +1,15 @@
+## htsjdk.samtools.metrics.StringHeader
+# picard.analysis.artifacts.SummarizeErrors INPUT=with_intervals.pre_adapter_detail_metrics OUTPUT=with_intervals.error_summary_metrics    VERBOSITY=INFO QUIET=false VALIDATION_STRINGENCY=STRICT COMPRESSION_LEVEL=5 MAX_RECORDS_IN_RAM=500000 CREATE_INDEX=false CREATE_MD5_FILE=false GA4GH_CLIENT_SECRETS=client_secrets.json
+## htsjdk.samtools.metrics.StringHeader
+# Started on: Mon Oct 24 14:14:02 EDT 2016
+
+## METRICS CLASS	picard.analysis.artifacts.ErrorSummaryMetrics
+REF_BASE	ALT_BASE	SUBSTITUTION	REF_COUNT	ALT_COUNT	SUBSTITUTION_RATE
+A	C	A>C	62	0	0
+A	G	A>G	62	0	0
+A	T	A>T	62	0	0
+C	A	C>A	40	4	0.090909
+C	G	C>G	40	0	0
+C	T	C>T	40	32	0.444444
+
+


### PR DESCRIPTION
@yfarjoun This is the PR I promised a few weeks ago.  The result is a new metrics file from CollectSequencingArtifactMetrics with six rows that look something like this:
```
REF_BASE  ALT_BASE  SUBSTITUTION  REF_COUNT  ALT_COUNT  SUBSTITUTION_RATE
A         C         A>C           207358     28         0.00014
A         G         A>G           207358     52         0.00025
A         T         A>T           207358     36         0.00017
C         A         C>A           181950     20         0.00011
C         G         C>G           181950     14         0.00008
C         T         C>T           181950     17         0.00009
```

I've been finding this super-useful to just get a summary of the different kinds of errors that are predominant in a library before diving into _how_ of _where_ they are coming from.

**Please note:** I haven't touched the tests yet.  If you're willing, I'd like you to take a first pass look at the code _first_.  Once you're happy with the calculations and the output format, I will extend the tests to cover the new functionality.  I just don't want to do that up front and then have to fix them all if you ask for some change that affects everything!