### PR TITLE
Removed explicit reference to LazyInitializer.

### DIFF
--- a/src/main/java/picard/sam/SamToFastq.java
+++ b/src/main/java/picard/sam/SamToFastq.java
@@ -261,12 +261,7 @@ public class SamToFastq extends CommandLineProgram {
                 final FastqWriter firstOfPairWriter = factory.newWriter(makeReadGroupFile(rg, "_1"));
                 // Create this writer on-the-fly; if we find no second-of-pair reads, don't bother making a writer (or delegating,
                 // if we're interleaving).
-                final Lazy<FastqWriter> lazySecondOfPairWriter = new Lazy<FastqWriter>(new Lazy.LazyInitializer<FastqWriter>() {
-                    @Override
-                    public FastqWriter make() {
-                        return INTERLEAVE ? firstOfPairWriter : factory.newWriter(makeReadGroupFile(rg, "_2"));
-                    }
-                });
+                final Lazy<FastqWriter> lazySecondOfPairWriter = new Lazy<>(() -> INTERLEAVE ? firstOfPairWriter : factory.newWriter(makeReadGroupFile(rg, "_2")));
                 writerMap.put(rg, new FastqWriters(firstOfPairWriter, lazySecondOfPairWriter, firstOfPairWriter));
             }
         }
@@ -460,12 +455,7 @@ public class SamToFastq extends CommandLineProgram {
 
         /** Simple constructor; all writers are pre-initialized.. */
         private FastqWriters(final FastqWriter firstOfPair, final FastqWriter secondOfPair, final FastqWriter unpaired) {
-            this(firstOfPair, new Lazy<FastqWriter>(new Lazy.LazyInitializer<FastqWriter>() {
-                @Override
-                public FastqWriter make() {
-                    return secondOfPair;
-                }
-            }), unpaired);
+            this(firstOfPair, new Lazy<>(() -> secondOfPair), unpaired);
         }
 
         public FastqWriter getFirstOfPair() {


### PR DESCRIPTION
### Description

LazyInitializer is getting deprecated in htsjdk, so I'm premptively removing any references to it here as lambda notation is enough.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

