### PR TITLE
Fix to handle overlapped read clipping in MergeBamAlignment when clipping already present

### DIFF
--- a/src/main/java/picard/sam/AbstractAlignmentMerger.java
+++ b/src/main/java/picard/sam/AbstractAlignmentMerger.java
@@ -630,8 +630,8 @@ public abstract class AbstractAlignmentMerger {
         int clipped = 0;
         while (iterator.hasNext()) {
             final CigarElement elem = iterator.next();
-            if (elem.getOperator() != CigarOperator.SOFT_CLIP) break;
-            clipped = elem.getLength();
+            if (elem.getOperator() != CigarOperator.SOFT_CLIP && elem.getOperator() != CigarOperator.HARD_CLIP) break;
+            if (elem.getOperator() == CigarOperator.SOFT_CLIP) clipped = elem.getLength();
         }
 
         return clipped;

--- a/src/test/java/picard/sam/AbstractAlignmentMergerTest.java
+++ b/src/test/java/picard/sam/AbstractAlignmentMergerTest.java
@@ -1,0 +1,52 @@
+package picard.sam;
+
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMRecordSetBuilder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+/**
+ * Tests related to code in AbstractAlignmentMerger
+ */
+public class AbstractAlignmentMergerTest {
+    @Test public void tesOverlappedReadClippingWithNonOverlappedReads() {
+        final SAMRecordSetBuilder set = new SAMRecordSetBuilder();
+        set.setReadLength(110);
+        final List<SAMRecord> recs = set.addPair("q1", 0, 100, 200, false, false, "110M", "110M", false, true, 30);
+        final SAMRecord r1 = recs.get(0);
+        final SAMRecord r2 = recs.get(1);
+        AbstractAlignmentMerger.clipForOverlappingReads(r1, r2);
+        Assert.assertEquals(r1.getAlignmentStart(), 100);
+        Assert.assertEquals(r1.getCigarString(), "110M");
+        Assert.assertEquals(r2.getAlignmentStart(), 200);
+        Assert.assertEquals(r2.getCigarString(), "110M");
+    }
+
+    @Test public void testBasicOverlappedReadClipping() {
+        final SAMRecordSetBuilder set = new SAMRecordSetBuilder();
+        set.setReadLength(110);
+        final List<SAMRecord> recs = set.addPair("q1", 0, 100, 90, false, false, "110M", "110M", false, true, 30);
+        final SAMRecord r1 = recs.get(0);
+        final SAMRecord r2 = recs.get(1);
+        AbstractAlignmentMerger.clipForOverlappingReads(r1, r2);
+        Assert.assertEquals(r1.getAlignmentStart(), 100);
+        Assert.assertEquals(r1.getCigarString(), "100M10S");
+        Assert.assertEquals(r2.getAlignmentStart(), 100);
+        Assert.assertEquals(r2.getCigarString(), "10S100M");
+    }
+
+    @Test public void testOverlappedReadClippingWithExistingSoftClipping() {
+        final SAMRecordSetBuilder set = new SAMRecordSetBuilder();
+        set.setReadLength(120);
+        final List<SAMRecord> recs = set.addPair("q1", 0, 100, 95, false, false, "110M10S", "15S105M", false, true, 30);
+        final SAMRecord r1 = recs.get(0);
+        final SAMRecord r2 = recs.get(1);
+        AbstractAlignmentMerger.clipForOverlappingReads(r1, r2);
+        Assert.assertEquals(r1.getAlignmentStart(), 100);
+        Assert.assertEquals(r1.getCigarString(), "100M20S");
+        Assert.assertEquals(r2.getAlignmentStart(), 100);
+        Assert.assertEquals(r2.getCigarString(), "20S100M");
+    }
+}

--- a/src/test/java/picard/sam/AbstractAlignmentMergerTest.java
+++ b/src/test/java/picard/sam/AbstractAlignmentMergerTest.java
@@ -49,4 +49,17 @@ public class AbstractAlignmentMergerTest {
         Assert.assertEquals(r2.getAlignmentStart(), 100);
         Assert.assertEquals(r2.getCigarString(), "20S100M");
     }
+
+    @Test public void testOverlappedReadClippingWithExistingSoftClippingAndHardClipping() {
+        final SAMRecordSetBuilder set = new SAMRecordSetBuilder();
+        set.setReadLength(120);
+        final List<SAMRecord> recs = set.addPair("q1", 0, 100, 95, false, false, "110M10S5H", "5H15S105M", false, true, 30);
+        final SAMRecord r1 = recs.get(0);
+        final SAMRecord r2 = recs.get(1);
+        AbstractAlignmentMerger.clipForOverlappingReads(r1, r2);
+        Assert.assertEquals(r1.getAlignmentStart(), 100);
+        Assert.assertEquals(r1.getCigarString(), "100M20S"); // Should ideally be 100M20S5H
+        Assert.assertEquals(r2.getAlignmentStart(), 100);
+        Assert.assertEquals(r2.getCigarString(), "20S100M"); // Should ideally be 5H20S100M
+    }
 }


### PR DESCRIPTION
### Description

Fixed the clipping of overlapping reads which is currently broken in the case where the reads _already_ contain soft-clipping.  If the reads contain softclipping at their 3' ends the overlapping read clipping should _add_ to that soft-clipping in order to stop the reads alignment's extending past each other's 5' ends.  Prior to the change, the existing soft-clipping was ignored, and hence the result was incorrect.

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable
