### PR TITLE
Fixed MergeBamAlignment/AbstractAlignmentMerger to use actual max rec…

### DIFF
--- a/src/main/java/picard/sam/AbstractAlignmentMerger.java
+++ b/src/main/java/picard/sam/AbstractAlignmentMerger.java
@@ -365,7 +365,7 @@ public abstract class AbstractAlignmentMerger {
         if (this.sortOrder == SortOrder.coordinate) {
             final SortingCollection<SAMRecord> sorted1 = SortingCollection.newInstance(
                     SAMRecord.class, new BAMRecordCodec(header), new SAMRecordCoordinateComparator(),
-                    MAX_RECORDS_IN_RAM);
+                    this.maxRecordsInRam);
             sink = new Sink(sorted1);
         }
         else { // catches queryname and unsorted


### PR DESCRIPTION
…ords in ram instead of hard-coded constant.

### Description

`MergeBamAlignment` calls `AbstractAlignmentMerger.setMaxRecordInRam`, but the value is ignored and the hard-coded constant/default value used instead.  This PR fixes that.
----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

