### PR TITLE
Include entirely HomRef Sample in CollectVariantCallingMetrics

### DIFF
--- a/src/main/java/picard/vcf/CallingMetricAccumulator.java
+++ b/src/main/java/picard/vcf/CallingMetricAccumulator.java
@@ -109,7 +109,8 @@ public class CallingMetricAccumulator implements VariantProcessor.Accumulator<Ca
     }
 
     public void setup(final VCFHeader vcfHeader) {
-        //noop.
+        //Use sampleMetricsMap.get in case a sample isn't ever put in the map (due to being all HomRef for example)
+        vcfHeader.getGenotypeSamples().stream().forEach(sampleName -> sampleMetricsMap.get(sampleName));
     }
 
     /** Incorporates the provided variant's data into the metric analysis. */

--- a/src/test/java/picard/vcf/CollectVariantCallingMetricsTest.java
+++ b/src/test/java/picard/vcf/CollectVariantCallingMetricsTest.java
@@ -191,4 +191,35 @@ public class CollectVariantCallingMetricsTest {
 
         Assert.assertEquals(detailMetrics.size(), 1, "Did not parse the expected number of detail metrics.");
     }
+
+    @Test
+    public void testAllHomRefVCF() throws IOException {
+        final File dbSnpFile = new File(TEST_DATA_DIR, "mini.dbsnp.vcf");
+        final File vcfFile = new File(TEST_DATA_DIR, "allHomRef.vcf");
+        final File indexedVcfFile = VcfTestUtils.createTemporaryIndexedVcfFromInput(vcfFile, "allHomRef.tmp.");
+        final File outFile = new File(TEST_DATA_DIR, "vcmetrics_allHomRef");
+        final File summaryFile = new File(outFile + ".variant_calling_summary_metrics");
+        final File detailFile = new File(outFile + ".variant_calling_detail_metrics");
+
+        outFile.deleteOnExit();
+        summaryFile.deleteOnExit();
+        detailFile.deleteOnExit();
+
+        final CollectVariantCallingMetrics program = new CollectVariantCallingMetrics();
+        program.INPUT = indexedVcfFile;
+        program.DBSNP = dbSnpFile;
+        program.OUTPUT = outFile;
+        Assert.assertEquals(program.doWork(), 0);
+
+        final MetricsFile<CollectVariantCallingMetrics.VariantCallingDetailMetrics, Comparable<?>> detail = new MetricsFile<>();
+        detail.read(new FileReader(detailFile));
+        boolean seenSampleWithOnlyHomRefs = false;
+        for (final CollectVariantCallingMetrics.VariantCallingDetailMetrics metrics : detail.getMetrics()) {
+            if (metrics.SAMPLE_ALIAS.equals("HG00116")) {
+                seenSampleWithOnlyHomRefs = true;
+                Assert.assertEquals(metrics.TOTAL_SNPS, 0);
+            }
+        }
+        Assert.assertTrue(seenSampleWithOnlyHomRefs);
+    }
 }

