### PR TITLE
Bump GKL version to avoid hanging in AVX support check.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ jacoco {
 final htsjdkVersion = System.getProperty('htsjdk.version', '2.10.1')
 
 dependencies {
-    compile('com.intel.gkl:gkl:0.5.2') {
+    compile('com.intel.gkl:gkl:0.5.3') {
         exclude module: 'htsjdk'
     }
     compile 'com.google.guava:guava:15.0'
@@ -238,7 +238,7 @@ task createMetricsDoc(dependsOn: classes, type: Javadoc) {
     doFirst {
         htmlDirInc.mkdirs()
     }
-    
+
     source = sourceSets.main.allJava
     classpath = sourceSets.main.runtimeClasspath
     outputs.dir(htmlDirInc)


### PR DESCRIPTION
### Description

This should fix #886. Before this change, the `IntelInflaterDeflaterLoadTest` failed on our CentOS box. With the upgraded dependency, that test passes.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

