### PR TITLE
Allow @RG PU tag to be unpopulated.

### DIFF
--- a/src/main/java/picard/fingerprint/FingerprintIdDetails.java
+++ b/src/main/java/picard/fingerprint/FingerprintIdDetails.java
@@ -133,8 +133,6 @@ public class FingerprintIdDetails {
                 this.runBarcode = tmp[0];
                 this.runLane = Integer.parseInt(tmp[1]);
                 this.molecularBarcode = (tmp.length == 3) ? tmp[2] : "";  // In older BAMS there may be no molecular barcode sequence
-            } else {
-                throw new IllegalArgumentException("Unexpected format " + puString + " for PU attribute");
             }
         } catch (final NumberFormatException e) {
             throw new IllegalArgumentException("Unexpected format " + puString + " for PU attribute");

--- a/src/main/java/picard/fingerprint/FingerprintIdDetails.java
+++ b/src/main/java/picard/fingerprint/FingerprintIdDetails.java
@@ -47,6 +47,7 @@ public class FingerprintIdDetails {
 
     public FingerprintIdDetails() {}
 
+    // If platformUnit is not populated, then fields will be initialized as flowcellBarcode="?", lane=-1, molecularBarcode="?"
     public FingerprintIdDetails(final String platformUnit, final String file) {
         getPlatformUnitDetails(platformUnit);
         this.platformUnit = platformUnit;


### PR DESCRIPTION
### Description

Previous versions of the fingerprint code were resilient to the PU attribute of the RG tag being unpopulated, but the newest version throws an exception if it is not populated in the format D047KACXX110901.1.ACCAACTG.  Removing the else branch that throws the exception restores the previous functionality, populating runBarcode, lane, and molecularBarcode with non-meaningful defaults (?/-1/?). 

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

