### PR TITLE
DSDEGP-454 Enable the IntelDeflater by default in all invocations of Picard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ report
 jacoco.data
 .gradle
 build
-*.bai

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ report
 jacoco.data
 .gradle
 build
+*.bai

--- a/build.gradle
+++ b/build.gradle
@@ -50,12 +50,21 @@ jacoco {
 final htsjdkVersion = System.getProperty('htsjdk.version', '2.10.1')
 
 dependencies {
-    compile 'com.intel.gkl:gkl:0.5.2'
+    compile('com.intel.gkl:gkl:0.5.2') {
+        exclude module: 'htsjdk'
+    }
     compile 'com.google.guava:guava:15.0'
     compile 'com.github.samtools:htsjdk:' + htsjdkVersion
     //tools dependency for doclet requires sdk devel
     compile(files(((URLClassLoader) ToolProvider.getSystemToolClassLoader()).getURLs()))
     testCompile 'org.testng:testng:6.9.10'
+}
+
+configurations.all {
+    resolutionStrategy {
+        // force the htsjdk version so we don't get a different one transitively
+        force 'com.github.samtools:htsjdk:' + htsjdkVersion
+    }
 }
 
 sourceCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ jacoco {
 final htsjdkVersion = System.getProperty('htsjdk.version', '2.10.1')
 
 dependencies {
+    compile 'com.intel.gkl:gkl:0.5.2'
     compile 'com.google.guava:guava:15.0'
     compile 'com.github.samtools:htsjdk:' + htsjdkVersion
     //tools dependency for doclet requires sdk devel

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     //tools dependency for doclet requires sdk devel
     compile(files(((URLClassLoader) ToolProvider.getSystemToolClassLoader()).getURLs()))
     testCompile 'org.testng:testng:6.9.10'
+    testCompile 'org.apache.commons:commons-lang3:3.6'
 }
 
 configurations.all {

--- a/src/main/java/picard/cmdline/CommandLineProgram.java
+++ b/src/main/java/picard/cmdline/CommandLineProgram.java
@@ -34,7 +34,10 @@ import htsjdk.samtools.metrics.Header;
 import htsjdk.samtools.metrics.MetricBase;
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.metrics.StringHeader;
-import htsjdk.samtools.util.*;
+import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.samtools.util.BlockGunzipper;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Log;
 import htsjdk.variant.variantcontext.writer.Options;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 
@@ -85,7 +88,8 @@ public abstract class CommandLineProgram {
     public ValidationStringency VALIDATION_STRINGENCY = ValidationStringency.DEFAULT_STRINGENCY;
 
     @Option(doc = "Compression level for all compressed files created (e.g. BAM and GELI).", common=true)
-    public int COMPRESSION_LEVEL = 1; // The default IntelDeflater is slow at levels > 1
+    // The default IntelDeflater is slow at levels > 1
+    public int COMPRESSION_LEVEL = 1;
 
     @Option(doc = "When writing SAM files that need to be sorted, this will specify the number of records stored in RAM before spilling to disk. Increasing this number reduces the number of file handles needed to sort a SAM file, and increases the amount of RAM needed.", optional=true, common=true)
     public Integer MAX_RECORDS_IN_RAM = SAMFileWriterImpl.getDefaultMaxRecordsInRam();
@@ -102,10 +106,10 @@ public abstract class CommandLineProgram {
     @Option(doc="Google Genomics API client_secrets.json file path.", common = true)
     public String GA4GH_CLIENT_SECRETS="client_secrets.json";
 
-    @Option(shortName = "jdk_deflater", doc = "Use the JDK Deflater instead of the IntelDeflater for writing BAMs", common = true)
+    @Option(shortName = "use_jdk_deflater", doc = "Use the JDK Deflater instead of the IntelDeflater for writing BAMs", common = true)
     public Boolean USE_JDK_DEFLATER = false;
 
-    @Option(shortName = "jdk_inflater", doc = "Use the JDK Inflater instead of the IntelInflater for reading BAMs", common = true)
+    @Option(shortName = "use_jdk_inflater", doc = "Use the JDK Inflater instead of the IntelInflater for reading BAMs", common = true)
     public Boolean USE_JDK_INFLATER = false;
     
     private final String standardUsagePreamble = CommandLineParser.getStandardUsagePreamble(getClass());
@@ -209,7 +213,7 @@ public abstract class CommandLineProgram {
                     new Date(), System.getProperty("user.name"), InetAddress.getLocalHost().getHostName(),
                     System.getProperty("os.name"), System.getProperty("os.version"), System.getProperty("os.arch"),
                     System.getProperty("java.vm.name"), System.getProperty("java.runtime.version"),
-                    USE_JDK_DEFLATER ? "JdkDeflater" : "IntelDeflater", USE_JDK_INFLATER ? "JdkInflater" : "IntelInflater",
+                    USE_JDK_DEFLATER ? "Jdk" : "Intel", USE_JDK_INFLATER ? "Jdk" : "Intel",
                     commandLineParser.getVersion());
                 System.err.println(msg);
             }

--- a/src/main/java/picard/cmdline/CommandLineProgram.java
+++ b/src/main/java/picard/cmdline/CommandLineProgram.java
@@ -85,7 +85,7 @@ public abstract class CommandLineProgram {
     public ValidationStringency VALIDATION_STRINGENCY = ValidationStringency.DEFAULT_STRINGENCY;
 
     @Option(doc = "Compression level for all compressed files created (e.g. BAM and GELI).", common=true)
-    public int COMPRESSION_LEVEL = BlockCompressedStreamConstants.DEFAULT_COMPRESSION_LEVEL;
+    public int COMPRESSION_LEVEL = 1; // The default IntelDeflater is slow at levels > 1
 
     @Option(doc = "When writing SAM files that need to be sorted, this will specify the number of records stored in RAM before spilling to disk. Increasing this number reduces the number of file handles needed to sort a SAM file, and increases the amount of RAM needed.", optional=true, common=true)
     public Integer MAX_RECORDS_IN_RAM = SAMFileWriterImpl.getDefaultMaxRecordsInRam();

--- a/src/main/java/picard/cmdline/CommandLineProgram.java
+++ b/src/main/java/picard/cmdline/CommandLineProgram.java
@@ -107,10 +107,10 @@ public abstract class CommandLineProgram {
     @Option(doc="Google Genomics API client_secrets.json file path.", common = true)
     public String GA4GH_CLIENT_SECRETS="client_secrets.json";
 
-    @Option(shortName = "use_jdk_deflater", doc = "Use the JDK Deflater instead of the Intel Deflater for writing with BlockCompressedOutputStreams", common = true)
+    @Option(shortName = "use_jdk_deflater", doc = "Use the JDK Deflater instead of the Intel Deflater for writing compressed output", common = true)
     public Boolean USE_JDK_DEFLATER = false;
 
-    @Option(shortName = "use_jdk_inflater", doc = "Use the JDK Inflater instead of the Intel Inflater for reading with BlockGunzippers", common = true)
+    @Option(shortName = "use_jdk_inflater", doc = "Use the JDK Inflater instead of the Intel Inflater for reading compressed input", common = true)
     public Boolean USE_JDK_INFLATER = false;
     
     private final String standardUsagePreamble = CommandLineParser.getStandardUsagePreamble(getClass());
@@ -218,7 +218,7 @@ public abstract class CommandLineProgram {
                     new Date(), System.getProperty("user.name"), InetAddress.getLocalHost().getHostName(),
                     System.getProperty("os.name"), System.getProperty("os.version"), System.getProperty("os.arch"),
                     System.getProperty("java.vm.name"), System.getProperty("java.runtime.version"),
-                    usingIntelDeflater ? "Jdk" : "Intel", usingIntelInflater ? "Jdk" : "Intel",
+                    usingIntelDeflater ? "Intel" : "Jdk", usingIntelInflater ? "Intel" : "Jdk",
                     commandLineParser.getVersion());
                 System.err.println(msg);
             }

--- a/src/test/java/picard/IntelInflaterDeflaterLoadTest.java
+++ b/src/test/java/picard/IntelInflaterDeflaterLoadTest.java
@@ -1,0 +1,37 @@
+package picard;
+
+import com.intel.gkl.compression.IntelDeflater;
+import com.intel.gkl.compression.IntelInflater;
+import org.apache.commons.lang3.SystemUtils;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+/**
+ * Test that the Intel Inflater and Deflater can be loaded successfully.
+ */
+public class IntelInflaterDeflaterLoadTest {
+    @Test
+    public void testIntelInflaterIsAvailable() {
+        checkIntelSupported("IntelInflater");
+        Assert.assertTrue(new IntelInflater().load(null),
+                "Intel shared library was not loaded. This could be due to a configuration error, or your system might not support it.");
+    }
+
+    @Test
+    public void testIntelDeflaterIsAvailable() {
+        checkIntelSupported("IntelDeflater");
+        Assert.assertTrue(new IntelDeflater().load(null),
+                "Intel shared library was not loaded. This could be due to a configuration error, or your system might not support it.");
+    }
+
+    private void checkIntelSupported(final String componentName) {
+        if (!SystemUtils.IS_OS_LINUX && !SystemUtils.IS_OS_MAC) {
+            throw new SkipException(componentName + " is not available on this platform");
+        }
+
+        if (SystemUtils.OS_ARCH != null && SystemUtils.OS_ARCH.equals("ppc64le")) {
+            throw new SkipException(componentName + " is not available for this architecture");
+        }
+    }
+}

--- a/src/test/java/picard/analysis/CollectMultipleMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectMultipleMetricsTest.java
@@ -335,8 +335,10 @@ public class CollectMultipleMetricsTest extends CommandLineProgramTest {
         final String flowCellBarcode = "TESTBARCODE";
 
         tempSamFile = File.createTempFile("CollectGcBias", ".bam", TEST_DIR);
+        final File tempSamIndex = new File(tempSamFile.getAbsolutePath().replace("bam", "bai"));
         final File tempSamFileUnsorted = File.createTempFile("CollectGcBias", ".bam", TEST_DIR);
         tempSamFileUnsorted.deleteOnExit();
+        tempSamIndex.deleteOnExit();
         tempSamFile.deleteOnExit();
 
         BufferedLineReader bufferedLineReader = null;

--- a/src/test/java/picard/analysis/CollectWgsMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectWgsMetricsTest.java
@@ -136,8 +136,10 @@ public class CollectWgsMetricsTest extends CommandLineProgramTest {
 
         //Create Sam Files
         tempSamFile = File.createTempFile("CollectWgsMetrics", ".bam", TEST_DIR);
+        final File tempSamIndex = new File(tempSamFile.getAbsolutePath().replace("bam", "bai"));
         final File tempSamFileUnsorted = File.createTempFile("CollectWgsMetrics", ".bam", TEST_DIR);
         tempSamFileUnsorted.deleteOnExit();
+        tempSamIndex.deleteOnExit();
         tempSamFile.deleteOnExit();
         final File sortedSamIdx = new File(TEST_DIR, tempSamFile.getName() + ".idx");
         sortedSamIdx.deleteOnExit();

--- a/src/test/java/picard/sam/FilterSamReadsTest.java
+++ b/src/test/java/picard/sam/FilterSamReadsTest.java
@@ -95,11 +95,11 @@ public class FilterSamReadsTest extends CommandLineProgramTest {
         // Build a sam file for testing
         final File inputSam = File.createTempFile("testSam", ".sam", TEST_DIR);
         inputSam.deleteOnExit();
-        final File sortedSamIdx = new File(TEST_DIR, inputSam.getName() + ".bai");
+        final File sortedSamIdx = new File(TEST_DIR, inputSam.getName() + ".idx");
         sortedSamIdx.deleteOnExit();
 
         final SAMFileWriter writer = new SAMFileWriterFactory()
-                .setCreateIndex(true).makeBAMWriter(builder.getHeader(), false, inputSam);
+                .setCreateIndex(true).makeSAMWriter(builder.getHeader(), false, inputSam);
 
         for (final SAMRecord record : builder) {
             writer.addAlignment(record);

--- a/src/test/java/picard/sam/FilterSamReadsTest.java
+++ b/src/test/java/picard/sam/FilterSamReadsTest.java
@@ -95,7 +95,7 @@ public class FilterSamReadsTest extends CommandLineProgramTest {
         // Build a sam file for testing
         final File inputSam = File.createTempFile("testSam", ".sam", TEST_DIR);
         inputSam.deleteOnExit();
-        final File sortedSamIdx = new File(TEST_DIR, inputSam.getName() + ".idx");
+        final File sortedSamIdx = new File(TEST_DIR, inputSam.getName() + ".bai");
         sortedSamIdx.deleteOnExit();
 
         final SAMFileWriter writer = new SAMFileWriterFactory()
@@ -109,6 +109,7 @@ public class FilterSamReadsTest extends CommandLineProgramTest {
         final File intervalFile = new File(intervalFilename);
 
         FilterSamReads filterTest = setupProgram(intervalFile, inputSam, FilterSamReads.Filter.includePairedIntervals);
+
         Assert.assertEquals(filterTest.doWork(),0);
 
         long count = getReadCount(filterTest);


### PR DESCRIPTION
### Description

This mirrors what was done for GATK in broadinstitute/gsa-unstable#1572.

Comwell workflow ID in gotc-dev: 7012caa5-ea19-4f99-82f3-a1f2ca200ad6

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable