### PR TITLE
Reverse increase in runtime which results from a sanity test when maxCoverage is large.

### DIFF
--- a/src/main/java/picard/analysis/CollectWgsMetrics.java
+++ b/src/main/java/picard/analysis/CollectWgsMetrics.java
@@ -475,16 +475,17 @@ static final String USAGE_DETAILS = "<p>This tool collects metrics about the fra
             // add to the collector
             collector.addInfo(info);
 
-            // check that we added the same number of bases to the raw coverage histogram and the base quality histograms
-            if (Arrays.stream(collector.unfilteredBaseQHistogramArray).sum() !=  LongStream.rangeClosed(0, collector.coverageCap).map(i -> (i * collector.unfilteredDepthHistogramArray[(int)i])).sum()) {
-                throw new PicardException("updated coverage and baseQ distributions unequally");
-            }
-
             // Record progress and perhaps stop
             progress.record(info.getSequenceName(), info.getPosition());
             if (usingStopAfter && ++counter > stopAfter) break;
         }
 
+        // check that we added the same number of bases to the raw coverage histogram and the base quality histograms
+        final long sumBaseQ= Arrays.stream(collector.unfilteredBaseQHistogramArray).sum();
+        final long sumDepthHisto = LongStream.rangeClosed(0, collector.coverageCap).map(i -> (i * collector.unfilteredDepthHistogramArray[(int) i])).sum();
+        if (sumBaseQ != sumDepthHisto) {
+            log.error("Coverage and baseQ distributions contain different amount of bases!");
+        }
 
         final MetricsFile<WgsMetrics, Integer> out = getMetricsFile();
         collector.addToMetricsFile(out, INCLUDE_BQ_HISTOGRAM, dupeFilter, mapqFilter, pairFilter);


### PR DESCRIPTION
Moved a O(maxCoverage * nLoci) sanity test which significantly increases run-time for CollectWgsMetrics when the maxCoverage is large, as it is by default for CollectRawWgsMetrics. This test was moved to the end of the iteration over loci, making it essentially an O(maxCoverage) test---much less of a burden.

### Description

_Give your PR a **concise** yet **descriptive** title_
_Please explain the changes you made here._
_Explain the **motivation** for making this change. What existing problem does the pull request solve?_
_Mention any issues fixed, addressed or otherwise related to this pull request, including issue numbers or hard links for issues in other repos._
_You can delete these instructions once you have written your PR description._

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

