### PR TITLE
Fix in GenotypeConcordance for writing VCFs with no-call genotypes

### DIFF
--- a/src/main/java/picard/vcf/GenotypeConcordance.java
+++ b/src/main/java/picard/vcf/GenotypeConcordance.java
@@ -432,9 +432,18 @@ public class GenotypeConcordance extends CommandLineProgram {
             final List<Allele> truthAlleles = alleles.truthAlleles();
             final List<Allele> callAlleles  = alleles.callAlleles();
 
+            // Get the alleles present at this site for both samples to use for the output variant context.
+            final Set<Allele> siteAlleles = new HashSet<>();
+            if (truthContext != null) {
+                siteAlleles.addAll(truthContext.getAlleles());
+            }
+            if (callContext != null) {
+                siteAlleles.addAll(callContext.getAlleles());
+            }
+
             // Initialize the variant context builder
             final VariantContext initialContext = (callContext == null) ? truthContext : callContext;
-            builder = new VariantContextBuilder(initialContext.getSource(), initialContext.getContig(), initialContext.getStart(), initialContext.getEnd(), Collections.emptyList());
+            builder = new VariantContextBuilder(initialContext.getSource(), initialContext.getContig(), initialContext.getStart(), initialContext.getEnd(), siteAlleles);
             builder.computeEndFromAlleles(allAlleles, initialContext.getStart());
             builder.log10PError(initialContext.getLog10PError());
 
@@ -443,7 +452,7 @@ public class GenotypeConcordance extends CommandLineProgram {
             addToGenotypes(genotypes, callContext, CALL_SAMPLE, OUTPUT_VCF_CALL_SAMPLE_NAME, allAlleles, callAlleles, false);
 
             // set the alleles and genotypes
-            builder.alleles(alleles.allAlleles).genotypes(genotypes);
+            builder.genotypes(genotypes);
 
             // set the concordance state attribute
             final TruthAndCallStates state = GenotypeConcordance.determineState(truthContext, TRUTH_SAMPLE, callContext, CALL_SAMPLE, MIN_GQ, MIN_DP);

--- a/src/test/java/picard/vcf/GenotypeConcordanceTest.java
+++ b/src/test/java/picard/vcf/GenotypeConcordanceTest.java
@@ -559,4 +559,17 @@ public class GenotypeConcordanceTest {
         truthReader.close();
         callReader.close();
     }
+
+    @Test
+    public void testNoCallVariants() {
+        final GenotypeConcordance genotypeConcordance = new GenotypeConcordance();
+        genotypeConcordance.TRUTH_VCF = new File(TEST_DATA_PATH, "mini.vcf");
+        genotypeConcordance.TRUTH_SAMPLE = "NA20801";
+        genotypeConcordance.CALL_VCF = new File(TEST_DATA_PATH, "mini.vcf");
+        genotypeConcordance.CALL_SAMPLE = "NA19920";
+        genotypeConcordance.OUTPUT = new File(OUTPUT_DATA_PATH, "TwoNoCalls");
+        genotypeConcordance.OUTPUT_VCF = true;
+
+        Assert.assertEquals(genotypeConcordance.instanceMain(new String[0]), 0);
+    }
 }


### PR DESCRIPTION
### Description

This addresses #768. If the truth or call VCF has a no call genotype, GenotypeConcordance can still calculate the metrics, but breaks if you try to write a new VCF. This fixes the variant context that is written, to get the allele from the site rather than the genotypes.
----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

