### PR TITLE
Small documentation update to BedToIntervalList.

### DIFF
--- a/src/main/java/picard/util/BedToIntervalList.java
+++ b/src/main/java/picard/util/BedToIntervalList.java
@@ -64,9 +64,16 @@ public class BedToIntervalList extends CommandLineProgram {
             "     -Strand - Indicates +/- strand for the interval (either + or -) <br /> " +
             "     -Interval name - (Each interval should have a unique name) " +
             "</pre>" +
-            "  <br /><br />" +
-            "This tool requires sequence dictionary file (with \".dict\" extension), which can be created from a reference sequence " +
-            "using Picard's CreateSequenceDictionary tool."+
+            "<br/>" +
+            "This tool requires sequence dictionary, provided with the SEQUENCE_DICTIONARY or SD argument. " +
+            "This argument can be any of:" +
+            "<pre>" +
+            "    - A file with .dict extension generated using Picard's CreateSequenceDictionaryTool</br>" +
+            "    - A <name>.fa or <name>.fasta file with a <name>.dict in the same directory</br>" +
+            "    - Another IntervalList that contains the dictionary to use</br>" +
+            "    - A VCF that contains #contig lines from which to generate a sequence dictionary</br>" +
+            "    - A SAM or BAM file with @SQ lines in the header from which to create a dictionary</br>" +
+            "</pre>" +
             "<h4>Usage example:</h4>" +
             "<pre>" +
             "java -jar picard.jar BedToIntervalList \\<br />" +
@@ -80,7 +87,8 @@ public class BedToIntervalList extends CommandLineProgram {
     @Option(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "The input BED file")
     public File INPUT;
 
-    @Option(shortName = StandardOptionDefinitions.SEQUENCE_DICTIONARY_SHORT_NAME, doc = "The sequence dictionary")
+    @Option(shortName = StandardOptionDefinitions.SEQUENCE_DICTIONARY_SHORT_NAME,
+            doc = "The sequence dictionary, or BAM/VCF/IntervalList from which a dictionary can be extracted.")
     public File SEQUENCE_DICTIONARY;
 
     @Option(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "The output Picard Interval List")

--- a/src/main/java/picard/util/BedToIntervalList.java
+++ b/src/main/java/picard/util/BedToIntervalList.java
@@ -65,14 +65,14 @@ public class BedToIntervalList extends CommandLineProgram {
             "     -Interval name - (Each interval should have a unique name) " +
             "</pre>" +
             "<br/>" +
-            "This tool requires sequence dictionary, provided with the SEQUENCE_DICTIONARY or SD argument. " +
-            "This argument can be any of:" +
+            "This tool requires a sequence dictionary, provided with the SEQUENCE_DICTIONARY or SD argument. " +
+            "The value given to this argument can be any of the following:" +
             "<pre>" +
             "    - A file with .dict extension generated using Picard's CreateSequenceDictionaryTool</br>" +
-            "    - A <name>.fa or <name>.fasta file with a <name>.dict in the same directory</br>" +
-            "    - Another IntervalList that contains the dictionary to use</br>" +
+            "    - A reference.fa or reference.fasta file with a reference.dict in the same directory</br>" +
+            "    - Another IntervalList with @SQ lines in the header from which to generate a dictionary</br>" +
             "    - A VCF that contains #contig lines from which to generate a sequence dictionary</br>" +
-            "    - A SAM or BAM file with @SQ lines in the header from which to create a dictionary</br>" +
+            "    - A SAM or BAM file with @SQ lines in the header from which to generate a dictionary</br>" +
             "</pre>" +
             "<h4>Usage example:</h4>" +
             "<pre>" +


### PR DESCRIPTION
### Description

Small documentation update to make it clear that the `SD` argument can take one of many files from which a dictionary can be extracted.  Since this capability is there, it would be nice to have it documented.

----

### Checklist (never delete this)

- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

