### PR TITLE
Fix random seed in down sample

### DIFF
--- a/src/main/java/picard/sam/DownsampleSam.java
+++ b/src/main/java/picard/sam/DownsampleSam.java
@@ -118,11 +118,11 @@ public class DownsampleSam extends CommandLineProgram {
             log.warn("Running DownsampleSam with PROBABILITY=1! This will likely just recreate the input file.");
         }
 
-        final Random r = RANDOM_SEED == null ? new Random() : new Random(RANDOM_SEED);
+        final Integer seed = RANDOM_SEED == null ? new Random().nextInt() : RANDOM_SEED;
         final SamReader in = SamReaderFactory.makeDefault().referenceSequence(REFERENCE_SEQUENCE).open(SamInputResource.of(INPUT));
         final SAMFileWriter out = new SAMFileWriterFactory().makeSAMOrBAMWriter(in.getFileHeader(), true, OUTPUT);
         final ProgressLogger progress = new ProgressLogger(log, (int) 1e7, "Wrote");
-        final DownsamplingIterator iterator = DownsamplingIteratorFactory.make(in, STRATEGY, PROBABILITY, ACCURACY, RANDOM_SEED);
+        final DownsamplingIterator iterator = DownsamplingIteratorFactory.make(in, STRATEGY, PROBABILITY, ACCURACY, seed);
         final QualityYieldMetricsCollector metricsCollector = new QualityYieldMetricsCollector(true, false, false);
 
         while (iterator.hasNext()) {

--- a/src/test/java/picard/sam/DownsampleSamTest.java
+++ b/src/test/java/picard/sam/DownsampleSamTest.java
@@ -1,0 +1,152 @@
+package picard.sam;
+
+import htsjdk.samtools.*;
+import htsjdk.samtools.util.BufferedLineReader;
+import htsjdk.samtools.util.IOUtil;
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import picard.cmdline.CommandLineProgramTest;
+import picard.sam.util.SamTestUtil;
+import htsjdk.samtools.DownsamplingIteratorFactory.Strategy;
+import picard.util.TestNGUtil;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+
+/**
+ * Created by farjoun on 9/21/17.
+ */
+public class DownsampleSamTest extends CommandLineProgramTest {
+    private static final String sample = "TestSample";
+    private static final String readGroupId = "TestReadGroup";
+    private static final String platform = "ILLUMINA";
+    private static final String library = "TestLibrary";
+
+    private static final File TEST_DIR = new File("testdata/picard/sam/DownsampleSam");
+    private static final File dict = new File(TEST_DIR, "header.dict");
+
+    private File tempDir;
+    private File tempSamFile;
+
+    private SAMRecordSetBuilder setBuilder = new SAMRecordSetBuilder(true, SAMFileHeader.SortOrder.coordinate);
+    private SAMReadGroupRecord readGroupRecord = new SAMReadGroupRecord(readGroupId);
+
+    @Override
+    public String getCommandLineProgramName() {
+            return DownsampleSam.class.getSimpleName();
+    }
+
+    //create a samfile with one tile and randomly placed reads within it.
+    @BeforeTest
+    void setupBuilder() throws IOException {
+        final int numReads = 10000;
+        final String flowCellBarcode = "TESTBARCODE";
+
+
+        final String separator = ":";
+        final int lane = 1;
+        final int tile = 2203;
+
+        //use fixed random seed to eliminate possibility of intermittent failures
+        final Random rg = new Random(31);
+        setBuilder.setReadGroup(readGroupRecord);
+        setBuilder.setUseNmFlag(true);
+
+        for (int i = 0; i < numReads; i++) {
+
+            final String readName = flowCellBarcode + separator + lane + separator + tile + separator + i;
+            setBuilder.addPair(readName, 1, 1, 100);
+        }
+
+        tempDir = IOUtil.createTempDir("ds_test", "Downsampling");
+        tempSamFile = File.createTempFile("DownsampleSam", ".bam", tempDir);
+
+        BufferedLineReader bufferedLineReader = null;
+        try {
+            bufferedLineReader = new BufferedLineReader(new FileInputStream(dict));
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+
+        final SAMTextHeaderCodec codec = new SAMTextHeaderCodec();
+        final SAMFileHeader header = codec.decode(bufferedLineReader, dict.toString());
+
+        readGroupRecord.setSample(sample);
+        readGroupRecord.setPlatform(platform);
+        readGroupRecord.setLibrary(library);
+
+        header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+        header.addReadGroup(readGroupRecord);
+
+        setBuilder.setHeader(header);
+
+        final SAMFileWriter writer = new SAMFileWriterFactory()
+                .setCreateIndex(true).makeBAMWriter(header, false, tempSamFile);
+
+        for (final SAMRecord record : setBuilder) {
+            writer.addAlignment(record);
+        }
+        writer.close();
+    }
+
+    @AfterTest
+    private void tearDown() {
+        IOUtil.deleteDirectoryTree(tempDir);
+    }
+
+    @DataProvider(name = "ValidArgumentsTestProvider")
+    public Object[][] ValidArgumentsTestProvider() {
+        final List<Object[]> objects = new ArrayList<>();
+        for(final Strategy strategy : Strategy.values())
+            for( final Integer seed : new Integer[]{1, null})
+        for (double i = 0.3; i <= 1; i += .1) {
+            final Object[] array = {i, strategy, seed};
+            objects.add(array);
+        }
+        return objects.toArray(new Object[1][]);
+    }
+
+    // test removing some reads from a sparse, single tile bam
+    @Test(dataProvider = "ValidArgumentsTestProvider")
+    public void testDownsampleStrategies(final double fraction, final Strategy strategy, final Integer seed) throws IOException {
+            testDownsampleWorker(tempSamFile, fraction, strategy.name(), seed);
+    }
+
+    private void testDownsampleWorker(final File samFile, final double fraction, final String strategy, final Integer seed) throws IOException {
+
+        final File downsampled = File.createTempFile("DownsampleSam", ".bam", tempDir);
+        final String[] args = new String[]{
+                "INPUT=" + samFile.getAbsolutePath(),
+                "OUTPUT=" + downsampled.getAbsolutePath(),
+                "PROBABILITY=" + fraction,
+                "STRATEGY=" + strategy,
+                "RANDOM_SEED=" + ((seed==null)?"null":seed.toString()),
+                "CREATE_INDEX=true"
+        };
+
+        // make sure results is successful
+        Assert.assertEquals(runPicardCommandLine(args), 0);
+
+        // make sure that the resulting BAM is valid.
+        final ValidateSamFile validateSamFile = new ValidateSamFile();
+
+        validateSamFile.INPUT = downsampled;
+        Assert.assertEquals(validateSamFile.doWork(), 0);
+
+        // make sure that the total number of record in the resulting file in in the ballpark:
+        // don't run this when the seed is null since that is non-deterministic and might (unlikely) fail to hit the bounds.
+        if (seed!=null) {
+            TestNGUtil.assertGreaterThan(SamTestUtil.countSamTotalRecord(downsampled), fraction * .8 * SamTestUtil.countSamTotalRecord(samFile));
+            TestNGUtil.assertLessThan(SamTestUtil.countSamTotalRecord(downsampled), fraction * 1.2 * SamTestUtil.countSamTotalRecord(samFile));
+        }
+    }
+}

--- a/src/test/java/picard/sam/util/SamTestUtil.java
+++ b/src/test/java/picard/sam/util/SamTestUtil.java
@@ -1,0 +1,23 @@
+package picard.sam.util;
+
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
+
+import java.io.File;
+
+/**
+ * Created by farjoun on 9/21/17.
+ */
+public class SamTestUtil {
+    public static long countSamTotalRecord(final File samFile) {
+        final SamReader reader = SamReaderFactory.make().open(samFile);
+        assert reader.hasIndex();
+        long total = 0;
+
+        for (int i = 0; i < reader.getFileHeader().getSequenceDictionary().size(); i++) {
+            total += reader.indexing().getIndex().getMetaData(i).getAlignedRecordCount();
+            total += reader.indexing().getIndex().getMetaData(i).getUnalignedRecordCount();
+        }
+        return total;
+    }
+}

--- a/src/test/java/picard/util/TestNGUtil.java
+++ b/src/test/java/picard/util/TestNGUtil.java
@@ -19,7 +19,8 @@ import static java.lang.Math.abs;
 public class TestNGUtil {
 
     static final double EPSILON = 1e-300; //a constant near the smallest possible positive value representable in double,
-    // not actually the smallest possible value on purpose, since that would be indistinguishable from 0 and then useless.
+
+     // not actually the smallest possible value on purpose, since that would be indistinguishable from 0 and then useless.
     // This is small enough to be meaningless, but representable.
 
 
@@ -122,5 +123,13 @@ public class TestNGUtil {
         }
 
         return data.iterator();
+    }
+
+    static public void assertGreaterThan(final double lhs, final double rhs) {
+        Assert.assertTrue(lhs > rhs, String.format("Expected inequality is not true: %g > %g", lhs, rhs));
+    }
+
+    static public void assertLessThan(final double lhs, final double rhs) {
+        Assert.assertTrue(lhs < rhs, String.format("Expected inequality is not true: %g < %g", lhs, rhs));
     }
 }

--- a/testdata/picard/sam/DownsampleSam/header.dict
+++ b/testdata/picard/sam/DownsampleSam/header.dict
@@ -1,0 +1,9 @@
+@HD	VN:1.0	SO:unsorted
+@SQ	SN:chr1	LN:10100	UR:header.fasta
+@SQ	SN:chr2	LN:10100	UR:header.fasta
+@SQ	SN:chr3	LN:10100	UR:header.fasta
+@SQ	SN:chr4	LN:10100	UR:header.fasta
+@SQ	SN:chr5	LN:10100	UR:header.fasta
+@SQ	SN:chr6	LN:10100	UR:header.fasta
+@SQ	SN:chr7	LN:40400	UR:header.fasta
+@SQ	SN:chr8	LN:20200	UR:header.fasta


### PR DESCRIPTION
 Fixes #935 so that RANDOM_SEED=null is a working option that results in random results.
----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

