### PR TITLE
Made METRICS_FILE optional in DownsampleSam, which was fairly clearly the original intent.

### DIFF
--- a/src/main/java/picard/sam/DownsampleSam.java
+++ b/src/main/java/picard/sam/DownsampleSam.java
@@ -97,7 +97,7 @@ public class DownsampleSam extends CommandLineProgram {
             "Higher accuracy will generally require more memory.")
     public double ACCURACY = 0.0001;
 
-    @Option(shortName = "M", doc = "The file to write metrics to (QualityYieldMetrics)")
+    @Option(shortName = "M", doc = "The file to write metrics to (QualityYieldMetrics)", optional=true)
     public File METRICS_FILE;
 
     private final Log log = Log.getInstance(DownsampleSam.class);


### PR DESCRIPTION
### Description

DownsampleSam recently gained the ability to output metrics on how many reads were retained etc.  The code checks all over the place for `METRICS_FILE == null`, but the `METRICS_FILE` option was never set to `optional=true`.  This fixes that.

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

