### PR TITLE
Added a public accessor for the per-target coverage information.

### DIFF
--- a/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
+++ b/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
@@ -58,14 +58,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * TargetMetrics, are metrics to measure how well we hit specific targets (or baits) when using a targeted sequencing process like hybrid selection
@@ -404,6 +397,11 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
         /** Sets the name of the bait set explicitly instead of inferring it from the bait file. */
         public void setBaitSetName(final String name) {
             this.metrics.PROBE_SET = name;
+        }
+
+        /** Returns the accumulated coverage per target. */
+        public Map<Interval,Coverage> getCoverageByTarget() {
+            return Collections.unmodifiableMap(this.coverageByTarget);
         }
 
         /** Adds information about an individual SAMRecord to the statistics. */

--- a/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
+++ b/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
@@ -399,8 +399,12 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
             this.metrics.PROBE_SET = name;
         }
 
-        /** Returns the accumulated coverage per target. */
-        public Map<Interval,Coverage> getCoverageByTarget() {
+        /**
+         * Returns the accumulated coverage per target.  Note that while the returned Map is
+         * immutable, it is possible that the underlying Map will continue to be mutated if
+         * the map is retrieved prior to additional calls to {@link #acceptRecord(SAMRecord)}.
+         */
+        public Map<Interval, Coverage> getCoverageByTarget() {
             return Collections.unmodifiableMap(this.coverageByTarget);
         }
 


### PR DESCRIPTION
I find that I'm using the `HsMetricCollector` and related classes programmatically a lot, and it would be really nice to be able to access the per-base and per-target coverage information that is accumulated without having to write it out to a file and parse it back in again.  This PR adds a one-line accessor to make the information available to other classes.