### PR TITLE
PO-7741, make the fiveToThree value in histogram zero if the denominator is zero

### DIFF
--- a/src/main/java/picard/analysis/directed/RnaSeqMetricsCollector.java
+++ b/src/main/java/picard/analysis/directed/RnaSeqMetricsCollector.java
@@ -380,7 +380,10 @@ public class RnaSeqMetricsCollector extends SAMRecordMultiLevelCollector<RnaSeqM
 
                     fivePrimeSkews.increment(fivePrimeCoverage / mean);
                     threePrimeSkews.increment(threePrimeCoverage / mean);
-                    fiveToThreeSkews.increment(fivePrimeCoverage / threePrimeCoverage);
+                    final double fiveToThree = (Math.abs(((double)0.0) - threePrimeCoverage) >  (double).000001)
+                            ? fivePrimeCoverage / threePrimeCoverage
+                            : (double)0.0;
+                    fiveToThreeSkews.increment(fiveToThree);
                 }
 
                 // Calculate normalized coverage vs. normalized position

--- a/src/main/java/picard/analysis/directed/RnaSeqMetricsCollector.java
+++ b/src/main/java/picard/analysis/directed/RnaSeqMetricsCollector.java
@@ -380,10 +380,7 @@ public class RnaSeqMetricsCollector extends SAMRecordMultiLevelCollector<RnaSeqM
 
                     fivePrimeSkews.increment(fivePrimeCoverage / mean);
                     threePrimeSkews.increment(threePrimeCoverage / mean);
-                    final double fiveToThree = (Math.abs(((double)0.0) - threePrimeCoverage) >  (double).000001)
-                            ? fivePrimeCoverage / threePrimeCoverage
-                            : (double)0.0;
-                    fiveToThreeSkews.increment(fiveToThree);
+                    fiveToThreeSkews.increment(MathUtil.divide(fivePrimeCoverage, threePrimeCoverage));
                 }
 
                 // Calculate normalized coverage vs. normalized position

--- a/src/main/java/picard/util/MathUtil.java
+++ b/src/main/java/picard/util/MathUtil.java
@@ -112,6 +112,18 @@ final public class MathUtil {
         return bd.doubleValue();
     }
 
+    /**
+     * Divide two Doubles but return 0.0 if the denominator is 0
+     * @param numerator dividend
+     * @param denominator divisor
+     * @return numerator/denominator unless denominator is 0, in which case returns 0
+     */
+    public static double divide(final double numerator, final double denominator) {
+        return Math.abs(0.0 - denominator) >  0.000001
+                ? numerator / denominator
+                : 0.0;
+    }
+
     /** Returns the largest value stored in the array. */
     public static double max(final double[] nums) {
         return nums[indexOfMax(nums)];

--- a/src/test/java/picard/util/MathUtilTest.java
+++ b/src/test/java/picard/util/MathUtilTest.java
@@ -83,4 +83,18 @@ public class MathUtilTest {
             Assert.assertEquals(actual[i], expected[i],"Array differ at position " +i);
         }
     }
+
+    @Test(dataProvider = "divideDoubleTestCases")
+    public void testDivideDouble (final double numerator, final double denominator, final double expected) {
+        Assert.assertEquals(MathUtil.divide(numerator, denominator), expected);
+    }
+
+    @DataProvider
+    public Object[][] divideDoubleTestCases() {
+        return new Object[][] {
+                new Object[] {15.0, 3.0, 5.0},
+                new Object[] {15.0, 0.0, 0.0}
+        };
+    }
+
 }


### PR DESCRIPTION
When the threePrimeCoverage value is 0, the median of the histogram can end up being infinity.  This change makes the result a 0 instead.

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

