### PR TITLE
ExtractIlluminaBarcodes throws a NullPointerException in the case of an empty lane directory

### DIFF
--- a/src/main/java/picard/illumina/parser/IlluminaFileUtil.java
+++ b/src/main/java/picard/illumina/parser/IlluminaFileUtil.java
@@ -265,6 +265,11 @@ public class IlluminaFileUtil {
         final File laneDir = new File(basecallDir, IlluminaFileUtil.longLaneStr(lane));
         final File[] cycleDirs = IOUtil.getFilesMatchingRegexp(laneDir, IlluminaFileUtil.CYCLE_SUBDIRECTORY_PATTERN);
 
+        // Either the lane or the cycle directory do not exist!
+        if (cycleDirs == null) {
+            return false;
+        }
+
         //CBCLs
         final List<File> cbcls = new ArrayList<>();
         Arrays.asList(cycleDirs)


### PR DESCRIPTION
@jacarey want to take a look?

Exception:
```
Exception in thread "main" java.lang.NullPointerException
	at java.util.Objects.requireNonNull(Objects.java:203)
	at java.util.Arrays$ArrayList.<init>(Arrays.java:3813)
	at java.util.Arrays.asList(Arrays.java:3800)
	at picard.illumina.parser.IlluminaFileUtil.hasCbcls(IlluminaFileUtil.java:270)
	at picard.illumina.ExtractIlluminaBarcodes.customCommandLineValidation(ExtractIlluminaBarcodes.java:447)
	at picard.cmdline.CommandLineProgram.parseArgs(CommandLineProgram.java:323)
	at picard.cmdline.CommandLineProgram.instanceMain(CommandLineProgram.java:196)
	at picard.cmdline.PicardCommandLine.instanceMain(PicardCommandLine.java:98)
	at picard.cmdline.PicardCommandLine.main(PicardCommandLine.java:108)
```