### PR TITLE
Fix sorting of lifted intervals in LiftOverIntervalList

### DIFF
--- a/src/main/java/picard/util/LiftOverIntervalList.java
+++ b/src/main/java/picard/util/LiftOverIntervalList.java
@@ -120,8 +120,7 @@ public class LiftOverIntervalList extends CommandLineProgram {
             }
         }
 
-        toIntervals.sorted();
-        toIntervals.write(OUTPUT);
+        toIntervals.sorted().write(OUTPUT);
         return anyFailed ? 1 : 0;
     }
 }


### PR DESCRIPTION
### Description

LiftOverIntervalList called `toIntervals.sorted()` and discarded the result, and then continued to write out the unsorted `toIntervals`.  This fixes that.

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable