### PR TITLE
Converted the tests of @DataProviders to using....a @DataProvider!

### DIFF
--- a/src/test/java/picard/TestDataProviders.java
+++ b/src/test/java/picard/TestDataProviders.java
@@ -1,6 +1,7 @@
 package picard;
 
 import org.testng.Assert;
+import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import picard.cmdline.ClassFinder;
@@ -39,6 +40,12 @@ public class TestDataProviders {
         }
     }
 
+    @Test
+    public void IndependentTestOfDataProviderTest() throws IllegalAccessException, InvocationTargetException, InstantiationException {
+        testAllDataProvidersdata();
+    }
+
+
     @DataProvider(name = "DataprovidersThatDontTestThemselves")
     public Iterator<Object[]> testAllDataProvidersdata() throws IllegalAccessException, InstantiationException, InvocationTargetException {
         int i = 0;
@@ -66,6 +73,15 @@ public class TestDataProviders {
         final Class clazz = container.clazz;
         System.err.println("Method: " + method + " Class: " + clazz.getName());
 
-        method.invoke(clazz.newInstance());
+        Object instance = clazz.newInstance();
+
+        // Some tests assume that the @BeforeSuite methods will be called before the @DataProviders
+        for (final Method otherMethod : clazz.getMethods()) {
+            if (otherMethod.isAnnotationPresent(BeforeSuite.class)) {
+                otherMethod.invoke(instance);
+            }
+        }
+
+        method.invoke(instance);
     }
 }

--- a/src/test/java/picard/TestDataProviders.java
+++ b/src/test/java/picard/TestDataProviders.java
@@ -37,7 +37,7 @@ public class TestDataProviders {
     }
 
     @DataProvider(name = "DataprovidersThatDontTestThemselves")
