### PR TITLE
Add option to CollectWgsMetrics to output theoretical sensitivity at various allele fractions

### DIFF
--- a/src/main/java/picard/analysis/AbstractWgsMetricsCollector.java
+++ b/src/main/java/picard/analysis/AbstractWgsMetricsCollector.java
@@ -184,8 +184,7 @@ public abstract class AbstractWgsMetricsCollector<T extends AbstractRecordAndOff
                 basesExcludedByCapping,
                 coverageCap,
                 getUnfilteredBaseQHistogram(),
-                collectWgsMetrics.SAMPLE_SIZE
-        );
+                collectWgsMetrics.SAMPLE_SIZE);
     }
 
     /**

--- a/src/main/java/picard/analysis/CollectRawWgsMetrics.java
+++ b/src/main/java/picard/analysis/CollectRawWgsMetrics.java
@@ -30,6 +30,8 @@ import picard.cmdline.CommandLineProgramProperties;
 import picard.cmdline.Option;
 import picard.cmdline.programgroups.Metrics;
 
+import java.io.File;
+
 import static picard.cmdline.StandardOptionDefinitions.MINIMUM_MAPPING_QUALITY_SHORT_NAME;
 
 /**

--- a/src/main/java/picard/analysis/CollectWgsMetrics.java
+++ b/src/main/java/picard/analysis/CollectWgsMetrics.java
@@ -118,6 +118,9 @@ static final String USAGE_DETAILS = "<p>This tool collects metrics about the fra
     @Option(doc="Sample Size used for Theoretical Het Sensitivity sampling. Default is 10000.", optional = true)
     public int SAMPLE_SIZE=10000;
 
+    @Option(doc="Output for Theoretical Sensitivity metrics.  Default is null.", optional = true)
+    public File THEORETICAL_SENSITIVITY_OUTPUT;
+
     @Option(doc = "If true, fast algorithm is used.")
     public boolean USE_FAST_ALGORITHM = false;
 
@@ -133,7 +136,7 @@ static final String USAGE_DETAILS = "<p>This tool collects metrics about the fra
     private SAMFileHeader header = null;
 
     private final Log log = Log.getInstance(CollectWgsMetrics.class);
-    private static final double LOG_ODDS_THRESHOLD = 3.0;
+    private static final double LOG_ODDS_THRESHOLD = 3;
 
     /** Metrics for evaluating the performance of whole genome sequencing experiments. */
     public static class WgsMetrics extends MergeableMetricBase {
@@ -466,6 +469,31 @@ static final String USAGE_DETAILS = "<p>This tool collects metrics about the fra
         final MetricsFile<WgsMetrics, Integer> out = getMetricsFile();
         processor.addToMetricsFile(out, INCLUDE_BQ_HISTOGRAM, dupeFilter, mapqFilter, pairFilter);
         out.write(OUTPUT);
+
+        if(THEORETICAL_SENSITIVITY_OUTPUT != null) {
+            final double[] depthDoubleArray = TheoreticalSensitivity.normalizeHistogram(collector.getUnfilteredDepthHistogram());
+            final double[] baseQDoubleArray = TheoreticalSensitivity.normalizeHistogram(collector.getUnfilteredBaseQHistogram());
+
+            collector.getUnfilteredBaseQHistogram();
+            collector.getUnfilteredDepthHistogram();
+
+            TheoreticalSensitivityMetrics theoreticalSensitivityMetrics = new TheoreticalSensitivityMetrics();
+            int theoreticalHetSensitivitySampleSize = 10000;
+
+            double logOddsThreshold = 6.2; // This threshold is used because it is the value used for MuTect2.
+            theoreticalSensitivityMetrics.SENSITIVITY_AT_0_1 = TheoreticalSensitivity.theoreticalSensitivity(depthDoubleArray, baseQDoubleArray, theoreticalHetSensitivitySampleSize, logOddsThreshold, 0.001);
+            theoreticalSensitivityMetrics.SENSITIVITY_AT_0_5 = TheoreticalSensitivity.theoreticalSensitivity(depthDoubleArray, baseQDoubleArray, theoreticalHetSensitivitySampleSize, logOddsThreshold, 0.005);
+            theoreticalSensitivityMetrics.SENSITIVITY_AT_01 = TheoreticalSensitivity.theoreticalSensitivity(depthDoubleArray, baseQDoubleArray, theoreticalHetSensitivitySampleSize, logOddsThreshold, 0.01);
+            theoreticalSensitivityMetrics.SENSITIVITY_AT_02 = TheoreticalSensitivity.theoreticalSensitivity(depthDoubleArray, baseQDoubleArray, theoreticalHetSensitivitySampleSize, logOddsThreshold, 0.02);
+            theoreticalSensitivityMetrics.SENSITIVITY_AT_05 = TheoreticalSensitivity.theoreticalSensitivity(depthDoubleArray, baseQDoubleArray, theoreticalHetSensitivitySampleSize, logOddsThreshold, 0.05);
+            theoreticalSensitivityMetrics.SENSITIVITY_AT_10 = TheoreticalSensitivity.theoreticalSensitivity(depthDoubleArray, baseQDoubleArray, theoreticalHetSensitivitySampleSize, logOddsThreshold, 0.10);
+            theoreticalSensitivityMetrics.SENSITIVITY_AT_30 = TheoreticalSensitivity.theoreticalSensitivity(depthDoubleArray, baseQDoubleArray, theoreticalHetSensitivitySampleSize, logOddsThreshold, 0.30);
+            theoreticalSensitivityMetrics.SENSITIVITY_AT_50 = TheoreticalSensitivity.theoreticalSensitivity(depthDoubleArray, baseQDoubleArray, theoreticalHetSensitivitySampleSize, logOddsThreshold, 0.50);
+
+            final MetricsFile<TheoreticalSensitivityMetrics, Double> tsOut = getMetricsFile();
+            tsOut.addMetric(theoreticalSensitivityMetrics);
+            tsOut.write(THEORETICAL_SENSITIVITY_OUTPUT);
+        }
 
         return 0;
     }

