### PR TITLE
Default output for CreateSequenceDictionary

### DIFF
--- a/src/main/java/picard/sam/CreateSequenceDictionary.java
+++ b/src/main/java/picard/sam/CreateSequenceDictionary.java
@@ -152,22 +152,20 @@ public class CreateSequenceDictionary extends CommandLineProgram {
             URI = "file:" + REFERENCE.getAbsolutePath();
         }
         if (OUTPUT == null) {
-            OUTPUT = getDefaultDictionaryNameForFasta(REFERENCE);
+            // TODO: use the htsjdk method implemented in https://github.com/samtools/htsjdk/pull/774
+            OUTPUT = getDefaultDictionaryForReferenceSequence(REFERENCE);
             logger.info("Output dictionary will be written in ", OUTPUT);
         }
         return null;
     }
 
-    // TODO: move this method to ReferenceSequenceFileFactory
+    // TODO: this method will be in htsjdk (https://github.com/samtools/htsjdk/pull/774)
     @VisibleForTesting
-    static File getDefaultDictionaryNameForFasta(final File fastaFile) {
+    static File getDefaultDictionaryForReferenceSequence(final File fastaFile) {
         final String name = fastaFile.getName();
-        final Optional<String> extension = ReferenceSequenceFileFactory.FASTA_EXTENSIONS
-                .stream().filter(name::endsWith).findFirst();
-        if (!extension.isPresent()) {
-            throw new IllegalArgumentException("File is not a supported reference file type: " + fastaFile.getAbsolutePath());
-        }
-        final int extensionIndex = name.length() - extension.get().length();
+        final String extension = ReferenceSequenceFileFactory.FASTA_EXTENSIONS.stream().filter(name::endsWith).findFirst()
+                .orElseGet(() -> {throw new IllegalArgumentException("File is not a supported reference file type: " + fastaFile.getAbsolutePath());});
+        final int extensionIndex = name.length() - extension.length();
         return new File(fastaFile.getParentFile(), name.substring(0, extensionIndex) + IOUtil.DICT_FILE_EXTENSION);
     }
 

--- a/src/main/java/picard/sam/CreateSequenceDictionary.java
+++ b/src/main/java/picard/sam/CreateSequenceDictionary.java
@@ -82,8 +82,8 @@ public class CreateSequenceDictionary extends CommandLineProgram {
     @Option(doc = "Input reference fasta or fasta.gz", shortName = StandardOptionDefinitions.REFERENCE_SHORT_NAME)
     public File REFERENCE;
 
-    @Option(doc = "Output SAM or BAM file containing only the sequence dictionary",
-            shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME)
+    @Option(doc = "Output SAM file containing only the sequence dictionary. By default it will use the base name of the input reference with the .dict extension",
+            shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, optional = true)
     public File OUTPUT;
 
     @Option(doc = "Put into AS field of sequence dictionary entry if supplied", optional = true)
@@ -145,6 +145,14 @@ public class CreateSequenceDictionary extends CommandLineProgram {
     protected String[] customCommandLineValidation() {
         if (URI == null) {
             URI = "file:" + REFERENCE.getAbsolutePath();
+        }
+        if (OUTPUT == null) {
+            // determine the name for the dict file in the same way as CachingIndexedFastaSequenceFile.checkAndCreate
+            final String name = REFERENCE.getName();
+            final String fastaExt = ReferenceSequenceFileFactory.FASTA_EXTENSIONS.stream()
+                    .filter(name::endsWith).findFirst().orElseGet(() -> "");
+            OUTPUT = new File(REFERENCE.getParentFile(),
+                    REFERENCE.getName().replace(fastaExt, IOUtil.DICT_FILE_EXTENSION));
         }
         return null;
     }

--- a/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
+++ b/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
@@ -24,6 +24,7 @@
 package picard.sam;
 
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import picard.cmdline.CommandLineProgramTest;
 import picard.PicardException;
@@ -45,6 +46,23 @@ public class CreateSequenceDictionaryTest extends CommandLineProgramTest {
 
     public String getCommandLineProgramName() {
         return CreateSequenceDictionary.class.getSimpleName();
+    }
+
+    @DataProvider
+    public Object[][] fastaNames() {
+        return new Object[][] {
+                {"break.fa", "break.dict"},
+                {"break.txt.txt", "break.txt.dict"},
+                {"break.fasta.fasta", "break.fasta.dict"},
+                {"break.fa.gz", "break.dict"},
+                {"break.txt.gz.txt.gz", "break.txt.gz.dict"},
+                {"break.fasta.gz.fasta.gz", "break.fasta.gz.dict"}
+        };
+    }
+
+    @Test(dataProvider = "fastaNames")
+    public void testGetDictionaryNameForFasta(final String fastaFile, final String expectedDict) throws Exception {
+        Assert.assertEquals(CreateSequenceDictionary.getDefaultDictionaryNameForFasta(new File(fastaFile)), new File(expectedDict));
     }
 
     @Test

--- a/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
+++ b/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
@@ -61,8 +61,8 @@ public class CreateSequenceDictionaryTest extends CommandLineProgramTest {
     }
 
     @Test(dataProvider = "fastaNames")
-    public void testGetDictionaryNameForFasta(final String fastaFile, final String expectedDict) throws Exception {
-        Assert.assertEquals(CreateSequenceDictionary.getDefaultDictionaryNameForFasta(new File(fastaFile)), new File(expectedDict));
+    public void testGetDefaultDictionaryForReferenceSequence(final String fastaFile, final String expectedDict) throws Exception {
+        Assert.assertEquals(CreateSequenceDictionary.getDefaultDictionaryForReferenceSequence(new File(fastaFile)), new File(expectedDict));
     }
 
     @Test

--- a/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
+++ b/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
@@ -61,6 +61,19 @@ public class CreateSequenceDictionaryTest extends CommandLineProgramTest {
     }
 
     @Test
+    public void testDefaultOutputFile() throws Exception {
+        final File expectedDict = new File(TEST_DATA_DIR + "/sam", "basic.dict");
+        expectedDict.deleteOnExit();
+        Assert.assertFalse(expectedDict.exists());
+        final String[] argv = {
+                "REFERENCE=" + BASIC_FASTA,
+                "TRUNCATE_NAMES_AT_WHITESPACE=false"
+        };
+        Assert.assertEquals(runPicardCommandLine(argv), 0);
+        Assert.assertTrue(expectedDict.exists());
+    }
+
+    @Test
     public void testForEquivalence() throws Exception {
         final File outputDict = File.createTempFile("CreateSequenceDictionaryTest.", ".dict");
         outputDict.delete();


### PR DESCRIPTION
### Description

`CreateSequenceDictionary` requires always to specified the output name, but GATK programs assumes that the file name is the FASTA name without the extension and ending in __.dict__. Thus, I included the following changes:
* Optional output argument with updated documentation for default behavior.
* Sets the output name as in the GATK framework (port of https://github.com/broadinstitute/gatk/pull/2243) if no one is provided.
* Test for default output name.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests


