### PR TITLE
Yf rev  htsjdk

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ jacoco {
     toolVersion = "0.7.5.201505241946"
 }
 
-final htsjdkVersion = System.getProperty('htsjdk.version', '2.9.0')
+final htsjdkVersion = System.getProperty('htsjdk.version', '2.9.1')
 
 dependencies {
     compile 'com.google.guava:guava:15.0'

--- a/src/test/java/picard/util/FifoBufferTest.java
+++ b/src/test/java/picard/util/FifoBufferTest.java
@@ -57,8 +57,8 @@ public class FifoBufferTest {
         }
 
         // Run the input file through the FifoBuffer and back into another file
-        final Md5CalculatingInputStream in   = new Md5CalculatingInputStream(new FileInputStream(inputFile), null);
-        final Md5CalculatingOutputStream out = new Md5CalculatingOutputStream(new FileOutputStream("/dev/null"), null);
+        final Md5CalculatingInputStream in   = new Md5CalculatingInputStream(new FileInputStream(inputFile), (File)null);
+        final Md5CalculatingOutputStream out = new Md5CalculatingOutputStream(new FileOutputStream("/dev/null"), (File)null);
         final PrintStream outStream = new PrintStream(out);
         final FifoBuffer buffer = new FifoBuffer(in, outStream);
         buffer.BUFFER_SIZE = 128 * 1024 * 1024;


### PR DESCRIPTION
This brings picard to htsjdk 2.9.1 and fixes a small ambiguity in a constructor in one of the tests.

