### PR TITLE
Overflow in TargetMetricsCollector.Coverage

### DIFF
--- a/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
+++ b/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
@@ -908,9 +908,11 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
         /** Gets the coverage depths as an array of ints. */
         public int[] getDepths() { return this.depths; }
 
-        public int getTotal() {
-            int total = 0;
-            for (int i=0; i<depths.length; ++i) total += depths[i];
+        public long getTotal() {
+            long total = 0;
+            for (int i=0; i<depths.length; ++i) {
+                total += (total < Long.MAX_VALUE - depths[i]) ? depths[i] : Long.MAX_VALUE - total;
+            }
             return total;
         }
 

--- a/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
+++ b/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
@@ -880,8 +880,13 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
 
         /** Adds a single point of depth at the desired offset into the coverage array. */
         public void addBase(final int offset) {
-            if (offset >= 0 && offset < this.depths.length && this.depths[offset] < Integer.MAX_VALUE) {
-                this.depths[offset] += 1;
+            addBase(offset, 1);
+        }
+
+        /** Adds some depth at the desired offset into the coverage array. */
+        public void addBase(final int offset, final int depth) {
+            if (offset >= 0 && offset < this.depths.length && this.depths[offset] < Integer.MAX_VALUE - depth) {
+                this.depths[offset] += depth;
             }
         }
 

--- a/src/test/java/picard/analysis/directed/CollectTargetedMetricsTest.java
+++ b/src/test/java/picard/analysis/directed/CollectTargetedMetricsTest.java
@@ -9,6 +9,7 @@ import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecordSetBuilder;
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.util.Histogram;
+import htsjdk.samtools.util.Interval;
 import htsjdk.variant.utils.SAMSequenceDictionaryExtractor;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
@@ -194,4 +195,13 @@ public class CollectTargetedMetricsTest extends CommandLineProgramTest {
         Assert.assertTrue(TestNGUtil.compareDoubleWithAccuracy(histogram.get(33).getValue(), 10D, 0.01));
     }
 
+    @Test
+    public void testCoverageGetTotalOverflow() {
+        final Interval interval = new Interval("chr1", 1, 2);
+        final TargetMetricsCollector.Coverage coverage = new TargetMetricsCollector.Coverage(interval, 0);
+        for (int offset = 0; offset <= interval.length(); offset++) {
+            coverage.addBase(offset, Integer.MAX_VALUE - 1);
+        }
+        Assert.assertEquals((long)coverage.getTotal(), 2 * (long)(Integer.MAX_VALUE - 1));
+    }
 }


### PR DESCRIPTION
This affects `CollectHsMetrics`, `CollectTargetedMetrics`, and `CollectTargetedPcrMetrics`.  

I have included a test that fails, and then the bugfix. 

The depths per-base for a target is stored as an `int`, but the `total depth` across all bases as a target is returned as an `int`, which for very high (think 20M reads over a short target) coverage, can cause the total to overflow. 