### PR TITLE
Total clusers is now a long in GcBiasSummaryMetrics.

### DIFF
--- a/src/main/java/picard/analysis/GcBiasMetricsCollector.java
+++ b/src/main/java/picard/analysis/GcBiasMetricsCollector.java
@@ -190,7 +190,7 @@ public class GcBiasMetricsCollector extends MultiLevelCollector<GcBiasMetrics, I
                 final int[] readsByGc = gcCur.readsByGc;
                 final long[] errorsByGc = gcCur.errorsByGc;
                 final long[] basesByGc = gcCur.basesByGc;
-                final int totalClusters = gcCur.totalClusters;
+                final long totalClusters = gcCur.totalClusters;
                 final long totalAlignedReads = gcCur.totalAlignedReads;
                 final String group = gcCur.group;
 
@@ -308,7 +308,7 @@ public class GcBiasMetricsCollector extends MultiLevelCollector<GcBiasMetrics, I
     //Keeps track of each level of GcCalculation
     /////////////////////////////////////////////////////////////////////////////
     class GcObject {
-        int totalClusters = 0;
+        long totalClusters = 0;
         long totalAlignedReads = 0;
         int[] readsByGc = new int[BINS];
         long[] basesByGc = new long[BINS];

--- a/src/main/java/picard/analysis/GcBiasSummaryMetrics.java
+++ b/src/main/java/picard/analysis/GcBiasSummaryMetrics.java
@@ -38,7 +38,7 @@ public class GcBiasSummaryMetrics extends MultilevelMetrics {
     public int WINDOW_SIZE;
 
     /** The total number of clusters that were seen in the gc bias calculation. */
-    public int TOTAL_CLUSTERS;
+    public long TOTAL_CLUSTERS;
 
     /** The total number of aligned reads used to compute the gc bias metrics. */
     public long ALIGNED_READS;


### PR DESCRIPTION
Previously it was an integer, which could be an issue if we have many
clusters.