### PR TITLE
Bugfix 960 - Handle dashes and Ns in UmiAwareMarkDuplicatesWithMateCigar

### DIFF
--- a/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
@@ -62,6 +62,10 @@ public class UmiAwareMarkDuplicatesWithMateCigar extends SimpleMarkDuplicatesWit
             "they must also have sufficiently similar UMIs. In this context, 'sufficiently similar' is parameterized by the command line " +
             "argument MAX_EDIT_DISTANCE_TO_JOIN, which sets the edit distance between UMIs that will be considered to be part of the same " +
             "original molecule. This logic allows for sequencing errors in UMIs.</p>" +
+            "<p> If UMIs contain dashes, the dashes will be ignored. If UMIs contain Ns, these UMIs will not contribute to UMI metrics " +
+            "associated with each record. If the MAX_EDIT_DISTANCE_TO_JOIN allows, UMIs with Ns will be included in the duplicate set and" +
+            "the UMI metrics associated with each duplicate set. Ns are counted as an edit distance from other bases {ATCG}, but are not" +
+            "considered different from each other.</p>" +
             "<p>This tool is NOT intended to be used on data without UMIs; for marking duplicates in non-UMI data, see MarkDuplicates or " +
             "MarkDuplicatesWithMateCigar. Mixed data (where some reads have UMIs and others do not) is not supported.</p>" +
             "" +

--- a/src/main/java/picard/sam/markduplicates/UmiUtil.java
+++ b/src/main/java/picard/sam/markduplicates/UmiUtil.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam.markduplicates;
+import htsjdk.samtools.SAMRecord;
+
+/**
+ *
+ * A collection of functions for use in processing UMIs
+ *
+ * @author mduran
+ */
+
+public class UmiUtil {
+
+    /** Returns an instance of the UMI without dashes */
+    public static String getSanitizedUMI(final SAMRecord record, final String umiTag) {
+        String umi = record.getStringAttribute(umiTag);
+        if (umi == null) return null;
+        return umi.replace("-", "");
+    }
+}

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
@@ -191,6 +191,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
             Assert.assertEquals(observedMetrics.INFERRED_UMI_ENTROPY, expectedMetrics.INFERRED_UMI_ENTROPY, tolerance, "INFERRED_UMI_ENTROPY does not match expected");
             Assert.assertEquals(observedMetrics.OBSERVED_UMI_ENTROPY, expectedMetrics.OBSERVED_UMI_ENTROPY, tolerance, "OBSERVED_UMI_ENTROPY does not match expected");
             Assert.assertEquals(observedMetrics.UMI_BASE_QUALITIES, expectedMetrics.UMI_BASE_QUALITIES, tolerance, "UMI_BASE_QUALITIES does not match expected");
+            Assert.assertEquals(observedMetrics.PCT_UMI_WITH_N, expectedMetrics.PCT_UMI_WITH_N, tolerance,"PERCENT_UMI_WITH_N does not match expected" );
         }
 
         // Also do tests from AbstractMarkDuplicatesCommandLineProgramTester


### PR DESCRIPTION
### Description






This fixes (https://github.com/broadinstitute/picard/issues/960), where UmiAwareMarkDuplicatesWithMateCigar saw dashes and Ns in the UMIs as unique bases. Dashes are now ignored in the UMI length calculation. UMIs that contain Ns are still kept in duplicate sets, if edit distance allows, but no longer contribute to the UMI metrics associated with each record. A new metric, PCT_UMI_WITH_N, was added to give a sense of how frequent N containing UMIs are. 
### Checklist (never delete this)
Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [x] Final thumbs-up from reviewer
- [x] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

