### PR TITLE
Add support for KS and FO in AddOrReplaceReadGroups

### DIFF
--- a/src/main/java/picard/sam/AddOrReplaceReadGroups.java
+++ b/src/main/java/picard/sam/AddOrReplaceReadGroups.java
@@ -88,9 +88,15 @@ public class AddOrReplaceReadGroups extends CommandLineProgram {
     @Argument(shortName = "DT", doc = "Read Group run date", optional = true)
     public Iso8601Date RGDT;
 
+    @Argument(shortName = "KS", doc = "Read Group key sequence", optional = true)
+    public String RGKS;
+
+    @Argument(shortName = "FO", doc = "Read Group flow order", optional = true)
+    public String RGFO;
+
     @Argument(shortName = "PI", doc = "Read Group predicted insert size", optional = true)
     public Integer RGPI;
-    
+
     @Argument(shortName = "PG", doc = "Read Group program group", optional = true)
     public String RGPG;
     
@@ -124,6 +130,8 @@ public class AddOrReplaceReadGroups extends CommandLineProgram {
         if (RGPI != null) rg.setPredictedMedianInsertSize(RGPI);
         if (RGPG != null) rg.setProgramGroup(RGPG);
         if (RGPM != null) rg.setPlatformModel(RGPM);
+        if (RGKS != null) rg.setKeySequence(RGKS);
+        if (RGFO != null) rg.setFlowOrder(RGFO);
 
         log.info(String.format("Created read group ID=%s PL=%s LB=%s SM=%s%n", rg.getId(), rg.getPlatform(), rg.getLibrary(), rg.getSample()));
 


### PR DESCRIPTION
### Description
As said in [issue](https://github.com/broadinstitute/picard/issues/763) **AddOrReplaceReadGroups** doesn't support tags **FO** *(Flow order)* and **KS** *(Key sequence)* from the SAM specification.

### Implementation
Add possibility to pass **KS** and **FO** command line options to **AddOrReplaceReadGroups** tool.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

