### PR TITLE
Shl doc update description of Picard haplotype_map option

### DIFF
--- a/src/main/java/picard/fingerprint/CheckFingerprint.java
+++ b/src/main/java/picard/fingerprint/CheckFingerprint.java
@@ -103,7 +103,7 @@ public class CheckFingerprint extends CommandLineProgram {
             "(VCF or BAM read group header) will be used.")
     public String EXPECTED_SAMPLE_ALIAS;
 
-    @Option(shortName="H", doc = "File that maps SNPs to blocks in high LD. See " +
+    @Option(shortName="H", doc = "The file lists a set of SNPs, optionally arranged in high-LD blocks, to be used for fingerprinting. See " +          
             "https://software.broadinstitute.org/gatk/documentation/article?id=9526 for details.")
     public File HAPLOTYPE_MAP;
 

--- a/src/main/java/picard/fingerprint/CheckFingerprint.java
+++ b/src/main/java/picard/fingerprint/CheckFingerprint.java
@@ -103,7 +103,8 @@ public class CheckFingerprint extends CommandLineProgram {
             "(VCF or BAM read group header) will be used.")
     public String EXPECTED_SAMPLE_ALIAS;
 
-    @Option(shortName="H", doc = "A file of haplotype information produced by the CheckFingerprint program.")
+    @Option(shortName="H", doc = "File that maps SNPs to blocks in high LD. See " +
+            "https://software.broadinstitute.org/gatk/documentation/article?id=9526 for details.")
     public File HAPLOTYPE_MAP;
 
     @Option(shortName="LOD", doc = "When counting haplotypes checked and matching, count only haplotypes " +

--- a/src/main/java/picard/fingerprint/CrosscheckReadGroupFingerprints.java
+++ b/src/main/java/picard/fingerprint/CrosscheckReadGroupFingerprints.java
@@ -62,7 +62,7 @@ public class CrosscheckReadGroupFingerprints extends CommandLineProgram {
             doc="Optional output file to write metrics to. Default is to write to stdout.")
     public File OUTPUT;
 
-    @Option(shortName="H", doc="File that maps SNPs to blocks in high LD. See " +
+    @Option(shortName="H", doc="The file lists a set of SNPs, optionally arranged in high-LD blocks, to be used for fingerprinting. See " +
 	    "https://software.broadinstitute.org/gatk/documentation/article?id=9526 for details.")
     public File HAPLOTYPE_MAP;
 

--- a/src/main/java/picard/fingerprint/CrosscheckReadGroupFingerprints.java
+++ b/src/main/java/picard/fingerprint/CrosscheckReadGroupFingerprints.java
@@ -62,7 +62,8 @@ public class CrosscheckReadGroupFingerprints extends CommandLineProgram {
             doc="Optional output file to write metrics to. Default is to write to stdout.")
     public File OUTPUT;
 
-    @Option(shortName="H", doc="The file of haplotype data to use to pick SNPs to fingerprint")
+    @Option(shortName="H", doc="File that maps SNPs to blocks in high LD. See " +
+	    "https://software.broadinstitute.org/gatk/documentation/article?id=9526 for details.")
     public File HAPLOTYPE_MAP;
 
     @Option(shortName="LOD",


### PR DESCRIPTION
Two tools that are currently available have discordant descriptions for this option and one description refers to the option as an output instead of an input. #783 describes the discordance. I also wrote up a GATK article to better describe the format, including a format that the next release of Picard should allow (VCF). The article is public [here](http://gatkforums.broadinstitute.org/dsde/discussion/9526).

#### The option descriptions are now identical, accurate and point to the webpage detailing the formats.

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

