### PR TITLE
Extend travis build matrix to separate Barclay tests from legacy tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
     - $HOME/.m2
+env:
+  matrix:
+    - RUN_BARCLAY_TESTS=true
+    - RUN_BARCLAY_TESTS=false
 jdk:
   - oraclejdk8
   - openjdk8
@@ -14,7 +18,14 @@ before_install:
   - wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
   - sudo apt-get -qq update
   - sudo apt-get install -y --no-install-recommends r-base-dev r-recommended qpdf
-script: ./gradlew jacocoTestReport
+script:
+  - if [[ $RUN_BARCLAY_TESTS == true ]]; then
+      echo "Running tests using the Barclay command line parser.";
+      ./gradlew barclayTest;
+    else
+      echo "Running tests using the legacy Picard command line parser.";
+      ./gradlew jacocoTestReport;
+    fi
 after_success:
   - ./gradlew coveralls
   - if [ "$TRAVIS_BRANCH" == "master" ]; then

--- a/build.gradle
+++ b/build.gradle
@@ -31,21 +31,6 @@ repositories {
     }
 }
 
-jacocoTestReport {
-    dependsOn test
-    group = "Reporting"
-    description = "Generate Jacoco coverage reports after running tests."
-    additionalSourceDirs = files(sourceSets.main.allJava.srcDirs)
-
-    reports {
-        xml.enabled = true // coveralls plugin depends on xml format report
-        html.enabled = true
-    }
-}
-
-jacoco {
-    toolVersion = "0.7.5.201505241946"
-}
 
 final htsjdkVersion = System.getProperty('htsjdk.version', '2.12.0')
 
@@ -274,6 +259,22 @@ tasks.withType(Test) {
             }
         }
     }
+}
+
+jacocoTestReport {
+    dependsOn legacyTest
+    group = "Reporting"
+    description = "Generate Jacoco coverage reports after running tests."
+    additionalSourceDirs = files(sourceSets.main.allJava.srcDirs)
+
+    reports {
+        xml.enabled = true // coveralls plugin depends on xml format report
+        html.enabled = true
+    }
+}
+
+jacoco {
+    toolVersion = "0.7.5.201505241946"
 }
 
 task wrapper(type: Wrapper) {


### PR DESCRIPTION
Separate the Barclay tests from the legacy tests in the build matrix as suggested [here](https://github.com/broadinstitute/picard/issues/950) so that both always run. This makes the failure reason clear in the case where a test failure is parser-sensitive. This was tested using a forced failure [here](https://travis-ci.org/broadinstitute/picard/builds/285173742).

### Checklist (never delete this)

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ X] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