-    public Iterator<Object[]> testAllDataProvidersdata() throws Exception {
+    public Iterator<Object[]> testAllDataProvidersData() throws Exception {
         return TestNGUtil.getDataProviders("picard");
     }
 
@@ -52,8 +52,8 @@ public class TestDataProviders {
 
         Object instance = clazz.newInstance();
 
-        Set<Method> methodSet = Sets.newHashSet();
-        methodSet.addAll(Arrays.asList(clazz.getDeclaredMethods()));
+        Set<Method> methodSet = new HashSet<>();
+        methodSet.addAll(Arrays.asList(clazz.getInMethods()));
         methodSet.addAll(Arrays.asList(clazz.getMethods()));
 
         // Some tests assume that the @BeforeSuite methods will be called before the @DataProviders

--- a/src/test/java/picard/TestDataProviders.java
+++ b/src/test/java/picard/TestDataProviders.java
@@ -3,6 +3,7 @@ package picard;
 import org.testng.Assert;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.DataProvider;
+import org.testng.annotations.NoInjection;
 import org.testng.annotations.Test;
 import picard.cmdline.ClassFinder;
 
@@ -23,32 +24,15 @@ import java.util.List;
  * @author Yossi Farjoun
  */
 public class TestDataProviders {
-    private static class Container {
-        public final Method method;
-        public final Class<?> clazz;
-
-        // Encapsulation (of the Method) is required due to what seems to be a bug in TestNG.
-
-        public Container(Method method, Class clazz) {
-            this.method = method;
-            this.clazz = clazz;
-        }
-
-        @Override
-        public String toString() {
-            return clazz.getName() + "::" + method.getName();
-        }
-    }
 
     @Test
     public void IndependentTestOfDataProviderTest() throws IllegalAccessException, InvocationTargetException, InstantiationException {
         testAllDataProvidersdata();
     }
 
-
     @DataProvider(name = "DataprovidersThatDontTestThemselves")
     public Iterator<Object[]> testAllDataProvidersdata() throws IllegalAccessException, InstantiationException, InvocationTargetException {
-        int i = 0;
+
         List<Object[]> data = new ArrayList<>();
         final ClassFinder classFinder = new ClassFinder();
         classFinder.find("picard", Object.class);
@@ -57,20 +41,20 @@ public class TestDataProviders {
             if (Modifier.isAbstract(testClass.getModifiers())) continue;
             for (final Method method : testClass.getMethods()) {
                 if (method.isAnnotationPresent(DataProvider.class)) {
-                    data.add(new Object[]{new Container(method, testClass)});
+                    data.add(new Object[]{method, testClass});
                 }
             }
         }
         Assert.assertTrue(data.size() > 1);
-        Assert.assertEquals(data.stream().filter(c -> ((Container) c[0]).method.getName().equals("testAllDataProvidersdata")).count(), 1);
+        Assert.assertEquals(data.stream().filter(c -> ((Method) c[0]).getName().equals("testAllDataProvidersdata")).count(), 1);
 
         return data.iterator();
     }
 
+    // @NoInjection annotations required according to this test:
+    // https://github.com/cbeust/testng/blob/master/src/test/java/test/inject/NoInjectionTest.java
     @Test(dataProvider = "DataprovidersThatDontTestThemselves")
-    public void testDataProviderswithDP(final Container container) throws IllegalAccessException, InstantiationException, InvocationTargetException {
-        final Method method = container.method;
-        final Class clazz = container.clazz;
+    public void testDataProviderswithDP(@NoInjection final Method method, final Class clazz) throws IllegalAccessException, InstantiationException, InvocationTargetException {
         System.err.println("Method: " + method + " Class: " + clazz.getName());
 
         Object instance = clazz.newInstance();

--- a/src/test/java/picard/TestDataProviders.java
+++ b/src/test/java/picard/TestDataProviders.java
@@ -32,8 +32,8 @@ public class TestDataProviders {
         Assert.assertTrue(data.hasNext(), "Found no data from testAllDataProvidersdata. Something is wrong.");
 
         Assert.assertEquals( StreamSupport.stream(Spliterators.spliteratorUnknownSize(data, 0), false)
-                        .filter(c -> ((Method) c[0]).getName().equals("testAllDataProvidersdata")).count(), 1,
-                "getDataProviders didn't find testAllDataProvidersdata, which is in this class. Something is wrong.");
+                        .filter(c -> ((Method) c[0]).getName().equals("testAllDataProvidersData")).count(), 1,
+                "getDataProviders didn't find testAllDataProvidersData, which is in this class. Something is wrong.");
     }
 
     @DataProvider(name = "DataprovidersThatDontTestThemselves")

--- a/src/test/java/picard/TestDataProviders.java
+++ b/src/test/java/picard/TestDataProviders.java
@@ -3,15 +3,11 @@ package picard;
 import org.testng.Assert;
 import org.testng.annotations.*;
 import org.testng.annotations.Test;
-import org.testng.collections.Sets;
-import picard.cmdline.ClassFinder;
 import picard.util.TestNGUtil;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.*;
-import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 /**

--- a/src/test/java/picard/util/TestNGUtil.java
+++ b/src/test/java/picard/util/TestNGUtil.java
@@ -3,12 +3,13 @@ package picard.util;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.*;
 
 import org.testng.Assert;
+import org.testng.collections.Sets;
+import picard.cmdline.ClassFinder;
 
 import static java.lang.Math.abs;
 
@@ -92,5 +93,34 @@ public class TestNGUtil {
         for (int i = 0; i < lhs.length; ++i) {
             Assert.assertTrue(compareDoubleWithAccuracy(lhs[i], rhs[i], accuracy), "Arrays disagree at position " + i + ":  " + lhs[i] + " vs. " + rhs[i] + ". ");
         }
+    }
+
+    /** A Method that returns all the Methods that are annotated with @DataProvider
+     * in a given package. Should be moved to htsjdk and used from there
+     *
+     * @param pakkage the package under hwich to look for classes and methods
+     * @return an iterator to collection of Object[]'s consisting of {Method method, Class clazz} pair.
+     * where method has the @DataProviderAnnotation and is a member of clazz.
+     */
+    public static Iterator<Object[]> getDataProviders(final String pakkage) {
+        List<Object[]> data = new ArrayList<>();
+        final ClassFinder classFinder = new ClassFinder();
+        classFinder.find(pakkage, Object.class);
+
+        for (final Class<?> testClass : classFinder.getClasses()) {
+            if (Modifier.isAbstract(testClass.getModifiers()) || Modifier.isInterface(testClass.getModifiers()))
+                continue;
+            Set<Method> methodSet = Sets.newHashSet();
+            methodSet.addAll(Arrays.asList(testClass.getDeclaredMethods()));
+            methodSet.addAll(Arrays.asList(testClass.getMethods()));
+
+            for (final Method method : methodSet) {
+                if (method.isAnnotationPresent(DataProvider.class)) {
+                    data.add(new Object[]{method, testClass});
+                }
+            }
+        }
+
+        return data.iterator();
     }
 }

--- a/src/test/java/picard/util/TestNGUtil.java
+++ b/src/test/java/picard/util/TestNGUtil.java
@@ -98,14 +98,14 @@ public class TestNGUtil {
     /** A Method that returns all the Methods that are annotated with @DataProvider
      * in a given package. Should be moved to htsjdk and used from there
      *
-     * @param pakkage the package under hwich to look for classes and methods
+     * @param packageName the package under which to look for classes and methods
      * @return an iterator to collection of Object[]'s consisting of {Method method, Class clazz} pair.
      * where method has the @DataProviderAnnotation and is a member of clazz.
      */
-    public static Iterator<Object[]> getDataProviders(final String pakkage) {
+    public static Iterator<Object[]> getDataProviders(final String packageName) {
         List<Object[]> data = new ArrayList<>();
         final ClassFinder classFinder = new ClassFinder();
-        classFinder.find(pakkage, Object.class);
+        classFinder.find(packageName, Object.class);
 
         for (final Class<?> testClass : classFinder.getClasses()) {
             if (Modifier.isAbstract(testClass.getModifiers()) || Modifier.isInterface(testClass.getModifiers()))


### PR DESCRIPTION
### Description
Improves the Test of DataProviders to use a @DataProvider which will show all the tests separately so that in case of failures it will not abort after the first failure.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

