### PR TITLE
Extract CommandLineProgram finding/processing code for reuse.

### DIFF
--- a/src/main/java/picard/cmdline/PicardCommandLine.java
+++ b/src/main/java/picard/cmdline/PicardCommandLine.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 /*
  * The MIT License
@@ -108,37 +110,29 @@ public class PicardCommandLine {
 
     /** Returns the command line program specified, or prints the usage and exits with exit code 1 **/
     private static CommandLineProgram extractCommandLineProgram(final String[] args, final List<String> packageList, final String commandLineName) {
-        /** Get the set of classes that are our command line programs **/
-        final ClassFinder classFinder = new ClassFinder();
-        for (final String pkg : packageList) {
-            classFinder.find(pkg, CommandLineProgram.class);
-        }
-        String missingAnnotationClasses = "";
-
-        final Map<String, Class<?>> simpleNameToClass = new HashMap<String, Class<?>>();
-        for (final Class clazz : classFinder.getClasses()) {
-            // No interfaces, synthetic, primitive, local, or abstract classes.
-            if (!clazz.isInterface() && !clazz.isSynthetic() && !clazz.isPrimitive() && !clazz.isLocalClass()
-                    && !Modifier.isAbstract(clazz.getModifiers())) {
-                final CommandLineProgramProperties property = getProgramProperty(clazz);
-                // Check for missing annotations
-                if (null == property) {
-                    if (missingAnnotationClasses.isEmpty()) missingAnnotationClasses += clazz.getSimpleName();
-                    else missingAnnotationClasses += ", " + clazz.getSimpleName();
-                }
-                else if (!property.omitFromCommandLine()) { /** We should check for missing annotations later **/
-                    if (simpleNameToClass.containsKey(clazz.getSimpleName())) {
-                        throw new RuntimeException("Simple class name collision: " + clazz.getSimpleName());
+        final Map<String, Class<?>> simpleNameToClass = new HashMap<>();
+        final List<String> missingAnnotationClasses = new ArrayList<>();
+        processAllCommandLinePrograms(
+                packageList,
+                (Class<CommandLineProgram> clazz, CommandLineProgramProperties clProperties) -> {
+                    // Check for missing annotations
+                    if (null == clProperties) {
+                        missingAnnotationClasses.add(clazz.getSimpleName());
                     }
-                    simpleNameToClass.put(clazz.getSimpleName(), clazz);
+                    else if (!clProperties.omitFromCommandLine()) { /** We should check for missing annotations later **/
+                        if (simpleNameToClass.containsKey(clazz.getSimpleName())) {
+                            throw new RuntimeException("Simple class name collision: " + clazz.getSimpleName());
+                        }
+                        simpleNameToClass.put(clazz.getSimpleName(), clazz);
+                    }
                 }
-            }
-        }
+        );
         if (!missingAnnotationClasses.isEmpty()) {
-            throw new RuntimeException("The following classes are missing the required CommandLineProgramProperties annotation: " + missingAnnotationClasses);
+            throw new RuntimeException("The following classes are missing the required CommandLineProgramProperties annotation: " +
+                    missingAnnotationClasses.stream().collect(Collectors.joining((", "))));
         }
 
-        final Set<Class<?>> classes = new HashSet<Class<?>>();
+        final Set<Class<?>> classes = new HashSet<>();
         classes.addAll(simpleNameToClass.values());
 
         if (args.length < 1) {
@@ -164,6 +158,27 @@ public class PicardCommandLine {
             }
         }
         return null;
+    }
+
+    /**
+     * Process each {@code CommandLineProgram}-derived class given a list of packages.
+     * @param packageList list of packages to search
+     * @param clpClassProcessor function to process each CommandLineProgram class found in {@code packageList} (note
+     *                          that the {@code CommandLineProgramProperties} argument may be null)
+     */
+    public static void processAllCommandLinePrograms(
+            final List<String> packageList,
+            final BiConsumer<Class<CommandLineProgram>, CommandLineProgramProperties> clpClassProcessor) {
+        final ClassFinder classFinder = new ClassFinder();
+        packageList.forEach(pkg -> classFinder.find(pkg, CommandLineProgram.class));
+
+        for (final Class clazz : classFinder.getClasses()) {
+            // No interfaces, synthetic, primitive, local, or abstract classes.
+            if (!clazz.isInterface() && !clazz.isSynthetic() && !clazz.isPrimitive() && !clazz.isLocalClass()
+                    && !Modifier.isAbstract(clazz.getModifiers())) {
+                clpClassProcessor.accept(clazz, PicardCommandLine.getProgramProperty(clazz));
+            }
+        }
     }
 
     public static CommandLineProgramProperties getProgramProperty(Class clazz) {

--- a/src/test/java/picard/cmdline/PicardCommandLineTest.java
+++ b/src/test/java/picard/cmdline/PicardCommandLineTest.java
@@ -3,14 +3,10 @@ package picard.cmdline;
 import org.broadinstitute.barclay.argparser.CommandLineArgumentParser;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.lang.reflect.Modifier;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
-import static picard.cmdline.PicardCommandLine.getProgramProperty;
+import java.util.*;
 
 /**
  * Created by farjoun on 9/10/15.
@@ -23,39 +19,44 @@ public class PicardCommandLineTest {
         picardCommandLine.instanceMain(new String[]{""});
     }
 
+    @Test
+    public void testProcessCommandLinePrograms() {
+        final List<Class<CommandLineProgram>> allCLPs = new ArrayList<>();
+
+        PicardCommandLine.processAllCommandLinePrograms(
+                Collections.singletonList("picard"),
+                (Class<CommandLineProgram> clazz, CommandLineProgramProperties clProperties) -> {
+                    allCLPs.add(clazz);
+                });
+        Assert.assertTrue(allCLPs.size() > 0);
+        allCLPs.forEach(clazz -> Assert.assertTrue(CommandLineProgram.class.isAssignableFrom(clazz)));
+    }
+
     // Find every CommandLineProgram in picard, instantiate it, and initialize a Barclay parser using the
-    // resulting object. This catches any CommandLineProgram that depends on using duplicate (of overridable) arguments,
+    // resulting object. This catches any CommandLineProgram that depends on using duplicate (of overrideable) arguments,
     // which are not accepted by the Barclay parser, and have no other tests where this would surface.
     //
     // NOTE that it does NOT test that those tools actually work correctly, only that they aren't immediately
     // rejected with a CommandLineParserInternalException from the Barclay parser.
     @Test
     public void testLaunchAllCommandLineProgramsWithBarclayParser() {
-        final ClassFinder classFinder = new ClassFinder();
-        for (final String pkg : Collections.singletonList("picard")) {
-            classFinder.find(pkg, CommandLineProgram.class);
-        }
-
-        for (final Class clazz : classFinder.getClasses()) {
-            // No interfaces, synthetic, primitive, local, or abstract classes.
-            if (!clazz.isInterface() && !clazz.isSynthetic() && !clazz.isPrimitive() && !clazz.isLocalClass()
-                    && !Modifier.isAbstract(clazz.getModifiers())) {
-                final CommandLineProgramProperties clProperties = getProgramProperty(clazz);
-                // Check for missing annotations
-                if (null != clProperties) {
-                    try {
-                        final Object commandLineProgram = clazz.newInstance();
+        PicardCommandLine.processAllCommandLinePrograms(
+                Collections.singletonList("picard"),
+                (Class<CommandLineProgram> clazz, CommandLineProgramProperties clProperties) -> {
+                    // Check for missing annotations
+                    if (null != clProperties) {
                         try {
-                            new CommandLineArgumentParser(commandLineProgram);
-                        } catch (CommandLineException.CommandLineParserInternalException e) {
-                            throw new RuntimeException("Barclay command line parser internal exception parsing class: " + clazz.getName(), e);
+                            final Object commandLineProgram = clazz.newInstance();
+                            try {
+                                new CommandLineArgumentParser(commandLineProgram);
+                            } catch (CommandLineException.CommandLineParserInternalException e) {
+                                throw new RuntimeException("Barclay command line parser internal exception parsing class: " + clazz.getName(), e);
+                            }
+                        } catch (IllegalAccessException | InstantiationException e) {
+                            throw new RuntimeException("Failure instantiating command line program: " + clazz.getName(), e);
                         }
-                    } catch (IllegalAccessException | InstantiationException e) {
-                        throw new RuntimeException("Failure instantiating command line program: " + clazz.getName(), e);
                     }
                 }
-            }
-        }
+        );
     }
-
 }


### PR DESCRIPTION
### Description

Extract CommandLineProgram finding/processing code for reuse, as requested [here](https://github.com/broadinstitute/picard-private/pull/987);

### Checklist (never delete this)

#### Content
- [ x] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [x ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

