### PR TITLE
updating gradle from 2.13 -> 3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -233,7 +233,7 @@ task createMetricsDoc(dependsOn: classes, type: Javadoc) << {
 
 task wrapper(type: Wrapper) {
     description = "Regenerate the gradle wrapper"
-    gradleVersion = '2.13'
+    gradleVersion = '3.1'
 }
 
 task javadocJar(type: Jar, dependsOn: documentAll) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri May 13 14:00:35 EDT 2016
+#Mon Oct 24 16:22:03 EDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-bin.zip


### PR DESCRIPTION
this should help ease some development pains by allowing use of composite builds and other new gradle features

Composite builds are a feature that makes it easier to develop across multiple repos simultaneously.  The intellij experimental branch has support for using composite builds.  See https://blog.jetbrains.com/idea/2016/10/intellij-idea-2016-3-eap-gradle-composite-builds-and-android-studio-2-2/ for more information.
