### PR TITLE
Publish every snapshot build to artifactory.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,6 @@ before_install:
 script: ./gradlew jacocoTestReport
 after_success:
   - ./gradlew coveralls
+  - if [ "$TRAVIS_BRANCH" == "master" ]; then
+        ./gradlew uploadArchives;
+    fi

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven {
-        url "https://artifactory.broadinstitute.org/artifactory/libs-snapshot/" //for htsjdk snapshots
+        url "https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot/" //for htsjdk snapshots
     }
 }
 
@@ -285,7 +285,7 @@ uploadArchives {
                 authentication(userName: project.findProperty("sonatypeUsername"), password: project.findProperty("sonatypePassword"))
             }
 
-            snapshotRepository(url: "https://artifactory.broadinstitute.org/artifactory/libs-snapshot-local/") {
+            snapshotRepository(url: "https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot-local/") {
                 authentication(userName: System.env.ARTIFACTORY_USERNAME, password: System.env.ARTIFACTORY_PASSWORD)
             }
 


### PR DESCRIPTION
Propose to publish a snapshot build to artifactory for each commit to master to make it easy for downstream projects (picard-private, gatk) to depend on interim builds.

@lbergelson I modeled this on htsjdk, which doesn't include encrypted artifactory credentials in the travis yaml, but still seems to work. Do you know how it publishes without those env settings ?

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [X] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

