### PR TITLE
Support in-line skips and molecular barcodes.

### DIFF
--- a/src/main/java/picard/illumina/CollectIlluminaLaneMetrics.java
+++ b/src/main/java/picard/illumina/CollectIlluminaLaneMetrics.java
@@ -26,7 +26,12 @@ package picard.illumina;
 
 import htsjdk.samtools.metrics.MetricBase;
 import htsjdk.samtools.metrics.MetricsFile;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import picard.PicardException;
 import picard.cmdline.CommandLineProgram;
 import picard.cmdline.CommandLineProgramProperties;
@@ -37,11 +42,10 @@ import picard.illumina.parser.*;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
+
+import javax.xml.parsers.DocumentBuilderFactory;
 
 /**
  * Command-line wrapper around {@link IlluminaLaneMetricsCollector}.
@@ -81,29 +85,34 @@ public class CollectIlluminaLaneMetrics extends CommandLineProgram {
     @Option(doc = "The prefix to be prepended to the file name of the output file; an appropriate suffix will be applied", shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME)
     public String OUTPUT_PREFIX;
 
-    @Option(doc = ReadStructure.PARAMETER_DOC, shortName = "RS")
+    @Option(doc = ReadStructure.PARAMETER_DOC + "\nIf not given, will use the RunInfo.xml in the run directory.", shortName = "RS", optional = true)
     public ReadStructure READ_STRUCTURE;
-
-    @Option(doc = "Include skips and molecular barcodes for both phasing and pre-phasing values.  Use this if the either of the former are in-line in the read(s) (not in index reads).")
-    public boolean INCLUDE_SKIPS_AND_MOLECULAR_BARCODES = false;
 
     @Override
     protected int doWork() {
         final MetricsFile<MetricBase, Comparable<?>> laneMetricsFile = this.getMetricsFile();
         final MetricsFile<MetricBase, Comparable<?>> phasingMetricsFile = this.getMetricsFile();
 
-        // If skips or molecular identifiers are part of the read structure and also part of the non-index reads (line),
-        // then convert them template descriptors for our purposes.
-        if (INCLUDE_SKIPS_AND_MOLECULAR_BARCODES) {
-            final List<ReadDescriptor> descriptors = READ_STRUCTURE.descriptors.stream().map(descriptor -> {
-                if (descriptor.type == ReadType.Skip || descriptor.type == ReadType.MolecularIndex) {
-                    return new ReadDescriptor(descriptor.length, ReadType.Template);
+        if (READ_STRUCTURE == null) {
+            final File runInfo = new File(RUN_DIRECTORY + "/" + "RunInfo.xml");
+            IOUtil.assertFileIsReadable(runInfo);
+            try {
+                final Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(runInfo);
+                final NodeList reads = document.getElementsByTagName("Read");
+                final List<ReadDescriptor> descriptors = new ArrayList<>(reads.getLength());
+                for (int i = 0; i < reads.getLength(); i++) {
+                    final Node read = reads.item(i);
+                    final NamedNodeMap attributes = read.getAttributes();
+                    final int readNumber = Integer.parseInt(attributes.getNamedItem("Number").getNodeValue());
+                    final int numCycles = Integer.parseInt(attributes.getNamedItem("NumCycles").getNodeValue());
+                    final boolean isIndexedRead = attributes.getNamedItem("IsIndexedRead").getNodeValue().toUpperCase().equals("Y");
+                    if (readNumber != i + 1) throw new PicardException("Read number in RunInfo.xml was out of order: " + (i+1) + " != " + readNumber);
+                    descriptors.add(new ReadDescriptor(numCycles, isIndexedRead ? ReadType.Barcode: ReadType.Template));
                 }
-                else {
-                    return descriptor;
-                }
-            }).collect(Collectors.toList());
-            READ_STRUCTURE = new ReadStructure(descriptors);
+                READ_STRUCTURE = new ReadStructure(descriptors);
+            } catch (final Exception e) {
+                throw new PicardException(e.getMessage());
+            }
         }
 
         IlluminaLaneMetricsCollector.collectLaneMetrics(RUN_DIRECTORY, OUTPUT_DIRECTORY, OUTPUT_PREFIX, laneMetricsFile, phasingMetricsFile, READ_STRUCTURE);

--- a/src/test/java/picard/illumina/IlluminaLaneMetricsCollectorTest.java
+++ b/src/test/java/picard/illumina/IlluminaLaneMetricsCollectorTest.java
@@ -8,6 +8,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;import java.lang.Exception;import java.lang.Object;import java.lang.String;
+import java.util.Arrays;
 
 /** @author mccowan */
 public class IlluminaLaneMetricsCollectorTest {
@@ -20,19 +21,21 @@ public class IlluminaLaneMetricsCollectorTest {
 
     @Test(dataProvider = "testLaneMetrics")
     public void testWriteLaneMetrics(final String testRun) throws Exception {
-        final CollectIlluminaLaneMetrics clp = new CollectIlluminaLaneMetrics();
-        clp.OUTPUT_DIRECTORY = IOUtil.createTempDir("illuminaLaneMetricsCollectorTest", null);
-        clp.RUN_DIRECTORY = new File(TEST_DIRECTORY, testRun);
-        clp.OUTPUT_PREFIX = "test";
-        clp.READ_STRUCTURE = new ReadStructure("101T8B101T");
-        clp.doWork();
+        for (final boolean useReadStructure : Arrays.asList(true, false)) {
+            final CollectIlluminaLaneMetrics clp = new CollectIlluminaLaneMetrics();
+            clp.OUTPUT_DIRECTORY = IOUtil.createTempDir("illuminaLaneMetricsCollectorTest", null);
+            clp.RUN_DIRECTORY = new File(TEST_DIRECTORY, testRun);
+            clp.OUTPUT_PREFIX = "test";
+            if (useReadStructure) clp.READ_STRUCTURE = new ReadStructure("101T8B101T");
+            clp.doWork();
 
-        final File laneMetricsFile = buildOutputFile(clp.OUTPUT_DIRECTORY, clp.OUTPUT_PREFIX, IlluminaLaneMetrics.getExtension());
-        final File canonicalOutputFile = buildOutputFile(TEST_DIRECTORY, testRun, IlluminaLaneMetrics.getExtension());
+            final File laneMetricsFile = buildOutputFile(clp.OUTPUT_DIRECTORY, clp.OUTPUT_PREFIX, IlluminaLaneMetrics.getExtension());
+            final File canonicalOutputFile = buildOutputFile(TEST_DIRECTORY, testRun, IlluminaLaneMetrics.getExtension());
 
-        IOUtil.assertFilesEqual(canonicalOutputFile, laneMetricsFile);
+            IOUtil.assertFilesEqual(canonicalOutputFile, laneMetricsFile);
 
-        IOUtil.deleteDirectoryTree(clp.OUTPUT_DIRECTORY);
+            IOUtil.deleteDirectoryTree(clp.OUTPUT_DIRECTORY);
+        }
     }
 
     @DataProvider(name = "testLaneMetrics")
@@ -46,22 +49,24 @@ public class IlluminaLaneMetricsCollectorTest {
 
     @Test(dataProvider = "testCollectIlluminaLaneMetrics")
     public void testCollectIlluminaLaneMetrics(final String testRun, final ReadStructure readStructure) throws Exception {
-        final File runDirectory = new File(TILE_RUN_DIRECTORY, testRun);
-        final CollectIlluminaLaneMetrics clp = new CollectIlluminaLaneMetrics();
-        clp.OUTPUT_DIRECTORY = IOUtil.createTempDir("illuminaLaneMetricsCollectorTest", null);
-        clp.RUN_DIRECTORY = runDirectory;
-        clp.OUTPUT_PREFIX = "test";
-        clp.READ_STRUCTURE = readStructure;
-        clp.doWork();
+        for (final boolean useReadStructure : Arrays.asList(true, false)) {
+            final File runDirectory = new File(TILE_RUN_DIRECTORY, testRun);
+            final CollectIlluminaLaneMetrics clp = new CollectIlluminaLaneMetrics();
+            clp.OUTPUT_DIRECTORY = IOUtil.createTempDir("illuminaLaneMetricsCollectorTest", null);
+            clp.RUN_DIRECTORY = runDirectory;
+            clp.OUTPUT_PREFIX = "test";
+            if (useReadStructure) clp.READ_STRUCTURE = readStructure;
+            clp.doWork();
 
-        final File phasingMetricsPhile = buildOutputFile(clp.OUTPUT_DIRECTORY, clp.OUTPUT_PREFIX, IlluminaPhasingMetrics.getExtension());
-        final File canonicalPhasingPhile = buildOutputFile(runDirectory, testRun, IlluminaPhasingMetrics.getExtension());
-        IOUtil.assertFilesEqual(canonicalPhasingPhile, phasingMetricsPhile);
+            final File phasingMetricsPhile = buildOutputFile(clp.OUTPUT_DIRECTORY, clp.OUTPUT_PREFIX, IlluminaPhasingMetrics.getExtension());
+            final File canonicalPhasingPhile = buildOutputFile(runDirectory, testRun, IlluminaPhasingMetrics.getExtension());
+            IOUtil.assertFilesEqual(canonicalPhasingPhile, phasingMetricsPhile);
 
-        final File laneMetricsFile = buildOutputFile(clp.OUTPUT_DIRECTORY, clp.OUTPUT_PREFIX, IlluminaLaneMetrics.getExtension());
-        final File canonicalLaneFile = buildOutputFile(runDirectory, testRun, IlluminaLaneMetrics.getExtension());
-        IOUtil.assertFilesEqual(canonicalLaneFile, laneMetricsFile);
-        IOUtil.deleteDirectoryTree(clp.OUTPUT_DIRECTORY);
+            final File laneMetricsFile = buildOutputFile(clp.OUTPUT_DIRECTORY, clp.OUTPUT_PREFIX, IlluminaLaneMetrics.getExtension());
+            final File canonicalLaneFile = buildOutputFile(runDirectory, testRun, IlluminaLaneMetrics.getExtension());
+            IOUtil.assertFilesEqual(canonicalLaneFile, laneMetricsFile);
+            IOUtil.deleteDirectoryTree(clp.OUTPUT_DIRECTORY);
+        }
     }
 
     @DataProvider(name = "testCollectIlluminaLaneMetrics")

--- a/testdata/picard/illumina/IlluminaLaneMetricsCollectorTest/130318_SL-HBB_0226_BFCC1WYMACXX/RunInfo.xml
+++ b/testdata/picard/illumina/IlluminaLaneMetricsCollectorTest/130318_SL-HBB_0226_BFCC1WYMACXX/RunInfo.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<RunInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="4">
+  <Run Id="130318_SL-HBB_0226_BFCC1WYMACXX" Number="226">
+    <Flowcell>BFCC1WYMACXX</Flowcell>
+    <Instrument>SL-HBB</Instrument>
+    <Date>130318</Date>
+    <Reads>
+      <Read Number="1" NumCycles="101" IsIndexedRead="N" />
+      <Read Number="2" NumCycles="8" IsIndexedRead="Y" />
+      <Read Number="3" NumCycles="101" IsIndexedRead="N" />
+    </Reads>
+  </Run>
+</RunInfo>	

--- a/testdata/picard/illumina/IlluminaLaneMetricsCollectorTest/130321_SL-MAK_0035_FC000000000-A306B/RunInfo.xml
+++ b/testdata/picard/illumina/IlluminaLaneMetricsCollectorTest/130321_SL-MAK_0035_FC000000000-A306B/RunInfo.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<RunInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="4">
+  <Run Id="130321_SL-MAK_0035_FC000000000-A306B" Number="35">
+    <Flowcell>FC000000000-A306B</Flowcell>
+    <Instrument>SL-MAK</Instrument>
+    <Date>130321</Date>
+    <Reads>
+      <Read Number="1" NumCycles="101" IsIndexedRead="N" />
+      <Read Number="2" NumCycles="8" IsIndexedRead="Y" />
+      <Read Number="3" NumCycles="101" IsIndexedRead="N" />
+    </Reads>
+  </Run>
+</RunInfo>	

--- a/testdata/picard/illumina/IlluminaLaneMetricsCollectorTest/130401_SL-HAC_0022_BH07PBADXX/RunInfo.xml
+++ b/testdata/picard/illumina/IlluminaLaneMetricsCollectorTest/130401_SL-HAC_0022_BH07PBADXX/RunInfo.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<RunInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="4">
+	<Run Id="130401_SL-HAC_0022_BH07PBADXX" Number="22">
+    <Flowcell>BH07PBADXX</Flowcell>
+    <Instrument>SL-HAC</Instrument>
+    <Date>130401</Date>
+    <Reads>
+      <Read Number="1" NumCycles="101" IsIndexedRead="N" />
+      <Read Number="2" NumCycles="8" IsIndexedRead="Y" />
+      <Read Number="3" NumCycles="101" IsIndexedRead="N" />
+    </Reads>
+  </Run>
+</RunInfo>	

--- a/testdata/picard/illumina/IlluminaLaneMetricsCollectorTest/tileRuns/A67HY/RunInfo.xml
+++ b/testdata/picard/illumina/IlluminaLaneMetricsCollectorTest/tileRuns/A67HY/RunInfo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<RunInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="4">
+  <Run>
+    <Reads>
+      <Read Number="1" NumCycles="8" IsIndexedRead="Y" />
+      <Read Number="2" NumCycles="8" IsIndexedRead="Y" />
+    </Reads>
+  </Run>
+</RunInfo>	

--- a/testdata/picard/illumina/IlluminaLaneMetricsCollectorTest/tileRuns/A7LE0/RunInfo.xml
+++ b/testdata/picard/illumina/IlluminaLaneMetricsCollectorTest/tileRuns/A7LE0/RunInfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<RunInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="4">
+  <Run>
+    <Reads>
+      <Read Number="1" NumCycles="25" IsIndexedRead="N" />
+      <Read Number="2" NumCycles="8" IsIndexedRead="Y" />
+      <Read Number="3" NumCycles="8" IsIndexedRead="Y" />
+      <Read Number="4" NumCycles="25" IsIndexedRead="N" />
+    </Reads>
+  </Run>
+</RunInfo>	

--- a/testdata/picard/illumina/IlluminaLaneMetricsCollectorTest/tileRuns/C2MFAACXX/RunInfo.xml
+++ b/testdata/picard/illumina/IlluminaLaneMetricsCollectorTest/tileRuns/C2MFAACXX/RunInfo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<RunInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="4">
+  <Run>
+    <Reads>
+      <Read Number="1" NumCycles="95" IsIndexedRead="N" />
+      <Read Number="2" NumCycles="101" IsIndexedRead="N" />
+    </Reads>
+  </Run>
+</RunInfo>	

--- a/testdata/picard/illumina/IlluminaLaneMetricsCollectorTest/tileRuns/H7BATADXX/RunInfo.xml
+++ b/testdata/picard/illumina/IlluminaLaneMetricsCollectorTest/tileRuns/H7BATADXX/RunInfo.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<RunInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="4">
+  <Run>
+    <Reads>
+      <Read Number="1" NumCycles="76" IsIndexedRead="N" />
+      <Read Number="2" NumCycles="8" IsIndexedRead="Y" />
+      <Read Number="3" NumCycles="76" IsIndexedRead="N" />
+    </Reads>
+  </Run>
+</RunInfo>	

--- a/testdata/picard/illumina/IlluminaLaneMetricsCollectorTest/tileRuns/H7H7RADXX/RunInfo.xml
+++ b/testdata/picard/illumina/IlluminaLaneMetricsCollectorTest/tileRuns/H7H7RADXX/RunInfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<RunInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="4">
+  <Run>
+    <Reads>
+      <Read Number="1" NumCycles="101" IsIndexedRead="N" />
+      <Read Number="2" NumCycles="8" IsIndexedRead="Y" />
+      <Read Number="3" NumCycles="8" IsIndexedRead="Y" />
+      <Read Number="4" NumCycles="101" IsIndexedRead="N" />
+    </Reads>
+  </Run>
+</RunInfo>	


### PR DESCRIPTION
Solves issue https://github.com/broadinstitute/picard/issues/688

The phasing and pre-phasing metrics need all template cycles, including those that are marked as skips or molecular barcodes when the latter two are in-line in the reads.  I have not solved the case where we have both skips/molecular-barcodes in the index reads AND inline in the templates.  I added an option (`INCLUDE_SKIPS_AND_MOLECULAR_BARCODES`) that converts each skip or molecular barcode descriptor to a template descriptor for the purposes of `CollectIlluminaLaneMetrics`.

@yfarjoun want to take a look?
