### PR TITLE
Clarify NEAR_DISTANCE parameter doesn't apply to target intervals

### DIFF
--- a/src/main/java/picard/analysis/directed/CollectTargetedMetrics.java
+++ b/src/main/java/picard/analysis/directed/CollectTargetedMetrics.java
@@ -80,7 +80,7 @@ public abstract class CollectTargetedMetrics<METRIC extends MultilevelMetrics, C
     public File PER_BASE_COVERAGE;
 
     @Option(optional = true, doc= "The maximum distance between a read and the nearest probe/bait/amplicon for the read to be " +
-            "considered 'near probe' and included in percent selected.")
+            "considered 'near probe' and included in percent selected. Not applied to the target intervals.")
     public int NEAR_DISTANCE = TargetedPcrMetricsCollector.NEAR_PROBE_DISTANCE_DEFAULT;
 
     @Option(shortName = MINIMUM_MAPPING_QUALITY_SHORT_NAME, doc = "Minimum mapping quality for a read to contribute coverage.", overridable = true)


### PR DESCRIPTION
Based on user confusion in https://github.com/broadinstitute/dsde-docs/issues/2144
Update to documentation.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

