### PR TITLE
Adds a couple of metrics computed on UMIs

### DIFF
--- a/src/main/java/picard/sam/UmiMetrics.java
+++ b/src/main/java/picard/sam/UmiMetrics.java
@@ -49,23 +49,31 @@ public class UmiMetrics extends MetricBase {
     // Number of duplicate sets found after taking UMIs into account
     public long DUPLICATE_SETS_WITH_UMI = 0;
 
-    // This is a measure of entropy (in base 4) to indicate the amount of
-    // information (given as effective bases) provided by each observed UMI
-    public double EFFECTIVE_LENGTH_OF_OBSERVED_UMIS = 0;
+    // Entropy (in base 4) of the observed UMI sequences, indicating the
+    // effective number of bases in the UMIs.  If this is significantly
+    // smaller than UMI_LENGTH, it indicates that the UMIs are not
+    // distributed uniformly.
+    public double OBSERVED_UMI_ENTROPY = 0;
 
-    public double EFFECTIVE_LENGTH_OF_INFERRED_UMIS = 0;
+    // Entropy (in base 4) of the inferred UMI sequences, indicating the
+    // effective number of bases in the inferred UMIs.  If this is significantly
+    // smaller than UMI_LENGTH, it indicates that the UMIs are not
+    // distributed uniformly.
+    public double INFERRED_UMI_ENTROPY = 0;
 
     // Estimation of Phred scaled quality scores for UMIs
-    public double ESTIMATED_BASE_QUALITY_OF_UMIS;
+    public double UMI_BASE_QUALITIES;
 
-    // MLE estimation of reads that will be falsely labeled as being part of a duplicate set due to UMI collisions
-    public double EXPECTED_READS_WITH_UMI_COLLISION;
+    // MLE estimation of reads that will be falsely labeled as being part of a duplicate set due to UMI collisions.
+    // This estimate is computed over every duplicate set, and effectively accounts for the distribution of duplicate
+    // set sizes.
+    public double UMI_COLLISION_EST;
 
     // Phred scale of MLE estimate of collision rate
     public double UMI_COLLISION_Q;
 
     public void estimateBaseQualities(final int observedUmiBases) {
-        ESTIMATED_BASE_QUALITY_OF_UMIS = -10.0*Math.log10((double) OBSERVED_BASE_ERRORS / (double) observedUmiBases);
+        UMI_BASE_QUALITIES = -10.0*Math.log10((double) OBSERVED_BASE_ERRORS / (double) observedUmiBases);
     }
 
     public UmiMetrics() {}
@@ -81,10 +89,10 @@ public class UmiMetrics extends MetricBase {
         OBSERVED_BASE_ERRORS = observedBaseErrors;
         DUPLICATE_SETS_WITHOUT_UMI = duplicateSetsWithoutUmi;
         DUPLICATE_SETS_WITH_UMI = duplicateSetsWithUmi;
-        EFFECTIVE_LENGTH_OF_INFERRED_UMIS = effectiveLengthOfInferredUmis;
-        EFFECTIVE_LENGTH_OF_OBSERVED_UMIS = effectiveLengthOfObservedUmis;
-        ESTIMATED_BASE_QUALITY_OF_UMIS = estimatedBaseQualityOfUmis;
-        EXPECTED_READS_WITH_UMI_COLLISION = expectedUmiCollisions;
+        INFERRED_UMI_ENTROPY = effectiveLengthOfInferredUmis;
+        OBSERVED_UMI_ENTROPY = effectiveLengthOfObservedUmis;
+        UMI_BASE_QUALITIES = estimatedBaseQualityOfUmis;
+        UMI_COLLISION_EST = expectedUmiCollisions;
         UMI_COLLISION_Q = umiCollisionQ;
     }
 }

--- a/src/main/java/picard/sam/UmiMetrics.java
+++ b/src/main/java/picard/sam/UmiMetrics.java
@@ -24,9 +24,11 @@
 
 package picard.sam;
 
+import java.util.stream.Collectors;
 import com.google.common.math.LongMath;
 import htsjdk.samtools.metrics.MetricBase;
 import htsjdk.samtools.util.Histogram;
