### PR TITLE
Makes the Fingerprint code more robust to data 

### DIFF
--- a/src/main/java/picard/fingerprint/FingerprintIdDetails.java
+++ b/src/main/java/picard/fingerprint/FingerprintIdDetails.java
@@ -45,9 +45,11 @@ public class FingerprintIdDetails {
 
     static final String multipleValuesString = "<MULTIPLE_VALUES>";
 
-    public FingerprintIdDetails() {}
+    public FingerprintIdDetails() {
+    }
 
-    // If platformUnit is not populated, then fields will be initialized as flowcellBarcode="?", lane=-1, molecularBarcode="?"
+    // If platformUnit is not populated, or "improperly" formatted (or missing), then fields will be initialized as
+    // flowcellBarcode="?", lane=-1, molecularBarcode="?"
     public FingerprintIdDetails(final String platformUnit, final String file) {
         getPlatformUnitDetails(platformUnit);
         this.platformUnit = platformUnit;
@@ -92,12 +94,12 @@ public class FingerprintIdDetails {
 
     public FingerprintIdDetails merge(final FingerprintIdDetails other) {
 
-        platformUnit     = equalValueOrElse(platformUnit,     other.platformUnit,     multipleValuesString);
-        runBarcode       = equalValueOrElse(runBarcode,       other.runBarcode,       multipleValuesString);
-        runLane          = equalValueOrElse(runLane,          other.runLane,          Integer.MIN_VALUE);
-        library          = equalValueOrElse(library,          other.library,          multipleValuesString);
-        file             = equalValueOrElse(file,             other.file,             multipleValuesString);
-        sample           = equalValueOrElse(sample,           other.sample,           multipleValuesString);
+        platformUnit = equalValueOrElse(platformUnit, other.platformUnit, multipleValuesString);
+        runBarcode = equalValueOrElse(runBarcode, other.runBarcode, multipleValuesString);
+        runLane = equalValueOrElse(runLane, other.runLane, Integer.MIN_VALUE);
+        library = equalValueOrElse(library, other.library, multipleValuesString);
+        file = equalValueOrElse(file, other.file, multipleValuesString);
+        sample = equalValueOrElse(sample, other.sample, multipleValuesString);
         molecularBarcode = equalValueOrElse(molecularBarcode, other.molecularBarcode, multipleValuesString);
 
         return this;
@@ -125,18 +127,21 @@ public class FingerprintIdDetails {
      */
     private void getPlatformUnitDetails(final String puString) {
 
-        final String[] tmp = puString.split("\\."); // Expect to look like: D047KACXX110901.1.ACCAACTG
         this.runBarcode = "?";
         this.runLane = -1;
         this.molecularBarcode = "?";
-        try {
-            if ((tmp.length == 3) || (tmp.length == 2)) {
-                this.runBarcode = tmp[0];
+
+        if (puString == null) return;
+
+        final String[] tmp = puString.split("\\."); // Expect to look like: D047KACXX110901.1.ACCAACTG
+        if ((tmp.length == 3) || (tmp.length == 2)) {
+            this.runBarcode = tmp[0];
+            this.molecularBarcode = (tmp.length == 3) ? tmp[2] : "";  // In older BAMS there may be no molecular barcode sequence
+            try {
                 this.runLane = Integer.parseInt(tmp[1]);
-                this.molecularBarcode = (tmp.length == 3) ? tmp[2] : "";  // In older BAMS there may be no molecular barcode sequence
+            } catch (final NumberFormatException e) {
+                //no-op. return with whatever was parsed
             }
-        } catch (final NumberFormatException e) {
-            throw new IllegalArgumentException("Unexpected format " + puString + " for PU attribute");
         }
     }
 }


### PR DESCRIPTION
Makes the Fingerprint code more robust to data  that has non-conforming (or missing!) PU fields
----

### Description
While At Broad we use sequencing data consisting of reads with RG tags that point to RG records with PU records, populated with well, formed strings (FLOWCELL.LANE, or FC.LANE.BARCODE), this is hardly the case everywhere

Currently the fingerprinting code breaks if it cannot find the PU field or if the lane "part" is not an integer. This PR protects against that eventuality....


### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

