### PR TITLE
Make Transition enum public

### DIFF
--- a/src/main/java/picard/analysis/artifacts/Transition.java
+++ b/src/main/java/picard/analysis/artifacts/Transition.java
@@ -4,7 +4,10 @@ import htsjdk.samtools.util.SequenceUtil;
 
 import java.util.Arrays;
 
-enum Transition {
+/**
+ * Enum representation of a transition from one base to any other.
+ */
+public enum Transition {
     AtoA('A','A'), AtoC('A','C'), AtoG('A','G'), AtoT('A','T'),
     CtoA('C','A'), CtoC('C','C'), CtoG('C','G'), CtoT('C','T'),
     GtoA('G','A'), GtoC('G','C'), GtoG('G','G'), GtoT('G','T'),

--- a/src/main/java/picard/analysis/artifacts/Transition.java
+++ b/src/main/java/picard/analysis/artifacts/Transition.java
@@ -3,7 +3,6 @@ package picard.analysis.artifacts;
 import htsjdk.samtools.util.SequenceUtil;
 
 import java.util.Arrays;
-import java.util.function.Supplier;
 
 /**
  * Enum representation of a transition from one base to any other.
@@ -27,28 +26,20 @@ public enum Transition {
     }
 
     /**
-     * Gets a the enum representing the transition from a 'reference" got a 'call' base.
+     * Gets a the enum representing the transition from a 'reference" to a 'call' base.
      *
      * <p>For example, a transtion from 'A' to 'T' would return {@link #AtoT}.
      *
-     * @param ref reference base.
-     * @param call call base.
+     * @param ref reference base (one of of {A, C, T, G}).
+     * @param call call base (one of of {A, C, T, G}).
      *
-     * @return enum representation for the transition-
+     * @return enum representation for the transition.
      */
     public static Transition transitionOf(final char ref, final char call) {
-        return transitionIndexMap[baseIndexOf(ref, () -> "ref")][baseIndexOf(call, () -> "call")];
-    }
-
-    private static int baseIndexOf(final char base, final Supplier<String> paramName) {
         try {
-            final int index = baseIndexMap[base];
-            if (index == -1) {
-                throw new IllegalArgumentException("invalid '" + paramName.get() + "' base: " + base);
-            }
-            return index;
+            return transitionIndexMap[baseIndexMap[ref]][baseIndexMap[call]];
         } catch (IndexOutOfBoundsException e) {
-            throw new IllegalArgumentException("invalid '" + paramName.get() + "' base: " + base);
+            throw new IllegalArgumentException(String.format("Base params should be one of {A, C, T, G} but ref=%s and call=%s", ref, call));
         }
     }
 

--- a/src/main/java/picard/analysis/artifacts/Transition.java
+++ b/src/main/java/picard/analysis/artifacts/Transition.java
@@ -3,6 +3,7 @@ package picard.analysis.artifacts;
 import htsjdk.samtools.util.SequenceUtil;
 
 import java.util.Arrays;
+import java.util.function.Supplier;
 
 /**
  * Enum representation of a transition from one base to any other.
@@ -25,8 +26,30 @@ public enum Transition {
         this.call = call;
     }
 
+    /**
+     * Gets a the enum representing the transition from a 'reference" got a 'call' base.
+     *
+     * <p>For example, a transtion from 'A' to 'T' would return {@link #AtoT}.
+     *
+     * @param ref reference base.
+     * @param call call base.
+     *
+     * @return enum representation for the transition-
+     */
     public static Transition transitionOf(final char ref, final char call) {
-        return transitionIndexMap[baseIndexMap[ref]][baseIndexMap[call]];
+        return transitionIndexMap[baseIndexOf(ref, () -> "ref")][baseIndexOf(call, () -> "call")];
+    }
+
+    private static int baseIndexOf(final char base, final Supplier<String> paramName) {
+        try {
+            final int index = baseIndexMap[base];
+            if (index == -1) {
+                throw new IllegalArgumentException("invalid '" + paramName.get() + "' base: " + base);
+            }
+            return index;
+        } catch (IndexOutOfBoundsException e) {
+            throw new IllegalArgumentException("invalid '" + paramName.get() + "' base: " + base);
+        }
     }
 
     /**
@@ -41,8 +64,10 @@ public enum Transition {
         return transitionOf((char) SequenceUtil.complement((byte) this.ref), (char) SequenceUtil.complement((byte) this.call));
     }
 
+    /** Gets the reference for the transition. */
     public char ref() { return this.ref; }
 
+    /** Gets the call for the transition. */
     public char call() { return this.call; }
 
     @Override

--- a/src/main/java/picard/analysis/artifacts/Transition.java
+++ b/src/main/java/picard/analysis/artifacts/Transition.java
@@ -26,7 +26,7 @@ public enum Transition {
     }
 
     /**
-     * Gets a the enum representing the transition from a 'reference" to a 'call' base.
+     * Gets a the enum representing the transition from a 'reference' to a 'call' base.
      *
      * <p>For example, a transtion from 'A' to 'T' would return {@link #AtoT}.
      *

--- a/src/test/java/picard/analysis/artifacts/TransitionTest.java
+++ b/src/test/java/picard/analysis/artifacts/TransitionTest.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Daniel Gómez-Sánchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package picard.analysis.artifacts;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class TransitionTest {
+
+    @DataProvider
+    public Iterator<Object[]> allTransitions() {
+        return Stream.of(Transition.values()).map(t -> new Object[]{t}).iterator();
+    }
+
+    @Test(dataProvider = "allTransitions")
+    public void testIdentityAfterTwoComplement(final Transition transition) {
+        Assert.assertEquals(transition.complement().complement(), transition);
+    }
+
+    @Test(dataProvider = "allTransitions")
+    public void testTransitionOfSelf(final Transition transition) {
+        final Transition ofSelf = Transition.transitionOf(transition.ref(), transition.call());
+        Assert.assertEquals(ofSelf, transition);
+        Assert.assertSame(ofSelf, transition);
+    }
+
+    @DataProvider
+    public Object[][] badBases() {
+        return new Object[][] {{Character.MIN_VALUE}, {Transition.Base.A.base - 1}, {'Z'}, {Character.MAX_VALUE}};
+    }
+
+    @Test(dataProvider = "badBases", expectedExceptions = IllegalArgumentException.class)
+    public void testInvalidRef(final char wrongBase) {
+        Transition.transitionOf(wrongBase, 'A');
+    }
+
+    @Test(dataProvider = "badBases", expectedExceptions = IllegalArgumentException.class)
+    public void testInvalidCall(final char wrongBase) {
+        Transition.transitionOf('A', wrongBase);
+    }
+}

--- a/src/test/java/picard/analysis/artifacts/TransitionTest.java
+++ b/src/test/java/picard/analysis/artifacts/TransitionTest.java
@@ -1,27 +1,3 @@
-/*
- * The MIT License (MIT)
- *
- * Copyright (c) 2015 Daniel Gómez-Sánchez
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-
 package picard.analysis.artifacts;
 
 import org.testng.Assert;


### PR DESCRIPTION
### Description

As described in https://github.com/broadinstitute/gatk/issues/3632, this enum may be useful in downstream projects. Thus, this PR adds a class javadoc and makes public the enum.

----

### Checklist (never delete this)

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

