### PR TITLE
Add PG tag to every read option

### DIFF
--- a/src/main/java/picard/sam/AbstractAlignmentMerger.java
+++ b/src/main/java/picard/sam/AbstractAlignmentMerger.java
@@ -91,7 +91,7 @@ public abstract class AbstractAlignmentMerger {
     private boolean addMateCigar = false;
     private boolean unmapContaminantReads = false;
     private UnmappingReadStrategy unmappingReadsStrategy = UnmappingReadStrategy.DO_NOT_CHANGE;
-    private boolean addPGTagToReads = false;
+    private boolean addPGTagToReads = true;
 
 
     private final SamRecordFilter alignmentFilter = new SamRecordFilter() {

--- a/src/main/java/picard/sam/AbstractAlignmentMerger.java
+++ b/src/main/java/picard/sam/AbstractAlignmentMerger.java
@@ -26,7 +26,6 @@ package picard.sam;
 import htsjdk.samtools.*;
 import htsjdk.samtools.filter.FilteringSamIterator;
 import htsjdk.samtools.filter.SamRecordFilter;
-import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.reference.ReferenceSequenceFileWalker;
 import htsjdk.samtools.SAMFileHeader.SortOrder;
 import htsjdk.samtools.util.*;
@@ -125,14 +124,22 @@ public abstract class AbstractAlignmentMerger {
 
         /** Adds a record to the sink. */
         void add(final SAMRecord rec) {
-            if (writer != null) writer.addAlignment(rec);
-            if (sorter != null) sorter.add(rec);
+            if (writer != null) {
+                writer.addAlignment(rec);
+            }
+            if (sorter != null) {
+                sorter.add(rec);
+            }
         }
 
         /** Closes the underlying resource. */
         void close() {
-            if (this.writer != null) this.writer.close();
-            if (this.sorter != null) this.sorter.doneAdding();
+            if (this.writer != null) {
+                this.writer.close();
+            }
+            if (this.sorter != null) {
+                this.sorter.doneAdding();
+            }
         }
     }
 
@@ -315,7 +322,10 @@ public abstract class AbstractAlignmentMerger {
         this.maxRecordsInRam = maxRecordsInRam;
     }
 
-    /** Allows the caller to decide whether or not to write the PG tag to reads when applicable */
+    /**
+     * Set addPGTagToReads. If true, the PG will be added to reads when applicable. If false, the PG tag will not be added.
+     * Default is true
+     */
     public void setAddPGTagToReads(final boolean addPGTagToReads) {
         this.addPGTagToReads = addPGTagToReads;
     }
@@ -453,13 +463,19 @@ public abstract class AbstractAlignmentMerger {
                         // this avoids the scenario of having multiple unmapped reads with the same name & pair flags
                         if (!firstToWrite.getReadUnmappedFlag() || isPrimaryAlignment) {
                             addIfNotFiltered(sink, firstToWrite);
-                            if (firstToWrite.getReadUnmappedFlag()) ++unmapped;
-                            else ++aligned;
+                            if (firstToWrite.getReadUnmappedFlag()) {
+                                ++unmapped;
+                            } else {
+                                ++aligned;
+                            }
                         }
                         if (!secondToWrite.getReadUnmappedFlag() || isPrimaryAlignment) {
                             addIfNotFiltered(sink, secondToWrite);
-                            if (!secondToWrite.getReadUnmappedFlag()) ++aligned;
-                            else ++unmapped;
+                            if (!secondToWrite.getReadUnmappedFlag()) {
+                                ++aligned;
+                            } else {
+                                ++unmapped;
+                            }
                         }
                     }
 
@@ -477,7 +493,9 @@ public abstract class AbstractAlignmentMerger {
                             if (!out.getReadUnmappedFlag()) {
                                 addIfNotFiltered(sink, out);
                                 ++aligned;
-                            } else ++unmapped;
+                            } else {
+                                ++unmapped;
+                            }
                         }
                     }
                 } else {
@@ -487,9 +505,14 @@ public abstract class AbstractAlignmentMerger {
                         transferAlignmentInfoToFragment(recToWrite, nextAligned.getFragment(i), unmapDueToContaminant, clone);
                         // Only write unmapped read if it was originally the primary.
                         // this avoids the scenario of having multiple unmapped reads with the same name & pair flags
-                        if (!recToWrite.getReadUnmappedFlag() || isPrimary) addIfNotFiltered(sink, recToWrite);
-                        if (recToWrite.getReadUnmappedFlag()) ++unmapped;
-                        else ++aligned;
+                        if (!recToWrite.getReadUnmappedFlag() || isPrimary) {
+                            addIfNotFiltered(sink, recToWrite);
+                        }
+                        if (recToWrite.getReadUnmappedFlag()) {
+                            ++unmapped;
+                        } else {
+                            ++aligned;
+                        }
                     }
                     // Take all of the supplemental reads which had been stashed and add them (as appropriate) to sorted
                     for (final SAMRecord supplementalRec : nextAligned.getSupplementalFirstOfPairOrFragment()) {
@@ -499,7 +522,9 @@ public abstract class AbstractAlignmentMerger {
                         if (!recToWrite.getReadUnmappedFlag()) {
                             addIfNotFiltered(sink, recToWrite);
                             ++aligned;
-                        } else ++unmapped;
+                        } else {
+                            ++unmapped;
+                        }
                     }
                 }
                 nextAligned = nextAligned();
