### PR TITLE
Fix for issue #432 CreateSequenceDictionary stalls indefinitely with large genomes 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ jacoco {
     toolVersion = "0.7.5.201505241946"
 }
 
-final htsjdkVersion = System.getProperty('htsjdk.version', '2.7.0')
+final htsjdkVersion = System.getProperty('htsjdk.version', '2.8.0')
 
 dependencies {
     compile 'com.google.guava:guava:15.0'

--- a/src/main/java/picard/sam/CreateSequenceDictionary.java
+++ b/src/main/java/picard/sam/CreateSequenceDictionary.java
@@ -140,11 +140,12 @@ public class CreateSequenceDictionary extends CommandLineProgram {
                     getReferenceSequenceFile(REFERENCE, TRUNCATE_NAMES_AT_WHITESPACE);
             SAMSequenceDictionaryCodec samDictCodec = new SAMSequenceDictionaryCodec(writer);
 
+            samDictCodec.encodeHeaderLine(false);
             // read reference sequence one by one and write its metadata
             ReferenceSequence refSeq;
             while ((refSeq = refSeqFile.nextSequence()) != null) {
                 final SAMSequenceRecord samSequenceRecord = makeSequenceRecord(refSeq);
-                samDictCodec.encodeSQLine(samSequenceRecord);
+                samDictCodec.encodeSequenceRecord(samSequenceRecord);
                 sequenceNames.add(refSeq.getName());
             }
         } catch (FileNotFoundException e) {

--- a/src/main/java/picard/sam/CreateSequenceDictionary.java
+++ b/src/main/java/picard/sam/CreateSequenceDictionary.java
@@ -39,10 +39,10 @@ import picard.PicardException;
 import picard.cmdline.CommandLineProgram;
 import picard.cmdline.CommandLineProgramProperties;
 import picard.cmdline.Option;
-import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.programgroups.Fasta;
+import picard.cmdline.StandardOptionDefinitions;
 
-import java.io.*;
+import java.io.File;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -71,7 +71,6 @@ public class CreateSequenceDictionary extends CommandLineProgram {
             "" +
             "</pre>" +
             "<hr />";
-
     // The following attributes define the command-line arguments
 
     @Option(doc = "Input reference fasta or fasta.gz", shortName = StandardOptionDefinitions.REFERENCE_SHORT_NAME)

--- a/src/main/java/picard/sam/CreateSequenceDictionary.java
+++ b/src/main/java/picard/sam/CreateSequenceDictionary.java
@@ -42,7 +42,7 @@ import picard.cmdline.Option;
 import picard.cmdline.programgroups.Fasta;
 import picard.cmdline.StandardOptionDefinitions;
 
-import java.io.File;
+import java.io.*;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -135,7 +135,7 @@ public class CreateSequenceDictionary extends CommandLineProgram {
 
         // SortingCollection is used to check uniqueness of sequence names
         final SortingCollection<String> sequenceNames = makeSortingCollection();
-        try (Writer writer = makeWriter()) {
+        try (BufferedWriter writer = makeWriter()) {
             final ReferenceSequenceFile refSeqFile = ReferenceSequenceFileFactory.
                     getReferenceSequenceFile(REFERENCE, TRUNCATE_NAMES_AT_WHITESPACE);
             SAMSequenceDictionaryCodec samDictCodec = new SAMSequenceDictionaryCodec(writer);
@@ -168,13 +168,15 @@ public class CreateSequenceDictionary extends CommandLineProgram {
         return 0;
     }
 
-    private Writer makeWriter() throws FileNotFoundException {
-        return new AsciiWriter(this.CREATE_MD5_FILE ?
+    private BufferedWriter makeWriter() throws FileNotFoundException {
+        return new BufferedWriter(
+                new AsciiWriter(this.CREATE_MD5_FILE ?
                         new Md5CalculatingOutputStream(
                                 new FileOutputStream(OUTPUT, false),
                                 new File(OUTPUT.getAbsolutePath() + ".md5")
                         )
                         : new FileOutputStream(OUTPUT)
+                )
         );
     }
 

--- a/src/main/java/picard/sam/CreateSequenceDictionary.java
+++ b/src/main/java/picard/sam/CreateSequenceDictionary.java
@@ -170,8 +170,7 @@ public class CreateSequenceDictionary extends CommandLineProgram {
 
             samDictCodec.encodeHeaderLine(false);
             // read reference sequence one by one and write its metadata
-            ReferenceSequence refSeq;
-            while ((refSeq = refSeqFile.nextSequence()) != null) {
+            for (ReferenceSequence refSeq = refSeqFile.nextSequence(); refSeq != null; refSeq = refSeqFile.nextSequence()) {
                 final SAMSequenceRecord samSequenceRecord = makeSequenceRecord(refSeq);
                 samDictCodec.encodeSequenceRecord(samSequenceRecord);
                 sequenceNames.add(refSeq.getName());
@@ -187,15 +186,15 @@ public class CreateSequenceDictionary extends CommandLineProgram {
 
         if(!iterator.hasNext()) return 0;
 
-        String first = iterator.next();
+        String current = iterator.next();
         while (iterator.hasNext()) {
             final String next = iterator.next();
-            if (first.equals(next)) {
+            if (current.equals(next)) {
                 OUTPUT.delete();
-                throw new PicardException("Sequence name " + first +
+                throw new PicardException("Sequence name " + current +
                         " appears more than once in reference file");
             }
-            first = next;
+            current = next;
         }
         return 0;
     }
@@ -249,6 +248,7 @@ public class CreateSequenceDictionary extends CommandLineProgram {
     private SortingCollection<String> makeSortingCollection() {
         final String name = getClass().getSimpleName();
         final File tmpDir = IOUtil.createTempDir(name, null);
+        tmpDir.deleteOnExit();
         // 256 byte for one name, and 1/10 part of all memory for this, rough estimate
         long maxNamesInRam = Runtime.getRuntime().maxMemory() / 256 / 10;
         return SortingCollection.newInstance(

--- a/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
+++ b/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
@@ -70,13 +70,17 @@ public class CreateSequenceDictionaryTest extends CommandLineProgramTest {
                 "TRUNCATE_NAMES_AT_WHITESPACE=false"
         };
         Assert.assertEquals(runPicardCommandLine(argv), 0);
-        
+
         List<String> currentDict = new BufferedReader(new FileReader(outputDict))
                 .lines()
+                //remove info about location fasta file
+                .map(s -> s.replaceAll("UR:.*", ""))
                 .collect(Collectors.toList());
 
-        List<String> expectedDict = new BufferedReader(new FileReader("testdata/picard/reference/csd_dict.dict"))
+        List<String> expectedDict = new BufferedReader(new FileReader(TEST_DATA_DIR + "/reference/csd_dict.dict"))
                 .lines()
+                //remove info about location fasta file
+                .map(s -> s.replaceAll("UR:.*", ""))
                 .collect(Collectors.toList());
 
         Assert.assertEquals(currentDict, expectedDict);

--- a/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
+++ b/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
@@ -28,15 +28,20 @@ import org.testng.annotations.Test;
 import picard.cmdline.CommandLineProgramTest;
 import picard.PicardException;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author alecw@broadinstitute.org
  */
 public class CreateSequenceDictionaryTest extends CommandLineProgramTest {
-    public static File TEST_DATA_DIR = new File("testdata/picard/sam");
-    public static File BASIC_FASTA = new File(TEST_DATA_DIR, "basic.fasta");
-    public static File DUPLICATE_FASTA = new File(TEST_DATA_DIR, "duplicate_sequence_names.fasta");
+    public static File TEST_DATA_DIR = new File("testdata/picard");
+    public static File BASIC_FASTA = new File(TEST_DATA_DIR + "/sam", "basic.fasta");
+    public static File EQUIVALENCE_TEST_FASTA = new File(TEST_DATA_DIR + "/reference", "test.fasta");
+    public static File DUPLICATE_FASTA = new File(TEST_DATA_DIR + "/sam", "duplicate_sequence_names.fasta");
 
     public String getCommandLineProgramName() {
         return CreateSequenceDictionary.class.getSimpleName();
@@ -53,6 +58,28 @@ public class CreateSequenceDictionaryTest extends CommandLineProgramTest {
                 "TRUNCATE_NAMES_AT_WHITESPACE=false"
         };
         Assert.assertEquals(runPicardCommandLine(argv), 0);
+    }
+
+    @Test
+    public void testForEquivalence() throws Exception {
+        final File outputDict = File.createTempFile("CreateSequenceDictionaryTest.", ".dict");
+        outputDict.delete();
+        final String[] argv = {
+                "REFERENCE=" + EQUIVALENCE_TEST_FASTA,
+                "OUTPUT=" + outputDict,
+                "TRUNCATE_NAMES_AT_WHITESPACE=false"
+        };
+        Assert.assertEquals(runPicardCommandLine(argv), 0);
+        
+        List<String> currentDict = new BufferedReader(new FileReader(outputDict))
+                .lines()
+                .collect(Collectors.toList());
+
+        List<String> expectedDict = new BufferedReader(new FileReader("testdata/picard/reference/csd_dict.dict"))
+                .lines()
+                .collect(Collectors.toList());
+
+        Assert.assertEquals(currentDict, expectedDict);
     }
 
     /**

--- a/testdata/picard/reference/csd_dict.dict
+++ b/testdata/picard/reference/csd_dict.dict
@@ -1,0 +1,9 @@
+@HD	VN:1.5
+@SQ	SN:chr1	LN:101	M5:bd01f7e11515bb6beda8f7257902aa67	UR:file:/home/pavel/git/epm-cmbi/picard-pho/testdata/picard/reference/test.fasta
+@SQ	SN:chr2	LN:101	M5:31c33e2155b3de5e2554b693c475b310	UR:file:/home/pavel/git/epm-cmbi/picard-pho/testdata/picard/reference/test.fasta
+@SQ	SN:chr3	LN:101	M5:631593c6dd2048ae88dcce2bd505d295	UR:file:/home/pavel/git/epm-cmbi/picard-pho/testdata/picard/reference/test.fasta
+@SQ	SN:chr4	LN:101	M5:c60cb92f1ee5b78053c92bdbfa19abf1	UR:file:/home/pavel/git/epm-cmbi/picard-pho/testdata/picard/reference/test.fasta
+@SQ	SN:chr5	LN:101	M5:07ebc213c7611db0eacbb1590c3e9bda	UR:file:/home/pavel/git/epm-cmbi/picard-pho/testdata/picard/reference/test.fasta
+@SQ	SN:chr6	LN:101	M5:7be2f5e7ee39e60a6c3b5b6a41178c6d	UR:file:/home/pavel/git/epm-cmbi/picard-pho/testdata/picard/reference/test.fasta
+@SQ	SN:chr7	LN:202	M5:93763aaf6a455871c7d7a7718bff9ccf	UR:file:/home/pavel/git/epm-cmbi/picard-pho/testdata/picard/reference/test.fasta
+@SQ	SN:chr8	LN:202	M5:d339678efce576d5546e88b49a487b63	UR:file:/home/pavel/git/epm-cmbi/picard-pho/testdata/picard/reference/test.fasta

--- a/testdata/picard/reference/csd_dict.dict
+++ b/testdata/picard/reference/csd_dict.dict
@@ -1,9 +1,9 @@
 @HD	VN:1.5
-@SQ	SN:chr1	LN:101	M5:bd01f7e11515bb6beda8f7257902aa67	UR:file:/home/pavel/git/epm-cmbi/picard-pho/testdata/picard/reference/test.fasta
-@SQ	SN:chr2	LN:101	M5:31c33e2155b3de5e2554b693c475b310	UR:file:/home/pavel/git/epm-cmbi/picard-pho/testdata/picard/reference/test.fasta
-@SQ	SN:chr3	LN:101	M5:631593c6dd2048ae88dcce2bd505d295	UR:file:/home/pavel/git/epm-cmbi/picard-pho/testdata/picard/reference/test.fasta
-@SQ	SN:chr4	LN:101	M5:c60cb92f1ee5b78053c92bdbfa19abf1	UR:file:/home/pavel/git/epm-cmbi/picard-pho/testdata/picard/reference/test.fasta
-@SQ	SN:chr5	LN:101	M5:07ebc213c7611db0eacbb1590c3e9bda	UR:file:/home/pavel/git/epm-cmbi/picard-pho/testdata/picard/reference/test.fasta
-@SQ	SN:chr6	LN:101	M5:7be2f5e7ee39e60a6c3b5b6a41178c6d	UR:file:/home/pavel/git/epm-cmbi/picard-pho/testdata/picard/reference/test.fasta
-@SQ	SN:chr7	LN:202	M5:93763aaf6a455871c7d7a7718bff9ccf	UR:file:/home/pavel/git/epm-cmbi/picard-pho/testdata/picard/reference/test.fasta
-@SQ	SN:chr8	LN:202	M5:d339678efce576d5546e88b49a487b63	UR:file:/home/pavel/git/epm-cmbi/picard-pho/testdata/picard/reference/test.fasta
+@SQ	SN:chr1	LN:101	M5:bd01f7e11515bb6beda8f7257902aa67	UR:file:/path/to/testdata/picard/reference/test.fasta
+@SQ	SN:chr2	LN:101	M5:31c33e2155b3de5e2554b693c475b310	UR:file:/path/to/testdata/picard/reference/test.fasta
+@SQ	SN:chr3	LN:101	M5:631593c6dd2048ae88dcce2bd505d295	UR:file:/path/to/testdata/picard/reference/test.fasta
+@SQ	SN:chr4	LN:101	M5:c60cb92f1ee5b78053c92bdbfa19abf1	UR:file:/path/to/testdata/picard/reference/test.fasta
+@SQ	SN:chr5	LN:101	M5:07ebc213c7611db0eacbb1590c3e9bda	UR:file:/path/to/testdata/picard/reference/test.fasta
+@SQ	SN:chr6	LN:101	M5:7be2f5e7ee39e60a6c3b5b6a41178c6d	UR:file:/path/to/testdata/picard/reference/test.fasta
+@SQ	SN:chr7	LN:202	M5:93763aaf6a455871c7d7a7718bff9ccf	UR:file:/path/to/testdata/picard/reference/test.fasta
+@SQ	SN:chr8	LN:202	M5:d339678efce576d5546e88b49a487b63	UR:file:/path/to/testdata/picard/reference/test.fasta


### PR DESCRIPTION
We introduce two pull requests to Htsjdk (https://github.com/samtools/htsjdk/pull/744) and Picard Tools to resolve the issue https://github.com/broadinstitute/picard/issues/432 .

Original version of CreateSequenceDictionary creates and stores all reference sequences entirely in memory in a SAMHeader object and then writes it to a file.

In order to check sequence's names for uniqueness, they are added to a HashSet. This might lead to "Out of memory" exceptions for files with a large number of sequences .


**Changes in Htsjdk:**

In our implementation we introduce a new "on fly" codec SAMSequenceDictionaryCodec, which encodes each sequence and directly writes it to the Dictionary file. This allows us not to store sequences in memory.


**Changes in Picard Tools:**

CreateSequenceDictionary now uses new SAMSequenceDictionaryCodec to write dictionary file.

SortingCollection is used instead of a HashSet to verify the sequences names uniqueness , this allows us not to keep all the names in memory since identical names will be stored in the collection one after another and we can find duplicates in one pass. 

Please pay attention, that now CreateSequenceDictionary doesn't write HD line, since we think that it is not required, SequenceDictionary must contain only SQ line, not HD. If our assumption is wrong, correct us, please.

 

 

So, if we look at the plot "GC Times" from JMC: FlightRecorder, we will see that standard version of CreateSequenceDictionary have a big trouble with a large amount of records (several millions):

**The plot "GC Times" for a  Standard version:**
 
![selection_041](https://cloud.githubusercontent.com/assets/11179595/20395648/16c18ec0-acfd-11e6-8576-bf4c52013e4f.png)
![selection_043](https://cloud.githubusercontent.com/assets/11179595/20395649/16c275a6-acfd-11e6-9d54-63f1f20c50a4.png)


**The plot "GC Times" for a fixed version:**
![selection_040](https://cloud.githubusercontent.com/assets/11179595/20395646/16990892-acfd-11e6-829a-832b63679b73.png)
![selection_042](https://cloud.githubusercontent.com/assets/11179595/20395647/16be48c8-acfd-11e6-8eac-2982b09fe183.png)

How we can see, now CreateSequenceDictionary processes a big reference without troubles, for example time of execution for file from issue https://github.com/broadinstitute/picard/issues/432 is:

```
real 762.83
user 626.94
sys 67.02
```

Full GC reports (jmc flight recorder):
[JMC FR logs.zip](https://github.com/broadinstitute/picard/files/597773/JMC.FR.logs.zip)

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
