### PR TITLE
- remove reference to @Deprecated VariantContextWriterFactory in htsd…

### DIFF
--- a/src/main/java/picard/vcf/GatherVcfs.java
+++ b/src/main/java/picard/vcf/GatherVcfs.java
@@ -1,29 +1,27 @@
 package picard.vcf;
 
-import htsjdk.samtools.util.BlockCompressedInputStream;import htsjdk.samtools.util.BlockCompressedOutputStream;import htsjdk.samtools.util.BlockCompressedStreamConstants;import htsjdk.samtools.util.CloseableIterator;import htsjdk.samtools.util.CloserUtil;import htsjdk.samtools.util.CollectionUtil;import htsjdk.samtools.util.RuntimeIOException;import picard.PicardException;
-import picard.cmdline.CommandLineProgram;
-import picard.cmdline.CommandLineProgramProperties;
-import picard.cmdline.Option;
-import picard.cmdline.StandardOptionDefinitions;
-import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.PeekableIterator;
-import htsjdk.samtools.util.ProgressLogger;
 import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.util.*;
+import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextComparator;
 import htsjdk.variant.variantcontext.writer.Options;
 import htsjdk.variant.variantcontext.writer.VariantContextWriter;
-import htsjdk.variant.variantcontext.writer.VariantContextWriterFactory;
+import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 import htsjdk.variant.vcf.VCFFileReader;
 import htsjdk.variant.vcf.VCFHeader;
+import picard.PicardException;
+import picard.cmdline.CommandLineProgram;
+import picard.cmdline.CommandLineProgramProperties;
+import picard.cmdline.Option;
+import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.programgroups.VcfOrBcf;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.lang.IllegalArgumentException;import java.lang.IllegalStateException;import java.lang.Override;import java.lang.String;import java.util.EnumSet;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -90,7 +88,7 @@ public class GatherVcfs extends CommandLineProgram {
     /** Checks (via filename checking) that all files appear to be block compressed files. */
     private boolean areAllBlockCompressed(final List<File> input) {
         for (final File f : input) {
-            if (VariantContextWriterFactory.isBCFOutput(f) || !VariantContextWriterFactory.isCompressedVcf(f)) return false;
+            if (VCFFileReader.isBCF(f) || !AbstractFeatureReader.hasBlockCompressedExtension(f)) return false;
         }
 
         return true;
@@ -142,9 +140,17 @@ public class GatherVcfs extends CommandLineProgram {
                                       final boolean createIndex,
                                       final List<File> inputFiles,
                                       final File outputFile) {
-        final EnumSet<Options> options = EnumSet.copyOf(VariantContextWriterFactory.DEFAULT_OPTIONS);
-        if (createIndex) options.add(Options.INDEX_ON_THE_FLY); else options.remove(Options.INDEX_ON_THE_FLY);
-        final VariantContextWriter out = VariantContextWriterFactory.create(outputFile, sequenceDictionary, options);
+        final EnumSet<Options> options = EnumSet.copyOf(VariantContextWriterBuilder.DEFAULT_OPTIONS);
+        if (createIndex){
+            options.add(Options.INDEX_ON_THE_FLY);
+        } else {
+            options.remove(Options.INDEX_ON_THE_FLY);
+        }
+        final VariantContextWriter out = new VariantContextWriterBuilder()
+                .setOptions(options)
+                .setOutputFile(outputFile)
+                .setReferenceDictionary(sequenceDictionary)
+                .build();
 
         final ProgressLogger progress = new ProgressLogger(log, 10000);
         VariantContext lastContext = null;


### PR DESCRIPTION
### Description

htsjdk has deprecated VariantContextWriterFactory but Picard still used it in one place. 

This PR removes reference to that class in preparation to its removal from htsjdk.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [x] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests


…jk prior to removal from that codebase.