### PR TITLE
Fix CollectHsMetrics and CollectTargetedPcrMetrics to correctly handle…

### DIFF
--- a/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
+++ b/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
@@ -538,7 +538,13 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
                 final int numOverlappingBasesToClip = SAMUtils.getNumOverlappingAlignedBasesToClip(record);
                 rec = SAMUtils.clipOverlappingAlignedBases(record, numOverlappingBasesToClip, noSideEffects);
                 metrics.PCT_EXC_OVERLAP += numOverlappingBasesToClip;
-            } else rec = record;
+
+                // If clipping resulted in the read becoming unmapped (because all bases were clipped), return here
+                if (rec.getReadUnmappedFlag()) return;
+            }
+            else {
+                rec = record;
+            }
 
             // Find the target overlaps
             final Set<Interval> coveredTargets = new HashSet<>();

--- a/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
+++ b/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
@@ -32,7 +32,7 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
                 // test that read 2 (with mapping quality 1) is filtered out with minimum mapping quality 2
                 {TEST_DIR + "/lowmapq.sam",     intervals, 2, 0, true,  2, 202, 0,   0.0, 0.505, 0.0,   1000},
                 // test that we clip overlapping bases
-                {TEST_DIR + "/overlapping.sam", intervals, 0, 0, true,  2, 202, 0,   0.5, 0.505, 0.505, 1000},
+                {TEST_DIR + "/overlapping.sam", intervals, 0, 0, true,  2, 202, 0,   0.5, 0.505, 0, 1000},
                 // test that we do not clip overlapping bases
                 {TEST_DIR + "/overlapping.sam", intervals, 0, 0, false, 2, 202, 0,   0.0, 0.505, 0.505, 1000},
                 // A read 10 base pairs long. two intervals: one maps identically to the read, other does not overlap at all


### PR DESCRIPTION
… read pairs that are fully overlapped when CLIP_OVERLAPPING_READS=true.

### Description

We noticed a significant discrepancy between running CollectHsMetrics on an aligned BAM file, and the same BAM file after running it through fgbio's ClipOverlappingReads.  The results are expected to be the same, but mean target coverage was different by ~10% on the sample I was looking at.  I've diagnosed the problem - it's that a) the clipping code in HTSJDK sets reads to be unmapped but doesn't otherwise alter them if the request is to clip the entire read and b) TargetMetricsCollector never re-checks the the unmapped flag, and since the cigar and position are left on the read, it consumes the all the bases from these reads where it should consume none.

I've added a re-check of whether the read is unmapped and fixed the test that should have caught this in the first place.

### Checklist (never delete this)

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests