### PR TITLE
Adding custom adapter pairs to IlluminaBasecallsToSam

### DIFF
--- a/src/main/java/picard/illumina/ClusterDataToSamConverter.java
+++ b/src/main/java/picard/illumina/ClusterDataToSamConverter.java
@@ -89,7 +89,7 @@ public class ClusterDataToSamConverter implements
     public ClusterDataToSamConverter(final String runBarcode,
                                      final String readGroupId,
                                      final ReadStructure readStructure,
-                                     final List<IlluminaUtil.IlluminaAdapterPair> adapters) {
+                                     final List<AdapterPair> adapters) {
         this.readGroupId = readGroupId;
         
         this.readNameEncoder = new IlluminaReadNameEncoder(runBarcode);

--- a/src/main/java/picard/illumina/CustomAdapterPair.java
+++ b/src/main/java/picard/illumina/CustomAdapterPair.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.illumina;
+
+import htsjdk.samtools.util.SequenceUtil;
+import htsjdk.samtools.util.StringUtil;
+import picard.util.AdapterPair;
+
+class CustomAdapterPair implements AdapterPair {
+
+    private final String fivePrime, threePrime, fivePrimeReadOrder;
+    private final byte[] fivePrimeBytes, threePrimeBytes, fivePrimeReadOrderBytes;
+
+    CustomAdapterPair(final String fivePrime, final String threePrime) {
+        this.threePrime = threePrime;
+        this.threePrimeBytes = StringUtil.stringToBytes(threePrime);
+
+        this.fivePrime = fivePrime;
+        this.fivePrimeReadOrder = SequenceUtil.reverseComplement(fivePrime);
+        this.fivePrimeBytes = StringUtil.stringToBytes(fivePrime);
+        this.fivePrimeReadOrderBytes = StringUtil.stringToBytes(fivePrimeReadOrder);
+    }
+
+    public String get3PrimeAdapter() { return threePrime; }
+
+    public String get5PrimeAdapter() { return fivePrime; }
+
+    public String get3PrimeAdapterInReadOrder() { return threePrime; }
+
+    public String get5PrimeAdapterInReadOrder() { return fivePrimeReadOrder; }
+
+    public byte[] get3PrimeAdapterBytes() { return threePrimeBytes; }
+
+    public byte[] get5PrimeAdapterBytes() { return fivePrimeBytes; }
+
+    public byte[] get3PrimeAdapterBytesInReadOrder() { return threePrimeBytes; }
+
+    public byte[] get5PrimeAdapterBytesInReadOrder() { return fivePrimeReadOrderBytes; }
+
+    public String getName() { return "Custom adapter pair"; }
+}

--- a/src/main/java/picard/illumina/IlluminaBasecallsToFastq.java
+++ b/src/main/java/picard/illumina/IlluminaBasecallsToFastq.java
@@ -150,12 +150,9 @@ public class IlluminaBasecallsToFastq extends CommandLineProgram {
             mutex = {"OUTPUT_PREFIX"})
     public File MULTIPLEX_PARAMS;
 
-    @Option(doc = "Which adapters to look for in the read.")
-    public List<IlluminaUtil.IlluminaAdapterPair> ADAPTERS_TO_CHECK = new ArrayList<>(
-            Arrays.asList(IlluminaUtil.IlluminaAdapterPair.INDEXED,
-                    IlluminaUtil.IlluminaAdapterPair.DUAL_INDEXED,
-                    IlluminaUtil.IlluminaAdapterPair.NEXTERA_V2,
-                    IlluminaUtil.IlluminaAdapterPair.FLUIDIGM));
+    @Deprecated
+    @Option(doc = "Deprecated (No longer used). Which adapters to look for in the read.")
+    public List<IlluminaUtil.IlluminaAdapterPair> ADAPTERS_TO_CHECK = null;
 
     @Option(doc = "The number of threads to run in parallel. If NUM_PROCESSORS = 0, number of cores is automatically set to " +
             "the number of cores available on the machine. If NUM_PROCESSORS < 0, then the number of cores used will" +
@@ -232,6 +229,10 @@ public class IlluminaBasecallsToFastq extends CommandLineProgram {
 
         if (READ_NAME_FORMAT == ReadNameFormat.CASAVA_1_8 && FLOWCELL_BARCODE == null) {
             errors.add("FLOWCELL_BARCODE is required when using Casava1.8-style read name headers.");
+        }
+
+        if (ADAPTERS_TO_CHECK != null) {
+            log.warn("ADAPTERS_TO_CHECK is not used");
         }
         
         if (errors.isEmpty()) {

--- a/src/main/java/picard/illumina/MarkIlluminaAdapters.java
+++ b/src/main/java/picard/illumina/MarkIlluminaAdapters.java
@@ -146,7 +146,7 @@ public class MarkIlluminaAdapters extends CommandLineProgram {
     @Override
     protected String[] customCommandLineValidation() {
         if ((FIVE_PRIME_ADAPTER != null && THREE_PRIME_ADAPTER == null) || (THREE_PRIME_ADAPTER != null && FIVE_PRIME_ADAPTER == null)) {
-            return new String[]{"Either both or neither of THREE_PRIME_ADAPTER and FIVE_PRIME_ADAPTER must be set."};
+            return new String[]{"THREE_PRIME_ADAPTER and FIVE_PRIME_ADAPTER must either both be null or both be set."};
         } else {
             return null;
         }
@@ -250,39 +250,5 @@ public class MarkIlluminaAdapters extends CommandLineProgram {
 
         CloserUtil.close(in);
         return 0;
-    }
-
-    private final class CustomAdapterPair implements AdapterPair {
-
-        final String fivePrime, threePrime, fivePrimeReadOrder;
-        final byte[] fivePrimeBytes, threePrimeBytes, fivePrimeReadOrderBytes;
-
-        private CustomAdapterPair(final String fivePrime, final String threePrime) {
-            this.threePrime = threePrime;
-            this.threePrimeBytes = StringUtil.stringToBytes(threePrime);
-
-            this.fivePrime = fivePrime;
-            this.fivePrimeReadOrder = SequenceUtil.reverseComplement(fivePrime);
-            this.fivePrimeBytes = StringUtil.stringToBytes(fivePrime);
-            this.fivePrimeReadOrderBytes = StringUtil.stringToBytes(fivePrimeReadOrder);
-        }
-
-        public String get3PrimeAdapter() { return threePrime; }
-
-        public String get5PrimeAdapter() { return fivePrime; }
-
-        public String get3PrimeAdapterInReadOrder() { return threePrime; }
-
-        public String get5PrimeAdapterInReadOrder() { return fivePrimeReadOrder; }
-
-        public byte[] get3PrimeAdapterBytes() { return threePrimeBytes; }
-
-        public byte[] get5PrimeAdapterBytes() { return fivePrimeBytes; }
-
-        public byte[] get3PrimeAdapterBytesInReadOrder() { return threePrimeBytes; }
-
-        public byte[] get5PrimeAdapterBytesInReadOrder() { return fivePrimeReadOrderBytes; }
-
-        public String getName() { return "Custom adapter pair"; }
     }
 }


### PR DESCRIPTION
See discussion https://github.com/broadinstitute/picard/issues/790

Majority of the code lifted over from `MarkIlluminaAdapters`.  Other custom adapter marking options, by way of consensus, have not been lifted over.

@yfarjoun care to take a look?