### PR TITLE
Sort IlluminaDataProviderFactory.availableTiles consistently in all ctors

### DIFF
--- a/src/main/java/picard/illumina/parser/IlluminaDataProviderFactory.java
+++ b/src/main/java/picard/illumina/parser/IlluminaDataProviderFactory.java
@@ -189,6 +189,7 @@ public class IlluminaDataProviderFactory {
         if (availableTiles.isEmpty()) {
             throw new PicardException("No available tiles were found, make sure that " + basecallDirectory.getAbsolutePath() + " has a lane " + lane);
         }
+        availableTiles.sort(NewIlluminaBasecallsConverter.TILE_NUMBER_COMPARATOR);
 
         outputMapping = new OutputMapping(readStructure);
     }


### PR DESCRIPTION
### Description
IlluminaDataProviderFactory is a handy way to get the list of tiles in a flowcell.  Knowing the order in which Picard processes tiles is important if one wants to parallelize basecalling by processing subsets of tiles.  Picard's tile order is idiosyncratic, and the ordering is implemented in a method in a package-private class.  For CBCLs, the availableTiles list is sorted, so this change merely makes it so that availableTiles is always sorted regardless of which ctor was called.
----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

Note: There do not appear to be any tests for IlluminaDataProviderFactory for me to modify.

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

