### PR TITLE
Add a doc note to change VALIDATION_STRINGENCY if validation error

### DIFF
--- a/src/main/java/picard/sam/RevertSam.java
+++ b/src/main/java/picard/sam/RevertSam.java
@@ -108,6 +108,9 @@ public class RevertSam extends CommandLineProgram {
             "Will output a BAM/SAM file per read group. By default, all outputs will be in BAM format. " +
             "However, outputs will be in SAM format if the input path ends with '.sam', or CRAM format if it ends with '.cram'." +
             " This behaviour can be overriden with OUTPUT_BY_READGROUP_FILE_FORMAT option."+
+            "<p>Note: If the program fails due to a SAM validation error, consider setting the VALIDATION_STRINGENCY option to " +
+            "LENIENT or SILENT if the failures are expected to be obviated by the reversion process " +
+            "(e.g. invalid alignment information will be obviated when the REMOVE_ALIGNMENT_INFORMATION option is used).</p>" +
             "<hr />";
     @Option(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "The input SAM/BAM file to revert the state of.")
     public File INPUT;


### PR DESCRIPTION
### Description

For RevertSam, the user may want to keep reads that fail the SAM validation criteria. Documentation was added to change the VALIDATION_STRINGENCY if the tool stops processing due to a  SAM file validation error.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [X] All tests passing on Travis

#### Review
- [X] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