--- a/testdata/picard/vcf/allHomRef.vcf
+++ b/testdata/picard/vcf/allHomRef.vcf
@@ -1,0 +1,147 @@
+##fileformat=VCFv4.1
+##ApplyRecalibration="analysis_type=ApplyRecalibration input_file=[] read_buffer_size=null phone_home=STANDARD gatk_key=null tag=NA read_filter=[] intervals=[/seq/tng/mccowan/VARIANT_CALLING_FAUXCELL/v1/VARIANT_CALLING_FAUXCELL.padded.interval_list] excludeIntervals=null interval_set_rule=UNION interval_merging=ALL interval_padding=0 reference_sequence=/seq/references/Homo_sapiens_assembly19/v1/Homo_sapiens_assembly19.fasta nonDeterministicRandomSeed=false disableRandomization=false maxRuntime=-1 maxRuntimeUnits=MINUTES downsampling_type=BY_SAMPLE downsample_to_fraction=null downsample_to_coverage=1000 use_legacy_downsampler=false baq=OFF baqGapOpenPenalty=40.0 fix_misencoded_quality_scores=false allow_potentially_misencoded_quality_scores=false performanceLog=null useOriginalQualities=false BQSR=null quantize_quals=0 disable_indel_quals=false emit_original_quals=false preserve_qscores_less_than=6 defaultBaseQualities=-1 validation_strictness=SILENT remove_program_records=false keep_program_records=false unsafe=null num_threads=1 num_cpu_threads_per_data_thread=1 num_io_threads=0 monitorThreadEfficiency=false num_bam_file_handles=null read_group_black_list=null pedigree=[] pedigreeString=[] pedigreeValidationType=STRICT allow_intervals_with_unindexed_bam=false generateShadowBCF=false logging_level=INFO log_to_file=null help=false input=[(RodBinding name=input source=/seq/tng/mccowan/VARIANT_CALLING_FAUXCELL/v1/VARIANT_CALLING_FAUXCELL.snps.unfiltered.vcf)] recal_file=(RodBinding name=recal_file source=/seq/tng/mccowan/VARIANT_CALLING_FAUXCELL/v1/VARIANT_CALLING_FAUXCELL.snps.recal) tranches_file=/seq/tng/mccowan/VARIANT_CALLING_FAUXCELL/v1/VARIANT_CALLING_FAUXCELL.snps.tranches out=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub no_cmdline_in_header=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub sites_only=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub bcf=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub ts_filter_level=98.5 ignore_filter=null mode=SNP filter_mismatching_base_and_quals=false"
+##FILTER=<ID=Indel_FS,Description="FS>200.0">
+##FILTER=<ID=Indel_InbreedingCoeff,Description="InbreedingCoeff<-0.8">
+##FILTER=<ID=Indel_QD,Description="QD<2.0">
+##FILTER=<ID=Indel_ReadPosRankSum,Description="ReadPosRankSum<-20.0">
+##FILTER=<ID=LowQual,Description="Low quality">
+##FILTER=<ID=VQSRTrancheSNP98.50to98.60,Description="Truth sensitivity tranche level for SNP model at VQS Lod: 0.6803 <= x < 0.8195">
+##FILTER=<ID=VQSRTrancheSNP98.60to98.80,Description="Truth sensitivity tranche level for SNP model at VQS Lod: 0.391 <= x < 0.6803">
+##FILTER=<ID=VQSRTrancheSNP98.80to98.90,Description="Truth sensitivity tranche level for SNP model at VQS Lod: 0.2076 <= x < 0.391">
+##FILTER=<ID=VQSRTrancheSNP98.90to99.00,Description="Truth sensitivity tranche level for SNP model at VQS Lod: 0.0125 <= x < 0.2076">
+##FILTER=<ID=VQSRTrancheSNP99.00to99.30,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -0.92 <= x < 0.0125">
+##FILTER=<ID=VQSRTrancheSNP99.30to99.50,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -2.0012 <= x < -0.92">
+##FILTER=<ID=VQSRTrancheSNP99.50to99.90,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -47.4391 <= x < -2.0012">
+##FILTER=<ID=VQSRTrancheSNP99.90to100.00+,Description="Truth sensitivity tranche level for SNP model at VQS Lod < -3283.311">
+##FILTER=<ID=VQSRTrancheSNP99.90to100.00,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -3283.311 <= x < -47.4391">
+##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth (reads with MQ=255 or with bad mates are filtered)">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Normalized, Phred-scaled likelihoods for genotypes as defined in the VCF specification">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=BaseQRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt Vs. Ref base qualities">
+##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP Membership">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth; some reads may have been filtered">
+##INFO=<ID=DS,Number=0,Type=Flag,Description="Were any of the samples downsampled?">
+##INFO=<ID=Dels,Number=1,Type=Float,Description="Fraction of Reads Containing Spanning Deletions">
+##INFO=<ID=END,Number=1,Type=Integer,Description="Stop position of the interval">
+##INFO=<ID=FS,Number=1,Type=Float,Description="Phred-scaled p-value using Fisher's exact test to detect strand bias">
+##INFO=<ID=HaplotypeScore,Number=1,Type=Float,Description="Consistency of the site with at most two segregating haplotypes">
+##INFO=<ID=InbreedingCoeff,Number=1,Type=Float,Description="Inbreeding coefficient as estimated from the genotype likelihoods per-sample when compared against the Hardy-Weinberg expectation">
+##INFO=<ID=MLEAC,Number=A,Type=Integer,Description="Maximum likelihood expectation (MLE) for the allele counts (not necessarily the same as the AC), for each ALT allele, in the same order as listed">
+##INFO=<ID=MLEAF,Number=A,Type=Float,Description="Maximum likelihood expectation (MLE) for the allele frequency (not necessarily the same as the AF), for each ALT allele, in the same order as listed">
+##INFO=<ID=MQ,Number=1,Type=Float,Description="RMS Mapping Quality">
+##INFO=<ID=MQ0,Number=1,Type=Integer,Description="Total Mapping Quality Zero Reads">
+##INFO=<ID=MQRankSum,Number=1,Type=Float,Description="Z-score From Wilcoxon rank sum test of Alt vs. Ref read mapping qualities">
+##INFO=<ID=QD,Number=1,Type=Float,Description="Variant Confidence/Quality by Depth">
+##INFO=<ID=RPA,Number=.,Type=Integer,Description="Number of times tandem repeat unit is repeated, for each allele (including reference)">
+##INFO=<ID=RU,Number=1,Type=String,Description="Tandem repeat unit (bases)">
+##INFO=<ID=ReadPosRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt vs. Ref read position bias">
+##INFO=<ID=SNPEFF_AMINO_ACID_CHANGE,Number=1,Type=String,Description="Old/New amino acid for the highest-impact effect resulting from the current variant (in HGVS style)">
+##INFO=<ID=SNPEFF_CODON_CHANGE,Number=1,Type=String,Description="Old/New codon for the highest-impact effect resulting from the current variant">
+##INFO=<ID=SNPEFF_EFFECT,Number=1,Type=String,Description="The highest-impact effect resulting from the current variant (or one of the highest-impact effects, if there is a tie)">
+##INFO=<ID=SNPEFF_EXON_ID,Number=1,Type=String,Description="Exon ID for the highest-impact effect resulting from the current variant">
+##INFO=<ID=SNPEFF_FUNCTIONAL_CLASS,Number=1,Type=String,Description="Functional class of the highest-impact effect resulting from the current variant: [NONE, SILENT, MISSENSE, NONSENSE]">
+##INFO=<ID=SNPEFF_GENE_BIOTYPE,Number=1,Type=String,Description="Gene biotype for the highest-impact effect resulting from the current variant">
+##INFO=<ID=SNPEFF_GENE_NAME,Number=1,Type=String,Description="Gene name for the highest-impact effect resulting from the current variant">
+##INFO=<ID=SNPEFF_IMPACT,Number=1,Type=String,Description="Impact of the highest-impact effect resulting from the current variant [MODIFIER, LOW, MODERATE, HIGH]">
+##INFO=<ID=SNPEFF_TRANSCRIPT_ID,Number=1,Type=String,Description="Transcript ID for the highest-impact effect resulting from the current variant">
+##INFO=<ID=STR,Number=0,Type=Flag,Description="Variant is a short tandem repeat">
+##INFO=<ID=VQSLOD,Number=1,Type=Float,Description="Log odds ratio of being a true variant versus being false under the trained gaussian mixture model">
+##INFO=<ID=culprit,Number=1,Type=String,Description="The annotation which was the worst performing in the Gaussian mixture model, likely the reason why the variant was filtered out">
+##OriginalSnpEffCmd="SnpEff eff -v -onlyCoding true -c /seq/references/Homo_sapiens_assembly19/v1/snpEff/Homo_sapiens_assembly19.snpEff.config -i vcf -o vcf GRCh37.64 /seq/tng/mccowan/VARIANT_CALLING_FAUXCELL/v1/VARIANT_CALLING_FAUXCELL.unannotated.vcf "
+##OriginalSnpEffVersion="2.0.5 (build 2011-12-24), by Pablo Cingolani"
+##UnifiedGenotyper="analysis_type=UnifiedGenotyper input_file=[/seq/tng/mccowan/VARIANT_CALLING_FAUXCELL/v1/VARIANT_CALLING_FAUXCELL.bam.list] read_buffer_size=null phone_home=STANDARD gatk_key=null tag=NA read_filter=[] intervals=[/seq/tng/mccowan/VARIANT_CALLING_FAUXCELL/v1/scatter/temp_0001_of_50/scattered.intervals] excludeIntervals=null interval_set_rule=UNION interval_merging=ALL interval_padding=0 reference_sequence=/seq/references/Homo_sapiens_assembly19/v1/Homo_sapiens_assembly19.fasta nonDeterministicRandomSeed=false disableRandomization=false maxRuntime=-1 maxRuntimeUnits=MINUTES downsampling_type=BY_SAMPLE downsample_to_fraction=null downsample_to_coverage=75 use_legacy_downsampler=false baq=OFF baqGapOpenPenalty=40.0 fix_misencoded_quality_scores=false allow_potentially_misencoded_quality_scores=false performanceLog=null useOriginalQualities=false BQSR=null quantize_quals=0 disable_indel_quals=false emit_original_quals=false preserve_qscores_less_than=6 defaultBaseQualities=-1 validation_strictness=SILENT remove_program_records=false keep_program_records=false unsafe=null num_threads=1 num_cpu_threads_per_data_thread=1 num_io_threads=0 monitorThreadEfficiency=false num_bam_file_handles=null read_group_black_list=null pedigree=[] pedigreeString=[] pedigreeValidationType=STRICT allow_intervals_with_unindexed_bam=false generateShadowBCF=false logging_level=INFO log_to_file=null help=false genotype_likelihoods_model=BOTH pcr_error_rate=1.0E-4 computeSLOD=false annotateNDA=false pair_hmm_implementation=ORIGINAL min_base_quality_score=17 max_deletion_fraction=0.05 min_indel_count_for_genotyping=5 min_indel_fraction_per_sample=0.25 indel_heterozygosity=1.25E-4 indelGapContinuationPenalty=10 indelGapOpenPenalty=45 indelHaplotypeSize=80 indelDebug=false ignoreSNPAlleles=false allReadsSP=false ignoreLaneInfo=false reference_sample_calls=(RodBinding name= source=UNBOUND) reference_sample_name=null sample_ploidy=2 min_quality_score=1 max_quality_score=40 site_quality_prior=20 min_power_threshold_for_calling=0.95 min_reference_depth=100 exclude_filtered_reference_sites=false heterozygosity=0.0010 genotyping_mode=DISCOVERY output_mode=EMIT_VARIANTS_ONLY standard_min_confidence_threshold_for_calling=30.0 standard_min_confidence_threshold_for_emitting=30.0 alleles=(RodBinding name= source=UNBOUND) max_alternate_alleles=6 p_nonref_model=EXACT_INDEPENDENT contamination_fraction_to_filter=0.0 contamination_percentage_per_sample_file=/seq/tng/mccowan/VARIANT_CALLING_FAUXCELL/v1/alleleBiasedDownsamplingPerSample.txt logRemovedReadsFromContaminationFiltering=null exactcallslog=null dbsnp=(RodBinding name=dbsnp source=/seq/references/Homo_sapiens_assembly19/v1/Homo_sapiens_assembly19.dbsnp.vcf) comp=[] out=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub no_cmdline_in_header=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub sites_only=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub bcf=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub debug_file=null metrics_file=null annotation=[] excludeAnnotation=[] filter_mismatching_base_and_quals=false"
+##VariantAnnotator="analysis_type=VariantAnnotator input_file=[] read_buffer_size=null phone_home=STANDARD gatk_key=null tag=NA read_filter=[] intervals=[/seq/references/HybSelOligos/whole_exome_agilent_1.1_refseq_plus_3_boosters/whole_exome_agilent_1.1_refseq_plus_3_boosters.Homo_sapiens_assembly19.targets.interval_list] excludeIntervals=null interval_set_rule=UNION interval_merging=ALL interval_padding=50 reference_sequence=/seq/references/Homo_sapiens_assembly19/v1/Homo_sapiens_assembly19.fasta nonDeterministicRandomSeed=false disableRandomization=false maxRuntime=-1 maxRuntimeUnits=MINUTES downsampling_type=BY_SAMPLE downsample_to_fraction=null downsample_to_coverage=1000 use_legacy_downsampler=false baq=OFF baqGapOpenPenalty=40.0 fix_misencoded_quality_scores=false allow_potentially_misencoded_quality_scores=false performanceLog=null useOriginalQualities=false BQSR=null quantize_quals=0 disable_indel_quals=false emit_original_quals=false preserve_qscores_less_than=6 defaultBaseQualities=-1 validation_strictness=SILENT remove_program_records=false keep_program_records=false unsafe=null num_threads=1 num_cpu_threads_per_data_thread=1 num_io_threads=0 monitorThreadEfficiency=false num_bam_file_handles=null read_group_black_list=null pedigree=[] pedigreeString=[] pedigreeValidationType=STRICT allow_intervals_with_unindexed_bam=false generateShadowBCF=false logging_level=INFO log_to_file=null help=false variant=(RodBinding name=variant source=/seq/tng/mccowan/VARIANT_CALLING_FAUXCELL/v1/VARIANT_CALLING_FAUXCELL.unannotated.vcf) snpEffFile=(RodBinding name=snpEffFile source=/seq/tng/mccowan/VARIANT_CALLING_FAUXCELL/v1/VARIANT_CALLING_FAUXCELL.snpeff.vcf) dbsnp=(RodBinding name= source=UNBOUND) comp=[] resource=[] out=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub no_cmdline_in_header=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub sites_only=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub bcf=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub annotation=[SnpEff] excludeAnnotation=[] group=[] expression=[] useAllAnnotations=false list=false alwaysAppendDbsnpId=false MendelViolationGenotypeQualityThreshold=0.0 requireStrictAlleleMatch=false filter_mismatching_base_and_quals=false"
+##VariantFiltration="analysis_type=VariantFiltration input_file=[] read_buffer_size=null phone_home=STANDARD gatk_key=null tag=NA read_filter=[] intervals=[/seq/tng/mccowan/VARIANT_CALLING_FAUXCELL/v1/VARIANT_CALLING_FAUXCELL.padded.interval_list] excludeIntervals=null interval_set_rule=UNION interval_merging=ALL interval_padding=0 reference_sequence=/seq/references/Homo_sapiens_assembly19/v1/Homo_sapiens_assembly19.fasta nonDeterministicRandomSeed=false disableRandomization=false maxRuntime=-1 maxRuntimeUnits=MINUTES downsampling_type=BY_SAMPLE downsample_to_fraction=null downsample_to_coverage=1000 use_legacy_downsampler=false baq=OFF baqGapOpenPenalty=40.0 fix_misencoded_quality_scores=false allow_potentially_misencoded_quality_scores=false performanceLog=null useOriginalQualities=false BQSR=null quantize_quals=0 disable_indel_quals=false emit_original_quals=false preserve_qscores_less_than=6 defaultBaseQualities=-1 validation_strictness=SILENT remove_program_records=false keep_program_records=false unsafe=null num_threads=1 num_cpu_threads_per_data_thread=1 num_io_threads=0 monitorThreadEfficiency=false num_bam_file_handles=null read_group_black_list=null pedigree=[] pedigreeString=[] pedigreeValidationType=STRICT allow_intervals_with_unindexed_bam=false generateShadowBCF=false logging_level=INFO log_to_file=null help=false variant=(RodBinding name=variant source=/seq/tng/mccowan/VARIANT_CALLING_FAUXCELL/v1/VARIANT_CALLING_FAUXCELL.indels.unfiltered.vcf) mask=(RodBinding name= source=UNBOUND) out=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub no_cmdline_in_header=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub sites_only=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub bcf=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub filterExpression=[FS>200.0, QD<2.0, ReadPosRankSum<-20.0, InbreedingCoeff<-0.8] filterName=[Indel_FS, Indel_QD, Indel_ReadPosRankSum, Indel_InbreedingCoeff] genotypeFilterExpression=[] genotypeFilterName=[] clusterSize=3 clusterWindowSize=0 maskExtension=0 maskName=Mask missingValuesInExpressionsShouldEvaluateAsFailing=false invalidatePreviousFilters=false filter_mismatching_base_and_quals=false"
+##contig=<ID=1,length=249250621>
+##contig=<ID=2,length=243199373>
+##contig=<ID=3,length=198022430>
+##contig=<ID=4,length=191154276>
+##contig=<ID=5,length=180915260>
+##contig=<ID=6,length=171115067>
+##contig=<ID=7,length=159138663>
+##contig=<ID=8,length=146364022>
+##contig=<ID=9,length=141213431>
+##contig=<ID=10,length=135534747>
+##contig=<ID=11,length=135006516>
+##contig=<ID=12,length=133851895>
+##contig=<ID=13,length=115169878>
+##contig=<ID=14,length=107349540>
+##contig=<ID=15,length=102531392>
+##contig=<ID=16,length=90354753>
+##contig=<ID=17,length=81195210>
+##contig=<ID=18,length=78077248>
+##contig=<ID=19,length=59128983>
+##contig=<ID=20,length=63025520>
+##contig=<ID=21,length=48129895>
+##contig=<ID=22,length=51304566>
+##contig=<ID=X,length=155270560>
+##contig=<ID=Y,length=59373566>
+##contig=<ID=MT,length=16569>
+##contig=<ID=GL000207.1,length=4262>
+##contig=<ID=GL000226.1,length=15008>
+##contig=<ID=GL000229.1,length=19913>
+##contig=<ID=GL000231.1,length=27386>
+##contig=<ID=GL000210.1,length=27682>
+##contig=<ID=GL000239.1,length=33824>
+##contig=<ID=GL000235.1,length=34474>
+##contig=<ID=GL000201.1,length=36148>
+##contig=<ID=GL000247.1,length=36422>
+##contig=<ID=GL000245.1,length=36651>
+##contig=<ID=GL000197.1,length=37175>
+##contig=<ID=GL000203.1,length=37498>
+##contig=<ID=GL000246.1,length=38154>
+##contig=<ID=GL000249.1,length=38502>
+##contig=<ID=GL000196.1,length=38914>
+##contig=<ID=GL000248.1,length=39786>
+##contig=<ID=GL000244.1,length=39929>
+##contig=<ID=GL000238.1,length=39939>
+##contig=<ID=GL000202.1,length=40103>
+##contig=<ID=GL000234.1,length=40531>
+##contig=<ID=GL000232.1,length=40652>
+##contig=<ID=GL000206.1,length=41001>
+##contig=<ID=GL000240.1,length=41933>
+##contig=<ID=GL000236.1,length=41934>
+##contig=<ID=GL000241.1,length=42152>
+##contig=<ID=GL000243.1,length=43341>
+##contig=<ID=GL000242.1,length=43523>
+##contig=<ID=GL000230.1,length=43691>
+##contig=<ID=GL000237.1,length=45867>
+##contig=<ID=GL000233.1,length=45941>
+##contig=<ID=GL000204.1,length=81310>
+##contig=<ID=GL000198.1,length=90085>
+##contig=<ID=GL000208.1,length=92689>
+##contig=<ID=GL000191.1,length=106433>
+##contig=<ID=GL000227.1,length=128374>
+##contig=<ID=GL000228.1,length=129120>
+##contig=<ID=GL000214.1,length=137718>
+##contig=<ID=GL000221.1,length=155397>
+##contig=<ID=GL000209.1,length=159169>
+##contig=<ID=GL000218.1,length=161147>
+##contig=<ID=GL000220.1,length=161802>
+##contig=<ID=GL000213.1,length=164239>
+##contig=<ID=GL000211.1,length=166566>
+##contig=<ID=GL000199.1,length=169874>
+##contig=<ID=GL000217.1,length=172149>
+##contig=<ID=GL000216.1,length=172294>
+##contig=<ID=GL000215.1,length=172545>
+##contig=<ID=GL000205.1,length=174588>
+##contig=<ID=GL000219.1,length=179198>
+##contig=<ID=GL000224.1,length=179693>
+##contig=<ID=GL000223.1,length=180455>
+##contig=<ID=GL000195.1,length=182896>
+##contig=<ID=GL000212.1,length=186858>
+##contig=<ID=GL000222.1,length=186861>
+##contig=<ID=GL000200.1,length=187035>
+##contig=<ID=GL000193.1,length=189789>
+##contig=<ID=GL000194.1,length=191469>
+##contig=<ID=GL000225.1,length=211173>
+##contig=<ID=GL000192.1,length=547496>
+##contig=<ID=NC_007605,length=171823>
+##reference=file:///seq/references/Homo_sapiens_assembly19/v1/Homo_sapiens_assembly19.fasta
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	HG00116	HG00123	HG00158	HG00160	HG00265	HG00311	HG00371	HG00380	HG00404	HG00551	HG00610	HG00628	HG00635	HG01048	HG01079	HG01094	HG01247	HG01256	HG01260	HG01461	HG01488	NA06989	NA11918	NA11919	NA12341	NA18510	NA18520	NA18522	NA18574	NA18634	NA18867	NA18960	NA18986	NA19004	NA19067	NA19092	NA19102	NA19474	NA19675	NA19703	NA19711	NA19725	NA19819	NA19908	NA19920	NA20787	NA20798	NA20801	NA20803	NA20805
+1	69270	.	A	G	569.98	PASS	AC=23;AF=0.767;AN=30;BaseQRankSum=-2.920;DP=4121;Dels=0.00;FS=0.000;HaplotypeScore=0.0000;InbreedingCoeff=0.3609;MLEAC=24;MLEAF=0.800;MQ=3.91;MQ0=1518;MQRankSum=0.523;QD=0.55;ReadPosRankSum=-0.861;SNPEFF_AMINO_ACID_CHANGE=S108;SNPEFF_CODON_CHANGE=tcA/tcG;SNPEFF_EFFECT=SYNONYMOUS_CODING;SNPEFF_EXON_ID=exon_1_69037_69829;SNPEFF_FUNCTIONAL_CLASS=SILENT;SNPEFF_GENE_BIOTYPE=protein_coding;SNPEFF_GENE_NAME=OR4F5;SNPEFF_IMPACT=LOW;SNPEFF_TRANSCRIPT_ID=ENST00000534990;VQSLOD=-8.590e+00;culprit=MQ	GT:AD:DP:GQ:PL	0/0:60,18:75:9:0,9,89	./.	./.	./.	./.	./.	./.	./.	./.	./.	1/1:51,23:71:3:24,3,0	./.	./.	./.	1/1:59,15:72:3:33,3,0	./.	./.	./.	./.	./.	0/0:2,0:2:6:0,6,45	0/0:66,8:71:3:0,3,24	./.	./.	./.	0/0:75,0:75:9:0,9,81	1/1:183,17:197:9:82,9,0	0/1:56,19:63:18:18,0,18	./.	1/1:22,22:43:3:31,3,0	./.	./.	1/1:51,24:73:6:57,6,0	1/1:52,25:74:12:101,12,0	./.	./.	./.	1/1:63,12:72:6:47,6,0	./.	./.	./.	./.	./.	./.	./.	./.	1/1:40,56:93:9:78,9,0	1/1:63,14:74:6:47,6,0	1/1:79,11:87:3:24,3,0	./.


### PR DESCRIPTION
### Description
This ensures that CollectVariantCalling Detail Metrics will include samples that are only HomRef. Currently it doesn't output a line for them in the detail metrics. Note that the counts for that sample will all be 0 since there are no non-HomRef calls. 

This addresses #797 

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [x] Final thumbs-up from reviewer
- [x] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

