### PR TITLE
Adds usage statement to UmiAwareMarkDuplicatesWithMateCigar that it shouldn't be used with RNAseq or other technologies with long gaps.

### DIFF
--- a/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
@@ -63,7 +63,23 @@ public class UmiAwareMarkDuplicatesWithMateCigar extends SimpleMarkDuplicatesWit
             "argument MAX_EDIT_DISTANCE_TO_JOIN, which sets the edit distance between UMIs that will be considered to be part of the same " +
             "original molecule. This logic allows for sequencing errors in UMIs.</p>" +
             "<p>This tool is NOT intended to be used on data without UMIs; for marking duplicates in non-UMI data, see MarkDuplicates or " +
-            "MarkDuplicatesWithMateCigar. Mixed data (where some reads have UMIs and others do not) is not supported.</p>";
+            "MarkDuplicatesWithMateCigar. Mixed data (where some reads have UMIs and others do not) is not supported.</p>" +
+            "" +
+            "Note also that this tool will not work with alignments that have large gaps or deletions, such as those from RNA-seq data.  " +
+            "This is due to the need to buffer small genomic windows to ensure integrity of the duplicate marking, while large skips " +
+            "(ex. skipping introns) in the alignment records would force making that window very large, thus exhausting memory. <br />" +
+            "" +
+            "<p>Note: Metrics labeled as percentages are actually expressed as fractions!</p>" +
+            "<h4>Usage example:</h4>" +
+            "<pre>" +
+            "" +
+            "java -jar picard.jar UmiAwareMarkDuplicatesWithMateCigar \\<br />" +
+            "      I=input.bam \\<br />" +
+            "      O=umi_aware_mark_dups_w_mate_cig.bam \\<br />" +
+            "      M=umi_aware_mark_dups_w_mate_cig_duplicate_metrics.txt" +
+            "      UMI_METRICS=umi_aware_mark_dups_w_mate_cig_umi_metrics.txt" +
+            "</pre>" +
+            "<hr />";
 
     @Argument(shortName = "MAX_EDIT_DISTANCE_TO_JOIN", doc = "Largest edit distance that UMIs must have in order to be considered as coming from distinct source molecules.", optional = true)
     public int MAX_EDIT_DISTANCE_TO_JOIN = 1;

--- a/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
@@ -65,9 +65,9 @@ public class UmiAwareMarkDuplicatesWithMateCigar extends SimpleMarkDuplicatesWit
             "<p>This tool is NOT intended to be used on data without UMIs; for marking duplicates in non-UMI data, see MarkDuplicates or " +
             "MarkDuplicatesWithMateCigar. Mixed data (where some reads have UMIs and others do not) is not supported.</p>" +
             "" +
-            "Note also that this tool will not work with alignments that have large gaps or deletions, such as those from RNA-seq data.  " +
+            "<p>Note also that this tool will not work with alignments that have large gaps or deletions, such as those from RNA-seq data.  " +
             "This is due to the need to buffer small genomic windows to ensure integrity of the duplicate marking, while large skips " +
-            "(ex. skipping introns) in the alignment records would force making that window very large, thus exhausting memory. <br />" +
+            "(ex. skipping introns) in the alignment records would force making that window very large, thus exhausting memory. </p>" +
             "" +
             "<p>Note: Metrics labeled as percentages are actually expressed as fractions!</p>" +
             "<h4>Usage example:</h4>" +
@@ -76,7 +76,7 @@ public class UmiAwareMarkDuplicatesWithMateCigar extends SimpleMarkDuplicatesWit
             "java -jar picard.jar UmiAwareMarkDuplicatesWithMateCigar \\<br />" +
             "      I=input.bam \\<br />" +
             "      O=umi_aware_mark_dups_w_mate_cig.bam \\<br />" +
-            "      M=umi_aware_mark_dups_w_mate_cig_duplicate_metrics.txt" +
+            "      M=umi_aware_mark_dups_w_mate_cig_duplicate_metrics.txt \\<br />" +
             "      UMI_METRICS=umi_aware_mark_dups_w_mate_cig_umi_metrics.txt" +
             "</pre>" +
             "<hr />";


### PR DESCRIPTION
### Description

This adds a usage statement to UmiAwareMarkDuplicatesWithMateCigar that informs the user that this tool should not be used with RNAseq, or other sequencing technologies that have large alignment gaps.  Addressing issue #953 

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

