### PR TITLE
Replaced hard-coded uses of .vcf, .bcf, and .vcf.gz with static variables

### DIFF
--- a/src/main/java/picard/vcf/GenotypeConcordance.java
+++ b/src/main/java/picard/vcf/GenotypeConcordance.java
@@ -164,7 +164,7 @@ public class GenotypeConcordance extends CommandLineProgram {
     public static final String SUMMARY_METRICS_FILE_EXTENSION     = ".genotype_concordance_summary_metrics";
     public static final String DETAILED_METRICS_FILE_EXTENSION    = ".genotype_concordance_detail_metrics";
     public static final String CONTINGENCY_METRICS_FILE_EXTENSION = ".genotype_concordance_contingency_metrics";
-    public static final String OUTPUT_VCF_FILE_EXTENSION          = ".genotype_concordance.vcf.gz";
+    public static final String OUTPUT_VCF_FILE_EXTENSION          = ".genotype_concordance" + IOUtil.COMPRESSED_VCF_FILE_EXTENSION;
 
     protected GenotypeConcordanceCounts snpCounter;
     public GenotypeConcordanceCounts getSnpCounter() { return snpCounter; }

--- a/src/main/java/picard/vcf/MendelianViolations/FindMendelianViolations.java
+++ b/src/main/java/picard/vcf/MendelianViolations/FindMendelianViolations.java
@@ -235,7 +235,7 @@ public class FindMendelianViolations extends CommandLineProgram {
             headerLines.add(new VCFInfoHeaderLine(MendelianViolationDetector.ORIGINAL_AN, 1, VCFHeaderLineType.Integer, "Original AN"));
 
             for (final PedFile.PedTrio trio : pedFile.get().values()) {
-                final File outputFile = new File(VCF_DIR, IOUtil.makeFileNameSafe(trio.getFamilyId() + ".vcf"));
+                final File outputFile = new File(VCF_DIR, IOUtil.makeFileNameSafe(trio.getFamilyId() + IOUtil.VCF_FILE_EXTENSION));
                 LOG.info(String.format("Writing %s violation VCF to %s", trio.getFamilyId(), outputFile.getAbsolutePath()));
 
                 final VariantContextWriter out = new VariantContextWriterBuilder()

--- a/src/main/java/picard/vcf/VcfUtils.java
+++ b/src/main/java/picard/vcf/VcfUtils.java
@@ -1,15 +1,12 @@
 package picard.vcf;
 
+import htsjdk.samtools.util.IOUtil;
 import java.io.File;
 
 /**
  * Created by farjoun on 4/1/17.
  */
 public class VcfUtils {
-
-    static String UNCOMPRESSED_VCF_ENDING = ".vcf";
-    static String COMPRESSED_VCF_ENDING = ".vcf.gz";
-    static String BCF_ENDING = ".bcf";
 
     /**
      * Checks if the suffix is one of those that are allowed for the various
@@ -18,8 +15,8 @@ public class VcfUtils {
     static public boolean isVariantFile(final File file){
         final String name = file.getName();
 
-        return name.endsWith(UNCOMPRESSED_VCF_ENDING) ||
-                name.endsWith(COMPRESSED_VCF_ENDING) ||
-                name.endsWith(BCF_ENDING);
+        return name.endsWith(IOUtil.VCF_FILE_EXTENSION) ||
+                name.endsWith(IOUtil.COMPRESSED_VCF_FILE_EXTENSION) ||
+                name.endsWith(IOUtil.BCF_FILE_EXTENSION);
     }
 }

--- a/src/main/java/picard/vcf/filter/FilterVcf.java
+++ b/src/main/java/picard/vcf/filter/FilterVcf.java
@@ -156,7 +156,7 @@ public class FilterVcf extends CommandLineProgram {
 
     private boolean isVcfOrBcf(final File file) {
         final String fileName = file.getName();
-        return fileName.endsWith(".vcf") || fileName.endsWith(".bcf");
+        return fileName.endsWith(IOUtil.VCF_FILE_EXTENSION) || fileName.endsWith(IOUtil.BCF_FILE_EXTENSION);
     }
     
     /** Javascript filter implementing VariantFilter */


### PR DESCRIPTION
### Description

Replaced hard-coded uses of .vcf, .bcf, and .vcf.gz with static variables

(Didn't touch the tests or comments though)

Addresses https://github.com/broadinstitute/picard/issues/854 

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

