### PR TITLE
Add set UQ only option to SetNmMdAndUqTags

### DIFF
--- a/src/main/java/picard/sam/AbstractAlignmentMerger.java
+++ b/src/main/java/picard/sam/AbstractAlignmentMerger.java
@@ -559,7 +559,20 @@ public abstract class AbstractAlignmentMerger {
         if (isBisulfiteSequence) {  // recalculate the NM tag for bisulfite data
             record.setAttribute(SAMTag.NM.name(), SequenceUtil.calculateSamNmTag(record, referenceBases, 0, isBisulfiteSequence));
         }
+        fixUq(record, refSeqWalker, isBisulfiteSequence);
+    }
+
+    /** Calculates and sets UQ tag from the record and the reference
+     *
+     * @param record the record to be fixed
+     * @param refSeqWalker a ReferenceSequenceWalker that will be used to traverse the reference
+     * @param isBisulfiteSequence a flag indicating whether the sequence came from bisulfite-sequencing.
+     *
+     * No return value, modifies the provided record.
+     */
+    public static void fixUq(final SAMRecord record, final ReferenceSequenceFileWalker refSeqWalker, final boolean isBisulfiteSequence) {
         if (record.getBaseQualities() != SAMRecord.NULL_QUALS) {
+            final byte[] referenceBases = refSeqWalker.get(refSeqWalker.getSequenceDictionary().getSequenceIndex(record.getReferenceName())).getBases();
             record.setAttribute(SAMTag.UQ.name(), SequenceUtil.sumQualitiesOfMismatches(record, referenceBases, 0, isBisulfiteSequence));
         }
     }

