### PR TITLE
Fix bug that causes CollectHsMetrics (and friends) to double-count...

### DIFF
--- a/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
+++ b/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
@@ -619,10 +619,7 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
                 final boolean hasCoverage = c.hasCoverage();
                 final int[] targetDepths = c.getDepths();
 
-                if (!hasCoverage) {
-                    zeroCoverageTargets++;
-                    coverageDistribution[0] += c.getDepths().length;
-                }
+                if (!hasCoverage) zeroCoverageTargets++;
 
                 for (final int depth : targetDepths) {
                     if (0 < depth) totalCoverage += depth;

--- a/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
+++ b/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
@@ -1,6 +1,7 @@
 package picard.analysis.directed;
 
 import htsjdk.samtools.metrics.MetricsFile;
+import htsjdk.samtools.util.Histogram;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -67,8 +68,11 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
 
         Assert.assertEquals(runPicardCommandLine(args), 0);
 
-        final MetricsFile<HsMetrics, Comparable<?>> output = new MetricsFile<HsMetrics, Comparable<?>>();
+        final MetricsFile<HsMetrics, Integer> output = new MetricsFile<>();
         output.read(new FileReader(outfile));
+
+        final Histogram<Integer> coverageHistogram = output.getHistogram();
+        final long territory = (long) coverageHistogram.getSumOfValues();
 
         for (final HsMetrics metrics : output.getMetrics()) {
             // overlap
@@ -78,6 +82,7 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
             Assert.assertEquals(metrics.PCT_EXC_OVERLAP, pctExcOverlap);
             Assert.assertEquals(metrics.PCT_TARGET_BASES_1X, pctTargetBases1x);
             Assert.assertEquals(metrics.PCT_TARGET_BASES_2X, pctTargetBases2x);
+            Assert.assertEquals(metrics.TARGET_TERRITORY, territory);
         }
     }
 }

--- a/src/test/java/picard/analysis/directed/CollectTargetedMetricsTest.java
+++ b/src/test/java/picard/analysis/directed/CollectTargetedMetricsTest.java
@@ -144,12 +144,14 @@ public class CollectTargetedMetricsTest extends CommandLineProgramTest {
 
         Assert.assertEquals(runPicardCommandLine(args), 0);
 
-        final MetricsFile<TargetedPcrMetrics, Comparable<?>> output = new MetricsFile<TargetedPcrMetrics, Comparable<?>>();
+        final MetricsFile<TargetedPcrMetrics, Integer> output = new MetricsFile<>();
         output.read(new FileReader(outfile));
+        final long territory = (long) output.getHistogram().getSumOfValues();
 
         for (final TargetedPcrMetrics metrics : output.getMetrics()) {
             Assert.assertEquals(metrics.TOTAL_READS, numReads * 2);
             Assert.assertEquals(metrics.HET_SNP_SENSITIVITY, .997972, .02);
+            Assert.assertEquals(metrics.TARGET_TERRITORY, territory);
         }
     }
 }


### PR DESCRIPTION
…0-coverage sites in 0-coverage targets.
