### PR TITLE
New approach to splitting on sub-group in EstimateLibraryComplexity 

### DIFF
--- a/src/main/java/picard/sam/markduplicates/ElcHashBasedDuplicatesFinder.java
+++ b/src/main/java/picard/sam/markduplicates/ElcHashBasedDuplicatesFinder.java
@@ -42,6 +42,9 @@ class ElcHashBasedDuplicatesFinder extends ElcDuplicatesFinder {
 
     // We split each read on several parts, each part represent set of nucleotides,
     // which behind each other on numberOfHashesInGroup.
+    // f. i.:
+    // 1 2 3 4 1 2 3 4 1 2 3 4
+    // A C A T T A C G G A T T
     private int numberOfHashesInGroup = -1; //initial value
     private int minReadLenInGroup = Integer.MAX_VALUE; //initial value
 
@@ -78,12 +81,12 @@ class ElcHashBasedDuplicatesFinder extends ElcDuplicatesFinder {
         }
     }
 
-    private Set<PairedReadSequence> getSimilarReads(PairedReadSequence lhs) {
+    private Set<PairedReadSequence> getSimilarReads(final PairedReadSequence pattern) {
         final Set<PairedReadSequence> toCheck = new HashSet<>();
-        for (int[] hashesForRead: new int[][]{lhs.hashes1, lhs.hashes2}){
+        for (int[] hashesForRead: new int[][]{pattern.hashes1, pattern.hashes2}) {
             for (int hash : hashesForRead) {
                 List<PairedReadSequence> readsWithSameHash = readsByHashInGroup.get(hash);
-                // if size == 1, then this list contains only lhs read
+                // if size == 1, then this list contains only pattern read
                 if (readsWithSameHash.size() > 1) {
                     toCheck.addAll(readsWithSameHash);
                 }
@@ -106,7 +109,7 @@ class ElcHashBasedDuplicatesFinder extends ElcDuplicatesFinder {
             int[][] readHashValues = {prs.hashes1, prs.hashes2};
             for (int[] readHashValue : readHashValues) {
                 for (int key : readHashValue) {
-                    List<PairedReadSequence> dupCandidates
+                    final List<PairedReadSequence> dupCandidates
                             = readsByHashInGroup.computeIfAbsent(key, k -> new ArrayList<>());
                     dupCandidates.add(prs);
                 }

--- a/src/main/java/picard/sam/markduplicates/ElcHashBasedDuplicatesFinder.java
+++ b/src/main/java/picard/sam/markduplicates/ElcHashBasedDuplicatesFinder.java
@@ -40,13 +40,17 @@ import static picard.sam.markduplicates.EstimateLibraryComplexity.PairedReadSequ
  */
 class ElcHashBasedDuplicatesFinder extends ElcDuplicatesFinder {
 
-    // We split each read on several parts and each part has length hashLength.
-    // hashLength = (min read length) / (number of errors + 1)
-    private int hashLength = Integer.MAX_VALUE;
+    // We split each read on several parts, each part represent set of nucleotides,
+    // which behind each other on numberOfHashesInGroup.
+    private int numberOfHashesInGroup = -1; //initial value
+    private int minReadLenInGroup = Integer.MAX_VALUE; //initial value
+
+    private Map<Integer, List<PairedReadSequence>> readsByHashInGroup;
 
     ElcHashBasedDuplicatesFinder(double maxDiffRate, int maxReadLength, int minIdenticalBases,
                                  OpticalDuplicateFinder opticalDuplicateFinder) {
         super(maxDiffRate, maxReadLength, minIdenticalBases, opticalDuplicateFinder);
+        readsByHashInGroup = new HashMap<>();
     }
 
     @Override
@@ -58,23 +62,34 @@ class ElcHashBasedDuplicatesFinder extends ElcDuplicatesFinder {
         populateDupCandidates(sequences);
 
         //Duplicate set to filter the treated PairedReadSequences out
-        Set<PairedReadSequence> dupSet = new HashSet<>();
+        final Set<PairedReadSequence> dupSet = new HashSet<>();
+
         for (PairedReadSequence lhs : sequences) {
             if (dupSet.contains(lhs)) continue;
-
             final List<PairedReadSequence> dupes = new ArrayList<>();
-
-            for (PairedReadSequence rhs : lhs.dupCandidates) {
+            for (PairedReadSequence rhs : getSimilarReads(lhs)) {
                 if (dupSet.contains(rhs)) continue;
-
                 if (isDuplicate(lhs, rhs)) {
                     dupes.add(rhs);
                 }
             }
-
             dupSet.addAll(dupes);
             fillHistogram(duplicationHisto, opticalHisto, lhs, dupes);
         }
+    }
+
+    private Set<PairedReadSequence> getSimilarReads(PairedReadSequence lhs) {
+        final Set<PairedReadSequence> toCheck = new HashSet<>();
+        for (int[] hashesForRead: new int[][]{lhs.hashes1, lhs.hashes2}){
+            for (int hash : hashesForRead) {
+                List<PairedReadSequence> readsWithSameHash = readsByHashInGroup.get(hash);
+                // if size == 1, then this list contains only lhs read
+                if (readsWithSameHash.size() > 1) {
+                    toCheck.addAll(readsWithSameHash);
+                }
+            }
+        }
+        return toCheck;
     }
 
     /**
@@ -83,29 +98,18 @@ class ElcHashBasedDuplicatesFinder extends ElcDuplicatesFinder {
      */
     private void populateDupCandidates(List<PairedReadSequence> seqs) {
         // Contains hash value as a key and PairedReadSequences match this key as a value
-        Map<Integer, List<PairedReadSequence>> readsByHash = new HashMap<>();
+        readsByHashInGroup.clear();
 
-        // Iterate over all PairedReadSequence and split in sets according to the hash value 
+        // Iterate over all PairedReadSequence and split in sets according to the hash value
         // in a certain position
         for (PairedReadSequence prs : seqs) {
             int[][] readHashValues = {prs.hashes1, prs.hashes2};
             for (int[] readHashValue : readHashValues) {
                 for (int key : readHashValue) {
-                    List<PairedReadSequence> dupCandidates = readsByHash.get(key);
-
-                    if (dupCandidates == null) {
-                        dupCandidates = new ArrayList<>();
-                        readsByHash.put(key, dupCandidates);
-                    }
+                    List<PairedReadSequence> dupCandidates
+                            = readsByHashInGroup.computeIfAbsent(key, k -> new ArrayList<>());
                     dupCandidates.add(prs);
                 }
-            }
-        }
-
-        // Fill for each PairedReadSequence a set of possible duplicates
-        for (List<PairedReadSequence> dupCandidates : readsByHash.values()) {
-            for (PairedReadSequence prs : dupCandidates) {
-                prs.dupCandidates.addAll(dupCandidates);
             }
         }
     }
@@ -115,35 +119,28 @@ class ElcHashBasedDuplicatesFinder extends ElcDuplicatesFinder {
      */
     private void fillHashValues(List<PairedReadSequence> sequences) {
         for (PairedReadSequence prs : sequences) {
-            prs.initHashes(maxReadLength, hashLength, minIdenticalBases);
+            prs.initHashes(numberOfHashesInGroup, minIdenticalBases, minReadLenInGroup);
         }
     }
 
     /**
-     * Calculate hash length based on minReadLength and hashNumber
+     * Calculate hash length based on minReadLength and numberOfHashesInGroup
      */
     private void initHashLength(List<PairedReadSequence> sequences) {
-        if (sequences == null || sequences.isEmpty()) {
-            return;
-        }
         for (PairedReadSequence prs : sequences) {
-            int minReadLength = Math.min(
-                    Math.min(prs.read1.length, prs.read2.length) - minIdenticalBases,
-                    maxReadLength - minIdenticalBases
-            );
+            int minReadLength = Math.min(Math.min(prs.read1.length, prs.read2.length), maxReadLength);
 
-            //if read.length % shingle.length != 0, we have tail of the read which is not included in the hashValues,
-            // and we need extra hash value to get prs.hashValues.length = (number of errors) + 1
-            int hashNumber = (int) (minReadLength * maxDiffRate) + 1;
-            int currentHashLength = minReadLength / hashNumber;
-            if (hashLength > currentHashLength) {
-                hashLength = currentHashLength;
+            //search maximum number of hashes (if length of reads is similar number of hashes will be similar too)
+            int numberOfHashes = (int) ((minReadLength - minIdenticalBases) * maxDiffRate) + 1;
+            if (numberOfHashes > numberOfHashesInGroup) {
+                numberOfHashesInGroup = numberOfHashes;
+            }
+
+            //search minimum length of read for calculating hashes value
+            if (minReadLenInGroup > minReadLength) {
+                minReadLenInGroup = minReadLength;
             }
         }
-    }
-
-    private int getReadOffset(int k) {
-        return k * hashLength + minIdenticalBases;
     }
 
     private boolean isDuplicate(final PairedReadSequence lhs, final PairedReadSequence rhs) {
@@ -174,26 +171,24 @@ class ElcHashBasedDuplicatesFinder extends ElcDuplicatesFinder {
 
         return errors <= maxErrors;
     }
-
     /**
      * Compare hashes and if they are similar we compare bases corresponding to the hashes.
      */
     private int compareReadToRead(byte[] read1, int[] hashes1, byte[] read2, int[] hashes2, int maxErrors) {
         int errors = 0;
         final int minReadLength = minLength(read1, read2);
-        int minHashesLength = Math.min(hashes1.length, hashes2.length);
 
-        for (int k = 0; k < minHashesLength; ++k) {
+        for (int k = 0; k < numberOfHashesInGroup; ++k) {
             if (hashes1[k] != hashes2[k]) {
-                errors += compareHashes(read1, read2, getReadOffset(k), getReadOffset((k + 1)));
+                errors += compareHashes(read1, read2, k);
                 if (errors > maxErrors) {
                     return errors;
                 }
             }
         }
 
-        if (minReadLength > getReadOffset(minHashesLength)) {
-            errors += compareHashes(read1, read2, getReadOffset(minHashesLength), minReadLength);
+        if (minReadLength > minReadLenInGroup) {
+            errors += compareTails(read1, read2, minReadLenInGroup, minReadLength);
         }
 
         return errors;
@@ -204,7 +199,24 @@ class ElcHashBasedDuplicatesFinder extends ElcDuplicatesFinder {
      *
      * @return errors number for current part of the read
      */
-    private int compareHashes(byte[] read1, byte[] read2, int start, int stop) {
+    private int compareHashes(byte[] read1, byte[] read2, int k) {
+        int errors = 0;
+        int position = minIdenticalBases + k;
+        while (position < minReadLenInGroup) {
+            if (read1[position] != read2[position]) {
+                errors++;
+            }
+            position += numberOfHashesInGroup;
+        }
+        return errors;
+    }
+
+    /**
+     * Compare bases corresponding to the hashes.
+     *
+     * @return errors number for current part of the read
+     */
+    private int compareTails(byte[] read1, byte[] read2, int start, int stop) {
         int errors = 0;
         for (int i = start; i < stop; ++i) {
             if (read1[i] != read2[i]) {

--- a/src/main/java/picard/sam/markduplicates/EstimateLibraryComplexity.java
+++ b/src/main/java/picard/sam/markduplicates/EstimateLibraryComplexity.java
@@ -220,12 +220,12 @@ public class EstimateLibraryComplexity extends AbstractOpticalDuplicateFinderCom
         // skippedBases = 1
         // minReadLength = 15
         // So, method returns hashValues with 5 hash value
-        // first value calculated from read[0], read[5], read[10]
-        // second value calculated from read[1], read[6], read[11]
+        // first value calculated from read[1], read[6], read[11]
+        // second value calculated from read[2], read[7], read[12]
         // etc.
-        // chars from 15 to 19 position is a tail, see compareTails() in ElcHashBasedDuplicatesFinder
+        // chars from 16 to 19 position is a tail, see compareTails() in ElcHashBasedDuplicatesFinder
         private int[] getHashes(byte[] read, int numberOfHashes, int skippedBases, int minReadLength) {
-            int[] hashValues = new int[numberOfHashes];
+            final int[] hashValues = new int[numberOfHashes];
             for (int i = 0; i < numberOfHashes; ++i) {
                 hashValues[i] = 1;
                 int position = skippedBases + i;

--- a/src/main/java/picard/sam/markduplicates/EstimateLibraryComplexity.java
+++ b/src/main/java/picard/sam/markduplicates/EstimateLibraryComplexity.java
@@ -190,9 +190,6 @@ public class EstimateLibraryComplexity extends AbstractOpticalDuplicateFinderCom
         int[] hashes1;
         int[] hashes2;
 
-        // Possible candidates for this PairedReadSequence
-        Set<PairedReadSequence> dupCandidates;
-
         public static int getSizeInBytes() {
             // rough guess at memory footprint, summary size of all fields
             return 16 + 4 + (2 * 4) + 1 + 2 * (24 + 8 + NUMBER_BASES_IN_READ) + 2 + (2 * (24 + 8)) + 8 + 4;
@@ -210,26 +207,31 @@ public class EstimateLibraryComplexity extends AbstractOpticalDuplicateFinderCom
             return new PairedReadCodec();
         }
 
-        void initHashes(int maxReadLength, int hashLength, int skippedBases) {
-            dupCandidates = new HashSet<>();
-            hashes1 = getHashes(read1, maxReadLength, hashLength, skippedBases);
-            hashes2 = getHashes(read2, maxReadLength, hashLength, skippedBases);
+        void initHashes(int numberOfHashes, int skippedBases, int minReadLength) {
+            hashes1 = getHashes(read1, numberOfHashes, skippedBases, minReadLength);
+            hashes2 = getHashes(read2, numberOfHashes, skippedBases, minReadLength);
         }
 
-        // Split read by (MAX_DIFF_RATE * read.length + 1) parts and hash each part
-        private int[] getHashes(byte[] read, int maxReadLength, int hashLength, int skippedBases) {
-            int maxLengthWithoutHead = maxReadLength - skippedBases;
-            int hashNum = (Math.min(read.length - skippedBases, maxLengthWithoutHead)) /
-                    hashLength;
-            int[] hashValues = new int[hashNum];
-            for (int i = 0; i < hashNum; ++i) {
-                int st = skippedBases + i * hashLength;
-                int end = st + hashLength;
-
-                // use custom hash to avoid using System.arraycopy
+        // Split read by numberOfHashes parts and hash each part
+        // For instance:
+        //        0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
+        // read = A C G T A C G T A C G  T  A  C  G  T  A  C  G  T
+        // numberOfHashes = 5
+        // skippedBases = 1
+        // minReadLength = 15
+        // So, method returns hashValues with 5 hash value
+        // first value calculated from read[0], read[5], read[10]
+        // second value calculated from read[1], read[6], read[11]
+        // etc.
+        // chars from 15 to 19 position is a tail, see compareTails() in ElcHashBasedDuplicatesFinder
+        private int[] getHashes(byte[] read, int numberOfHashes, int skippedBases, int minReadLength) {
+            int[] hashValues = new int[numberOfHashes];
+            for (int i = 0; i < numberOfHashes; ++i) {
                 hashValues[i] = 1;
-                for (int j = st; j < end; ++j) {
-                    hashValues[i] = 31 * hashValues[i] + read[j];
+                int position = skippedBases + i;
+                while (position < minReadLength) {
+                    hashValues[i] = 31 * hashValues[i] + read[position];
+                    position += numberOfHashes;
                 }
             }
             return hashValues;


### PR DESCRIPTION
We introduce additional improvements in ELC algorithm, which are directed to increase diversity of hash value of PairedReadSequences.

# Problem
About the potential problem:
If we look at the group which contains about 100k PairedReadSequence and many of them have similar parts, according to current algorithm we will have reads which are similar to many other reads, and in this case we will lose main profit of current approach.

![image](https://cloud.githubusercontent.com/assets/11179595/21186897/266a7a3c-c227-11e6-8765-22b0156b76df.png)
In this example using current approach all 4 reads would be considered similar and eventually would undergo complete check, while actually they can have a lot of difference in other parts.

For example, this file is a group which contains PRS which are very similar in the one of parts but aren't duplicates
[0_241500.zip](https://github.com/broadinstitute/picard/files/652042/0_241500.zip)

It is a list of PRS, you can unzip this file and decode it by PairedReadSequencesCodec from EsimateLibraryComplexity.

# Solving
We want to propose a new approach to  calculate "hashes" that would result in another splitting on sub-groups:

![image](https://cloud.githubusercontent.com/assets/11179595/21186940/43bd8e62-c227-11e6-9e22-57d78ec60c76.png)

The main idea is build one "hash" of read from bases located within equal distance from each other.  
This approach provides more complex structure for the ﻿"hashes" and splitting on groups becomes more uniform.
Our new algorithm processes the group from the file above in less than a minute while old version of splitting on groups can not cope with this at all.
**Please note that it's case very unusual but can provide big trouble if you find it.**

**Before:**
![image](https://cloud.githubusercontent.com/assets/11179595/21186978/5b51638c-c227-11e6-90a5-4a19b041a400.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/11179595/21186984/64ec00f0-c227-11e6-8a23-6baa00bda611.png)
