### PR TITLE
Website: add catch for invalid flags in explain-flags.html

### DIFF
--- a/explain-flags.html
+++ b/explain-flags.html
@@ -20,17 +20,16 @@
     function explainFlags() {
         var flagValue = parseInt(document.getElementById('tb').value); //returns 0 or NaN if can't parse
         var summary  = ""; 
-        var badFlags = ""; // Stores the flags that don't make sense with unpaired reads
+        var badFlags = []; // Stores the flags that don't make sense with unpaired reads
         var asterix  = ""; // indicator for the user which flags are invalid with unpaired reads
         var pairedRead = lstFlags[0][1] & flagValue;
         for(var i = 0; i < lstFlags.length; i++) {
             var checkbox = document.getElementById('cb' + i)
             if(lstFlags[i][1] & flagValue) {
+                asterix = " (0x" + lstFlags[i][1].toString(16) + ")";
                 if (!pairedRead && (lstFlags[i][1] & 235)) {
-                    badFlags += " " + lstFlags[i][1];
-                    asterix = "<b>*</b>";
-                } else {
-                    asterix = "";
+                    badFlags.push(" 0x" + lstFlags[i][1].toString(16));
+                    asterix += "<b>*</b>";
                 }
                 summary  += " &nbsp; &nbsp; " + lstFlags[i][0] + asterix + "<br>";
                 checkbox.checked = true;
@@ -38,7 +37,12 @@
                 checkbox.checked = false;
             }
         }
-        if (badFlags != ""){
+        if (badFlags.length > 0){
+            if (badFlags.length == 2){
+                badFlags = badFlags.join(" and ");
+            } else {
+                badFlags[badFlags.length - 1] = " and" + badFlags[badFlags.length - 1];
+            }
             summary += "<br> &nbsp; &nbsp; <b>*Warning:</b> Flag(s)" + badFlags + " cannot be set when read is not paired";
         }
         document.getElementById('summary').innerHTML = summary;

--- a/explain-flags.html
+++ b/explain-flags.html
@@ -41,6 +41,8 @@
         if (badFlags != ""){
             summary += "<br> &nbsp; &nbsp; <b>*Warning:</b> Flag(s)" + badFlags + " cannot be set when read is not paired";
         }
+        document.getElementById('summary').innerHTML = summary;
+    }
     function checkboxClicked() {
         //compute the new flag value
         var newFlagValue = 0;

--- a/explain-flags.html
+++ b/explain-flags.html
@@ -19,23 +19,28 @@
         ["supplementary alignment", 0x800]];
     function explainFlags() {
         var flagValue = parseInt(document.getElementById('tb').value); //returns 0 or NaN if can't parse
-        var summary = "";
+        var summary  = ""; 
+        var badFlags = ""; // Stores the flags that don't make sense with unpaired reads
+        var asterix  = ""; // indicator for the user which flags are invalid with unpaired reads
         var pairedRead = lstFlags[0][1] & flagValue;
         for(var i = 0; i < lstFlags.length; i++) {
             var checkbox = document.getElementById('cb' + i)
             if(lstFlags[i][1] & flagValue) {
-                if (!pairedRead && i < 8){
-                    summary = " &nbsp; &nbsp; <b>Invalid flag: read not paired</b><br>";
+                if (!pairedRead && (lstFlags[i][1] & 235)) {
+                    badFlags += " " + lstFlags[i][1];
+                    asterix = "<b>*</b>";
                 } else {
-                    summary  += " &nbsp; &nbsp; " + lstFlags[i][0] + "<br>";
+                    asterix = "";
                 }
+                summary  += " &nbsp; &nbsp; " + lstFlags[i][0] + asterix + "<br>";
                 checkbox.checked = true;
             } else {
                 checkbox.checked = false;
             }
         }
-        document.getElementById('summary').innerHTML = summary;
-    }
+        if (badFlags != ""){
+            summary += "<br> &nbsp; &nbsp; <b>*Warning:</b> Flag(s)" + badFlags + " cannot be set when read is not paired";
+        }
     function checkboxClicked() {
         //compute the new flag value
         var newFlagValue = 0;

--- a/explain-flags.html
+++ b/explain-flags.html
@@ -20,10 +20,15 @@
     function explainFlags() {
         var flagValue = parseInt(document.getElementById('tb').value); //returns 0 or NaN if can't parse
         var summary = "";
+        var pairedRead = lstFlags[0][1] & flagValue;
         for(var i = 0; i < lstFlags.length; i++) {
             var checkbox = document.getElementById('cb' + i)
             if(lstFlags[i][1] & flagValue) {
-                summary  += " &nbsp; &nbsp; " + lstFlags[i][0] + "<br>";
+                if (!pairedRead && i < 8){
+                    summary = " &nbsp; &nbsp; <b>Invalid flag: read not paired</b><br>";
+                } else {
+                    summary  += " &nbsp; &nbsp; " + lstFlags[i][0] + "<br>";
+                }
                 checkbox.checked = true;
             } else {
                 checkbox.checked = false;

--- a/explain-flags.html
+++ b/explain-flags.html
@@ -20,18 +20,18 @@
     function explainFlags() {
         var flagValue = parseInt(document.getElementById('tb').value); //returns 0 or NaN if can't parse
         var summary  = ""; 
-        var badFlags = []; // Stores the flags that don't make sense with unpaired reads
-        var asterix  = ""; // indicator for the user which flags are invalid with unpaired reads
+        var badFlags = [];   // Stores the flags that don't make sense with unpaired reads
+        var hexString  = ""; // indicator for the user which flags are invalid with unpaired reads
         var pairedRead = lstFlags[0][1] & flagValue;
         for(var i = 0; i < lstFlags.length; i++) {
             var checkbox = document.getElementById('cb' + i)
             if(lstFlags[i][1] & flagValue) {
-                asterix = " (0x" + lstFlags[i][1].toString(16) + ")";
+                hexString = " (0x" + lstFlags[i][1].toString(16) + ")";
                 if (!pairedRead && (lstFlags[i][1] & 235)) {
                     badFlags.push(" 0x" + lstFlags[i][1].toString(16));
-                    asterix += "<b>*</b>";
+                    hexString += "<b>*</b>";
                 }
-                summary  += " &nbsp; &nbsp; " + lstFlags[i][0] + asterix + "<br>";
+                summary  += " &nbsp; &nbsp; " + lstFlags[i][0] + hexString + "<br>";
                 checkbox.checked = true;
             } else {
                 checkbox.checked = false;


### PR DESCRIPTION
### Description

I have added a catch in explain-flags.html that will send up a warning **Invalid flag: read not paired** in the case of invalid flag values like 128. I ran into this in issue #955, where I had visited the explain flags page, but had no indication that the flag was invalid. 


### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

