### PR TITLE
Added '.genotype_concordance' into the output VCF name.

### DIFF
--- a/src/main/java/picard/vcf/GenotypeConcordance.java
+++ b/src/main/java/picard/vcf/GenotypeConcordance.java
@@ -160,9 +160,10 @@ public class GenotypeConcordance extends CommandLineProgram {
     private final Log log = Log.getInstance(GenotypeConcordance.class);
     private final ProgressLogger progress = new ProgressLogger(log, 10000, "checked", "variants");
 
-    public static final String SUMMARY_METRICS_FILE_EXTENSION = ".genotype_concordance_summary_metrics";
-    public static final String DETAILED_METRICS_FILE_EXTENSION = ".genotype_concordance_detail_metrics";
+    public static final String SUMMARY_METRICS_FILE_EXTENSION     = ".genotype_concordance_summary_metrics";
+    public static final String DETAILED_METRICS_FILE_EXTENSION    = ".genotype_concordance_detail_metrics";
     public static final String CONTINGENCY_METRICS_FILE_EXTENSION = ".genotype_concordance_contingency_metrics";
+    public static final String OUTPUT_VCF_FILE_EXTENSION          = ".genotype_concordance.vcf.gz";
 
     protected GenotypeConcordanceCounts snpCounter;
     public GenotypeConcordanceCounts getSnpCounter() { return snpCounter; }
@@ -381,7 +382,7 @@ public class GenotypeConcordance extends CommandLineProgram {
     /** Gets the variant context writer if the output VCF is to be written, otherwise empty. */
     private Optional<VariantContextWriter> getVariantContextWriter(final VCFFileReader truthReader, final VCFFileReader callReader) {
         if (OUTPUT_VCF) {
-            final File outputVcfFile = new File(OUTPUT + ".genotype_concordance.vcf.gz");
+            final File outputVcfFile = new File(OUTPUT + OUTPUT_VCF_FILE_EXTENSION);
             final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
                     .setOutputFile(outputVcfFile)
                     .setReferenceDictionary(callReader.getFileHeader().getSequenceDictionary())

--- a/src/main/java/picard/vcf/GenotypeConcordance.java
+++ b/src/main/java/picard/vcf/GenotypeConcordance.java
@@ -381,7 +381,7 @@ public class GenotypeConcordance extends CommandLineProgram {
     /** Gets the variant context writer if the output VCF is to be written, otherwise empty. */
     private Optional<VariantContextWriter> getVariantContextWriter(final VCFFileReader truthReader, final VCFFileReader callReader) {
         if (OUTPUT_VCF) {
-            final File outputVcfFile = new File(OUTPUT + ".vcf.gz");
+            final File outputVcfFile = new File(OUTPUT + ".genotype_concordance.vcf.gz");
             final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
                     .setOutputFile(outputVcfFile)
                     .setReferenceDictionary(callReader.getFileHeader().getSequenceDictionary())

--- a/src/test/java/picard/vcf/GenotypeConcordanceTest.java
+++ b/src/test/java/picard/vcf/GenotypeConcordanceTest.java
@@ -131,7 +131,7 @@ public class GenotypeConcordanceTest {
             final File outputSummaryFile     = new File(outputBaseFileName.getAbsolutePath() + GenotypeConcordance.SUMMARY_METRICS_FILE_EXTENSION);
             final File outputDetailsFile     = new File(outputBaseFileName.getAbsolutePath() + GenotypeConcordance.DETAILED_METRICS_FILE_EXTENSION);
             final File outputContingencyFile = new File(outputBaseFileName.getAbsolutePath() + GenotypeConcordance.CONTINGENCY_METRICS_FILE_EXTENSION);
-            final Path outputVcfFile         = Paths.get(outputBaseFileName.getAbsolutePath() + ".vcf.gz");
+            final Path outputVcfFile         = Paths.get(outputBaseFileName.getAbsolutePath() + GenotypeConcordance.OUTPUT_VCF_FILE_EXTENSION);
             outputSummaryFile.deleteOnExit();
             outputDetailsFile.deleteOnExit();
             outputContingencyFile.deleteOnExit();


### PR DESCRIPTION
### Description

Change to genotype concordance when `OUTPUT_VCF` is true, to change the output filename to include `.genotype_concordance`.  The other output files have more meaningful names so if you use `O=foo.concordance` you end up with `foo.concordance.genotype_concordance_summary_metrics` etc. which seems redundant.  But if you use `O=foo` you get `foo.vcf.gz` out.  This is a problem if, like me, you tend to run things like `picard CollectGenotypeConcordanceMetrics OUTPUT_VCF=true TV=truth.vcf CV=foo.vcf.gz O=foo`.
### Checklist (never delete this)

- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable
