### PR TITLE
Must use a RIBOSOMAL_INTERVALS file if RRNA_FRAGMENT_PERCENTAGE = 0.0

### DIFF
--- a/src/main/java/picard/analysis/CollectRnaSeqMetrics.java
+++ b/src/main/java/picard/analysis/CollectRnaSeqMetrics.java
@@ -135,6 +135,15 @@ static final String USAGE_DETAILS = "<p>This tool takes a SAM/BAM file containin
     }
 
     @Override
+    protected String[] customCommandLineValidation() {
+        // No ribosomal intervals file and rRNA fragment percentage = 0
+        if ( RIBOSOMAL_INTERVALS == null && RRNA_FRAGMENT_PERCENTAGE == 0 ) {
+            throw new PicardException("Must use a RIBOSOMAL_INTERVALS file if RRNA_FRAGMENT_PERCENTAGE = 0.0");
+        }
+        return super.customCommandLineValidation();
+    }
+
+    @Override
     protected void setup(final SAMFileHeader header, final File samFile) {
 
         if (CHART_OUTPUT != null) IOUtil.assertFileIsWritable(CHART_OUTPUT);
@@ -143,7 +152,7 @@ static final String USAGE_DETAILS = "<p>This tool takes a SAM/BAM file containin
         LOG.info("Loaded " + geneOverlapDetector.getAll().size() + " genes.");
 
         final Long ribosomalBasesInitialValue = RIBOSOMAL_INTERVALS != null ? 0L : null;
-        final OverlapDetector<Interval> ribosomalSequenceOverlapDetector = RnaSeqMetricsCollector.makeOverlapDetector(samFile, header, RIBOSOMAL_INTERVALS);
+        final OverlapDetector<Interval> ribosomalSequenceOverlapDetector = RnaSeqMetricsCollector.makeOverlapDetector(samFile, header, RIBOSOMAL_INTERVALS, LOG);
 
         final HashSet<Integer> ignoredSequenceIndices = RnaSeqMetricsCollector.makeIgnoredSequenceIndicesSet(header, IGNORE_SEQUENCE);
 

--- a/src/main/java/picard/analysis/directed/RnaSeqMetricsCollector.java
+++ b/src/main/java/picard/analysis/directed/RnaSeqMetricsCollector.java
@@ -6,6 +6,7 @@ import htsjdk.samtools.util.CoordMath;
 import htsjdk.samtools.util.Histogram;
 import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.IntervalList;
+import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.OverlapDetector;
 import htsjdk.samtools.util.SequenceUtil;
 import picard.PicardException;
@@ -60,12 +61,15 @@ public class RnaSeqMetricsCollector extends SAMRecordMultiLevelCollector<RnaSeqM
         return new PerUnitRnaSeqMetricsCollector(sample, library, readGroup, ribosomalInitialValue);
     }
 
-    public static OverlapDetector<Interval> makeOverlapDetector(final File samFile, final SAMFileHeader header, final File ribosomalIntervalsFile) {
+    public static OverlapDetector<Interval> makeOverlapDetector(final File samFile, final SAMFileHeader header, final File ribosomalIntervalsFile, final Log log) {
 
-        OverlapDetector<Interval> ribosomalSequenceOverlapDetector = new OverlapDetector<Interval>(0, 0);
+        final OverlapDetector<Interval> ribosomalSequenceOverlapDetector = new OverlapDetector<Interval>(0, 0);
         if (ribosomalIntervalsFile != null) {
 
             final IntervalList ribosomalIntervals = IntervalList.fromFile(ribosomalIntervalsFile);
+            if (ribosomalIntervals.size() == 0) {
+                log.warn("The RIBOSOMAL_INTERVALS file, " + ribosomalIntervalsFile.getAbsolutePath() + " does not contain intervals");
+            }
             try {
                 SequenceUtil.assertSequenceDictionariesEqual(header.getSequenceDictionary(), ribosomalIntervals.getHeader().getSequenceDictionary());
             } catch (SequenceUtil.SequenceListsDifferException e) {


### PR DESCRIPTION
### Description

Fixes #728 
If the RIBOSOMAL_INTERVALS option is not given and RRNA_FRAGMENT_PERCENTAGE=0, then [this if statement](https://github.com/broadinstitute/picard/blob/master/src/main/java/picard/analysis/directed/RnaSeqMetricsCollector.java#L164) is always true and [rec.getReadLength()](https://github.com/broadinstitute/picard/blob/master/src/main/java/picard/analysis/directed/RnaSeqMetricsCollector.java#L167) will throw an `NullPointerException` since there no records in the input SAM file.

Fixed by throwing and exception if `RRNA_FRAGMENT_PERCENTAGE=0` and `RIBOSOMAL_INTERVALS` is not set or the file is empty.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [X] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [X] All tests passing on Travis

#### Review
- [X] Final thumbs-up from reviewer
- [X] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

