### PR TITLE
fix createMetricsDoclet gradle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -224,10 +224,16 @@ task documentStandardOptions(type: JavaExec) {
     outputs.file standardOptionsFile
  }
 
-task createMetricsDoc(dependsOn: classes, type: Javadoc) << {
+task createMetricsDoc(dependsOn: classes, type: Javadoc) {
+    doFirst {
+        htmlDirInc.mkdirs()
+    }
+    
     source = sourceSets.main.allJava
     classpath = sourceSets.main.runtimeClasspath
-    destinationDir = htmlDirInc
+    outputs.dir(htmlDirInc)
+
+    options.destinationDirectory = htmlDirInc
     options.doclet = 'picard.util.MetricsDoclet'
     options.docletpath = sourceSets.main.runtimeClasspath.asType(List)
 }


### PR DESCRIPTION
### Description

The gradle task `createMetricsDoclet` wasn't actually doing anything.  This fixes it so that it runs and creates the appropriate html.

Fixes https://broadinstitute.atlassian.net/browse/PO-7497?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