--- a/src/main/java/picard/analysis/TheoreticalSensitivity.java
+++ b/src/main/java/picard/analysis/TheoreticalSensitivity.java
@@ -41,14 +41,15 @@ public class TheoreticalSensitivity {
 
     private static final Log log = Log.getInstance(TheoreticalSensitivity.class);
     private static final int SAMPLING_MAX = 600; //prevent 'infinite' loops
-    private static final int MAX_CONSIDERED_DEPTH = 1000; //no point in looking any deeper than this, otherwise GC overhead is too high.
+    private static final int MAX_CONSIDERED_DEPTH = 10000; //no point in looking any deeper than this, otherwise GC overhead is too high.
+    private static int randomSeed = 51;
 
     /**
-     * @param depthDistribution the probability of depth n is depthDistribution[n] for n = 0, 1. . . N - 1
+     * @param depthDistribution   the probability of depth n is depthDistribution[n] for n = 0, 1. . . N - 1
      * @param qualityDistribution the probability of quality q is qualityDistribution[q] for q = 0, 1. . . Q
-     * @param sampleSize sample size is the number of random sums of quality scores for each m
-     * @param logOddsThreshold is the log_10 of the likelihood ratio required to call a SNP,
-     * for example 5 if the variant likelihood must be 10^5 times greater
+     * @param sampleSize          sample size is the number of random sums of quality scores for each m
+     * @param logOddsThreshold    is the log_10 of the likelihood ratio required to call a SNP,
+     *                            for example 5 if the variant likelihood must be 10^5 times greater
      */
     public static double hetSNPSensitivity(final double[] depthDistribution, final double[] qualityDistribution,
                                            final int sampleSize, final double logOddsThreshold) {
@@ -56,12 +57,12 @@ public class TheoreticalSensitivity {
     }
 
     /**
-     * @param depthDistribution the probability of depth n is depthDistribution[n] for n = 0, 1. . . N - 1
+     * @param depthDistribution   the probability of depth n is depthDistribution[n] for n = 0, 1. . . N - 1
      * @param qualityDistribution the probability of quality q is qualityDistribution[q] for q = 0, 1. . . Q
-     * @param sampleSize sample size is the number of random sums of quality scores for each m
-     * @param logOddsThreshold is the log_10 of the likelihood ratio required to call a SNP,
-     * for example 5 if the variant likelihood must be 10^5 times greater.
-     * @param withLogging true to output log messages, false otherwise.
+     * @param sampleSize          sample size is the number of random sums of quality scores for each m
+     * @param logOddsThreshold    is the log_10 of the likelihood ratio required to call a SNP,
+     *                            for example 5 if the variant likelihood must be 10^5 times greater.
+     * @param withLogging         true to output log messages, false otherwise.
      */
     public static double hetSNPSensitivity(final double[] depthDistribution, final double[] qualityDistribution,
                                            final int sampleSize, final double logOddsThreshold, final boolean withLogging) {
@@ -143,7 +144,7 @@ public class TheoreticalSensitivity {
         private Random rng;
 
         RouletteWheel(final double[] weights) {
-            rng = new Random(51);
+            rng = new Random(randomSeed);
             N = weights.length;
 
             probabilities = new ArrayList<>();
@@ -203,5 +204,137 @@ public class TheoreticalSensitivity {
             }
         }
         return normalizedHistogram;
+    }
+
+    /**
+     * Determines if a variant would be called under the particular conditions of a given total depth, alt depth,
+     * average base qualities, allele fraction of variant and log odds threshold necessary to exceed to call variant.
+     * @param totalDepth Depth at the site to be called, both alt and ref.
+     * @param altDepth Number of alt bases at this site.
+     * @param averageQuality Average Phred-scaled quality of bases
+     * @param alleleFraction Allele fraction we are attempting to detect
+     * @param logOddsThreshold Log odds threshold necessary to exceed for variant to be called
+     * @return
+     */
+    public static boolean isCalled(int totalDepth, int altDepth, double averageQuality, double alleleFraction, double logOddsThreshold) {
+        double threshold;
+        double sumOfQualities = altDepth * averageQuality;
+        threshold = 10.0 * (altDepth * Math.log10(1.0 / alleleFraction) + (totalDepth - altDepth) * Math.log10(1.0 / (1.0 - alleleFraction)) + logOddsThreshold);
+
+        return sumOfQualities > threshold;
+    }
+
+    /**
+     * Draw from a binomial distribution.
+     * @param trials Number of trials to perform
+     * @param p Probability of individual success
+     * @param uniformRNG Random number generator to use for making draw
+     * @return Number of total successes
+     */
+    public static int binomialDraw(final int trials, final double p, final Random uniformRNG) {
+        if (p > 1.0 || p < 0) {
+            throw new PicardException("Probabilities should be between 0 and 1, found value " + p + ".");
+        }
+
+        int successes = 0;
+        for (int i = 0; i < trials; i++) {
+            if (uniformRNG.nextDouble() < p) {
+                successes++;
+            }
+        }
+        return successes;
+    }
+
+    /**
+     * Calculates the theoretical sensitivity with a given Phred-scaled quality score distribution at a constant
+     * depth.
+     * @param depth Depth to compute sensitivity at
+     * @param qualityDistribution Phred-scaled quality score distribution
+     * @param logOddsThreshold Log odd threshold necessary to exceed for variant to be called
+     * @param sampleSize sampleSize is the total number of simulations to run
+     * @param alleleFraction the allele fraction to evaluate sensitivity at
+     * @param randomSeed random number seed to use for random number generator
+     * @return
+     */
+    public static double sensitivityAtConstantDepth(final int depth, final double[] qualityDistribution, final double logOddsThreshold, final int sampleSize, final double alleleFraction, final int randomSeed) {
+        final RouletteWheel qualityRW = new RouletteWheel(trimDistribution(qualityDistribution));
+        final Random uniformRNG = new Random(randomSeed);
+
+        int altDepth = 0;
+        int calledVariants = 0;
+        for (int k = 0; k < sampleSize; k++) {
+            altDepth = binomialDraw(depth, alleleFraction, uniformRNG);
+
+            int sumOfQualities = 0;
+            for (int i = 0; i < altDepth; i++) {
+                sumOfQualities += qualityRW.draw();
+            }
+            if (isCalled(depth, altDepth, (double) sumOfQualities / (double) altDepth, alleleFraction, logOddsThreshold)) {
+                calledVariants++;
+            }
+        }
+        return (double) calledVariants / sampleSize;
+    }
+
+    /**
+     * Calculates the theoretical sensitivity with a given Phred-scaled quality score distribution at a constant
+     * depth.
+     * @param depth Depth to compute sensitivity at
+     * @param qualityDistribution Phred-scaled quality score distribution
+     * @param logOddsThreshold Log odds threshold necessary to exceed for variant to be called
+     * @param sampleSize the total number of simulations to run
+     * @param alleleFraction the allele fraction to evaluate sensitivity at
+     * @return
+     */
+    public static double sensitivityAtConstantDepth(final int depth, final double[] qualityDistribution, final double logOddsThreshold, final int sampleSize, final double alleleFraction) {
+        return sensitivityAtConstantDepth(depth, qualityDistribution, logOddsThreshold, sampleSize, alleleFraction, randomSeed);
+    }
+
+    /**
+     * Calculates the theoretical sensitivity with a given Phred-scaled quality score distribution and depth
+     * distribution.
+     * @param depthDistribution Depth distribution to compute theoretical sensitivity over
+     * @param qualityDistribution Phred-scaled quality score distribution
+     * @param sampleSize the total number of simulations to run
+     * @param logOddsThreshold Log odds threshold necessary to exceed for variant to be called
+     * @param alleleFraction the allele fraction to evaluate sensitivity at
+     * @return
+     */
+    public static double theoreticalSensitivity(final double[] depthDistribution, final double[] qualityDistribution,
+                                                final int sampleSize, final double logOddsThreshold, final double alleleFraction) {
+        double sensitivity = 0.0;
+        for (int k = 0; k < depthDistribution.length; k++) {
+            if(k % 10 == 0) {
+                log.info("Calculting sensitivity at depth " + k + " of " + depthDistribution.length);
+            }
+            sensitivity += sensitivityAtConstantDepth(k, qualityDistribution, logOddsThreshold, sampleSize, alleleFraction) * depthDistribution[k];
+        }
+        return sensitivity;
+    }
+
+    /**
+     * Removes trailing zeros in a distribution.  The purpose of this function is to prevent other
+     * functions from evaluating in regions where the distribution has zero probability.
+     * @param distribution Distribution of base qualities
+     * @return Distribution of base qualities removing any trailing zeros
+     */
+    public static double[] trimDistribution(final double[] distribution) {
+        int endOfDistribution = 0;
+
+        // Locate the index of the distribution where all the values remaining at
+        // larger indices are zero.
+        for(endOfDistribution = distribution.length-1;endOfDistribution >= 0;endOfDistribution--) {
+            if(distribution[endOfDistribution] != 0) {
+                break;
+            }
+        }
+
+        // Remove trailing zeros.
+        final double[] trimmedDistribution = new double[endOfDistribution+1];
+        for(int i = 0;i <= endOfDistribution;i++) {
+            trimmedDistribution[i] = distribution[i];
+        }
+
+        return trimmedDistribution;
     }
 }

--- a/src/main/java/picard/analysis/TheoreticalSensitivityMetrics.java
+++ b/src/main/java/picard/analysis/TheoreticalSensitivityMetrics.java
@@ -1,0 +1,33 @@
+package picard.analysis;
+
+import htsjdk.samtools.metrics.MetricBase;
+
+/**
+ * Created by fleharty on 6/30/17.
+ */
+public class TheoreticalSensitivityMetrics extends MetricBase {
+    /** Theoretical sensitivity at 0.1% allele fraction */
+    public double SENSITIVITY_AT_0_1 = 0.0;
+    /** Theoretical sensitivity at 0.1% allele fraction */
+
+    /** Theoretical sensitivity at 0.5% allele fraction */
+    public double SENSITIVITY_AT_0_5 = 0.0;
+
+    /** Theoretical sensitivity at 1% allele fraction */
+    public double SENSITIVITY_AT_01 = 0.0;
+
+    /** Theoretical sensitivity at 2% allele fraction */
+    public double SENSITIVITY_AT_02 = 0.0;
+
+    /** Theoretical sensitivity at 5% allele fraction */
+    public double SENSITIVITY_AT_05 = 0.0;
+
+    /** Theoretical sensitivity at 10% allele fraction */
+    public double SENSITIVITY_AT_10 = 0.0;
+
+    /** Theoretical sensitivity at 30% allele fraction */
+    public double SENSITIVITY_AT_30 = 0.0;
+
+    /** Theoretical sensitivity at 50% allele fraction */
+    public double SENSITIVITY_AT_50 = 0.0;
+}

--- a/src/main/java/picard/analysis/directed/CollectHsMetrics.java
+++ b/src/main/java/picard/analysis/directed/CollectHsMetrics.java
@@ -105,6 +105,9 @@ static final String USAGE_DETAILS = "This tool takes a SAM/BAM file input and co
     @Option(doc = "True if we are to clip overlapping reads, false otherwise.", optional=true, overridable = true)
     public boolean CLIP_OVERLAPPING_READS = true;
 
+    @Option(doc = "Output theoretical sensitivities for variable allele fraction.", optional=true)
+    public File TheoreticalSensitivityOutput;
+
     @Override
     protected IntervalList getProbeIntervals() {
         for (final File file : BAIT_INTERVALS) IOUtil.assertFileIsReadable(file);

--- a/src/test/java/picard/analysis/TheoreticalSensitivityTest.java
+++ b/src/test/java/picard/analysis/TheoreticalSensitivityTest.java
@@ -207,7 +207,7 @@ public class TheoreticalSensitivityTest {
     }
 
     @Test(dataProvider = "hetSensDataProvider")
-    public void testHetSensTargeted(final double expected, final File metricsFile) throws Exception{
+    public void testHetSensTargeted(final double expected, final File metricsFile) throws Exception {
         final double tolerance = 0.000_000_01;
 
         final MetricsFile Metrics = new MetricsFile();
@@ -216,13 +216,117 @@ public class TheoreticalSensitivityTest {
         final Histogram depthHistogram = histograms.get(0);
         final Histogram qualityHistogram = histograms.get(1);
 
-        final double [] depthDistribution = TheoreticalSensitivity.normalizeHistogram(depthHistogram);
-        final double [] qualityDistribution = TheoreticalSensitivity.normalizeHistogram(qualityHistogram);
+        final double[] depthDistribution = TheoreticalSensitivity.normalizeHistogram(depthHistogram);
+        final double[] qualityDistribution = TheoreticalSensitivity.normalizeHistogram(qualityHistogram);
 
         final int sampleSize = 1_000;
         final double logOddsThreshold = 3.0;
 
         final double result = TheoreticalSensitivity.hetSNPSensitivity(depthDistribution, qualityDistribution, sampleSize, logOddsThreshold);
         Assert.assertEquals(result, expected, tolerance);
+    }
+
+    @DataProvider(name = "TheoreticalSensitivityConstantDepthDataProvider")
+    public Object[][] fractionalAlleleSensDataProvider() {
+        final File wgsMetricsFile = new File(TEST_DIR, "test_Solexa-332667.wgs_metrics");
+        final File targetedMetricsFile = new File(TEST_DIR, "test_25103070136.targeted_pcr_metrics");
+
+        //These magic numbers come from a separate implementation of the code in R.
+        return new Object[][]{
+                // expected sensitivity, metrics file, allele fraction, constant depth, sample size.
+                {1.00, wgsMetricsFile, .5, 30, 10000},
+                {1.00, wgsMetricsFile, .5, 30, 10000},
+                {0.78, targetedMetricsFile, .1, 30, 10000},
+                {0.26, targetedMetricsFile, 0.1, 10, 10000}
+        };
+    }
+
+    @Test(dataProvider = "TheoreticalSensitivityConstantDepthDataProvider")
+    public void testSensitivityAtConstantDepth(final double expected, final File metricsFile, final double alleleFraction, final int depth, final int sampleSize) throws Exception {
+        // This tests Theoretical Sensitivity assuming a uniform depth with a distribution of base quality scores.
+        // Because this only tests sensitivity at a constant depth, we use this for testing the code at high depths.
+        final double tolerance = 0.01;
+        final MetricsFile Metrics = new MetricsFile();
+        Metrics.read(new FileReader(metricsFile));
+        final List<Histogram> histograms = Metrics.getAllHistograms();
+        final Histogram qualityHistogram = histograms.get(1);
+
+        final double[] qualityDistribution = TheoreticalSensitivity.normalizeHistogram(qualityHistogram);
+
+        // We ensure that even using different random seeds we converge to roughly the same value.
+        for(int i = 0;i < 3;i++) {
+            double result = TheoreticalSensitivity.sensitivityAtConstantDepth(depth, qualityDistribution, 3, sampleSize, alleleFraction, i);
+            Assert.assertEquals(result, expected, tolerance);
+        }
+    }
+
+    @DataProvider(name = "TheoreticalSensitivityDataProvider")
+    public Object[][] arbFracSensDataProvider() {
+        final File wgsMetricsFile = new File(TEST_DIR, "test_Solexa-332667.wgs_metrics");
+
+        // This test acts primarily as an intergration test.  The sample size of 100
+        // is not quite large enough to converge properly
+        return new Object[][] {
+                {0.90, wgsMetricsFile,       .5, 100},
+                {0.77, wgsMetricsFile,       .3, 100},
+                {0.29, wgsMetricsFile,       .1, 100},
+                {0.08, wgsMetricsFile,       .05, 100},
+        };
+    }
+
+    @Test(dataProvider = "TheoreticalSensitivityDataProvider")
+    public void testSensitivity(final double expected, final File metricsFile, final double alleleFraction, final int sampleSize) throws Exception {
+        // This tests Theoretical Sensitivity using distributions on both base quality scores
+        // and the depth histogram.
+
+        // We use a pretty forgiving tolerance here because for these tests
+        // we are not using large enough sample sizes to converge.
+        final double tolerance = 0.02;
+
+        final MetricsFile Metrics = new MetricsFile();
+        Metrics.read(new FileReader(metricsFile));
+        final List<Histogram> histograms = Metrics.getAllHistograms();
+        final Histogram depthHistogram = histograms.get(0);
+        final Histogram qualityHistogram = histograms.get(1);
+
+        final double[] qualityDistribution = TheoreticalSensitivity.normalizeHistogram(qualityHistogram);
+        final double[] depthDistribution = TheoreticalSensitivity.normalizeHistogram(depthHistogram);
+
+        final double result = TheoreticalSensitivity.theoreticalSensitivity(depthDistribution, qualityDistribution, sampleSize, 3, alleleFraction);
+
+        Assert.assertEquals(result, expected, tolerance);
+    }
+
+    @DataProvider(name = "equivalanceHetVsArbitrary")
+    public Object[][] equivalenceHetVsFull() {
+        final File wgsMetricsFile = new File(TEST_DIR, "test_Solexa-332667.wgs_metrics");
+        final File targetedMetricsFile = new File(TEST_DIR, "test_25103070136.targeted_pcr_metrics");
+
+        return new Object[][] {
+                // The sample sizes chosen here for these tests are smaller than what would normally be used
+                // in order to keep the test time low.  It should be noted that for larger sample sizes
+                // the values converge.
+                {wgsMetricsFile, 0.01, 300},
+                {targetedMetricsFile, 0.01, 50}
+        };
+    }
+
+    @Test (dataProvider = "equivalanceHetVsArbitrary")
+    public void testHetVsArbitrary(final File metricsFile, final double tolerance, final int sampleSize) throws Exception {
+        // This test compares Theoretical Sensitivity for arbitrary allele fractions with the theoretical het sensitivity
+        // model.  Since allele fraction of 0.5 is equivalent to a het, these should provide the same answer.
+        final MetricsFile Metrics = new MetricsFile();
+        Metrics.read(new FileReader(metricsFile));
+        final List<Histogram> histograms = Metrics.getAllHistograms();
+        final Histogram depthHistogram = histograms.get(0);
+        final Histogram qualityHistogram = histograms.get(1);
+
+        final double[] qualityDistribution = TheoreticalSensitivity.normalizeHistogram(qualityHistogram);
+        final double[] depthDistribution = TheoreticalSensitivity.normalizeHistogram(depthHistogram);
+
+        final double resultFromTS = TheoreticalSensitivity.theoreticalSensitivity(depthDistribution, qualityDistribution, sampleSize, 3, 0.5);
+        final double resultFromTHS = TheoreticalSensitivity.hetSNPSensitivity(depthDistribution, qualityDistribution, sampleSize, 3);
+
+        Assert.assertEquals(resultFromTHS, resultFromTS, tolerance);
     }
 }


### PR DESCRIPTION
### Description

This adds the THEORETICAL_SENSITIVITY_OUTPUT option to CollectWgsMetrics.  This option allows a user to specify a file that will contain the theoretical sensitivities at various allele fractions.

This augments the current TheoreticalHetSensitivity so that we can now calculate theoretical sensitivities for non-germline samples.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

