### PR TITLE
Do not require an index when checking fingerprints

### DIFF
--- a/src/main/java/picard/fingerprint/FingerprintChecker.java
+++ b/src/main/java/picard/fingerprint/FingerprintChecker.java
@@ -125,8 +125,8 @@ public class FingerprintChecker {
      *                         of an individual sample to load (and exclude all others).
      * @return a Map of Sample name to Fingerprint
      */
-    public Map<String,Fingerprint> loadFingerprints(final File fingerprintFile, final String specificSample) {
-        final VCFFileReader reader = new VCFFileReader(fingerprintFile);
+    public Map<String, Fingerprint> loadFingerprints(final File fingerprintFile, final String specificSample) {
+        final VCFFileReader reader = new VCFFileReader(fingerprintFile, false);
         final CloseableIterator<VariantContext> iterator = reader.iterator();  
 
         SequenceUtil.assertSequenceDictionariesEqual(this.haplotypes.getHeader().getSequenceDictionary(),

--- a/src/test/java/picard/fingerprint/FingerprintCheckerTest.java
+++ b/src/test/java/picard/fingerprint/FingerprintCheckerTest.java
@@ -94,12 +94,10 @@ public class FingerprintCheckerTest {
     @Test(dataProvider = "checkFingerprintsVcfDataProvider")
     public void testCheckFingerprints(File vcfFile,  File genotypesFile,  String observedSampleAlias,  String expectedSampleAlias,
                                       double llExpectedSample, double llRandomSample, double lodExpectedSample) throws IOException {
-        final File indexedInputVcf = VcfTestUtils.createIndexedVcf(vcfFile, "fingerprintcheckertest.tmp.");
-        final File indexedGenotypesVcf = VcfTestUtils.createIndexedVcf(genotypesFile, "fingerprintcheckertest.tmp.");
 
         final FingerprintChecker fpChecker = new FingerprintChecker(SUBSETTED_HAPLOTYPE_DATABASE_FOR_TESTING);
-        final List<FingerprintResults> results = fpChecker.checkFingerprints(Collections.singletonList(indexedInputVcf),
-                Collections.singletonList(indexedGenotypesVcf),
+        final List<FingerprintResults> results = fpChecker.checkFingerprints(Collections.singletonList(vcfFile),
+                Collections.singletonList(genotypesFile),
                 observedSampleAlias,
                 expectedSampleAlias);
         Assert.assertEquals(results.size(), 1);


### PR DESCRIPTION
A move out of GenotypeReader uses the default VCFFileReader which requires an index, this is a break from the previous behaviour, and non-needed since the usecase is to iterate through the entire file, not query for a particular location.

This PR uses the version of VCFFileReader that doesn't require an index, and changes the tests so that an index isn't created...

