### PR TITLE
Fixing lift-over (again) WRT genotypes

### DIFF
--- a/src/main/java/picard/vcf/LiftoverVcf.java
+++ b/src/main/java/picard/vcf/LiftoverVcf.java
@@ -331,7 +331,6 @@ public class LiftoverVcf extends CommandLineProgram {
 
         final VariantContextBuilder builder = new VariantContextBuilder(vc);
 
-        builder.genotypes(source.getGenotypes());
         builder.filters(source.getFilters());
         builder.log10PError(source.getLog10PError());
         builder.attributes(source.getAttributes());
@@ -438,7 +437,6 @@ public class LiftoverVcf extends CommandLineProgram {
 
         final Map<Allele, Allele> reverseComplementAlleleMap = new HashMap<>(2);
 
-        reverseComplementAlleleMap.clear();
         final List<Allele> alleles = new ArrayList<>();
 
         for (final Allele oldAllele : source.getAlleles()) {

--- a/src/main/java/picard/vcf/LiftoverVcf.java
+++ b/src/main/java/picard/vcf/LiftoverVcf.java
@@ -385,7 +385,6 @@ public class LiftoverVcf extends CommandLineProgram {
         final List<Allele> alleles = new ArrayList<>();
         final Map<Allele, Allele> reverseComplementAlleleMap = new HashMap<>(2);
 
-
         for (final Allele oldAllele : source.getAlleles()) {
             if (target.isPositiveStrand() || oldAllele.isSymbolic()) {
                 alleles.add(oldAllele);
@@ -406,7 +405,6 @@ public class LiftoverVcf extends CommandLineProgram {
 
         builder.id(source.getID());
         builder.attributes(source.getAttributes());
-
         builder.genotypes(fixGenotypes(source.getGenotypes(), reverseComplementAlleleMap));
         builder.filters(source.getFilters());
         builder.log10PError(source.getLog10PError());

--- a/src/main/java/picard/vcf/LiftoverVcf.java
+++ b/src/main/java/picard/vcf/LiftoverVcf.java
@@ -229,7 +229,6 @@ public class LiftoverVcf extends CommandLineProgram {
                 TMP_DIR);
 
         ProgressLogger progress = new ProgressLogger(log, 1000000, "read");
-        // a mapping from original allele to reverse complemented allele
 
         for (final VariantContext ctx : in) {
             ++total;
@@ -273,18 +272,17 @@ public class LiftoverVcf extends CommandLineProgram {
                 refSeq = refSeqs.get(target.getContig());
                 //flipping indels:
 
-                final Map<Allele, Allele> reverseComplementAlleleMap = new HashMap<>(10);
-                final VariantContext flippedIndel = flipIndel(ctx, liftOver, refSeq, reverseComplementAlleleMap);
+                final VariantContext flippedIndel = flipIndel(ctx, liftOver, refSeq);
                 if (flippedIndel == null) {
                     throw new IllegalArgumentException("Unexpectedly found null VC. This should have not happened.");
                 } else {
-                    tryToAddVariant(flippedIndel, refSeq, reverseComplementAlleleMap, ctx);
+                    tryToAddVariant(flippedIndel, refSeq, ctx);
                 }
             } else {
                 refSeq = refSeqs.get(target.getContig());
                 final VariantContext liftedVariant = liftSimpleVariant(ctx, target);
 
-                tryToAddVariant(liftedVariant, refSeq, Collections.emptyMap(), ctx);
+                tryToAddVariant(liftedVariant, refSeq, ctx);
             }
             progress.record(ctx.getContig(), ctx.getStart());
         }
@@ -326,15 +324,14 @@ public class LiftoverVcf extends CommandLineProgram {
      *
      * @param vc new {@link VariantContext}
      * @param refSeq {@link ReferenceSequence} of new reference
-     * @param alleleMap a {@link Map} mapping the old alleles to the new alleles (for fixing the genotypes)
      * @param source the original {@link VariantContext} to use for putting the original location information into vc
      * @return true if successful, false if failed due to mismatching reference allele.
      */
-    private void tryToAddVariant(final VariantContext vc, final ReferenceSequence refSeq, final Map<Allele, Allele> alleleMap, final VariantContext source) {
+    private void tryToAddVariant(final VariantContext vc, final ReferenceSequence refSeq,  final VariantContext source) {
 
         final VariantContextBuilder builder = new VariantContextBuilder(vc);
 
-        builder.genotypes(fixGenotypes(source.getGenotypes(), alleleMap));
+        builder.genotypes(source.getGenotypes());
         builder.filters(source.getFilters());
         builder.log10PError(source.getLog10PError());
         builder.attributes(source.getAttributes());
@@ -362,7 +359,7 @@ public class LiftoverVcf extends CommandLineProgram {
         if (mismatchesReference) {
             rejects.add(new VariantContextBuilder(source)
                     .filter(FILTER_MISMATCHING_REF_ALLELE)
-                    .attribute(ATTEMPTED_LOCUS, String.format("%s:%d-%d",vc.getContig(),vc.getStart(),vc.getEnd()))
+                    .attribute(ATTEMPTED_LOCUS, String.format("%s:%d-%d", vc.getContig(), vc.getStart(), vc.getEnd()))
                     .make());
             failedAlleleCheck++;
         } else {
@@ -387,12 +384,15 @@ public class LiftoverVcf extends CommandLineProgram {
             return null;
         }
         final List<Allele> alleles = new ArrayList<>();
+        final Map<Allele, Allele> reverseComplementAlleleMap = new HashMap<>(2);
+
 
         for (final Allele oldAllele : source.getAlleles()) {
             if (target.isPositiveStrand() || oldAllele.isSymbolic()) {
                 alleles.add(oldAllele);
             } else {
                 final Allele fixedAllele = Allele.create(SequenceUtil.reverseComplement(oldAllele.getBaseString()), oldAllele.isReference());
+                reverseComplementAlleleMap.put(oldAllele, fixedAllele);
                 alleles.add(fixedAllele);
             }
         }
@@ -406,6 +406,11 @@ public class LiftoverVcf extends CommandLineProgram {
                 alleles);
 
         builder.id(source.getID());
+        builder.attributes(source.getAttributes());
+
+        builder.genotypes(fixGenotypes(source.getGenotypes(), reverseComplementAlleleMap));
+        builder.filters(source.getFilters());
+        builder.log10PError(source.getLog10PError());
 
         return builder.make();
     }
@@ -416,7 +421,7 @@ public class LiftoverVcf extends CommandLineProgram {
      * @param referenceSequence the reference sequence of the target
      * @return a flipped variant-context.
      */
-    protected static VariantContext flipIndel(final VariantContext source, final LiftOver liftOver, final ReferenceSequence referenceSequence, final Map<Allele, Allele> reverseComplementAlleleMap) {
+    protected static VariantContext flipIndel(final VariantContext source, final LiftOver liftOver, final ReferenceSequence referenceSequence) {
         if (!source.isBiallelic()) return null;  //only supporting biallelic indels, for now.
 
         final Interval originalLocus = new Interval(source.getContig(), source.getStart(), source.getEnd());
@@ -430,6 +435,8 @@ public class LiftoverVcf extends CommandLineProgram {
 
         // a boolean to protect against trying to access the -1 position in the reference array
         final boolean addToStart = target.getStart() > 1;
+
+        final Map<Allele, Allele> reverseComplementAlleleMap = new HashMap<>(2);
 
         reverseComplementAlleleMap.clear();
         final List<Allele> alleles = new ArrayList<>();

--- a/src/test/java/picard/vcf/LiftoverVcfTest.java
+++ b/src/test/java/picard/vcf/LiftoverVcfTest.java
@@ -54,13 +54,7 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         };
     }
 
-    @Test
-    public void liftoverReverseStrandSelftest() {
-        liftoverReverseStrand();
-    }
-
-
-    @Test(dataProvider = "liftoverReverseStrand" )
+    @Test(dataProvider = "liftoverReverseStrand")
     public void testReverseComplementedIndels(final String filename, final int expectedPassing, final int expectedFailing) {
         final File liftOutputFile = new File(OUTPUT_DATA_PATH, "lift-delete-me.vcf");
         final File rejectOutputFile = new File(OUTPUT_DATA_PATH, "reject-delete-me.vcf");
@@ -92,11 +86,6 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
                 {false, LiftoverVcf.EXIT_CODE_WHEN_CONTIG_NOT_IN_REFERENCE},
                 {true, 0}
         };
-    }
-
-    @Test
-    public void dataTestHaplotypeProbabilitiesFromSequenceAddToProbsSelftest() {
-        dataTestHaplotypeProbabilitiesFromSequenceAddToProbs();
     }
 
     @Test(dataProvider = "dataTestMissingContigInReference")
@@ -163,11 +152,6 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         }
     }
 
-    @Test
-    public void indelFlipDataSelftest() {
-        indelFlipData();
-    }
-
     @DataProvider(name = "indelFlipData")
     public Iterator<Object[]> indelFlipData() {
 
@@ -197,7 +181,7 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         final Allele TTT = Allele.create("TTT", false);
         final Allele ATT = Allele.create("ATT", false);
         final Allele GTT = Allele.create("GTT", false);
-        final Allele AAC= Allele.create("AAC", false);
+        final Allele AAC = Allele.create("AAC", false);
         final Allele TAG = Allele.create("TAG", false);
         final Allele ACGT = Allele.create("ACGT", false);
         final Allele AACG = Allele.create("AACG", false);
@@ -213,7 +197,7 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
 
         // simple deletion
         // TTT*/T -> AAA*/A turns into left-aligned CAA*/C at position 1
-        int start = CHAIN_SIZE - 3 ;
+        int start = CHAIN_SIZE - 3;
         int stop = start + 2;
         builder.start(start).stop(stop).alleles(CollectionUtil.makeList(RefTTT, T));
         result_builder.start(1).stop(3).alleles(CollectionUtil.makeList(RefCAA, C));
@@ -224,8 +208,6 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         result_builder.genotypes(resultGenotypeBuilder.make());
 
         tests.add(new Object[]{builder.make(), reference, result_builder.make()});
-
-
 
         //simple insertion
         // T*/TTT -> A*/AAA -> turns into left-aligned C*/CAA at position 1
@@ -241,7 +223,6 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
 
         builder.noGenotypes();
         result_builder.noGenotypes();
-
 
         // non-simple deletion
         //  ACGT(T)*/A(T) -> AACG(T)*/A(T)
@@ -382,14 +363,13 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         start = CHAIN_SIZE - 4;
         stop = CHAIN_SIZE - 1;
 
-        builder.start(start).stop(stop).alleles(CollectionUtil.makeList(Allele.create("TTTT",true), Allele.create("TTTTG")));
+        builder.start(start).stop(stop).alleles(CollectionUtil.makeList(Allele.create("TTTT", true), Allele.create("TTTTG")));
         result_builder.start(1).stop(1).alleles(CollectionUtil.makeList(RefC, Allele.create("CC")));
         genotypeBuilder.alleles(builder.getAlleles());
         resultGenotypeBuilder.alleles(result_builder.getAlleles());
         builder.genotypes(genotypeBuilder.make());
         result_builder.genotypes(resultGenotypeBuilder.make());
         tests.add(new Object[]{builder.make(), reference, result_builder.make()});
-
 
         return tests.iterator();
     }
@@ -402,11 +382,6 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         final VariantContext flipped = LiftoverVcf.flipIndel(source, liftOver, reference);
 
         assertVcAreEqual(flipped, result);
-    }
-
-    @Test
-    public void leftAlignAllelesDataSelftest() {
-        leftAlignAllelesData();
     }
 
     @DataProvider(name = "leftAlignAllelesData")
@@ -452,7 +427,7 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         // CAAA*/CCAAA -> C->CC
         int start = 1;
         int stop = 4;
-        builder.start(start).stop(stop).alleles(CollectionUtil.makeList(Allele.create("CAAA",true), Allele.create("CCAAA") ));
+        builder.start(start).stop(stop).alleles(CollectionUtil.makeList(Allele.create("CAAA", true), Allele.create("CCAAA")));
 
         result_builder.start(1).stop(1).alleles(CollectionUtil.makeList(RefC, Allele.create("CC")));
         genotypeBuilder.alleles(builder.getAlleles());
@@ -461,7 +436,6 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         result_builder.genotypes(resultGenotypeBuilder.make());
 
         tests.add(new Object[]{builder.make(), reference, result_builder.make()});
-
 
         // simple SNP
         // G*/A -> G/A
@@ -475,7 +449,6 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         builder.genotypes(genotypeBuilder.make());
         result_builder.genotypes(resultGenotypeBuilder.make());
         tests.add(new Object[]{builder.make(), reference, result_builder.make()});
-
 
         builder.source("test2");
         for (start = 1; start <= reference.getBases().length; start++) {
@@ -637,11 +610,6 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         assertVcAreEqual(leftAlignVariant(source, reference), result);
     }
 
-    @Test
-    public void indelNoFlipDataSelftest() {
-        indelNoFlipData();
-    }
-
     @DataProvider(name = "indelNoFlipData")
     public Iterator<Object[]> indelNoFlipData() {
 
@@ -733,7 +701,6 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         result_builder.genotypes(resultGenotypeBuilder.make());
         tests.add(new Object[]{liftOver, twoIntervalChainReference, builder.make(), result_builder.make()});
 
-
         // near start of second interval indel
         builder.source("test7");
         builder.start(start).stop(start).alleles(CollectionUtil.makeList(ARef, T));
@@ -767,7 +734,6 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         builder.genotypes(genotypeBuilder.make());
         result_builder.genotypes(resultGenotypeBuilder.make());
         tests.add(new Object[]{liftOver, twoIntervalChainReference, builder.make(), result_builder.make()});
-
 
         // straddling interval indel
         builder.source("test9");
@@ -830,7 +796,7 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
     }
 
     @Test(dataProvider = "indelNoFlipData")
-    public void testLiftOverSimpleIndels( final LiftOver liftOver, final ReferenceSequence reference, final VariantContext source, final VariantContext result) {
+    public void testLiftOverSimpleIndels(final LiftOver liftOver, final ReferenceSequence reference, final VariantContext source, final VariantContext result) {
 
         final Interval target = liftOver.liftOver(new Interval(source.getContig(), source.getStart(), source.getEnd()), .95);
 
@@ -845,7 +811,7 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         }
 
         Assert.assertNotNull(actual, "null status");
-        Assert.assertEquals(actual.getContig(), expected.getContig(),"Different contigs: ");
+        Assert.assertEquals(actual.getContig(), expected.getContig(), "Different contigs: ");
         Assert.assertEquals(actual.getStart(), expected.getStart(), "Different starts: ");
         Assert.assertEquals(actual.getEnd(), expected.getEnd(), "Different ends: ");
 
@@ -861,7 +827,7 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         Assert.assertEquals(actual.getSampleNamesOrderedByName(), expected.getSampleNamesOrderedByName(), "Sample names differ");
 
         for (final String name : expected.getSampleNamesOrderedByName()) {
-            Assert.assertEquals(actual.get(name).getAlleles(), expected.get(name).getAlleles(),"Alleles differ for sample "+ name);
+            Assert.assertEquals(actual.get(name).getAlleles(), expected.get(name).getAlleles(), "Alleles differ for sample " + name);
         }
     }
 }

--- a/testdata/picard/vcf/testLiftoverBiallelicIndels.vcf
+++ b/testdata/picard/vcf/testLiftoverBiallelicIndels.vcf
@@ -1,5 +1,6 @@
 ##fileformat=VCFv4.1
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
-chr1	1	.	C	CCCCT	15676.17	PASS	.
-chr1	61	.	GT	G	724.43	PASS	.
-chr1	72	.	T	A	100	PASS	.
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Sample1
+chr1	1	.	C	CCCCT	15676.17	PASS	.	GT	0/0
+chr1	61	.	GT	G	724.43	PASS	.	GT	0/1
+chr1	72	.	T	A	100	PASS	.	GT	0/1


### PR DESCRIPTION
### Description

LiftOverVcf didn't do a good job lifting over genotypes in simple (non-flipped indel, and all SNPs) cases. 

This was discovered thanks to @bbimber who opened a pr #929 which I closed since the stack trace shown was out-of-date. I hope that this PR revoles the issue, but if not, @bbimber is invited to re-open that PR, or open a new issue documenting the issue at hand.

@bbimber's original description, that I neglected to copy here:
...while picard tries to update the alleles in genotypes for reverse complementation, it does not update the alleles in VariantContextBuilder to reflect any of those changes. This PR applies similar logic to the set of Ref/Alt alleles as already happens for the genotype alleles.

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

