### PR TITLE
Fix RevertSam to SANITIZE output when RG is missing

### DIFF
--- a/src/main/java/picard/sam/RevertSam.java
+++ b/src/main/java/picard/sam/RevertSam.java
@@ -397,7 +397,7 @@ public class RevertSam extends CommandLineProgram {
                 for (final SAMRecord rec : recs) {
                     // The only valid quality score encoding scheme is standard; if it's not standard, change it.
                     final FastqQualityFormat recordFormat = readGroupToFormat.get(rec.getReadGroup());
-                    if (!recordFormat.equals(FastqQualityFormat.Standard)) {
+                    if (recordFormat != null && !recordFormat.equals(FastqQualityFormat.Standard)) {
                         final byte[] quals = rec.getBaseQualities();
                         for (int i = 0; i < quals.length; i++) {
                             quals[i] -= SolexaQualityConverter.ILLUMINA_TO_PHRED_SUBTRAHEND;

--- a/src/test/java/picard/sam/RevertSamTest.java
+++ b/src/test/java/picard/sam/RevertSamTest.java
@@ -445,12 +445,25 @@ public class RevertSamTest extends CommandLineProgramTest {
     }
 
     @Test(expectedExceptions = PicardException.class)
-    public void testNoRgInfo() {
+    public void testNoRgInfoOutputByRg() {
         final String [] args = new String[]{
                 "I=testdata/picard/sam/bam2fastq/paired/bad/missing-rg-info.sam",
                 "OUTPUT_BY_READGROUP=true",
                 "O=."
         };
         runPicardCommandLine(args);
+    }
+
+    @Test
+    public void testNoRgInfoSanitize() throws Exception {
+        final File output = File.createTempFile("no-rg-reverted", ".sam");
+        output.deleteOnExit();
+        final String [] args = new String[]{
+                "I=testdata/picard/sam/bam2fastq/paired/bad/missing-rg-info.sam",
+                "SANITIZE=true",
+                "O=" + output.getAbsolutePath()
+        };
+        Assert.assertEquals(runPicardCommandLine(args), 0);
+        verifyPositiveResults(output, new RevertSam(), true, true, false, false, null, 240, null, null);
     }
 }


### PR DESCRIPTION
### Description

Fixes #849.
Fixes a NullPointerException when RevertSam is run with SANITIZE=true, The NPE is due to trying to find a specific read group format for an input SAM/BAM file without read groups (RG) . Though this file fails `ValidateSamFile`, it should still be processed.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [X] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [X] All tests passing on Travis

#### Review
- [X] Final thumbs-up from reviewer
- [X] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