+import htsjdk.samtools.util.QualityUtil;
 import static htsjdk.samtools.util.StringUtil.hammingDistance;
 
 /**
@@ -34,10 +36,6 @@ import static htsjdk.samtools.util.StringUtil.hammingDistance;
  * within a stream of SAMRecords using the UmiAwareDuplicateSetIterator.
  */
 public class UmiMetrics extends MetricBase {
-    private Histogram<String> observedUmis = new Histogram<>();
-    private Histogram<String> inferredUmis = new Histogram<>();
-    private int observedUmiBases = 0;
-
     /** Number of bases in each UMI */
     public int UMI_LENGTH;
 
@@ -74,26 +72,12 @@ public class UmiMetrics extends MetricBase {
     /** Estimation of Phred scaled quality scores for UMIs */
     public double UMI_BASE_QUALITIES;
 
-    /** MLE estimation of reads that will be falsely labeled as being part of a duplicate set due to UMI collisions.
-     * This estimate is computed over every duplicate set, and effectively accounts for the distribution of duplicate
-     * set sizes.  This is an experimental metric, and should be used with caution.
-     */
-    public double UMI_COLLISION_EST;
-
-    /** Phred scale of MLE estimate of collision rate.  This is an experimental metric. */
-    public double UMI_COLLISION_Q;
-
-    public void estimateBaseQualities(final int observedUmiBases) {
-        UMI_BASE_QUALITIES = -10.0*Math.log10((double) OBSERVED_BASE_ERRORS / (double) observedUmiBases);
-    }
-
     public UmiMetrics() {}
 
     public UmiMetrics(final int length, final int observedUniqueUmis, final int inferredUniqueUmis,
                       final int observedBaseErrors, final int duplicateSetsWithoutUmi,
                       final int duplicateSetsWithUmi, final double effectiveLengthOfInferredUmis,
-                      final double effectiveLengthOfObservedUmis, final double estimatedBaseQualityOfUmis,
-                      final double expectedUmiCollisions, final double umiCollisionQ) {
+                      final double effectiveLengthOfObservedUmis, final double estimatedBaseQualityOfUmis) {
         UMI_LENGTH = length;
         OBSERVED_UNIQUE_UMIS = observedUniqueUmis;
         INFERRED_UNIQUE_UMIS = inferredUniqueUmis;
@@ -103,64 +87,27 @@ public class UmiMetrics extends MetricBase {
         INFERRED_UMI_ENTROPY = effectiveLengthOfInferredUmis;
         OBSERVED_UMI_ENTROPY = effectiveLengthOfObservedUmis;
         UMI_BASE_QUALITIES = estimatedBaseQualityOfUmis;
-        UMI_COLLISION_EST = expectedUmiCollisions;
-        UMI_COLLISION_Q = umiCollisionQ;
     }
 
-    public void calculateDerivedFields() {
+    public void calculateDerivedFields(final Histogram<String> observedUmis, Histogram<String> inferredUmis, long observedUmiBases) {
         OBSERVED_UNIQUE_UMIS = observedUmis.size();
         INFERRED_UNIQUE_UMIS = inferredUmis.size();
 
         OBSERVED_UMI_ENTROPY = effectiveNumberOfBases(observedUmis);
         INFERRED_UMI_ENTROPY = effectiveNumberOfBases(inferredUmis);
 
-        UMI_COLLISION_Q = -10 * Math.log10(UMI_COLLISION_EST / inferredUmis.size());
-        estimateBaseQualities(observedUmiBases);
+        UMI_BASE_QUALITIES = QualityUtil.getPhredScoreFromErrorProbability((double) OBSERVED_BASE_ERRORS / (double) observedUmiBases);
     }
 
     private double effectiveNumberOfBases(Histogram<?> observations) {
-        double entropyBase4 = 0.0;
-
         double totalObservations = observations.getSumOfValues();
-        for (Histogram.Bin observation : observations.values()) {
-            double pObservation = observation.getValue() / totalObservations;
-            entropyBase4 = entropyBase4 - pObservation * Math.log(pObservation);
-        }
 
         // Convert to log base 4 so that the entropy is now a measure
         // of the effective number of DNA bases.  If we used log(2.0)
         // our result would be in bits.
-        return entropyBase4 / Math.log(4.0);
-    }
-
-    public void updateDuplicateSetMetrics(final int maxEditDistanceToJoin, final int duplicateSetSize) {
-        DUPLICATE_SETS_WITH_UMI += duplicateSetSize;
-        DUPLICATE_SETS_WITHOUT_UMI++;
-
-        // For each duplicate set estimate the number of expected UMI collisions
-        double nWaysUmisCanDiffer = 0; // Number of ways two UMIs may contain errors, but be considered the same
-        for (int k = 0; k <= maxEditDistanceToJoin; k++) {
-            if (UMI_LENGTH > 0) {
-                nWaysUmisCanDiffer = nWaysUmisCanDiffer + LongMath.binomial(UMI_LENGTH, k) * Math.pow(3.0, k);
-            }
-        }
-
-        // The probability of two non-duplicate UMIs are drawn from a uniform distribution being correctly labeled as
-        // not belonging to the same UMI family is given as, pCorrectlyLabeled = nWaysUmisCanDiffer / 4^metrics.UMI_LENGTH.
-        // Estimate of probability all members in the duplicate set are correctly labeled is given by
-        // pAllMembersCorrectlyLabeled = (1 - pCorrectlyLabeled)^duplicateSets.size().
-        // The expected number of reads incorrectly labeled as belonging to a duplicate set is given as,
-        // (1 - pAllMembersCorrectlyLabeled) * duplicateSets.size().
-        UMI_COLLISION_EST = UMI_COLLISION_EST +
-                (1 - Math.pow(1 - nWaysUmisCanDiffer / Math.pow(4, UMI_LENGTH), duplicateSetSize - 1)) * duplicateSetSize;
-    }
-
-    public void updateUmiRecordMetrics(final String currentUmi, final String inferredUmi) {
-        OBSERVED_BASE_ERRORS += hammingDistance(currentUmi, inferredUmi);
-
-        observedUmiBases += UMI_LENGTH;
-        observedUmis.increment(currentUmi);
-        inferredUmis.increment(inferredUmi);
+        double entropyBase4 = observations.values().stream().collect(Collectors.summingDouble(
+                v -> -v.getValue() / totalObservations * Math.log(v.getValue() / totalObservations))) / Math.log(4.0);
+        return entropyBase4;
     }
 }
 

--- a/src/main/java/picard/sam/UmiMetrics.java
+++ b/src/main/java/picard/sam/UmiMetrics.java
@@ -38,45 +38,49 @@ public class UmiMetrics extends MetricBase {
     private Histogram<String> inferredUmis = new Histogram<>();
     private int observedUmiBases = 0;
 
-    // Number of bases in each UMI
+    /** Number of bases in each UMI */
     public int UMI_LENGTH;
 
-    // Number of different UMI sequences observed
+    /** Number of different UMI sequences observed */
     public long OBSERVED_UNIQUE_UMIS = 0;
 
-    // Number of different inferred UMI sequences derived
+    /** Number of different inferred UMI sequences derived */
     public long INFERRED_UNIQUE_UMIS = 0;
 
-    // Number of errors inferred by comparing the observed and inferred UMIs
+    /** Number of errors inferred by comparing the observed and inferred UMIs */
     public long OBSERVED_BASE_ERRORS = 0;
 
-    // Number of duplicate sets found before taking UMIs into account
+    /** Number of duplicate sets found before taking UMIs into account */
     public long DUPLICATE_SETS_WITHOUT_UMI = 0;
 
-    // Number of duplicate sets found after taking UMIs into account
+    /** Number of duplicate sets found after taking UMIs into account */
     public long DUPLICATE_SETS_WITH_UMI = 0;
 
-    // Entropy (in base 4) of the observed UMI sequences, indicating the
-    // effective number of bases in the UMIs.  If this is significantly
-    // smaller than UMI_LENGTH, it indicates that the UMIs are not
-    // distributed uniformly.
+    /**
+     * Entropy (in base 4) of the observed UMI sequences, indicating the
+     * effective number of bases in the UMIs.  If this is significantly
+     * smaller than UMI_LENGTH, it indicates that the UMIs are not
+     * distributed uniformly.
+     */
     public double OBSERVED_UMI_ENTROPY = 0;
 
-    // Entropy (in base 4) of the inferred UMI sequences, indicating the
-    // effective number of bases in the inferred UMIs.  If this is significantly
-    // smaller than UMI_LENGTH, it indicates that the UMIs are not
-    // distributed uniformly.
+    /** Entropy (in base 4) of the inferred UMI sequences, indicating the
+     * effective number of bases in the inferred UMIs.  If this is significantly
+     * smaller than UMI_LENGTH, it indicates that the UMIs are not
+     * distributed uniformly.
+     */
     public double INFERRED_UMI_ENTROPY = 0;
 
-    // Estimation of Phred scaled quality scores for UMIs
+    /** Estimation of Phred scaled quality scores for UMIs */
     public double UMI_BASE_QUALITIES;
 
-    // MLE estimation of reads that will be falsely labeled as being part of a duplicate set due to UMI collisions.
-    // This estimate is computed over every duplicate set, and effectively accounts for the distribution of duplicate
-    // set sizes.
+    /** MLE estimation of reads that will be falsely labeled as being part of a duplicate set due to UMI collisions.
+     * This estimate is computed over every duplicate set, and effectively accounts for the distribution of duplicate
+     * set sizes.  This is an experimental metric, and should be used with caution.
+     */
     public double UMI_COLLISION_EST;
 
-    // Phred scale of MLE estimate of collision rate
+    /** Phred scale of MLE estimate of collision rate.  This is an experimental metric. */
     public double UMI_COLLISION_Q;
 
     public void estimateBaseQualities(final int observedUmiBases) {

--- a/src/main/java/picard/sam/UmiMetrics.java
+++ b/src/main/java/picard/sam/UmiMetrics.java
@@ -24,13 +24,20 @@
 
 package picard.sam;
 
+import com.google.common.math.LongMath;
 import htsjdk.samtools.metrics.MetricBase;
+import htsjdk.samtools.util.Histogram;
+import static htsjdk.samtools.util.StringUtil.hammingDistance;
 
 /**
  * Metrics that are calculated during the process of marking duplicates
  * within a stream of SAMRecords using the UmiAwareDuplicateSetIterator.
  */
 public class UmiMetrics extends MetricBase {
+    private Histogram<String> observedUmis = new Histogram<>();
+    private Histogram<String> inferredUmis = new Histogram<>();
+    private int observedUmiBases = 0;
+
     // Number of bases in each UMI
     public int UMI_LENGTH;
 
@@ -95,4 +102,61 @@ public class UmiMetrics extends MetricBase {
         UMI_COLLISION_EST = expectedUmiCollisions;
         UMI_COLLISION_Q = umiCollisionQ;
     }
+
+    public void calculateDerivedFields() {
+        OBSERVED_UNIQUE_UMIS = observedUmis.size();
+        INFERRED_UNIQUE_UMIS = inferredUmis.size();
+
+        OBSERVED_UMI_ENTROPY = effectiveNumberOfBases(observedUmis);
+        INFERRED_UMI_ENTROPY = effectiveNumberOfBases(inferredUmis);
+
+        UMI_COLLISION_Q = -10 * Math.log10(UMI_COLLISION_EST / inferredUmis.size());
+        estimateBaseQualities(observedUmiBases);
+    }
+
+    private double effectiveNumberOfBases(Histogram<?> observations) {
+        double entropyBase4 = 0.0;
+
+        double totalObservations = observations.getSumOfValues();
+        for (Histogram.Bin observation : observations.values()) {
+            double pObservation = observation.getValue() / totalObservations;
+            entropyBase4 = entropyBase4 - pObservation * Math.log(pObservation);
+        }
+
+        // Convert to log base 4 so that the entropy is now a measure
+        // of the effective number of DNA bases.  If we used log(2.0)
+        // our result would be in bits.
+        return entropyBase4 / Math.log(4.0);
+    }
+
+    public void updateDuplicateSetMetrics(final int maxEditDistanceToJoin, final int duplicateSetSize) {
+        DUPLICATE_SETS_WITH_UMI += duplicateSetSize;
+        DUPLICATE_SETS_WITHOUT_UMI++;
+
+        // For each duplicate set estimate the number of expected UMI collisions
+        double nWaysUmisCanDiffer = 0; // Number of ways two UMIs may contain errors, but be considered the same
+        for (int k = 0; k <= maxEditDistanceToJoin; k++) {
+            if (UMI_LENGTH > 0) {
+                nWaysUmisCanDiffer = nWaysUmisCanDiffer + LongMath.binomial(UMI_LENGTH, k) * Math.pow(3.0, k);
+            }
+        }
+
+        // The probability of two non-duplicate UMIs are drawn from a uniform distribution being correctly labeled as
+        // not belonging to the same UMI family is given as, pCorrectlyLabeled = nWaysUmisCanDiffer / 4^metrics.UMI_LENGTH.
+        // Estimate of probability all members in the duplicate set are correctly labeled is given by
+        // pAllMembersCorrectlyLabeled = (1 - pCorrectlyLabeled)^duplicateSets.size().
+        // The expected number of reads incorrectly labeled as belonging to a duplicate set is given as,
+        // (1 - pAllMembersCorrectlyLabeled) * duplicateSets.size().
+        UMI_COLLISION_EST = UMI_COLLISION_EST +
+                (1 - Math.pow(1 - nWaysUmisCanDiffer / Math.pow(4, UMI_LENGTH), duplicateSetSize - 1)) * duplicateSetSize;
+    }
+
+    public void updateUmiRecordMetrics(final String currentUmi, final String inferredUmi) {
+        OBSERVED_BASE_ERRORS += hammingDistance(currentUmi, inferredUmi);
+
+        observedUmiBases += UMI_LENGTH;
+        observedUmis.increment(currentUmi);
+        inferredUmis.increment(inferredUmi);
+    }
 }
+

--- a/src/main/java/picard/sam/UmiMetrics.java
+++ b/src/main/java/picard/sam/UmiMetrics.java
@@ -1,0 +1,90 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam;
+
+import htsjdk.samtools.metrics.MetricBase;
+
+/**
+ * Metrics that are calculated during the process of marking duplicates
+ * within a stream of SAMRecords using the UmiAwareDuplicateSetIterator.
+ */
+public class UmiMetrics extends MetricBase {
+    // Number of bases in each UMI
+    public int UMI_LENGTH;
+
+    // Number of different UMI sequences observed
+    public long OBSERVED_UNIQUE_UMIS = 0;
+
+    // Number of different inferred UMI sequences derived
+    public long INFERRED_UNIQUE_UMIS = 0;
+
+    // Number of errors inferred by comparing the observed and inferred UMIs
+    public long OBSERVED_BASE_ERRORS = 0;
+
+    // Number of duplicate sets found before taking UMIs into account
+    public long DUPLICATE_SETS_WITHOUT_UMI = 0;
+
+    // Number of duplicate sets found after taking UMIs into account
+    public long DUPLICATE_SETS_WITH_UMI = 0;
+
+    // This is a measure of entropy (in base 4) to indicate the amount of
+    // information (given as effective bases) provided by each observed UMI
+    public double EFFECTIVE_LENGTH_OF_OBSERVED_UMIS = 0;
+
+    public double EFFECTIVE_LENGTH_OF_INFERRED_UMIS = 0;
+
+    // Estimation of Phred scaled quality scores for UMIs
+    public double ESTIMATED_BASE_QUALITY_OF_UMIS;
+
+    // MLE estimation of reads that will be falsely labeled as being part of a duplicate set due to UMI collisions
+    public double EXPECTED_READS_WITH_UMI_COLLISION;
+
+    // Phred scale of MLE estimate of collision rate
+    public double UMI_COLLISION_Q;
+
+    public void estimateBaseQualities(final int observedUmiBases) {
+        ESTIMATED_BASE_QUALITY_OF_UMIS = -10.0*Math.log10((double) OBSERVED_BASE_ERRORS / (double) observedUmiBases);
+    }
+
+    public UmiMetrics() {}
+
+    public UmiMetrics(final int length, final int observedUniqueUmis, final int inferredUniqueUmis,
+                      final int observedBaseErrors, final int duplicateSetsWithoutUmi,
+                      final int duplicateSetsWithUmi, final double effectiveLengthOfInferredUmis,
+                      final double effectiveLengthOfObservedUmis, final double estimatedBaseQualityOfUmis,
+                      final double expectedUmiCollisions, final double umiCollisionQ) {
+        UMI_LENGTH = length;
+        OBSERVED_UNIQUE_UMIS = observedUniqueUmis;
+        INFERRED_UNIQUE_UMIS = inferredUniqueUmis;
+        OBSERVED_BASE_ERRORS = observedBaseErrors;
+        DUPLICATE_SETS_WITHOUT_UMI = duplicateSetsWithoutUmi;
+        DUPLICATE_SETS_WITH_UMI = duplicateSetsWithUmi;
+        EFFECTIVE_LENGTH_OF_INFERRED_UMIS = effectiveLengthOfInferredUmis;
+        EFFECTIVE_LENGTH_OF_OBSERVED_UMIS = effectiveLengthOfObservedUmis;
+        ESTIMATED_BASE_QUALITY_OF_UMIS = estimatedBaseQualityOfUmis;
+        EXPECTED_READS_WITH_UMI_COLLISION = expectedUmiCollisions;
+        UMI_COLLISION_Q = umiCollisionQ;
+    }
+}

--- a/src/main/java/picard/sam/markduplicates/UmiAwareDuplicateSetIterator.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareDuplicateSetIterator.java
@@ -66,7 +66,7 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
     /**
      * Creates a UMI aware duplicate set iterator
      *
-     * @param wrappedIterator       UMI aware duplicate set iterator is a wrapper
+     * @param wrappedIterator       Iterator of DuplicatesSets to use and break-up by UMI.
      * @param maxEditDistanceToJoin The edit distance between UMIs that will be used to union UMIs into groups
      * @param umiTag                The tag used in the bam file that designates the UMI
      * @param assignedUmiTag        The tag in the bam file that designates the assigned UMI
@@ -88,10 +88,7 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
     public void close() {
         isOpen = false;
         wrappedIterator.close();
-
-        if (metrics.UMI_LENGTH > 0) {
-            metrics.calculateDerivedFields();
-        }
+        metrics.calculateDerivedFields();
     }
 
     @Override
@@ -144,12 +141,13 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
                 String currentUmi = rec.getStringAttribute(umiTag);
 
                 if (currentUmi != null) {
-                    // All UMIs should be the same length
+                    // All UMIs should be the same length, the code presently does not support variable length UMIs
+                    // TODO: Add support for variable length UMIs
                     if (!haveWeSeenFirstRead) {
-                        metrics.UMI_LENGTH = currentUmi.length();
+                        metrics.MEAN_UMI_LENGTH = currentUmi.length();
                         haveWeSeenFirstRead = true;
                     } else {
-                        if (metrics.UMI_LENGTH != currentUmi.length()) {
+                        if (metrics.MEAN_UMI_LENGTH != currentUmi.length()) {
                             throw new PicardException("UMIs of differing lengths were found.");
                         }
                     }

--- a/src/main/java/picard/sam/markduplicates/UmiAwareDuplicateSetIterator.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareDuplicateSetIterator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016 The Broad Institute
+ * Copyright (c) 2017 The Broad Institute
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,18 +34,14 @@
 
 package picard.sam.markduplicates;
 
-import com.google.common.math.LongMath;
 import htsjdk.samtools.DuplicateSet;
 import htsjdk.samtools.DuplicateSetIterator;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.util.CloseableIterator;
-import htsjdk.samtools.util.Histogram;
 import picard.PicardException;
 import picard.sam.UmiMetrics;
 
 import java.util.*;
-
-import static htsjdk.samtools.util.StringUtil.hammingDistance;
 
 /**
  * UmiAwareDuplicateSetIterator is an iterator that wraps a duplicate set iterator
@@ -63,13 +59,7 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
     private boolean isOpen = false;
     private UmiMetrics metrics;
     private boolean haveWeSeenFirstRead = false;
-    private long duplicateSetsWithUmi = 0;
-    private long duplicateSetsWithoutUmi = 0;
     private double expectedCollisions = 0;
-    private int observedUmiBases = 0;
-
-    private Histogram<String> observedUmis = new Histogram<>();
-    private Histogram<String> inferredUmis = new Histogram<>();
 
     /**
      * Creates a UMI aware duplicate set iterator
@@ -98,9 +88,8 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
         wrappedIterator.close();
 
         if (metrics.UMI_LENGTH > 0) {
-            collectMetrics();
+            metrics.calculateDerivedFields();
         }
-
     }
 
     @Override
@@ -147,7 +136,6 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
         for (DuplicateSet ds : duplicateSets) {
             List<SAMRecord> records = ds.getRecords();
             SAMRecord representativeRead = ds.getRepresentative();
-
             String inferredUmi = representativeRead.getStringAttribute(inferredUmiTag);
 
             for (SAMRecord rec : records) {
@@ -163,65 +151,12 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
                             throw new PicardException("UMIs of differing lengths were found.");
                         }
                     }
-
-                    metrics.OBSERVED_BASE_ERRORS += hammingDistance(currentUmi, inferredUmi);
-                    observedUmiBases += metrics.UMI_LENGTH;
-
-                    observedUmis.increment(currentUmi);
-                    inferredUmis.increment(inferredUmi);
+                    metrics.updateUmiRecordMetrics(currentUmi, inferredUmi);
                 }
             }
         }
-        duplicateSetsWithUmi += duplicateSets.size();
-        duplicateSetsWithoutUmi++;
-
-        // For each duplicate set estimate the number of expected UMI collisions
-        double nWaysUmisCanDiffer = 0; // Number of ways two UMIs may contain errors, but be considered the same
-        for (int k = 0; k <= maxEditDistanceToJoin; k++) {
-            if (metrics.UMI_LENGTH > 0) {
-                nWaysUmisCanDiffer = nWaysUmisCanDiffer + LongMath.binomial(metrics.UMI_LENGTH, k) * Math.pow(3.0, k);
-            }
-        }
-
-        // The probability of two non-duplicate UMIs are drawn from a uniform distribution being correctly labeled as
-        // not belonging to the same UMI family is given as, pCorrectlyLabeled = nWaysUmisCanDiffer / 4^metrics.UMI_LENGTH.
-        // Estimate of probability all members in the duplicate set are correctly labeled is given by
-        // pAllMembersCorrectlyLabeled = (1 - pCorrectlyLabeled)^duplicateSets.size().
-        // The expected number of reads incorrectly labeled as belonging to a duplicate set is given as,
-        // (1 - pAllMembersCorrectlyLabeled) * duplicateSets.size().
-        expectedCollisions = expectedCollisions +
-                (1 - Math.pow(1 - nWaysUmisCanDiffer / Math.pow(4, metrics.UMI_LENGTH), duplicateSets.size() - 1)) * duplicateSets.size();
+        metrics.updateDuplicateSetMetrics(maxEditDistanceToJoin, duplicateSets.size());
 
         nextSetsIterator = duplicateSets.iterator();
-    }
-
-    private void collectMetrics() {
-        metrics.OBSERVED_UNIQUE_UMIS = observedUmis.size();
-        metrics.INFERRED_UNIQUE_UMIS = inferredUmis.size();
-
-        metrics.OBSERVED_UMI_ENTROPY = effectiveNumberOfBases(observedUmis);
-        metrics.INFERRED_UMI_ENTROPY = effectiveNumberOfBases(inferredUmis);
-
-        metrics.DUPLICATE_SETS_WITH_UMI = duplicateSetsWithUmi;
-        metrics.DUPLICATE_SETS_WITHOUT_UMI = duplicateSetsWithoutUmi;
-        metrics.UMI_COLLISION_EST = expectedCollisions;
-
-        metrics.UMI_COLLISION_Q = -10 * Math.log10(expectedCollisions / inferredUmis.size());
-        metrics.estimateBaseQualities(observedUmiBases);
-    }
-
-    private double effectiveNumberOfBases(Histogram<?> observations) {
-        double entropyBase4 = 0.0;
-
-        double totalObservations = observations.getSumOfValues();
-        for (Histogram.Bin observation : observations.values()) {
-            double pObservation = observation.getValue() / totalObservations;
-            entropyBase4 = entropyBase4 - pObservation * Math.log(pObservation);
-        }
-
-        // Convert to log base 4 so that the entropy is now a measure
-        // of the effective number of DNA bases.  If we used log(2.0)
-        // our result would be in bits.
-        return entropyBase4 / Math.log(4.0);
     }
 }

--- a/src/main/java/picard/sam/markduplicates/UmiAwareDuplicateSetIterator.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareDuplicateSetIterator.java
@@ -90,7 +90,7 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
         wrappedIterator.close();
 
         if (metrics.UMI_LENGTH > 0) {
-            metrics.calculateDerivedFields(observedUmiBases);
+            metrics.calculateDerivedFields();
         }
     }
 
@@ -157,8 +157,7 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
                     // Update UMI metrics associated with each record
                     metrics.OBSERVED_BASE_ERRORS += hammingDistance(currentUmi, inferredUmi);
                     observedUmiBases += currentUmi.length();
-                    metrics.observedUmis.increment(currentUmi);
-                    metrics.inferredUmis.increment(inferredUmi);
+                    metrics.addUmiObservation(currentUmi, inferredUmi);
                 }
             }
         }

--- a/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
@@ -69,8 +69,9 @@ public class UmiAwareMarkDuplicatesWithMateCigar extends SimpleMarkDuplicatesWit
     @Option(shortName = "MAX_EDIT_DISTANCE_TO_JOIN", doc = "Largest edit distance that UMIs must have in order to be considered as coming from distinct source molecules.", optional = true)
     public int MAX_EDIT_DISTANCE_TO_JOIN = 1;
 
-    @Option(shortName = "UMI_METRICS", doc = "UMI Metrics", optional = true)
-    public File UMI_METRICS_FILE = null;
+    // The UMI_METRICS file provides various statistical measurements collected about the UMIs during deduplication.
+    @Option(shortName = "UMI_METRICS", doc = "UMI Metrics")
+    public File UMI_METRICS_FILE;
 
     @Option(shortName = "UMI_TAG_NAME", doc = "Tag name to use for UMI", optional = true)
     public String UMI_TAG_NAME = "RX";
@@ -89,15 +90,16 @@ public class UmiAwareMarkDuplicatesWithMateCigar extends SimpleMarkDuplicatesWit
 
     @Override
     protected int doWork() {
+        // Before we do anything, make sure the UMI_METRICS_FILE can be written to.
+        IOUtil.assertFileIsWritable(UMI_METRICS_FILE);
+
         // Perform Mark Duplicates work
         int retval=super.doWork();
 
         // Write metrics specific to UMIs
-        if(UMI_METRICS_FILE != null) {
-            MetricsFile<UmiMetrics, Double> metricsFile = getMetricsFile();
-            metricsFile.addMetric(metrics);
-            metricsFile.write(UMI_METRICS_FILE);
-        }
+        MetricsFile<UmiMetrics, Double> metricsFile = getMetricsFile();
+        metricsFile.addMetric(metrics);
+        metricsFile.write(UMI_METRICS_FILE);
         return retval;
     }
 

--- a/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
@@ -32,7 +32,6 @@ import htsjdk.samtools.util.*;
 import picard.cmdline.CommandLineProgramProperties;
 import picard.cmdline.Option;
 import picard.cmdline.programgroups.Alpha;
-import picard.sam.UmiMetrics;
 
 import java.io.File;
 

--- a/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016 The Broad Institute
+ * Copyright (c) 2017 The Broad Institute
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
@@ -93,7 +93,7 @@ public class UmiAwareMarkDuplicatesWithMateCigar extends SimpleMarkDuplicatesWit
         IOUtil.assertFileIsWritable(UMI_METRICS_FILE);
 
         // Perform Mark Duplicates work
-        int retval=super.doWork();
+        int retval = super.doWork();
 
         // Write metrics specific to UMIs
         MetricsFile<UmiMetrics, Double> metricsFile = getMetricsFile();

--- a/src/main/java/picard/sam/markduplicates/UmiMetrics.java
+++ b/src/main/java/picard/sam/markduplicates/UmiMetrics.java
@@ -107,9 +107,11 @@ public class UmiMetrics extends MetricBase {
         // Convert to log base 4 so that the entropy is now a measure
         // of the effective number of DNA bases.  If we used log(2.0)
         // our result would be in bits.
-        double entropyBase4 = observations.values().stream().collect(Collectors.summingDouble(
-                v -> -v.getValue() / totalObservations * Math.log(v.getValue() / totalObservations))) / MathUtil.LOG_4_BASE_E;
-        return entropyBase4;
+        double entropyBaseE = observations.values().stream().collect(Collectors.summingDouble(
+                v -> {double p = v.getValue() / totalObservations;
+                        return -p * Math.log(p);}));
+
+        return entropyBaseE / MathUtil.LOG_4_BASE_E;
     }
 }
 

--- a/src/main/java/picard/sam/markduplicates/UmiMetrics.java
+++ b/src/main/java/picard/sam/markduplicates/UmiMetrics.java
@@ -40,7 +40,7 @@ public class UmiMetrics extends MetricBase {
     private long observedUmiBases = 0;
 
     /** Number of bases in each UMI */
-    public int UMI_LENGTH;
+    public double MEAN_UMI_LENGTH = 0.0;
 
     /** Number of different UMI sequences observed */
     public long OBSERVED_UNIQUE_UMIS = 0;
@@ -73,15 +73,15 @@ public class UmiMetrics extends MetricBase {
     public double INFERRED_UMI_ENTROPY = 0;
 
     /** Estimation of Phred scaled quality scores for UMIs */
-    public double UMI_BASE_QUALITIES;
+    public double UMI_BASE_QUALITIES = 0.0;
 
     public UmiMetrics() {}
 
-    public UmiMetrics(final int length, final int observedUniqueUmis, final int inferredUniqueUmis,
+    public UmiMetrics(final double length, final int observedUniqueUmis, final int inferredUniqueUmis,
                       final int observedBaseErrors, final int duplicateSetsWithoutUmi,
                       final int duplicateSetsWithUmi, final double effectiveLengthOfInferredUmis,
                       final double effectiveLengthOfObservedUmis, final double estimatedBaseQualityOfUmis) {
-        UMI_LENGTH = length;
+        MEAN_UMI_LENGTH = length;
         OBSERVED_UNIQUE_UMIS = observedUniqueUmis;
         INFERRED_UNIQUE_UMIS = inferredUniqueUmis;
         OBSERVED_BASE_ERRORS = observedBaseErrors;

--- a/src/main/java/picard/sam/markduplicates/UmiMetrics.java
+++ b/src/main/java/picard/sam/markduplicates/UmiMetrics.java
@@ -35,8 +35,9 @@ import picard.util.MathUtil;
  * within a stream of SAMRecords using the UmiAwareDuplicateSetIterator.
  */
 public class UmiMetrics extends MetricBase {
-    Histogram<String> observedUmis = new Histogram<>();
-    Histogram<String> inferredUmis = new Histogram<>();
+    private final Histogram<String> observedUmis = new Histogram<>();
+    private final Histogram<String> inferredUmis = new Histogram<>();
+    private long observedUmiBases = 0;
 
     /** Number of bases in each UMI */
     public int UMI_LENGTH;
@@ -91,7 +92,7 @@ public class UmiMetrics extends MetricBase {
         UMI_BASE_QUALITIES = estimatedBaseQualityOfUmis;
     }
 
-    public void calculateDerivedFields(long observedUmiBases) {
+    public void calculateDerivedFields() {
         OBSERVED_UNIQUE_UMIS = observedUmis.size();
         INFERRED_UNIQUE_UMIS = inferredUmis.size();
 
@@ -99,6 +100,17 @@ public class UmiMetrics extends MetricBase {
         INFERRED_UMI_ENTROPY = effectiveNumberOfBases(inferredUmis);
 
         UMI_BASE_QUALITIES = QualityUtil.getPhredScoreFromErrorProbability((double) OBSERVED_BASE_ERRORS / (double) observedUmiBases);
+    }
+
+    /**
+     * Add an observation of a UMI to the metrics
+     * @param observedUmi String containing the observed UMI
+     * @param inferredUmi String containing the UMI inferred after error correcting the observed UMI
+     */
+    public void addUmiObservation(String observedUmi, String inferredUmi) {
+        observedUmis.increment(observedUmi);
+        inferredUmis.increment(inferredUmi);
+        observedUmiBases += observedUmi.length();
     }
 
     private double effectiveNumberOfBases(Histogram<?> observations) {

--- a/src/main/java/picard/util/MathUtil.java
+++ b/src/main/java/picard/util/MathUtil.java
@@ -41,6 +41,10 @@ final public class MathUtil {
     /** The double value closest to 1 while still being less than 1. */
     public static final double MAX_PROB_BELOW_ONE = 0.9999999999999999d;
 
+    /** Constant to convert between the natural base e and 4.0.  Useful for
+     * entropy calculations on DNA. */
+    public static final double LOG_4_BASE_E = Math.log(4.0);
+
     /**
      *  this function mimics the behavior of log_1p but resulting in log _base 10_ of (1+x) instead of natural log of 1+x
      */

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
@@ -28,7 +28,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import htsjdk.samtools.util.QualityUtil;
 import picard.PicardException;
-import picard.sam.UmiMetrics;
 
 import java.util.*;
 

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
@@ -243,7 +243,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
         UmiAwareMarkDuplicatesWithMateCigarTester tester = getTester(false);
         tester.addArg("MAX_EDIT_DISTANCE_TO_JOIN=" + editDistanceToJoin);
 
-        for(int i = 0;i < umis.size();i++) {
+        for( int i = 0;i < umis.size();i++ ) {
             tester.addMatePairWithUmi(umis.get(i), assignedUmi.get(i), isDuplicate.get(i), isDuplicate.get(i));
         }
         tester.setExpectedAssignedUmis(assignedUmi);

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
@@ -26,6 +26,7 @@ package picard.sam.markduplicates;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import htsjdk.samtools.util.QualityUtil;
 import picard.PicardException;
 import picard.sam.UmiMetrics;
 
@@ -174,15 +175,11 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
         // effectiveLength4_1 is the effective UMI length observing 5 UMIs where 3 are the same and the other two are
         // unique
         double effectiveLength3_1_1 = -(3./5.)*Math.log(3./5.)/Math.log(4.) -2*(1./5.)*Math.log(1./5.)/Math.log(4.);
-        // estimatedBaseQualityk_n is the phred scaled base quality score where k of n bases are incorrect
-        double estimatedBaseQuality1_20 = -10*Math.log10(1./20.);
-        double estimatedBaseQuality3_20 = -10*Math.log10(3./20.);
 
-        // expectedCollisionsi_j_k where edit distance to join is i, duplicate sets is k and UMI length is k.
-        double expectedCollisions1_2_4 = 13./64.;
-        double expectedCollisions0_16_2 = (1. - Math.pow(1. - 1./16., 15))*16.*2.;
-        double collisionQ1_2_4 = -10*Math.log10(expectedCollisions1_2_4/2.0);
-        double collisionQ0_16_2 = -10*Math.log10(expectedCollisions0_16_2/16.0);
+        // estimatedBaseQualityk_n is the phred scaled base quality score where k of n bases are incorrect
+        double estimatedBaseQuality1_20 = QualityUtil.getPhredScoreFromErrorProbability(1./20.);
+        double estimatedBaseQuality3_20 = QualityUtil.getPhredScoreFromErrorProbability(3./20.);
+
         return new Object[][]{{
                 // Test basic error correction using edit distance of 1
                 Arrays.asList(new String[]{"AAAA", "AAAA", "ATTA", "AAAA", "AAAT"}), // Observed UMI
@@ -197,9 +194,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
                                4,                        // DUPLICATE_SETS_WITH_UMI
                                effectiveLength4_1,       // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
                                effectiveLength3_1_1,     // EFECTIVE_LENGTH_OF_OBSERVED_UMIS
-                               estimatedBaseQuality1_20, // ESTIMATED_BASE_QUALITY_OF_UMIS
-                               expectedCollisions1_2_4,  // EXPECTED_READS_WITH_UMI_COLLISION
-                               collisionQ1_2_4)          // UMI_COLLISION_Q
+                               estimatedBaseQuality1_20) // ESTIMATED_BASE_QUALITY_OF_UMIS
         }, {
                 // Test basic error correction using edit distance of 2
                 Arrays.asList(new String[]{"AAAA", "AAAA", "ATTA", "AAAA", "AAAT"}),
@@ -214,9 +209,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
                                2,                        // DUPLICATE_SETS_WITH_UMI
                                0.0,                      // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
                                effectiveLength3_1_1,     // EFECTIVE_LENGTH_OF_OBSERVED_UMIS
-                               estimatedBaseQuality3_20, // ESTIMATED_BASE_QUALITY_OF_UMIS
-                               0,                        // EXPECTED_READS_WITH_UMI_COLLISION
-                               Double.NaN)               // UMI_COLLISION_Q
+                               estimatedBaseQuality3_20) // ESTIMATED_BASE_QUALITY_OF_UMIS
         }, {
                 // Test maximum entropy (EFFECTIVE_LENGTH_OF_INFERRED_UMIS)
                 Arrays.asList(new String[]{"AA", "AT", "AC", "AG", "TA", "TT", "TC", "TG", "CA", "CT", "CC", "CG", "GA", "GT", "GC", "GG"}),
@@ -231,9 +224,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
                                16,                        // DUPLICATE_SETS_WITH_UMI
                                2.0,                       // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
                                2,                         // EFECTIVE_LENGTH_OF_OBSERVED_UMIS
-                               Double.NaN,                // ESTIMATED_BASE_QUALITY_OF_UMIS
-                               expectedCollisions0_16_2,  // EXPECTED_READS_WITH_UMI_COLLISION
-                               collisionQ0_16_2)          // UMI_COLLISION_Q
+                               -1)                        // ESTIMATED_BASE_QUALITY_OF_UMIS
         }};
     }
 

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016 The Broad Institute
+ * Copyright (c) 2017 The Broad Institute
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
@@ -185,7 +185,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
                 Arrays.asList(new String[]{"AAAA", "AAAA", "ATTA", "AAAA", "AAAA"}), // Expected inferred UMI
                 Arrays.asList(new Boolean[]{false, true, false, true, true}), // Should it be marked as duplicate?
                 1, // Edit Distance to Join
-                new UmiMetrics(4,                        // UMI_LENGTH
+                new UmiMetrics(4.0,                      // MEAN_UMI_LENGTH
                                3,                        // OBSERVED_UNIQUE_UMIS
                                2,                        // INFERRED_UNIQUE_UMIS
                                2,                        // OBSERVED_BASE_ERRORS (Note: This is 2 rather than 1 because we are using paired end reads)
@@ -200,7 +200,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
                 Arrays.asList(new String[]{"AAAA", "AAAA", "AAAA", "AAAA", "AAAA"}),
                 Arrays.asList(new Boolean[]{false, true, true, true, true}),
                 2,
-                new UmiMetrics(4,                        // UMI_LENGTH
+                new UmiMetrics(4.0,                      // MEAN_UMI_LENGTH
                                3,                        // OBSERVED_UNIQUE_UMIS
                                1,                        // INFERRED_UNIQUE_UMIS
                                6,                        // OBSERVED_BASE_ERRORS
@@ -215,12 +215,12 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
                 Arrays.asList(new String[]{"AA", "AT", "AC", "AG", "TA", "TT", "TC", "TG", "CA", "CT", "CC", "CG", "GA", "GT", "GC", "GG"}),
                 Arrays.asList(new Boolean[]{false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false}),
                 0,
-                new UmiMetrics(2,                         // UMI_LENGTH
+                new UmiMetrics(2.0,                       // MEAN_UMI_LENGTH
                                16,                        // OBSERVED_UNIQUE_UMIS
                                16,                        // INFERRED_UNIQUE_UMIS
                                0,                         // OBSERVED_BASE_ERRORS
                                2,                         // DUPLICATE_SETS_WITHOUT_UMI
-                               16,                        // DUPLICATE_SETS_WITH_UMI
+                               32,                        // DUPLICATE_SETS_WITH_UMI
                                2.0,                       // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
                                2,                         // EFECTIVE_LENGTH_OF_OBSERVED_UMIS
                                -1)                        // ESTIMATED_BASE_QUALITY_OF_UMIS

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
@@ -171,7 +171,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
             }
         }
 
-        if(expectedMetrics != null) {
+        if (expectedMetrics != null) {
             // Check the values written to metrics.txt against our input expectations
             final MetricsFile<UmiMetrics, Comparable<?>> metricsOutput = new MetricsFile<UmiMetrics, Comparable<?>>();
             try {

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
@@ -191,8 +191,6 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
             Assert.assertEquals(observedMetrics.INFERRED_UMI_ENTROPY, expectedMetrics.INFERRED_UMI_ENTROPY, tolerance, "INFERRED_UMI_ENTROPY does not match expected");
             Assert.assertEquals(observedMetrics.OBSERVED_UMI_ENTROPY, expectedMetrics.OBSERVED_UMI_ENTROPY, tolerance, "OBSERVED_UMI_ENTROPY does not match expected");
             Assert.assertEquals(observedMetrics.UMI_BASE_QUALITIES, expectedMetrics.UMI_BASE_QUALITIES, tolerance, "UMI_BASE_QUALITIES does not match expected");
-            Assert.assertEquals(observedMetrics.UMI_COLLISION_EST, expectedMetrics.UMI_COLLISION_EST, tolerance, "UMI_COLLISION_EST does not match expected");
-            Assert.assertEquals(observedMetrics.UMI_COLLISION_Q, expectedMetrics.UMI_COLLISION_Q, tolerance, "UMI_COLLISION_Q does not match expected");
         }
 
         // Also do tests from AbstractMarkDuplicatesCommandLineProgramTester

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
@@ -30,7 +30,6 @@ import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.metrics.MetricsFile;
 import org.testng.Assert;
 import picard.cmdline.CommandLineProgram;
-import picard.sam.UmiMetrics;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -187,7 +186,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
             Assert.assertEquals(observedMetrics.OBSERVED_UNIQUE_UMIS, expectedMetrics.OBSERVED_UNIQUE_UMIS, "OBSERVED_UNIQUE_UMIS does not match expected");
             Assert.assertEquals(observedMetrics.INFERRED_UNIQUE_UMIS, expectedMetrics.INFERRED_UNIQUE_UMIS, "INFERRED_UNIQUE_UMIS does not match expected");
             Assert.assertEquals(observedMetrics.OBSERVED_BASE_ERRORS, expectedMetrics.OBSERVED_BASE_ERRORS, "OBSERVED_BASE_ERRORS does not match expected");
-            Assert.assertEquals(observedMetrics.DUPLICATE_SETS_WITHOUT_UMI, expectedMetrics.DUPLICATE_SETS_WITHOUT_UMI, "DUPLICATE_SETS_WITHOUT_UMI does not match expected");
+            Assert.assertEquals(observedMetrics.DUPLICATE_SETS_IGNORING_UMI, expectedMetrics.DUPLICATE_SETS_IGNORING_UMI, "DUPLICATE_SETS_WITHOUT_UMI does not match expected");
             Assert.assertEquals(observedMetrics.INFERRED_UMI_ENTROPY, expectedMetrics.INFERRED_UMI_ENTROPY, tolerance, "INFERRED_UMI_ENTROPY does not match expected");
             Assert.assertEquals(observedMetrics.OBSERVED_UMI_ENTROPY, expectedMetrics.OBSERVED_UMI_ENTROPY, tolerance, "OBSERVED_UMI_ENTROPY does not match expected");
             Assert.assertEquals(observedMetrics.UMI_BASE_QUALITIES, expectedMetrics.UMI_BASE_QUALITIES, tolerance, "UMI_BASE_QUALITIES does not match expected");

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
@@ -48,7 +48,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
     private int readNameCounter = 0;
     private List<String> expectedAssignedUmis;
     private UmiMetrics expectedMetrics;
-    private File umiMetricsFile;
+    private File umiMetricsFile = new File(getOutputDir(), "umi_metrics.txt");
 
     // This tag is only used for testing, it indicates what we expect to see in the inferred UMI tag.
     private final String expectedUmiTag = "RE";
@@ -57,11 +57,11 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
     // AbstractMarkDuplicatesCommandLineProgramTester.  Since those tests use
     // reads that don't have UMIs we enable the ALLOW_MISSING_UMIS option.
     UmiAwareMarkDuplicatesWithMateCigarTester() {
+        addArg("UMI_METRICS_FILE=" + umiMetricsFile);
         addArg("ALLOW_MISSING_UMIS=" + true);
     }
 
     UmiAwareMarkDuplicatesWithMateCigarTester(final boolean allowMissingUmis) {
-        umiMetricsFile = new File(getOutputDir(), "umi_metrics.txt");
         addArg("UMI_METRICS_FILE=" + umiMetricsFile);
 
         if (allowMissingUmis) {
@@ -174,7 +174,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
         if(expectedMetrics != null) {
             // Check the values written to metrics.txt against our input expectations
             final MetricsFile<UmiMetrics, Comparable<?>> metricsOutput = new MetricsFile<UmiMetrics, Comparable<?>>();
-            try{
+            try {
                 metricsOutput.read(new FileReader(umiMetricsFile));
             }
             catch (final FileNotFoundException ex) {
@@ -188,10 +188,10 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
             Assert.assertEquals(observedMetrics.INFERRED_UNIQUE_UMIS, expectedMetrics.INFERRED_UNIQUE_UMIS, "INFERRED_UNIQUE_UMIS does not match expected");
             Assert.assertEquals(observedMetrics.OBSERVED_BASE_ERRORS, expectedMetrics.OBSERVED_BASE_ERRORS, "OBSERVED_BASE_ERRORS does not match expected");
             Assert.assertEquals(observedMetrics.DUPLICATE_SETS_WITHOUT_UMI, expectedMetrics.DUPLICATE_SETS_WITHOUT_UMI, "DUPLICATE_SETS_WITHOUT_UMI does not match expected");
-            Assert.assertEquals(observedMetrics.EFFECTIVE_LENGTH_OF_INFERRED_UMIS, expectedMetrics.EFFECTIVE_LENGTH_OF_INFERRED_UMIS, tolerance, "EFFECTIVE_LENGTH_OF_INFERRED_UMIS does not match expected");
-            Assert.assertEquals(observedMetrics.EFFECTIVE_LENGTH_OF_OBSERVED_UMIS, expectedMetrics.EFFECTIVE_LENGTH_OF_OBSERVED_UMIS, tolerance, "EFFECTIVE_LENGTH_OF_OBSERVED_UMIS does not match expected");
-            Assert.assertEquals(observedMetrics.ESTIMATED_BASE_QUALITY_OF_UMIS, expectedMetrics.ESTIMATED_BASE_QUALITY_OF_UMIS, tolerance, "ESTIMATED_BASE_QUALITY_OF_UMIS does not match expected");
-            Assert.assertEquals(observedMetrics.EXPECTED_READS_WITH_UMI_COLLISION, expectedMetrics.EXPECTED_READS_WITH_UMI_COLLISION, tolerance, "EXPECTED_READS_WITH_UMI_COLLISION does not match expected");
+            Assert.assertEquals(observedMetrics.INFERRED_UMI_ENTROPY, expectedMetrics.INFERRED_UMI_ENTROPY, tolerance, "INFERRED_UMI_ENTROPY does not match expected");
+            Assert.assertEquals(observedMetrics.OBSERVED_UMI_ENTROPY, expectedMetrics.OBSERVED_UMI_ENTROPY, tolerance, "OBSERVED_UMI_ENTROPY does not match expected");
+            Assert.assertEquals(observedMetrics.UMI_BASE_QUALITIES, expectedMetrics.UMI_BASE_QUALITIES, tolerance, "UMI_BASE_QUALITIES does not match expected");
+            Assert.assertEquals(observedMetrics.UMI_COLLISION_EST, expectedMetrics.UMI_COLLISION_EST, tolerance, "UMI_COLLISION_EST does not match expected");
             Assert.assertEquals(observedMetrics.UMI_COLLISION_Q, expectedMetrics.UMI_COLLISION_Q, tolerance, "UMI_COLLISION_Q does not match expected");
         }
 

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
@@ -182,11 +182,12 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
             double tolerance = 1e-6;
             Assert.assertEquals(metricsOutput.getMetrics().size(), 1);
             final UmiMetrics observedMetrics = metricsOutput.getMetrics().get(0);
-            Assert.assertEquals(observedMetrics.UMI_LENGTH, expectedMetrics.UMI_LENGTH, "UMI_LENGTH does not match expected");
+            Assert.assertEquals(observedMetrics.MEAN_UMI_LENGTH, expectedMetrics.MEAN_UMI_LENGTH, "UMI_LENGTH does not match expected");
             Assert.assertEquals(observedMetrics.OBSERVED_UNIQUE_UMIS, expectedMetrics.OBSERVED_UNIQUE_UMIS, "OBSERVED_UNIQUE_UMIS does not match expected");
             Assert.assertEquals(observedMetrics.INFERRED_UNIQUE_UMIS, expectedMetrics.INFERRED_UNIQUE_UMIS, "INFERRED_UNIQUE_UMIS does not match expected");
             Assert.assertEquals(observedMetrics.OBSERVED_BASE_ERRORS, expectedMetrics.OBSERVED_BASE_ERRORS, "OBSERVED_BASE_ERRORS does not match expected");
-            Assert.assertEquals(observedMetrics.DUPLICATE_SETS_IGNORING_UMI, expectedMetrics.DUPLICATE_SETS_IGNORING_UMI, "DUPLICATE_SETS_WITHOUT_UMI does not match expected");
+            Assert.assertEquals(observedMetrics.DUPLICATE_SETS_IGNORING_UMI, expectedMetrics.DUPLICATE_SETS_IGNORING_UMI, "DUPLICATE_SETS_IGNORING_UMI does not match expected");
+            Assert.assertEquals(observedMetrics.DUPLICATE_SETS_WITH_UMI, expectedMetrics.DUPLICATE_SETS_WITH_UMI, "DUPLICATE_SETS_WITH_UMI does not match expected");
             Assert.assertEquals(observedMetrics.INFERRED_UMI_ENTROPY, expectedMetrics.INFERRED_UMI_ENTROPY, tolerance, "INFERRED_UMI_ENTROPY does not match expected");
             Assert.assertEquals(observedMetrics.OBSERVED_UMI_ENTROPY, expectedMetrics.OBSERVED_UMI_ENTROPY, tolerance, "OBSERVED_UMI_ENTROPY does not match expected");
             Assert.assertEquals(observedMetrics.UMI_BASE_QUALITIES, expectedMetrics.UMI_BASE_QUALITIES, tolerance, "UMI_BASE_QUALITIES does not match expected");

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
@@ -27,9 +27,14 @@ package picard.sam.markduplicates;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.metrics.MetricsFile;
 import org.testng.Assert;
 import picard.cmdline.CommandLineProgram;
+import picard.sam.UmiMetrics;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.util.List;
 
 /**
@@ -42,6 +47,8 @@ import java.util.List;
 public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDuplicatesCommandLineProgramTester {
     private int readNameCounter = 0;
     private List<String> expectedAssignedUmis;
+    private UmiMetrics expectedMetrics;
+    private File umiMetricsFile;
 
     // This tag is only used for testing, it indicates what we expect to see in the inferred UMI tag.
     private final String expectedUmiTag = "RE";
@@ -54,6 +61,9 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
     }
 
     UmiAwareMarkDuplicatesWithMateCigarTester(final boolean allowMissingUmis) {
+        umiMetricsFile = new File(getOutputDir(), "umi_metrics.txt");
+        addArg("UMI_METRICS_FILE=" + umiMetricsFile);
+
         if (allowMissingUmis) {
             addArg("ALLOW_MISSING_UMIS=" + true);
         }
@@ -146,6 +156,11 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
         return this;
     }
 
+    UmiAwareMarkDuplicatesWithMateCigarTester setExpectedMetrics(final UmiMetrics expectedMetrics) {
+        this.expectedMetrics = expectedMetrics;
+        return this;
+    }
+
     @Override
     public void test() {
         final SamReader reader = SamReaderFactory.makeDefault().open(getOutput());
@@ -155,6 +170,31 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
                 Assert.assertEquals(record.getAttribute("MI"), record.getAttribute(expectedUmiTag));
             }
         }
+
+        if(expectedMetrics != null) {
+            // Check the values written to metrics.txt against our input expectations
+            final MetricsFile<UmiMetrics, Comparable<?>> metricsOutput = new MetricsFile<UmiMetrics, Comparable<?>>();
+            try{
+                metricsOutput.read(new FileReader(umiMetricsFile));
+            }
+            catch (final FileNotFoundException ex) {
+                System.err.println("Metrics file not found: " + ex);
+            }
+            double tolerance = 1e-6;
+            Assert.assertEquals(metricsOutput.getMetrics().size(), 1);
+            final UmiMetrics observedMetrics = metricsOutput.getMetrics().get(0);
+            Assert.assertEquals(observedMetrics.UMI_LENGTH, expectedMetrics.UMI_LENGTH, "UMI_LENGTH does not match expected");
+            Assert.assertEquals(observedMetrics.OBSERVED_UNIQUE_UMIS, expectedMetrics.OBSERVED_UNIQUE_UMIS, "OBSERVED_UNIQUE_UMIS does not match expected");
+            Assert.assertEquals(observedMetrics.INFERRED_UNIQUE_UMIS, expectedMetrics.INFERRED_UNIQUE_UMIS, "INFERRED_UNIQUE_UMIS does not match expected");
+            Assert.assertEquals(observedMetrics.OBSERVED_BASE_ERRORS, expectedMetrics.OBSERVED_BASE_ERRORS, "OBSERVED_BASE_ERRORS does not match expected");
+            Assert.assertEquals(observedMetrics.DUPLICATE_SETS_WITHOUT_UMI, expectedMetrics.DUPLICATE_SETS_WITHOUT_UMI, "DUPLICATE_SETS_WITHOUT_UMI does not match expected");
+            Assert.assertEquals(observedMetrics.EFFECTIVE_LENGTH_OF_INFERRED_UMIS, expectedMetrics.EFFECTIVE_LENGTH_OF_INFERRED_UMIS, tolerance, "EFFECTIVE_LENGTH_OF_INFERRED_UMIS does not match expected");
+            Assert.assertEquals(observedMetrics.EFFECTIVE_LENGTH_OF_OBSERVED_UMIS, expectedMetrics.EFFECTIVE_LENGTH_OF_OBSERVED_UMIS, tolerance, "EFFECTIVE_LENGTH_OF_OBSERVED_UMIS does not match expected");
+            Assert.assertEquals(observedMetrics.ESTIMATED_BASE_QUALITY_OF_UMIS, expectedMetrics.ESTIMATED_BASE_QUALITY_OF_UMIS, tolerance, "ESTIMATED_BASE_QUALITY_OF_UMIS does not match expected");
+            Assert.assertEquals(observedMetrics.EXPECTED_READS_WITH_UMI_COLLISION, expectedMetrics.EXPECTED_READS_WITH_UMI_COLLISION, tolerance, "EXPECTED_READS_WITH_UMI_COLLISION does not match expected");
+            Assert.assertEquals(observedMetrics.UMI_COLLISION_Q, expectedMetrics.UMI_COLLISION_Q, tolerance, "UMI_COLLISION_Q does not match expected");
+        }
+
         // Also do tests from AbstractMarkDuplicatesCommandLineProgramTester
         super.test();
     }


### PR DESCRIPTION
### Description

This PR adds several metrics to UmiAwareMarkDuplicatesWithMateCigar.

These metrics will provide users concise statistics about the UMIs in their data.

The metrics added include:
UMI_LENGTH - the length of the UMIs in bases
OBSERVED_UNIQUE_UMIS - the number of observed UMIs in the deduplicated bam
INFERRED_UNIQUE_UMIS - the number of UMIs observed in the deduplicated bam after error correction
DUPLICATE_SETS_WITHOUT_UMI - the number of duplicate sets that would be identified without using UMIs
DUPLICATE_SETS_WITH_UMI - the number of duplicate sets identified by taking the UMIs into account
INFERRED_UMI_ENTROPY - entropy of inferred (error corrected) UMIs in base 4
OBSERVED_UMI_ENTROPY - entropy of all observed UMIs in base 4
UMI_BASE_QUALITIES - Phred scaled estimate of base qualities in UMIs.
UMI_COLLISION_EST - Estimate of the number of read pairs in the bam that are incorrectly labeled as belonging to the same duplicate set
UMI_COLLISION_Q - Phred scaled estimate of the probability a given read will have the same UMI as another read with the same start and stop position, but having come from a different original molecule

The reason for this PR is to provide users with metrics associated with UMIs.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [x] Final thumbs-up from reviewer
- [x] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

