### PR TITLE
Change log4j logging to send all logging to stderr.

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
   <Appenders>
-    <Console name="Console" target="SYSTEM_OUT">
+    <Console name="Console" target="SYSTEM_ERR">
       <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %logger{1} - %msg%n"/>
     </Console>
   </Appenders>

--- a/src/test/java/picard/cmdline/CommandLineProgramStartupErrorLogTest.java
+++ b/src/test/java/picard/cmdline/CommandLineProgramStartupErrorLogTest.java
@@ -42,4 +42,22 @@ public class CommandLineProgramStartupErrorLogTest {
             System.setErr(oldStderr);
         }
     }
+
+
+    @Test
+    public void testNoStartupOutputLog() {
+        ByteArrayOutputStream stdoutStream = new ByteArrayOutputStream();
+        PrintStream newStdout = new PrintStream(stdoutStream);
+        PrintStream oldStdout = System.out;
+        System.setOut(newStdout);
+
+        CommandLineProgram clp = new MockCLP();
+
+        try {
+            clp.instanceMain(new String[]{});
+            Assert.assertTrue(stdoutStream.toString().isEmpty(), stdoutStream.toString());
+        } finally {
+            System.setOut(oldStdout);
+        }
+    }
 }


### PR DESCRIPTION
### Description

A recent change sent logging output from the intel deflator to STDOUT.  This unexepected output has caused problems for CLPs that use picard's stdout. 

This PR changes the log4j configuration to send all output to STDERR.
----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

