### PR TITLE
PO-8928: Don't calculate improper pair metrics on unpaired reads

### DIFF
--- a/src/main/java/picard/analysis/AlignmentSummaryMetricsCollector.java
+++ b/src/main/java/picard/analysis/AlignmentSummaryMetricsCollector.java
@@ -240,7 +240,7 @@ public class AlignmentSummaryMetricsCollector extends SAMRecordAndReferenceMulti
                         }
                     } else if(doRefMetrics) {
                         metrics.PF_READS_ALIGNED++;
-                        if (!record.getProperPairFlag()) metrics.PF_READS_IMPROPER_PAIRS++;
+                        if (record.getReadPairedFlag() && !record.getProperPairFlag()) metrics.PF_READS_IMPROPER_PAIRS++;
                         if (!record.getReadNegativeStrandFlag()) numPositiveStrand++;
                         if (record.getReadPairedFlag() && !record.getMateUnmappedFlag()) {
                             metrics.READS_ALIGNED_IN_PAIRS++;


### PR DESCRIPTION
### Description

CollectAlignmentSummaryMetrics fails with this exception when run on data that includes unpaired reads:

  Exception in thread "main" java.lang.IllegalStateException: Inappropriate call if not paired read

This fix checks that each read is paired before trying to check the proper pair flag.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

