### PR TITLE
add IOUtil.unrollFiles(INPUT, IOUtil.VCF_EXTENSIONS); to MergeVcfs

### DIFF
--- a/src/main/java/picard/vcf/MergeVcfs.java
+++ b/src/main/java/picard/vcf/MergeVcfs.java
@@ -94,6 +94,8 @@ public class MergeVcfs extends CommandLineProgram {
     protected int doWork() {
         final ProgressLogger progress = new ProgressLogger(log, 10000);
         final List<String> sampleList = new ArrayList<String>();
+        INPUT = IOUtil.unrollFiles(INPUT, IOUtil.VCF_EXTENSIONS);
+        for (final File f: INPUT) IOUtil.assertFileIsReadable(f);
         final Collection<CloseableIterator<VariantContext>> iteratorCollection = new ArrayList<CloseableIterator<VariantContext>>(INPUT.size());
         final Collection<VCFHeader> headers = new HashSet<VCFHeader>(INPUT.size());
 

--- a/src/main/java/picard/vcf/MergeVcfs.java
+++ b/src/main/java/picard/vcf/MergeVcfs.java
@@ -71,7 +71,7 @@ import java.util.List;
 )
 public class MergeVcfs extends CommandLineProgram {
 
-    @Option(shortName= StandardOptionDefinitions.INPUT_SHORT_NAME, doc="VCF or BCF input files File format is determined by file extension.", minElements=1)
+    @Option(shortName= StandardOptionDefinitions.INPUT_SHORT_NAME, doc="VCF or BCF input files (File format is determined by file extension), or a file having a '.list' suffix containing the path to the files.", minElements=1)
     public List<File> INPUT;
 
     @Option(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "The merged VCF or BCF file. File format is determined by file extension.")
@@ -95,7 +95,6 @@ public class MergeVcfs extends CommandLineProgram {
         final ProgressLogger progress = new ProgressLogger(log, 10000);
         final List<String> sampleList = new ArrayList<String>();
         INPUT = IOUtil.unrollFiles(INPUT, IOUtil.VCF_EXTENSIONS);
-        for (final File f: INPUT) IOUtil.assertFileIsReadable(f);
         final Collection<CloseableIterator<VariantContext>> iteratorCollection = new ArrayList<CloseableIterator<VariantContext>>(INPUT.size());
         final Collection<VCFHeader> headers = new HashSet<VCFHeader>(INPUT.size());
 


### PR DESCRIPTION
just like in GatherVcfs I've added 

```
INPUT = IOUtil.unrollFiles(INPUT, IOUtil.VCF_EXTENSIONS);
for (final File f: INPUT) IOUtil.assertFileIsReadable(f);
```

in MergeVcfs to support the 'list' extension

### Checklist

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [x ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

