### PR TITLE
Adding the ability to set a maximum size of duplicate sets for checking optical dups

### DIFF
--- a/src/main/java/picard/sam/markduplicates/util/AbstractOpticalDuplicateFinderCommandLineProgram.java
+++ b/src/main/java/picard/sam/markduplicates/util/AbstractOpticalDuplicateFinderCommandLineProgram.java
@@ -58,12 +58,18 @@ public abstract class AbstractOpticalDuplicateFinderCommandLineProgram extends C
             "appropriate. For other platforms and models, users should experiment to find what works best.")
     public int OPTICAL_DUPLICATE_PIXEL_DISTANCE = OpticalDuplicateFinder.DEFAULT_OPTICAL_DUPLICATE_DISTANCE;
 
+    @Argument(doc = "This number is the maximum size of a set of duplicate reads for which we will attempt to determine " +
+            "which are optical duplicates.  Please be aware that if you raise this value too high and do encounter a very " +
+            "large set of duplicate reads, it will severely affect the runtime of this tool.  To completely disable this check, " +
+            "set the value to -1.")
+    public long MAX_OPTICAL_DUPLICATE_SET_SIZE = OpticalDuplicateFinder.DEFAULT_MAX_DUPLICATE_SET_SIZE;
+
     // The tool with which to find optical duplicates
     protected OpticalDuplicateFinder opticalDuplicateFinder = null;
 
     // Needed for testing
     public void setupOpticalDuplicateFinder() {
-        this.opticalDuplicateFinder = new OpticalDuplicateFinder(READ_NAME_REGEX, OPTICAL_DUPLICATE_PIXEL_DISTANCE, LOG);
+        this.opticalDuplicateFinder = new OpticalDuplicateFinder(READ_NAME_REGEX, OPTICAL_DUPLICATE_PIXEL_DISTANCE, MAX_OPTICAL_DUPLICATE_SET_SIZE, LOG);
     }
 
     @Override

--- a/src/test/java/picard/sam/markduplicates/util/OpticalDuplicateFinderTest.java
+++ b/src/test/java/picard/sam/markduplicates/util/OpticalDuplicateFinderTest.java
@@ -125,6 +125,23 @@ public class OpticalDuplicateFinderTest {
         assertEquals(finder.findOpticalDuplicates(locs, locs.get(2)), new boolean[] {true, true, false});
     }
 
+    @Test
+    public void testMaxSetSize() {
+        final Log log = Log.getInstance(OpticalDuplicateFinderTest.class);
+        List<PhysicalLocation> locs = Arrays.asList(
+                loc(7, 1500, 1500),
+                loc(7, 1501, 1501),
+                loc(7, 1490, 1502));
+
+        // there should be at least 1 optical duplicate
+        final OpticalDuplicateFinder normalFinder = new OpticalDuplicateFinder(OpticalDuplicateFinder.DEFAULT_READ_NAME_REGEX, 100, log);
+        Assert.assertTrue(countTrue(normalFinder.findOpticalDuplicates(locs, null)) > 0);
+
+        // there should be zero optical duplicates
+        final OpticalDuplicateFinder constrainedFinder = new OpticalDuplicateFinder(OpticalDuplicateFinder.DEFAULT_READ_NAME_REGEX, 100, 1, log);
+        Assert.assertEquals(countTrue(constrainedFinder.findOpticalDuplicates(locs, null)), 0);
+    }
+
     /** Helper method to create a physical location. */
     private PhysicalLocation loc(final int tile, final int x, final int y) {
         final PhysicalLocation l = new PhysicalLocationInt() {


### PR DESCRIPTION
### Description

The algorithm for determining optical duplicates is n^2, which is fine when handling normal samples.  But when you hit a sample that has one or more duplicate sets with over 1 million read pairs, it's really bad (yup, that's over a trillion comparisons made in that algorithm; we're seeing that take over a week to run!).  While it may be worth making the algorithm more efficient one day, really once we have a duplicate set with that many reads we're okay just skipping the optical dup check.

In this PR I've added a max set size for the optical dup check.  I've set it to 300K because that's already ~10 billion comparisons.  A user can always disable this maximum (at his/her own peril) on the command-line.

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