@@ -702,9 +727,15 @@ public abstract class AbstractAlignmentMerger {
     private void transferAlignmentInfoToPairedRead(final SAMRecord firstUnaligned, final SAMRecord secondUnaligned,
                                                    final SAMRecord firstAligned, final SAMRecord secondAligned,
                                                    final boolean isContaminant, final boolean needsSafeReverseComplement) {
-        if (firstAligned != null) transferAlignmentInfoToFragment(firstUnaligned, firstAligned, isContaminant, needsSafeReverseComplement);
-        if (secondAligned != null) transferAlignmentInfoToFragment(secondUnaligned, secondAligned, isContaminant, needsSafeReverseComplement);
-        if (isClipOverlappingReads()) clipForOverlappingReads(firstUnaligned, secondUnaligned);
+        if (firstAligned != null) {
+            transferAlignmentInfoToFragment(firstUnaligned, firstAligned, isContaminant, needsSafeReverseComplement);
+        }
+        if (secondAligned != null) {
+            transferAlignmentInfoToFragment(secondUnaligned, secondAligned, isContaminant, needsSafeReverseComplement);
+        }
+        if (isClipOverlappingReads()) {
+            clipForOverlappingReads(firstUnaligned, secondUnaligned);
+        }
         SamPairUtil.setMateInfo(secondUnaligned, firstUnaligned, addMateCigar);
         if (!keepAlignerProperPairFlags) {
             SamPairUtil.setProperPairFlags(secondUnaligned, firstUnaligned, expectedOrientations);
@@ -753,8 +784,12 @@ public abstract class AbstractAlignmentMerger {
         int clipped = 0;
         while (iterator.hasNext()) {
             final CigarElement elem = iterator.next();
-            if (elem.getOperator() != CigarOperator.SOFT_CLIP && elem.getOperator() != CigarOperator.HARD_CLIP) break;
-            if (elem.getOperator() == CigarOperator.SOFT_CLIP) clipped = elem.getLength();
+            if (elem.getOperator() != CigarOperator.SOFT_CLIP && elem.getOperator() != CigarOperator.HARD_CLIP) {
+                break;
+            }
+            if (elem.getOperator() == CigarOperator.SOFT_CLIP) {
+                clipped = elem.getLength();
+            }
         }
 
         return clipped;
@@ -841,7 +876,9 @@ public abstract class AbstractAlignmentMerger {
                     rec.getAlignmentEnd(),
                     rec.getReadLength(),
                     rec.getCigar());
-            if (null != readCigar) rec.setCigar(readCigar);
+            if (null != readCigar) {
+                rec.setCigar(readCigar);
+            }
         }
 
         // If the read's mate maps off the end of the alignment, clip it
@@ -853,7 +890,9 @@ public abstract class AbstractAlignmentMerger {
                     SAMUtils.getMateAlignmentEnd(rec), // NB: this could be computed without another call to getMateCigar
                     mateCigar.getReadLength(),
                     mateCigar);
-            if (null != mateCigar) rec.setAttribute(SAMTag.MC.name(), mateCigar.toString());
+            if (null != mateCigar) {
+                rec.setAttribute(SAMTag.MC.name(), mateCigar.toString());
+            }
         }
     }
 
@@ -895,10 +934,14 @@ public abstract class AbstractAlignmentMerger {
 
         // All tags that start with a lower-case letter are user defined and should not be overridden by aligner
         // unless explicitly specified in attributesToRetain.
-        if (Character.isLowerCase(firstCharOfTag)) return true;
+        if (Character.isLowerCase(firstCharOfTag)) {
+            return true;
+        }
 
         for (final char c : RESERVED_ATTRIBUTE_STARTS) {
-            if (firstCharOfTag == c) return true;
+            if (firstCharOfTag == c) {
+                return true;
+            }
         }
         return false;
     }

--- a/src/main/java/picard/sam/AbstractAlignmentMerger.java
+++ b/src/main/java/picard/sam/AbstractAlignmentMerger.java
@@ -91,6 +91,7 @@ public abstract class AbstractAlignmentMerger {
     private boolean addMateCigar = false;
     private boolean unmapContaminantReads = false;
     private UnmappingReadStrategy unmappingReadsStrategy = UnmappingReadStrategy.DO_NOT_CHANGE;
+    private boolean addPGTagToReads = false;
 
 
     private final SamRecordFilter alignmentFilter = new SamRecordFilter() {
@@ -314,6 +315,11 @@ public abstract class AbstractAlignmentMerger {
         this.maxRecordsInRam = maxRecordsInRam;
     }
 
+    /** Allows the caller to decide whether or not to write the PG tag to reads when applicable */
+    public void setAddPGTagToReads(final boolean addPGTagToReads) {
+        this.addPGTagToReads = addPGTagToReads;
+    }
+
     /**
      * Do this unconditionally, not just for aligned records, for two reasons:
      * - An unaligned read has been processed by the aligner, so it is more truthful.
@@ -322,7 +328,7 @@ public abstract class AbstractAlignmentMerger {
      * and a separate chain for the unmapped reads.
      */
     private void maybeSetPgTag(final SAMRecord rec) {
-        if (this.programRecord != null) {
+        if (this.programRecord != null && addPGTagToReads) {
             rec.setAttribute(ReservedTagConstants.PROGRAM_GROUP_ID, this.programRecord.getProgramGroupId());
         }
     }

--- a/src/main/java/picard/sam/MergeBamAlignment.java
+++ b/src/main/java/picard/sam/MergeBamAlignment.java
@@ -36,6 +36,7 @@ import picard.PicardException;
 import picard.cmdline.CommandLineProgram;
 import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.programgroups.SamOrBam;
+import picard.sam.util.ReadOutputCommandLineProgram;
 
 import java.io.File;
 import java.util.*;
@@ -50,9 +51,9 @@ import java.util.*;
 @CommandLineProgramProperties(
         summary = MergeBamAlignment.USAGE_SUMMARY + MergeBamAlignment.USAGE_DETAILS,
         oneLineSummary = MergeBamAlignment.USAGE_SUMMARY,
-        programGroup = SamOrBam.class)
-@DocumentedFeature
-public class MergeBamAlignment extends CommandLineProgram {
+        programGroup = SamOrBam.class
+)
+public class MergeBamAlignment extends ReadOutputCommandLineProgram {
     static final String USAGE_SUMMARY = "Merge alignment data from a SAM or BAM with data in an unmapped BAM file.  ";
     static final String USAGE_DETAILS = "This tool produces a new SAM or BAM file that includes all aligned and unaligned reads and also carries " +
             "forward additional read attributes from the unmapped BAM (attributes that are otherwise lost in the process of alignment)." +
@@ -281,6 +282,7 @@ public class MergeBamAlignment extends CommandLineProgram {
         merger.setIncludeSecondaryAlignments(INCLUDE_SECONDARY_ALIGNMENTS);
         merger.setAttributesToReverse(ATTRIBUTES_TO_REVERSE);
         merger.setAttributesToReverseComplement(ATTRIBUTES_TO_REVERSE_COMPLEMENT);
+        merger.setAddPGTagToReads(ADD_PG_TAG_TO_READS);
         merger.mergeAlignment(REFERENCE_SEQUENCE);
         merger.close();
 

--- a/src/main/java/picard/sam/MergeBamAlignment.java
+++ b/src/main/java/picard/sam/MergeBamAlignment.java
@@ -33,7 +33,6 @@ import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import picard.PicardException;
-import picard.cmdline.CommandLineProgram;
 import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.programgroups.SamOrBam;
 import picard.sam.util.ReadOutputCommandLineProgram;
@@ -53,6 +52,7 @@ import java.util.*;
         oneLineSummary = MergeBamAlignment.USAGE_SUMMARY,
         programGroup = SamOrBam.class
 )
+@DocumentedFeature
 public class MergeBamAlignment extends ReadOutputCommandLineProgram {
     static final String USAGE_SUMMARY = "Merge alignment data from a SAM or BAM with data in an unmapped BAM file.  ";
     static final String USAGE_DETAILS = "This tool produces a new SAM or BAM file that includes all aligned and unaligned reads and also carries " +

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -179,6 +179,10 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
     @Argument(doc= "Determines how duplicate types are recorded in the DT optional attribute.")
     public DuplicateTaggingPolicy TAGGING_POLICY = DuplicateTaggingPolicy.DontTag;
 
+    @Option(doc= "If true, clear any original DT tags.  If your SAM doesn't have this tag, leave false as " +
+            "this is a speed increase.  Should be set to true if SAM does have this tag.")
+    public boolean CLEAR_DT = false;
+
     private SortingCollection<ReadEndsForMarkDuplicates> pairSort;
     private SortingCollection<ReadEndsForMarkDuplicates> fragSort;
     private SortingLongCollection duplicateIndexes;
@@ -355,7 +359,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
                     rec.getReadName().equals(opticalDuplicateQueryName) ||
                     recordInFileIndex == nextOpticalDuplicateIndex;
 
-            rec.setAttribute(DUPLICATE_TYPE_TAG, null);
+            if (CLEAR_DT) rec.setAttribute(DUPLICATE_TYPE_TAG, null);
 
             if (this.TAGGING_POLICY != DuplicateTaggingPolicy.DontTag && rec.getDuplicateReadFlag()) {
                 if (isOpticalDuplicate) {
@@ -393,7 +397,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
             if (this.REMOVE_DUPLICATES            && rec.getDuplicateReadFlag()) continue;
             if (this.REMOVE_SEQUENCING_DUPLICATES && isOpticalDuplicate)         continue;
 
-            if (PROGRAM_RECORD_ID != null)  rec.setAttribute(SAMTag.PG.name(), chainedPgIds.get(rec.getStringAttribute(SAMTag.PG.name())));
+            if (PROGRAM_RECORD_ID != null && ADD_PG_TAG_TO_READS) rec.setAttribute(SAMTag.PG.name(), chainedPgIds.get(rec.getStringAttribute(SAMTag.PG.name())));
             out.addAlignment(rec);
             progress.record(rec);
         }

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -179,7 +179,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
     @Argument(doc= "Determines how duplicate types are recorded in the DT optional attribute.")
     public DuplicateTaggingPolicy TAGGING_POLICY = DuplicateTaggingPolicy.DontTag;
 
-    @Option(doc= "If true, clear any original DT tags.  If your SAM doesn't have this tag, leave false as " +
+    @Argument(doc= "If true, clear any original DT tags.  If your SAM doesn't have this tag, leave false as " +
             "this is a speed increase.  Should be set to true if SAM does have this tag.")
     public boolean CLEAR_DT = true;
 

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -325,7 +325,6 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
                     (sortOrder == SAMFileHeader.SortOrder.queryname &&
                     recordInFileIndex > nextDuplicateIndex && rec.getReadName().equals(duplicateQueryName));
 
-
                 if (isDuplicate) {
                     duplicateQueryName = rec.getReadName();
                     rec.setDuplicateReadFlag(true);
@@ -358,7 +357,9 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
                     rec.getReadName().equals(opticalDuplicateQueryName) ||
                     recordInFileIndex == nextOpticalDuplicateIndex;
 
-            if (CLEAR_DT) rec.setAttribute(DUPLICATE_TYPE_TAG, null);
+            if (CLEAR_DT) {
+                rec.setAttribute(DUPLICATE_TYPE_TAG, null);
+            }
 
             if (this.TAGGING_POLICY != DuplicateTaggingPolicy.DontTag && rec.getDuplicateReadFlag()) {
                 if (isOpticalDuplicate) {
@@ -393,10 +394,15 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
 
             // Output the record if desired and bump the record index
             recordInFileIndex++;
-            if (this.REMOVE_DUPLICATES            && rec.getDuplicateReadFlag()) continue;
-            if (this.REMOVE_SEQUENCING_DUPLICATES && isOpticalDuplicate)         continue;
-
-            if (PROGRAM_RECORD_ID != null && ADD_PG_TAG_TO_READS) rec.setAttribute(SAMTag.PG.name(), chainedPgIds.get(rec.getStringAttribute(SAMTag.PG.name())));
+            if (this.REMOVE_DUPLICATES && rec.getDuplicateReadFlag()) {
+                continue;
+            }
+            if (this.REMOVE_SEQUENCING_DUPLICATES && isOpticalDuplicate) {
+                continue;
+            }
+            if (PROGRAM_RECORD_ID != null && ADD_PG_TAG_TO_READS) {
+                rec.setAttribute(SAMTag.PG.name(), chainedPgIds.get(rec.getStringAttribute(SAMTag.PG.name())));
+            }
             out.addAlignment(rec);
             progress.record(rec);
         }
@@ -687,7 +693,9 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
             } else {
                 if (nextChunk.size() > 1) {
                     markDuplicatePairs(nextChunk);
-                    if (TAG_DUPLICATE_SET_MEMBERS) addRepresentativeReadIndex(nextChunk);
+                    if (TAG_DUPLICATE_SET_MEMBERS) {
+                        addRepresentativeReadIndex(nextChunk);
+                    }
                 }
                 nextChunk.clear();
                 nextChunk.add(next);
@@ -696,7 +704,9 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
         }
         if (nextChunk.size() > 1) {
             markDuplicatePairs(nextChunk);
-            if (TAG_DUPLICATE_SET_MEMBERS) addRepresentativeReadIndex(nextChunk);
+            if (TAG_DUPLICATE_SET_MEMBERS) {
+                addRepresentativeReadIndex(nextChunk);
+            }
         }
         this.pairSort.cleanup();
         this.pairSort = null;
@@ -730,8 +740,12 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
 
         log.info("Sorting list of duplicate records.");
         this.duplicateIndexes.doneAddingStartIteration();
-        if (this.opticalDuplicateIndexes != null) this.opticalDuplicateIndexes.doneAddingStartIteration();
-        if (TAG_DUPLICATE_SET_MEMBERS) this.representativeReadIndicesForDuplicates.doneAdding();
+        if (this.opticalDuplicateIndexes != null) {
+            this.opticalDuplicateIndexes.doneAddingStartIteration();
+        }
+        if (TAG_DUPLICATE_SET_MEMBERS) {
+            this.representativeReadIndicesForDuplicates.doneAdding();
+        }
     }
 
     private boolean areComparableForDuplicates(final ReadEndsForMarkDuplicates lhs, final ReadEndsForMarkDuplicates rhs, final boolean compareRead2, final boolean useBarcodes) {
@@ -828,7 +842,9 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
 
                 // in query-sorted case, these will be the same.
                 // TODO: also in coordinate sorted, when one read is unmapped
-                if(end.read2IndexInFile != end.read1IndexInFile) addIndexAsDuplicate(end.read2IndexInFile);
+                if(end.read2IndexInFile != end.read1IndexInFile) {
+                    addIndexAsDuplicate(end.read2IndexInFile);
+                }
 
                 if (end.isOpticalDuplicate && this.opticalDuplicateIndexes != null) {
                     this.opticalDuplicateIndexes.add(end.read1IndexInFile);
@@ -848,7 +864,9 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
     private void markDuplicateFragments(final List<ReadEndsForMarkDuplicates> list, final boolean containsPairs) {
         if (containsPairs) {
             for (final ReadEndsForMarkDuplicates end : list) {
-                if (!end.isPaired()) addIndexAsDuplicate(end.read1IndexInFile);
+                if (!end.isPaired()) {
+                    addIndexAsDuplicate(end.read1IndexInFile);
+                }
             }
         } else {
             short maxScore = 0;
@@ -887,17 +905,37 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
             if (useBarcodes) {
                 final ReadEndsForMarkDuplicatesWithBarcodes lhsWithBarcodes = (ReadEndsForMarkDuplicatesWithBarcodes) lhs;
                 final ReadEndsForMarkDuplicatesWithBarcodes rhsWithBarcodes = (ReadEndsForMarkDuplicatesWithBarcodes) rhs;
-                if (compareDifference == 0) compareDifference = compareInteger(lhsWithBarcodes.barcode, rhsWithBarcodes.barcode);
-                if (compareDifference == 0) compareDifference = compareInteger(lhsWithBarcodes.readOneBarcode, rhsWithBarcodes.readOneBarcode);
-                if (compareDifference == 0) compareDifference = compareInteger(lhsWithBarcodes.readTwoBarcode, rhsWithBarcodes.readTwoBarcode);
+                if (compareDifference == 0) {
+                    compareDifference = compareInteger(lhsWithBarcodes.barcode, rhsWithBarcodes.barcode);
+                }
+                if (compareDifference == 0) {
+                    compareDifference = compareInteger(lhsWithBarcodes.readOneBarcode, rhsWithBarcodes.readOneBarcode);
+                }
+                if (compareDifference == 0) {
+                    compareDifference = compareInteger(lhsWithBarcodes.readTwoBarcode, rhsWithBarcodes.readTwoBarcode);
+                }
             }
-            if (compareDifference == 0) compareDifference = lhs.read1ReferenceIndex - rhs.read1ReferenceIndex;
-            if (compareDifference == 0) compareDifference = lhs.read1Coordinate - rhs.read1Coordinate;
-            if (compareDifference == 0) compareDifference = lhs.orientation - rhs.orientation;
-            if (compareDifference == 0) compareDifference = lhs.read2ReferenceIndex - rhs.read2ReferenceIndex;
-            if (compareDifference == 0) compareDifference = lhs.read2Coordinate - rhs.read2Coordinate;
-            if (compareDifference == 0) compareDifference = (int) (lhs.read1IndexInFile - rhs.read1IndexInFile);
-            if (compareDifference == 0) compareDifference = (int) (lhs.read2IndexInFile - rhs.read2IndexInFile);
+            if (compareDifference == 0) {
+                compareDifference = lhs.read1ReferenceIndex - rhs.read1ReferenceIndex;
+            }
+            if (compareDifference == 0) {
+                compareDifference = lhs.read1Coordinate - rhs.read1Coordinate;
+            }
+            if (compareDifference == 0) {
+                compareDifference = lhs.orientation - rhs.orientation;
+            }
+            if (compareDifference == 0) {
+                compareDifference = lhs.read2ReferenceIndex - rhs.read2ReferenceIndex;
+            }
+            if (compareDifference == 0) {
+                compareDifference = lhs.read2Coordinate - rhs.read2Coordinate;
+            }
+            if (compareDifference == 0) {
+                compareDifference = (int) (lhs.read1IndexInFile - rhs.read1IndexInFile);
+            }
+            if (compareDifference == 0) {
+                compareDifference = (int) (lhs.read2IndexInFile - rhs.read2IndexInFile);
+            }
 
             return compareDifference;
         }

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -179,8 +179,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
     @Argument(doc= "Determines how duplicate types are recorded in the DT optional attribute.")
     public DuplicateTaggingPolicy TAGGING_POLICY = DuplicateTaggingPolicy.DontTag;
 
-    @Argument(doc= "If true, clear any original DT tags.  If your SAM doesn't have this tag, leave false as " +
-            "this is a speed increase.  Should be set to true if SAM does have this tag.")
+    @Argument(doc= "Clear DT tag from input SAM records. Should be set to false if input SAM doesn't have this tag.  Default true")
     public boolean CLEAR_DT = true;
 
     private SortingCollection<ReadEndsForMarkDuplicates> pairSort;

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -242,7 +242,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
             log.info("Found " + (this.libraryIdGenerator.getNumberOfOpticalDuplicateClusters()) + " optical duplicate clusters.");
         }
 
-        final SamHeaderAndIterator headerAndIterator = openInputs();
+        final SamHeaderAndIterator headerAndIterator = openInputs(false);
         final SAMFileHeader header = headerAndIterator.header;
         final SAMFileHeader.SortOrder sortOrder = header.getSortOrder();
 
@@ -472,7 +472,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
                 maxInMemory,
                 TMP_DIR);
 
-        final SamHeaderAndIterator headerAndIterator = openInputs();
+        final SamHeaderAndIterator headerAndIterator = openInputs(true);
         final SAMFileHeader.SortOrder assumedSortOrder = headerAndIterator.header.getSortOrder();
         final SAMFileHeader header = headerAndIterator.header;
         final ReadEndsForMarkDuplicatesMap tmp = new DiskBasedReadEndsForMarkDuplicatesMap(MAX_FILE_HANDLES_FOR_READ_ENDS_MAP, diskCodec);
@@ -500,7 +500,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
                 pgIdsSeen.add(rec.getStringAttribute(SAMTag.PG.name()));
             }
 
-            // Of working in query-sorted, need to keep index of first record with any given query-name.
+            // If working in query-sorted, need to keep index of first record with any given query-name.
             if(assumedSortOrder == SAMFileHeader.SortOrder.queryname && !rec.getReadName().equals(duplicateQueryName)) {
                 duplicateQueryName  = rec.getReadName();
                 duplicateIndex      = index;
@@ -621,7 +621,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
         if (this.opticalDuplicateFinder.addLocationInformation(rec.getReadName(), ends)) {
             // calculate the RG number (nth in list)
             ends.readGroup = 0;
-            final String rg = (String) rec.getAttribute("RG");
+            final String rg = (String) rec.getAttribute(ReservedTagConstants.READ_GROUP_ID);
             final List<SAMReadGroupRecord> readGroups = header.getReadGroups();
 
             if (rg != null && readGroups != null) {
@@ -648,8 +648,6 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
     /**
      * Goes through the accumulated ReadEndsForMarkDuplicates objects and determines which of them are
      * to be marked as duplicates.
-     *
-     * @return an array with an ordered list of indexes into the source file
      */
     private void generateDuplicateIndexes(final boolean useBarcodes, final boolean indexOpticalDuplicates) {
         int entryOverhead;

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -181,7 +181,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
 
     @Option(doc= "If true, clear any original DT tags.  If your SAM doesn't have this tag, leave false as " +
             "this is a speed increase.  Should be set to true if SAM does have this tag.")
-    public boolean CLEAR_DT = false;
+    public boolean CLEAR_DT = true;
 
     private SortingCollection<ReadEndsForMarkDuplicates> pairSort;
     private SortingCollection<ReadEndsForMarkDuplicates> fragSort;

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicatesWithMateCigar.java
@@ -201,7 +201,7 @@ public class MarkDuplicatesWithMateCigar extends AbstractMarkDuplicatesCommandLi
      * Updates the program record if necessary.
      */
     private void updateProgramRecord(final SAMRecord record, final Map<String, String> chainedPgIds) {
-        if (PROGRAM_RECORD_ID != null) {
+        if (PROGRAM_RECORD_ID != null && ADD_PG_TAG_TO_READS) {
             final String pgId = record.getStringAttribute(SAMTag.PG.name());
             if (null == pgId) {
                 if (!warnedNullProgramRecords) {

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicatesWithMateCigar.java
@@ -126,7 +126,7 @@ public class MarkDuplicatesWithMateCigar extends AbstractMarkDuplicatesCommandLi
         IOUtil.assertFileIsWritable(METRICS_FILE);
 
         // Open the inputs
-        final SamHeaderAndIterator headerAndIterator = openInputs();
+        final SamHeaderAndIterator headerAndIterator = openInputs(true);
         final SAMFileHeader header = headerAndIterator.header;
 
         // Create the output header

--- a/src/main/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigar.java
@@ -94,7 +94,7 @@ public class SimpleMarkDuplicatesWithMateCigar extends MarkDuplicates {
         IOUtil.assertFileIsWritable(METRICS_FILE);
 
         // Open the inputs
-        final SamHeaderAndIterator headerAndIterator = openInputs();
+        final SamHeaderAndIterator headerAndIterator = openInputs(true);
         final SAMFileHeader header = headerAndIterator.header;
 
         // Create the output header

--- a/src/main/java/picard/sam/markduplicates/util/AbstractMarkDuplicatesCommandLineProgram.java
+++ b/src/main/java/picard/sam/markduplicates/util/AbstractMarkDuplicatesCommandLineProgram.java
@@ -201,14 +201,14 @@ public abstract class AbstractMarkDuplicatesCommandLineProgram extends AbstractO
      * Since this may read its inputs more than once this method does all the opening
      * and checking of the inputs.
      */
-    protected SamHeaderAndIterator openInputs() {
+    protected SamHeaderAndIterator openInputs(boolean eagerlyDecode) {
         final List<SAMFileHeader> headers = new ArrayList<>(INPUT.size());
         final List<SamReader> readers = new ArrayList<>(INPUT.size());
 
         for (final String input : INPUT) {
-            SamReader reader = SamReaderFactory.makeDefault()
-                .enable(SamReaderFactory.Option.EAGERLY_DECODE)
-                .open(SamInputResource.of(input));
+            SamReaderFactory readerFactory = SamReaderFactory.makeDefault();
+            SamReader reader = eagerlyDecode ? readerFactory.enable(SamReaderFactory.Option.EAGERLY_DECODE).open(SamInputResource.of(input)) :
+                    readerFactory.open(SamInputResource.of(input));
             final SAMFileHeader header = reader.getFileHeader();
 
             headers.add(header);

--- a/src/main/java/picard/sam/markduplicates/util/AbstractOpticalDuplicateFinderCommandLineProgram.java
+++ b/src/main/java/picard/sam/markduplicates/util/AbstractOpticalDuplicateFinderCommandLineProgram.java
@@ -27,6 +27,7 @@ package picard.sam.markduplicates.util;
 import org.broadinstitute.barclay.argparser.Argument;
 import picard.cmdline.*;
 import htsjdk.samtools.util.Log;
+import picard.sam.util.ReadOutputCommandLineProgram;
 
 /**
  * Abstract class that holds parameters and methods common to classes that optical duplicate detection.  We put them here so that
@@ -34,7 +35,7 @@ import htsjdk.samtools.util.Log;
  *
  * @author Tim Fennell
  */
-public abstract class AbstractOpticalDuplicateFinderCommandLineProgram extends CommandLineProgram {
+public abstract class AbstractOpticalDuplicateFinderCommandLineProgram extends ReadOutputCommandLineProgram {
     protected static Log LOG = Log.getInstance(AbstractOpticalDuplicateFinderCommandLineProgram.class);
 
 

--- a/src/main/java/picard/sam/markduplicates/util/LibraryIdGenerator.java
+++ b/src/main/java/picard/sam/markduplicates/util/LibraryIdGenerator.java
@@ -24,6 +24,7 @@
 
 package picard.sam.markduplicates.util;
 
+import htsjdk.samtools.ReservedTagConstants;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.SAMRecord;
@@ -81,7 +82,7 @@ public class LibraryIdGenerator {
      * returned.
      */
     public static String getLibraryName(final SAMFileHeader header, final SAMRecord rec) {
-        final String readGroupId = (String) rec.getAttribute("RG");
+        final String readGroupId = (String) rec.getAttribute(ReservedTagConstants.READ_GROUP_ID);
 
         if (readGroupId != null) {
             final SAMReadGroupRecord rg = header.getReadGroup(readGroupId);

--- a/src/main/java/picard/sam/util/ReadOutputCommandLineProgram.java
+++ b/src/main/java/picard/sam/util/ReadOutputCommandLineProgram.java
@@ -1,0 +1,14 @@
+package picard.sam.util;
+
+import picard.cmdline.CommandLineProgram;
+import picard.cmdline.Option;
+
+/**
+ * Abstract class that holds parameters and methods common to classes that want to add PG tags to reads in SAM/BAM files
+ *
+ */
+public abstract class ReadOutputCommandLineProgram extends CommandLineProgram {
+
+    @Option(doc = "Add PG tag to each read in a SAM or BAM", common = true)
+    public Boolean ADD_PG_TAG_TO_READS = false;
+}

--- a/src/main/java/picard/sam/util/ReadOutputCommandLineProgram.java
+++ b/src/main/java/picard/sam/util/ReadOutputCommandLineProgram.java
@@ -1,7 +1,7 @@
 package picard.sam.util;
 
+import org.broadinstitute.barclay.argparser.Argument;
 import picard.cmdline.CommandLineProgram;
-import picard.cmdline.Option;
 
 /**
  * Abstract class that holds parameters and methods common to classes that want to add PG tags to reads in SAM/BAM files
@@ -9,6 +9,6 @@ import picard.cmdline.Option;
  */
 public abstract class ReadOutputCommandLineProgram extends CommandLineProgram {
 
-    @Option(doc = "Add PG tag to each read in a SAM or BAM", common = true)
+    @Argument(doc = "Add PG tag to each read in a SAM or BAM", common = true)
     public Boolean ADD_PG_TAG_TO_READS = true;
 }

--- a/src/main/java/picard/sam/util/ReadOutputCommandLineProgram.java
+++ b/src/main/java/picard/sam/util/ReadOutputCommandLineProgram.java
@@ -10,5 +10,5 @@ import picard.cmdline.Option;
 public abstract class ReadOutputCommandLineProgram extends CommandLineProgram {
 
     @Option(doc = "Add PG tag to each read in a SAM or BAM", common = true)
-    public Boolean ADD_PG_TAG_TO_READS = false;
+    public Boolean ADD_PG_TAG_TO_READS = true;
 }

--- a/src/test/java/picard/sam/MergeBamAlignmentTest.java
+++ b/src/test/java/picard/sam/MergeBamAlignmentTest.java
@@ -1326,7 +1326,8 @@ public class MergeBamAlignmentTest extends CommandLineProgramTest {
                 "ALIGNED_READS_ONLY=" + alignReadsOnly,
                 "CLIP_ADAPTERS=" + clipAdapters,
                 "IS_BISULFITE_SEQUENCE=" + isBisulfiteSequence,
-                "MAX_INSERTIONS_OR_DELETIONS=" + maxInsOrDels));
+                "MAX_INSERTIONS_OR_DELETIONS=" + maxInsOrDels,
+                "ADD_PG_TAG_TO_READS=true"));
         if (alignedBams != null) {
             for (final File alignedBam : alignedBams) {
                 args.add("ALIGNED_BAM=" + alignedBam.getAbsolutePath());

--- a/src/test/java/picard/sam/MergeBamAlignmentTest.java
+++ b/src/test/java/picard/sam/MergeBamAlignmentTest.java
@@ -1326,8 +1326,7 @@ public class MergeBamAlignmentTest extends CommandLineProgramTest {
                 "ALIGNED_READS_ONLY=" + alignReadsOnly,
                 "CLIP_ADAPTERS=" + clipAdapters,
                 "IS_BISULFITE_SEQUENCE=" + isBisulfiteSequence,
-                "MAX_INSERTIONS_OR_DELETIONS=" + maxInsOrDels,
-                "ADD_PG_TAG_TO_READS=true"));
+                "MAX_INSERTIONS_OR_DELETIONS=" + maxInsOrDels));
         if (alignedBams != null) {
             for (final File alignedBam : alignedBams) {
                 args.add("ALIGNED_BAM=" + alignedBam.getAbsolutePath());

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesTest.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesTest.java
@@ -100,6 +100,7 @@ public class MarkDuplicatesTest extends AbstractMarkDuplicatesCommandLineProgram
             final File outputSam = new File(outputDir, TEST_BASE_NAME + ".sam");
             args.add("OUTPUT=" + outputSam.getAbsolutePath());
             args.add("METRICS_FILE=" + new File(outputDir, TEST_BASE_NAME + ".duplicate_metrics").getAbsolutePath());
+            args.add("ADD_PG_TAG_TO_READS=true");
             if (suppressPg) args.add("PROGRAM_RECORD_ID=null");
 
             // I generally prefer to call doWork rather than invoking the argument parser, but it is necessary

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesTest.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesTest.java
@@ -100,7 +100,6 @@ public class MarkDuplicatesTest extends AbstractMarkDuplicatesCommandLineProgram
             final File outputSam = new File(outputDir, TEST_BASE_NAME + ".sam");
             args.add("OUTPUT=" + outputSam.getAbsolutePath());
             args.add("METRICS_FILE=" + new File(outputDir, TEST_BASE_NAME + ".duplicate_metrics").getAbsolutePath());
-            args.add("ADD_PG_TAG_TO_READS=true");
             if (suppressPg) args.add("PROGRAM_RECORD_ID=null");
 
             // I generally prefer to call doWork rather than invoking the argument parser, but it is necessary

--- a/src/test/java/picard/sam/testers/SamFileTester.java
+++ b/src/test/java/picard/sam/testers/SamFileTester.java
@@ -327,6 +327,7 @@ public abstract class SamFileTester extends CommandLineProgramTest {
         output = new File(outputDir, "output.sam");
         args.add("INPUT=" + input.getAbsoluteFile());
         args.add("OUTPUT=" + output.getAbsoluteFile());
+        args.add("ADD_PG_TAG_TO_READS=true");
         Assert.assertEquals(runPicardCommandLine(args), 0);
         test();
     }

--- a/src/test/java/picard/sam/testers/SamFileTester.java
+++ b/src/test/java/picard/sam/testers/SamFileTester.java
@@ -327,7 +327,6 @@ public abstract class SamFileTester extends CommandLineProgramTest {
         output = new File(outputDir, "output.sam");
         args.add("INPUT=" + input.getAbsoluteFile());
         args.add("OUTPUT=" + output.getAbsoluteFile());
-        args.add("ADD_PG_TAG_TO_READS=true");
         Assert.assertEquals(runPicardCommandLine(args), 0);
         test();
     }


### PR DESCRIPTION
Adding the option to not write out PG tags for MarkDuplicates and MergeBamAlignment.  Default behavior is kept the same as it was before but you can get speed increases if you set them appropriately.