--- a/src/main/java/picard/sam/AbstractAlignmentMerger.java
+++ b/src/main/java/picard/sam/AbstractAlignmentMerger.java
@@ -554,7 +554,7 @@ public abstract class AbstractAlignmentMerger {
      * No return value, modifies the provided record.
      */
     public static void fixNmMdAndUq(final SAMRecord record, final ReferenceSequenceFileWalker refSeqWalker, final boolean isBisulfiteSequence) {
-        int seqIndex = refSeqWalker.getSequenceDictionary().getSequenceIndex(record.getReferenceName());
+        final int seqIndex = refSeqWalker.getSequenceDictionary().getSequenceIndex(record.getReferenceName());
         final byte[] referenceBases = refSeqWalker.get(seqIndex).getBases();
         // only recalculate NM if it isn't bisulfite, since it needs to be treated specially below
         SequenceUtil.calculateMdAndNmTags(record, referenceBases, true, !isBisulfiteSequence);
@@ -574,7 +574,7 @@ public abstract class AbstractAlignmentMerger {
      */
     public static void fixUq(final SAMRecord record, final ReferenceSequenceFileWalker refSeqWalker, final boolean isBisulfiteSequence) {
         if (record.getBaseQualities() != SAMRecord.NULL_QUALS) {
-            int seqIndex = refSeqWalker.getSequenceDictionary().getSequenceIndex(record.getReferenceName());
+            final int seqIndex = refSeqWalker.getSequenceDictionary().getSequenceIndex(record.getReferenceName());
             final byte[] referenceBases = refSeqWalker.get(seqIndex).getBases();
             record.setAttribute(SAMTag.UQ.name(), SequenceUtil.sumQualitiesOfMismatches(record, referenceBases, 0, isBisulfiteSequence));
         }

--- a/src/main/java/picard/sam/AbstractAlignmentMerger.java
+++ b/src/main/java/picard/sam/AbstractAlignmentMerger.java
@@ -554,8 +554,8 @@ public abstract class AbstractAlignmentMerger {
      * No return value, modifies the provided record.
      */
     public static void fixNmMdAndUq(final SAMRecord record, final ReferenceSequenceFileWalker refSeqWalker, final boolean isBisulfiteSequence) {
-        final ReferenceSequence refSeq = refSeqWalker.get(refSeqWalker.getSequenceDictionary().getSequenceIndex(record.getReferenceName()));
-        final byte[] referenceBases = refSeq.getBases();
+        int seqIndex = refSeqWalker.getSequenceDictionary().getSequenceIndex(record.getReferenceName());
+        final byte[] referenceBases = refSeqWalker.get(seqIndex).getBases();
         // only recalculate NM if it isn't bisulfite, since it needs to be treated specially below
         SequenceUtil.calculateMdAndNmTags(record, referenceBases, true, !isBisulfiteSequence);
         if (isBisulfiteSequence) {  // recalculate the NM tag for bisulfite data
@@ -574,8 +574,8 @@ public abstract class AbstractAlignmentMerger {
      */
     public static void fixUq(final SAMRecord record, final ReferenceSequenceFileWalker refSeqWalker, final boolean isBisulfiteSequence) {
         if (record.getBaseQualities() != SAMRecord.NULL_QUALS) {
-            final ReferenceSequence refSeq = refSeqWalker.get(refSeqWalker.getSequenceDictionary().getSequenceIndex(record.getReferenceName()));
-            final byte[] referenceBases = refSeq.getBases();
+            int seqIndex = refSeqWalker.getSequenceDictionary().getSequenceIndex(record.getReferenceName());
+            final byte[] referenceBases = refSeqWalker.get(seqIndex).getBases();
             record.setAttribute(SAMTag.UQ.name(), SequenceUtil.sumQualitiesOfMismatches(record, referenceBases, 0, isBisulfiteSequence));
         }
     }

--- a/src/main/java/picard/sam/AbstractAlignmentMerger.java
+++ b/src/main/java/picard/sam/AbstractAlignmentMerger.java
@@ -554,8 +554,7 @@ public abstract class AbstractAlignmentMerger {
      * No return value, modifies the provided record.
      */
     public static void fixNmMdAndUq(final SAMRecord record, final ReferenceSequenceFileWalker refSeqWalker, final boolean isBisulfiteSequence) {
-        final int seqIndex = refSeqWalker.getSequenceDictionary().getSequenceIndex(record.getReferenceName());
-        final byte[] referenceBases = refSeqWalker.get(seqIndex).getBases();
+        final byte[] referenceBases = refSeqWalker.get(record.getReferenceIndex()).getBases();
         // only recalculate NM if it isn't bisulfite, since it needs to be treated specially below
         SequenceUtil.calculateMdAndNmTags(record, referenceBases, true, !isBisulfiteSequence);
         if (isBisulfiteSequence) {  // recalculate the NM tag for bisulfite data
@@ -574,8 +573,7 @@ public abstract class AbstractAlignmentMerger {
      */
     public static void fixUq(final SAMRecord record, final ReferenceSequenceFileWalker refSeqWalker, final boolean isBisulfiteSequence) {
         if (record.getBaseQualities() != SAMRecord.NULL_QUALS) {
-            final int seqIndex = refSeqWalker.getSequenceDictionary().getSequenceIndex(record.getReferenceName());
-            final byte[] referenceBases = refSeqWalker.get(seqIndex).getBases();
+            final byte[] referenceBases = refSeqWalker.get(record.getReferenceIndex()).getBases();
             record.setAttribute(SAMTag.UQ.name(), SequenceUtil.sumQualitiesOfMismatches(record, referenceBases, 0, isBisulfiteSequence));
         }
     }

--- a/src/main/java/picard/sam/AbstractAlignmentMerger.java
+++ b/src/main/java/picard/sam/AbstractAlignmentMerger.java
@@ -26,6 +26,7 @@ package picard.sam;
 import htsjdk.samtools.*;
 import htsjdk.samtools.filter.FilteringSamIterator;
 import htsjdk.samtools.filter.SamRecordFilter;
+import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.reference.ReferenceSequenceFileWalker;
 import htsjdk.samtools.SAMFileHeader.SortOrder;
 import htsjdk.samtools.util.*;
@@ -553,7 +554,8 @@ public abstract class AbstractAlignmentMerger {
      * No return value, modifies the provided record.
      */
     public static void fixNmMdAndUq(final SAMRecord record, final ReferenceSequenceFileWalker refSeqWalker, final boolean isBisulfiteSequence) {
-        final byte[] referenceBases = refSeqWalker.get(refSeqWalker.getSequenceDictionary().getSequenceIndex(record.getReferenceName())).getBases();
+        final ReferenceSequence refSeq = refSeqWalker.get(refSeqWalker.getSequenceDictionary().getSequenceIndex(record.getReferenceName()));
+        final byte[] referenceBases = refSeq.getBases();
         // only recalculate NM if it isn't bisulfite, since it needs to be treated specially below
         SequenceUtil.calculateMdAndNmTags(record, referenceBases, true, !isBisulfiteSequence);
         if (isBisulfiteSequence) {  // recalculate the NM tag for bisulfite data
@@ -572,7 +574,8 @@ public abstract class AbstractAlignmentMerger {
      */
     public static void fixUq(final SAMRecord record, final ReferenceSequenceFileWalker refSeqWalker, final boolean isBisulfiteSequence) {
         if (record.getBaseQualities() != SAMRecord.NULL_QUALS) {
-            final byte[] referenceBases = refSeqWalker.get(refSeqWalker.getSequenceDictionary().getSequenceIndex(record.getReferenceName())).getBases();
+            final ReferenceSequence refSeq = refSeqWalker.get(refSeqWalker.getSequenceDictionary().getSequenceIndex(record.getReferenceName()));
+            final byte[] referenceBases = refSeq.getBases();
             record.setAttribute(SAMTag.UQ.name(), SequenceUtil.sumQualitiesOfMismatches(record, referenceBases, 0, isBisulfiteSequence));
         }
     }

--- a/src/main/java/picard/sam/SetNmMdAndUqTags.java
+++ b/src/main/java/picard/sam/SetNmMdAndUqTags.java
@@ -103,21 +103,16 @@ public class SetNmMdAndUqTags extends CommandLineProgram {
 
         final ReferenceSequenceFileWalker refSeq = new ReferenceSequenceFileWalker(REFERENCE_SEQUENCE);
 
-        if(SET_ONLY_UQ){
-            StreamSupport.stream(reader.spliterator(), false)
-                    .peek(rec -> {
-                        if (!rec.getReadUnmappedFlag())
+        StreamSupport.stream(reader.spliterator(), false)
+                .peek(rec -> {
+                    if (!rec.getReadUnmappedFlag()) {
+                        if (SET_ONLY_UQ)
                             AbstractAlignmentMerger.fixUq(rec, refSeq, IS_BISULFITE_SEQUENCE);
-                    })
-                    .forEach(writer::addAlignment);
-        } else {
-            StreamSupport.stream(reader.spliterator(), false)
-                    .peek(rec -> {
-                        if (!rec.getReadUnmappedFlag())
+                        else
                             AbstractAlignmentMerger.fixNmMdAndUq(rec, refSeq, IS_BISULFITE_SEQUENCE);
-                    })
-                    .forEach(writer::addAlignment);
-        }
+                    }
+                })
+                .forEach(writer::addAlignment);
         CloserUtil.close(reader);
         writer.close();
         return 0;

--- a/src/main/java/picard/sam/SetNmMdAndUqTags.java
+++ b/src/main/java/picard/sam/SetNmMdAndUqTags.java
@@ -73,6 +73,9 @@ public class SetNmMdAndUqTags extends CommandLineProgram {
     @Argument(doc = "Whether the file contains bisulfite sequence (used when calculating the NM tag).")
     public boolean IS_BISULFITE_SEQUENCE = false;
 
+    @Option(doc = "Only set the UQ tag, ignore MD and NM")
+    public boolean SET_ONLY_UQ = false;
+
     @Override
     protected boolean requiresReference() {
         return true;
@@ -100,10 +103,21 @@ public class SetNmMdAndUqTags extends CommandLineProgram {
 
         final ReferenceSequenceFileWalker refSeq = new ReferenceSequenceFileWalker(REFERENCE_SEQUENCE);
 
-        StreamSupport.stream(reader.spliterator(),false)
-                .peek(rec->{if(!rec.getReadUnmappedFlag()) AbstractAlignmentMerger.fixNmMdAndUq(rec, refSeq, IS_BISULFITE_SEQUENCE);})
-                .forEach(writer::addAlignment);
-
+        if(SET_ONLY_UQ){
+            StreamSupport.stream(reader.spliterator(), false)
+                    .peek(rec -> {
+                        if (!rec.getReadUnmappedFlag())
+                            AbstractAlignmentMerger.fixUq(rec, refSeq, IS_BISULFITE_SEQUENCE);
+                    })
+                    .forEach(writer::addAlignment);
+        } else {
+            StreamSupport.stream(reader.spliterator(), false)
+                    .peek(rec -> {
+                        if (!rec.getReadUnmappedFlag())
+                            AbstractAlignmentMerger.fixNmMdAndUq(rec, refSeq, IS_BISULFITE_SEQUENCE);
+                    })
+                    .forEach(writer::addAlignment);
+        }
         CloserUtil.close(reader);
         writer.close();
         return 0;

--- a/src/main/java/picard/sam/SetNmMdAndUqTags.java
+++ b/src/main/java/picard/sam/SetNmMdAndUqTags.java
@@ -68,7 +68,7 @@ public class SetNmMdAndUqTags extends CommandLineProgram {
     @Argument(doc = "Whether the file contains bisulfite sequence (used when calculating the NM tag).")
     public boolean IS_BISULFITE_SEQUENCE = false;
 
-    @Option(doc = "Only set the UQ tag, ignore MD and NM")
+    @Argument(doc = "Only set the UQ tag, ignore MD and NM")
     public boolean SET_ONLY_UQ = false;
 
     @Override

--- a/src/test/java/picard/sam/SetNmMdAndUqTagsTest.java
+++ b/src/test/java/picard/sam/SetNmMdAndUqTagsTest.java
@@ -11,7 +11,7 @@ public class SetNmMdAndUqTagsTest {
 
     private static final File fasta = new File("testdata/picard/sam/merger.fasta");
     @DataProvider(name="filesToFix")
-    Object[][] TestValidSortData() {
+    Object[][] testValidSortData() {
         return new Object[][]{
                 new Object[]{new File("testdata/picard/sam/aligned.sam"), fasta},
                 new Object[]{new File("testdata/picard/sam/aligned_queryname_sorted.sam"), fasta},
@@ -20,7 +20,7 @@ public class SetNmMdAndUqTagsTest {
     }
 
     @Test(dataProvider = "filesToFix")
-    public void TestValidSort(final File input, final File reference) throws IOException {
+    public void testValidSort(final File input, final File reference) throws IOException {
         final File sortOutput = File.createTempFile("Sort", ".bam");
         sortOutput.deleteOnExit();
         final File fixOutput = File.createTempFile("Fix", ".bam");
@@ -30,39 +30,67 @@ public class SetNmMdAndUqTagsTest {
 
         sort(input, sortOutput);
         fixFile(sortOutput, fixOutput, reference);
-        validate(fixOutput,validateOutput, reference);
+        validate(fixOutput,validateOutput, reference, false);
     }
 
-    private void validate(final File input, final File output, final File reference) {
+    @Test(dataProvider = "filesToFix")
+    public void testValidUqSort(final File input, final File reference) throws IOException {
+        final File sortOutput = File.createTempFile("Sort", ".bam");
+        sortOutput.deleteOnExit();
+        final File fixOutput = File.createTempFile("Fix", ".bam");
+        fixOutput.deleteOnExit();
+        final File validateOutput = File.createTempFile("Sort", ".validation_report");
+        validateOutput.deleteOnExit();
 
-        final String[] args = new String[] {
-                "INPUT="+input,
-                "OUTPUT="+output,
+        sort(input, sortOutput);
+        setUqOnly(sortOutput, fixOutput, reference);
+        //ignore warnings here because having no NM/MD tags throws a warning
+        validate(fixOutput,validateOutput, reference, true);
+    }
+
+    private void validate(final File input, final File output, final File reference, final boolean ignore_warnings) {
+        final String[] args = {
+                "INPUT=" + input,
+                "OUTPUT=" + output,
                 "MODE=VERBOSE",
-                "REFERENCE_SEQUENCE="+reference };
+                "REFERENCE_SEQUENCE=" + reference,
+                "IGNORE_WARNINGS=" + ignore_warnings
+        };
 
         ValidateSamFile validateSam = new ValidateSamFile();
         Assert.assertEquals(validateSam.instanceMain(args), 0, "validate did not succeed");
     }
 
     private void sort(final File input, final File output) {
-
-        final String[] args = new String[] {
+        final String[] args = {
                 "INPUT=" + input,
                 "OUTPUT=" + output,
                 "SORT_ORDER=coordinate"
-               };
+        };
 
         SortSam sortSam = new SortSam();
         Assert.assertEquals(sortSam.instanceMain(args), 0, "Sort did not succeed");
     }
 
     private void fixFile(final File input, final File output, final File reference) throws IOException {
+        final String[] args = {
+                "INPUT=" + input,
+                "OUTPUT=" + output,
+                "REFERENCE_SEQUENCE=" + reference
+        };
 
-        final String[] args = new String[] {
-                "INPUT="+input,
-                "OUTPUT="+output,
-                "REFERENCE_SEQUENCE="+reference };
+        SetNmMdAndUqTags setNmMdAndUqTags = new SetNmMdAndUqTags();
+        Assert.assertEquals(setNmMdAndUqTags.instanceMain(args), 0, "Fix did not succeed");
+    }
+
+    private void setUqOnly(final File input, final File output, final File reference) throws IOException {
+
+        final String[] args = {
+                "INPUT=" + input,
+                "OUTPUT=" + output,
+                "REFERENCE_SEQUENCE=" + reference,
+                "SET_ONLY_UQ=true"
+        };
 
         SetNmMdAndUqTags setNmMdAndUqTags = new SetNmMdAndUqTags();
         Assert.assertEquals(setNmMdAndUqTags.instanceMain(args), 0, "Fix did not succeed");


### PR DESCRIPTION
The idea for this is to run on a bam created from cram -> bam using Samtools.  Samtools adds the MD/NM tag to each record on the fly so there is no need to redo those calculations.  This makes it possible to only set the UQ tag.  

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

