### PR TITLE
- parallel map in MergableMetric fails since merge is not synchronized.

### DIFF
--- a/src/main/java/picard/analysis/MergeableMetricBase.java
+++ b/src/main/java/picard/analysis/MergeableMetricBase.java
@@ -125,7 +125,7 @@ public class MergeableMetricBase extends MetricBase {
      * @param many a Collection of MergeableMetricBase
      */
     public MergeableMetricBase merge(final Collection<? extends MergeableMetricBase> many) {
-        many.parallelStream().forEach(this::merge);
+        many.stream().forEach(this::merge);
         calculateDerivedFields();
         return this;
     }


### PR DESCRIPTION
### Description

This is kindof technical. MergableMetrics uses a parallelStream to merge a collection of MergableMetrics, this fails quite horribly in FindMendelianViolations with multiple threads. there is no reason for this as merging metrics is not typically a time-sensitive task, and so this PR changes it to a serial stream..seems to solve the problem. 


----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

