### PR TITLE
Use default HTSJDK method in CreateSequenceDictionary 

### DIFF
--- a/src/main/java/picard/sam/CreateSequenceDictionary.java
+++ b/src/main/java/picard/sam/CreateSequenceDictionary.java
@@ -23,7 +23,6 @@
  */
 package picard.sam;
 
-import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceDictionaryCodec;
 import htsjdk.samtools.SAMSequenceRecord;

--- a/src/main/java/picard/sam/CreateSequenceDictionary.java
+++ b/src/main/java/picard/sam/CreateSequenceDictionary.java
@@ -151,21 +151,10 @@ public class CreateSequenceDictionary extends CommandLineProgram {
             URI = "file:" + REFERENCE.getAbsolutePath();
         }
         if (OUTPUT == null) {
-            // TODO: use the htsjdk method implemented in https://github.com/samtools/htsjdk/pull/774
-            OUTPUT = getDefaultDictionaryForReferenceSequence(REFERENCE);
+            OUTPUT = ReferenceSequenceFileFactory.getDefaultDictionaryForReferenceSequence(REFERENCE);
             logger.info("Output dictionary will be written in ", OUTPUT);
         }
         return null;
-    }
-
-    // TODO: this method will be in htsjdk (https://github.com/samtools/htsjdk/pull/774)
-    @VisibleForTesting
-    static File getDefaultDictionaryForReferenceSequence(final File fastaFile) {
-        final String name = fastaFile.getName();
-        final String extension = ReferenceSequenceFileFactory.FASTA_EXTENSIONS.stream().filter(name::endsWith).findFirst()
-                .orElseGet(() -> {throw new IllegalArgumentException("File is not a supported reference file type: " + fastaFile.getAbsolutePath());});
-        final int extensionIndex = name.length() - extension.length();
-        return new File(fastaFile.getParentFile(), name.substring(0, extensionIndex) + IOUtil.DICT_FILE_EXTENSION);
     }
 
     /**

--- a/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
+++ b/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
@@ -24,7 +24,6 @@
 package picard.sam;
 
 import org.testng.Assert;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import picard.cmdline.CommandLineProgramTest;
 import picard.PicardException;

--- a/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
+++ b/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
@@ -48,23 +48,6 @@ public class CreateSequenceDictionaryTest extends CommandLineProgramTest {
         return CreateSequenceDictionary.class.getSimpleName();
     }
 
-    @DataProvider
-    public Object[][] fastaNames() {
-        return new Object[][] {
-                {"break.fa", "break.dict"},
-                {"break.txt.txt", "break.txt.dict"},
-                {"break.fasta.fasta", "break.fasta.dict"},
-                {"break.fa.gz", "break.dict"},
-                {"break.txt.gz.txt.gz", "break.txt.gz.dict"},
-                {"break.fasta.gz.fasta.gz", "break.fasta.gz.dict"}
-        };
-    }
-
-    @Test(dataProvider = "fastaNames")
-    public void testGetDefaultDictionaryForReferenceSequence(final String fastaFile, final String expectedDict) throws Exception {
-        Assert.assertEquals(CreateSequenceDictionary.getDefaultDictionaryForReferenceSequence(new File(fastaFile)), new File(expectedDict));
-    }
-
     @Test
     public void testBasic() throws Exception {
         final File outputDict = File.createTempFile("CreateSequenceDictionaryTest.", ".dict");


### PR DESCRIPTION
### Description

The changes introduced in #712 where ported to HTSJDK, making some code duplication between the two repositories (see #714). This PR removes the duplicated code in Picard.

__WARNING: this requires a new realease of HTSJDK. The last commit includes the artifactory snapshot to prove that it is working.__

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

