### PR TITLE
- oops broke the old option EXPECT_ALL_READ_GROUPS_TO_MATCH. Sorry.

### DIFF
--- a/src/main/java/picard/fingerprint/CrosscheckReadGroupFingerprints.java
+++ b/src/main/java/picard/fingerprint/CrosscheckReadGroupFingerprints.java
@@ -60,6 +60,11 @@ public class CrosscheckReadGroupFingerprints extends CrosscheckFingerprints {
             "and print out a library x library matrix with LOD scores.")
     public boolean CROSSCHECK_LIBRARIES = false;
 
+    @Option(doc="Expect all read groups' fingerprints to match, irrespective of their sample names.  By default (with this value set to " +
+            "false), read groups with different sample names are expected to mismatch, and those with the same sample name are expected " +
+            "to match.", mutex = {"EXPECT_ALL_GROUPS_TO_MATCH"})
+    public boolean EXPECT_ALL_READ_GROUPS_TO_MATCH = false;
+
     @Override
     protected String[] customCommandLineValidation() {
         final List<String> errors = new ArrayList<>();
@@ -85,6 +90,8 @@ public class CrosscheckReadGroupFingerprints extends CrosscheckFingerprints {
 
     @Override
     protected int doWork() {
+
+        if (EXPECT_ALL_READ_GROUPS_TO_MATCH) EXPECT_ALL_GROUPS_TO_MATCH = EXPECT_ALL_READ_GROUPS_TO_MATCH;
 
         if (CROSSCHECK_LIBRARIES) {
             CROSSCHECK_BY = CrosscheckMetric.DataType.LIBRARY;

--- a/src/main/java/picard/fingerprint/CrosscheckReadGroupFingerprints.java
+++ b/src/main/java/picard/fingerprint/CrosscheckReadGroupFingerprints.java
@@ -38,16 +38,14 @@ import java.util.List;
  * individual.
  *
  * @author Tim Fennell
+ *
+ * @deprecated 6/6/2017 Use {@link CrosscheckFingerprints} instead.
  */
 @CommandLineProgramProperties(
         usage = "DEPRECATED: USE CrosscheckFingerprints. Checks if all read groups within a set of BAM files appear to come from the same individual",
         usageShort = "DEPRECATED: USE CrosscheckFingerprints. Checks if all read groups appear to come from the same individual.",
         programGroup = Fingerprinting.class
 )
-/**
- @deprecated 6/6/2017
- Use  {@link CrosscheckFingerprints} instead.
- */
 @Deprecated
 public class CrosscheckReadGroupFingerprints extends CrosscheckFingerprints {
 
@@ -60,7 +58,7 @@ public class CrosscheckReadGroupFingerprints extends CrosscheckFingerprints {
             "and print out a library x library matrix with LOD scores.")
     public boolean CROSSCHECK_LIBRARIES = false;
 
-    @Option(doc="Expect all read groups' fingerprints to match, irrespective of their sample names.  By default (with this value set to " +
+    @Option(doc = "Expect all read groups' fingerprints to match, irrespective of their sample names.  By default (with this value set to " +
             "false), read groups with different sample names are expected to mismatch, and those with the same sample name are expected " +
             "to match.", mutex = {"EXPECT_ALL_GROUPS_TO_MATCH"})
     public boolean EXPECT_ALL_READ_GROUPS_TO_MATCH = false;
@@ -91,7 +89,9 @@ public class CrosscheckReadGroupFingerprints extends CrosscheckFingerprints {
     @Override
     protected int doWork() {
 
-        if (EXPECT_ALL_READ_GROUPS_TO_MATCH) EXPECT_ALL_GROUPS_TO_MATCH = EXPECT_ALL_READ_GROUPS_TO_MATCH;
+        if (EXPECT_ALL_READ_GROUPS_TO_MATCH) {
+            EXPECT_ALL_GROUPS_TO_MATCH = EXPECT_ALL_READ_GROUPS_TO_MATCH;
+        }
 
         if (CROSSCHECK_LIBRARIES) {
             CROSSCHECK_BY = CrosscheckMetric.DataType.LIBRARY;


### PR DESCRIPTION
In a previous change I mistakenly renamed option EXPECT_ALL_READ_GROUPS_TO_MATCH. This PR restores that option.

