### PR TITLE
Issue #772, fix the faulty logic of IF statements for mismatch count …

### DIFF
--- a/src/main/java/picard/analysis/AlignmentSummaryMetricsCollector.java
+++ b/src/main/java/picard/analysis/AlignmentSummaryMetricsCollector.java
@@ -301,12 +301,12 @@ public class AlignmentSummaryMetricsCollector extends SAMRecordAndReferenceMulti
                             boolean mismatch = !SequenceUtil.basesEqual(readBases[readBaseIndex], refBases[refIndex+i]);
                             boolean bisulfiteBase = false;
                             if (mismatch && isBisulfiteSequenced &&
-                                    record.getReadNegativeStrandFlag() &&
+                                   ( record.getReadNegativeStrandFlag() &&
                                     (refBases[refIndex + i] == 'G' || refBases[refIndex + i] == 'g') &&
                                     (readBases[readBaseIndex] == 'A' || readBases[readBaseIndex] == 'a')
                                     || ((!record.getReadNegativeStrandFlag()) &&
                                     (refBases[refIndex + i] == 'C' || refBases[refIndex + i] == 'c') &&
-                                    (readBases[readBaseIndex] == 'T') || readBases[readBaseIndex] == 't')) {
+                                    (readBases[readBaseIndex] == 'T') || readBases[readBaseIndex] == 't'))) {
 
                                 bisulfiteBase = true;
                                 mismatch = false;


### PR DESCRIPTION
…in Alignment Metrics Analysis

### Description

change the IF statement to have right mismatch count 
----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

