### PR TITLE
Added code that tests all the @DataProviders in the package

### DIFF
--- a/src/test/java/picard/TestDataProviders.java
+++ b/src/test/java/picard/TestDataProviders.java
@@ -3,88 +3,33 @@ package picard;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import picard.cmdline.ClassFinder;
 
-import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
 
 /**
- * Created by farjoun on 9/19/17.
+ * This test is a mechanism to check that none of the data-providers fail to run.
+ * It is needed because in the case that a data-provider fails (for some reason, perhaps a change in some other code
+ * causes it to throw an exception) the tests that rely on it will be sliently skipped.
+ * The only mention of this will be in test logs but since we normally avoid reading these logs and rely on the
+ * exit code, it will look like all the tests have passed.
+ *
+ * @author Yossi Farjoun
  */
 public class TestDataProviders {
 
-
-    /**
-     * Taken from: https://stackoverflow.com/a/862130/360496
-     *
-     * Scans all classes accessible from the context class loader which belong
-     * to the given package and subpackages.
-     *
-     * @param packageName The base package
-     * @return The classes
-     * @throws ClassNotFoundException
-     * @throws IOException
-     */
-    private Iterable<Class> getClasses(String packageName) throws ClassNotFoundException, IOException, URISyntaxException {
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        String path = packageName.replace('.', '/');
-        Enumeration<URL> resources = classLoader.getResources(path);
-        List<File> dirs = new ArrayList<>();
-        while (resources.hasMoreElements()) {
-            URL resource = resources.nextElement();
-            URI uri = new URI(resource.toString());
-            dirs.add(new File(uri.getPath()));
-        }
-        List<Class> classes = new ArrayList<>();
-        for (File directory : dirs) {
-            classes.addAll(findClasses(directory, packageName));
-        }
-
-        return classes;
-    }
-
-    /**
-     * Recursive method used to find all classes in a given directory and
-     * subdirs.
-     *
-     * @param directory   The base directory
-     * @param packageName The package name for classes found inside the base directory
-     * @return The classes
-     * @throws ClassNotFoundException
-     */
-    private List<Class> findClasses(File directory, String packageName) throws ClassNotFoundException {
-        List<Class> classes = new ArrayList<>();
-        if (!directory.exists()) {
-            return classes;
-        }
-        File[] files = directory.listFiles();
-        assert files != null;
-        for (File file : files) {
-            if (file.isDirectory()) {
-                classes.addAll(findClasses(file, packageName + "." + file.getName()));
-            } else if (file.getName().endsWith(".class")) {
-                classes.add(Class.forName(packageName + '.' + file.getName().substring(0, file.getName().length() - 6)));
-            }
-        }
-        return classes;
-    }
-
     @Test
-    public void testAllDataProviders() throws URISyntaxException, IOException, ClassNotFoundException, IllegalAccessException, InstantiationException, InvocationTargetException {
+    public void testAllDataProviders() throws IllegalAccessException, InstantiationException, InvocationTargetException {
         int i = 0;
-        for (Class testClass : getClasses("picard")) {
+        final ClassFinder classFinder = new ClassFinder();
+        classFinder.find("picard", Object.class);
+        for (Class testClass : classFinder.getClasses()) {
             if (Modifier.isAbstract(testClass.getModifiers())) continue;
             for (final Method method : testClass.getMethods()) {
                 if (method.isAnnotationPresent(DataProvider.class)) {
-                    System.err.println("Method: " + method.getName());
+                    System.err.println("Method: " + testClass.getName() + ":" + method.getName());
                     method.invoke(testClass.newInstance());
                     i++;
                 }

--- a/src/test/java/picard/TestDataProviders.java
+++ b/src/test/java/picard/TestDataProviders.java
@@ -1,0 +1,96 @@
+package picard;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+
+/**
+ * Created by farjoun on 9/19/17.
+ */
+public class TestDataProviders {
+
+
+    /**
+     * from:
+     *
+     * Scans all classes accessible from the context class loader which belong
+     * to the given package and subpackages.
+     *
+     * @param packageName The base package
+     * @return The classes
+     * @throws ClassNotFoundException
+     * @throws IOException
+     */
+    private Iterable<Class> getClasses(String packageName) throws ClassNotFoundException, IOException, URISyntaxException {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        String path = packageName.replace('.', '/');
+        Enumeration<URL> resources = classLoader.getResources(path);
+        List<File> dirs = new ArrayList<>();
+        while (resources.hasMoreElements()) {
+            URL resource = resources.nextElement();
+            URI uri = new URI(resource.toString());
+            dirs.add(new File(uri.getPath()));
+        }
+        List<Class> classes = new ArrayList<>();
+        for (File directory : dirs) {
+            classes.addAll(findClasses(directory, packageName));
+        }
+
+        return classes;
+    }
+
+    /**
+     * Recursive method used to find all classes in a given directory and
+     * subdirs.
+     *
+     * @param directory   The base directory
+     * @param packageName The package name for classes found inside the base directory
+     * @return The classes
+     * @throws ClassNotFoundException
+     */
+    private List<Class> findClasses(File directory, String packageName) throws ClassNotFoundException {
+        List<Class> classes = new ArrayList<>();
+        if (!directory.exists()) {
+            return classes;
+        }
+        File[] files = directory.listFiles();
+        assert files != null;
+        for (File file : files) {
+            if (file.isDirectory()) {
+                classes.addAll(findClasses(file, packageName + "." + file.getName()));
+            } else if (file.getName().endsWith(".class")) {
+                classes.add(Class.forName(packageName + '.' + file.getName().substring(0, file.getName().length() - 6)));
+            }
+        }
+        return classes;
+    }
+
+    @Test
+    public void testAllDataProviders() throws URISyntaxException, IOException, ClassNotFoundException, IllegalAccessException, InstantiationException, InvocationTargetException {
+        int i = 0;
+        for (Class testClass : getClasses("picard")) {
+            if(Modifier.isAbstract(testClass.getModifiers())) continue;
+            for (final Method method : testClass.getMethods()) {
+                if (method.isAnnotationPresent(DataProvider.class)) {
+                    System.err.println("Method: "+ method.getName());
+                    method.invoke(testClass.newInstance());
+                    i++;
+                }
+            }
+        }
+        Assert.assertNotSame(i,0);
+        System.err.println("Found: "+ i + " @DataProviders.");
+    }
+}

--- a/src/test/java/picard/TestDataProviders.java
+++ b/src/test/java/picard/TestDataProviders.java
@@ -23,7 +23,7 @@ public class TestDataProviders {
 
 
     /**
-     * from:
+     * Taken from: https://stackoverflow.com/a/862130/360496
      *
      * Scans all classes accessible from the context class loader which belong
      * to the given package and subpackages.
@@ -81,10 +81,10 @@ public class TestDataProviders {
     public void testAllDataProviders() throws URISyntaxException, IOException, ClassNotFoundException, IllegalAccessException, InstantiationException, InvocationTargetException {
         int i = 0;
         for (Class testClass : getClasses("picard")) {
-            if(Modifier.isAbstract(testClass.getModifiers())) continue;
+            if (Modifier.isAbstract(testClass.getModifiers())) continue;
             for (final Method method : testClass.getMethods()) {
                 if (method.isAnnotationPresent(DataProvider.class)) {
-                    System.err.println("Method: "+ method.getName());
+                    System.err.println("Method: " + method.getName());
                     method.invoke(testClass.newInstance());
                     i++;
                 }

--- a/src/test/java/picard/illumina/parser/readers/MMapBackedIteratorFactoryTest.java
+++ b/src/test/java/picard/illumina/parser/readers/MMapBackedIteratorFactoryTest.java
@@ -38,7 +38,6 @@ public class MMapBackedIteratorFactoryTest {
     }
 
     //Note these integers are different from the ones in fileAsBytes->bInts (because we're talking about 4 bytes at a time not one)
-    @DataProvider(name="passing_bin_asTdBuffer")
     public ByteBuffer headerAsByteBuffer(final int headerSize) {
         final byte [] bytes = fileAsBytes(0, headerSize-1);
         final ByteBuffer bb = ByteBuffer.allocate(bytes.length);
@@ -48,7 +47,6 @@ public class MMapBackedIteratorFactoryTest {
         return bb;
     }
 
-    @DataProvider(name="passing_bin_asTdBuffer")
     public ByteBuffer fileAsByteBuffer(final int headerSize) {
         final byte [] bytes = fileAsBytes(headerSize, FileLength-1);
         final ByteBuffer bb = ByteBuffer.allocate(bytes.length);


### PR DESCRIPTION
And makes sure that the do not error out. This will avoid scenarios where due to some change a data-provider fails to complete and the tests are silently skipped.

Found two cases of methods that were "marked" as data-providers, but were not, so I removed their annotation.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

