### PR TITLE
Enable FilterVcf to filter "sites only" VCFs

### DIFF
--- a/src/main/java/picard/vcf/filter/FilterApplyingVariantIterator.java
+++ b/src/main/java/picard/vcf/filter/FilterApplyingVariantIterator.java
@@ -95,7 +95,7 @@ public class FilterApplyingVariantIterator implements CloseableIterator<VariantC
         }
 
         // If all genotypes are filtered apply a site level filter
-        if (gtFilterStrings.keySet().containsAll(variantSamples)) {
+        if (!variantSamples.isEmpty() && gtFilterStrings.keySet().containsAll(variantSamples)) {
             filterStrings.add(ALL_GTS_FILTERED);
         }
 

--- a/src/test/java/picard/vcf/filter/TestFilterVcf.java
+++ b/src/test/java/picard/vcf/filter/TestFilterVcf.java
@@ -47,45 +47,52 @@ public class TestFilterVcf {
     private final File BAD_INPUT = new File("testdata/picard/vcf/filter/testFilteringNoSeqDictionary.vcf");
 
     /* write content of javascript in the returned file */
-	private File quickJavascriptFilter(String content) throws Exception {
-		final File out = File.createTempFile("jsfilter", ".js");
-		out.deleteOnExit();
-		try (final PrintWriter pw = new PrintWriter(out)) {
-			pw.println(content);
-		}
-		return out;
-	}
+    private File quickJavascriptFilter(String content) throws Exception {
+        final File out = File.createTempFile("jsfilter", ".js");
+        out.deleteOnExit();
+        try (final PrintWriter pw = new PrintWriter(out)) {
+            pw.println(content);
+        }
+        return out;
+    }
 
-	@Test
-	public void testJavaScript() throws Exception {
+    @Test
+    public void testJavaScript() throws Exception {
         final File out = VcfTestUtils.createTemporaryIndexedVcfFile("filterVcfTestJS.", ".vcf");
-		final FilterVcf filterer = new FilterVcf();
-		filterer.INPUT = INPUT;
-		filterer.OUTPUT = out;
-		filterer.JAVASCRIPT_FILE = quickJavascriptFilter("variant.getStart()%5 != 0");
+        final FilterVcf filterer = new FilterVcf();
+        filterer.INPUT = INPUT;
+        filterer.OUTPUT = out;
+        filterer.JAVASCRIPT_FILE = quickJavascriptFilter("variant.getStart()%5 != 0");
 
-		final int retval = filterer.doWork();
-		Assert.assertEquals(retval, 0);
+        final int retval = filterer.doWork();
+        Assert.assertEquals(retval, 0);
 
-		//count the number of reads
-		final int expectedNumber = 4;
-		int count=0;
-		VCFFileReader in = new VCFFileReader(filterer.OUTPUT, false);
-		CloseableIterator<VariantContext> iter = in.iterator();
-		while(iter.hasNext()) {
-			final VariantContext ctx = iter.next();
-			count += (ctx.isFiltered()?1:0);
-		}
-		iter.close();
-		in.close();
-		Assert.assertEquals(count, expectedNumber);
-	}
+        //count the number of reads
+        final int expectedNumber = 4;
+        int count = 0;
+        VCFFileReader in = new VCFFileReader(filterer.OUTPUT, false);
+        CloseableIterator<VariantContext> iter = in.iterator();
+        while (iter.hasNext()) {
+            final VariantContext ctx = iter.next();
+            count += (ctx.isFiltered() ? 1 : 0);
+        }
+        iter.close();
+        in.close();
+        Assert.assertEquals(count, expectedNumber);
+    }
 
-    /** Returns a sorted copy of the supplied set, for safer comparison. */
-    <T extends Comparable> SortedSet<T> sorted(Set<T> in) { return new TreeSet<T>(in); }
+    /**
+     * Returns a sorted copy of the supplied set, for safer comparison.
+     */
+    <T extends Comparable> SortedSet<T> sorted(Set<T> in) {
+        return new TreeSet<T>(in);
+    }
 
-    /** Tests that all records get PASS set as their filter when extreme values are used for filtering. */
-    @Test public void testNoFiltering() throws Exception {
+    /**
+     * Tests that all records get PASS set as their filter when extreme values are used for filtering.
+     */
+    @Test
+    public void testNoFiltering() throws Exception {
         final File out = testFiltering(INPUT, ".vcf.gz", 0, 0, 0, Double.MAX_VALUE);
         final VCFFileReader in = new VCFFileReader(out, false);
         for (final VariantContext ctx : in) {
@@ -96,32 +103,44 @@ public class TestFilterVcf {
         in.close();
     }
 
-    /** Tests that sites with a het allele balance < 0.4 are marked as filtered out. */
-    @Test public void testAbFiltering() throws Exception {
+    /**
+     * Tests that sites with a het allele balance < 0.4 are marked as filtered out.
+     */
+    @Test
+    public void testAbFiltering() throws Exception {
         final Set<String> fails = CollectionUtil.makeSet("tf2", "rs28566954", "rs28548431");
         final File out = testFiltering(INPUT, ".vcf.gz", 0.4, 0, 0, Double.MAX_VALUE);
-        final ListMap<String,String> filters = slurpFilters(out);
+        final ListMap<String, String> filters = slurpFilters(out);
         Assert.assertEquals(sorted(filters.keySet()), sorted(fails), "Failed sites did not match expected set of failed sites.");
     }
 
-    /** Tests that genotypes with DP < 18 are marked as failed, but not >= 18. */
-    @Test public void testDpFiltering() throws Exception {
+    /**
+     * Tests that genotypes with DP < 18 are marked as failed, but not >= 18.
+     */
+    @Test
+    public void testDpFiltering() throws Exception {
         final Set<String> fails = CollectionUtil.makeSet("rs71509448", "rs71628926", "rs13302979", "rs2710876");
         final File out = testFiltering(INPUT, ".vcf.gz", 0, 18, 0, Double.MAX_VALUE);
-        final ListMap<String,String> filters = slurpFilters(out);
+        final ListMap<String, String> filters = slurpFilters(out);
         Assert.assertEquals(sorted(filters.keySet()), sorted(fails), "Failed sites did not match expected set of failed sites.");
     }
 
-    /** Tests that genotypes with DP < 18 are marked as failed, but not >= 18. */
-    @Test public void testDpFilteringToVcf() throws Exception {
+    /**
+     * Tests that genotypes with DP < 18 are marked as failed, but not >= 18.
+     */
+    @Test
+    public void testDpFilteringToVcf() throws Exception {
         final Set<String> fails = CollectionUtil.makeSet("rs71509448", "rs71628926", "rs13302979", "rs2710876");
         final File out = testFiltering(INPUT, ".vcf", 0, 18, 0, Double.MAX_VALUE);
-        final ListMap<String,String> filters = slurpFilters(out);
+        final ListMap<String, String> filters = slurpFilters(out);
         Assert.assertEquals(sorted(filters.keySet()), sorted(fails), "Failed sites did not match expected set of failed sites.");
     }
 
-    /** Tests that genotypes with low GQ are filtered appropriately. */
-    @Test public void testGqFiltering() throws Exception {
+    /**
+     * Tests that genotypes with low GQ are filtered appropriately.
+     */
+    @Test
+    public void testGqFiltering() throws Exception {
         final Set<String> fails = CollectionUtil.makeSet("rs71509448"); // SNP with GQ=21; lowest GQ in file
 
         {
@@ -141,22 +160,28 @@ public class TestFilterVcf {
         }
     }
 
-    /** Tests that genotypes with DP < 18 are marked as failed, but not >= 18. */
-    @Test public void testFsFiltering() throws Exception {
+    /**
+     * Tests that genotypes with DP < 18 are marked as failed, but not >= 18.
+     */
+    @Test
+    public void testFsFiltering() throws Exception {
         final Set<String> fails = CollectionUtil.makeSet("rs13303033", "rs28548431", "rs2799066");
         final File out = testFiltering(INPUT, ".vcf.gz", 0, 0, 0, 5.0d);
-        final ListMap<String,String> filters = slurpFilters(out);
+        final ListMap<String, String> filters = slurpFilters(out);
         Assert.assertEquals(sorted(filters.keySet()), sorted(fails), "Failed sites did not match expected set of failed sites.");
     }
 
-    @Test public void testCombinedFiltering() throws Exception {
-        final TreeSet<String> fails = new TreeSet<String>(CollectionUtil.makeSet("rs13302979", "rs13303033", "rs2710876" , "rs2799066" , "rs28548431", "rs28566954", "rs71509448", "rs71628926", "tf2"));
+    @Test
+    public void testCombinedFiltering() throws Exception {
+        final TreeSet<String> fails = new TreeSet<String>(CollectionUtil.makeSet("rs13302979", "rs13303033", "rs2710876", "rs2799066", "rs28548431", "rs28566954", "rs71509448", "rs71628926", "tf2"));
         final File out = testFiltering(INPUT, ".vcf.gz", 0.4, 18, 22, 5.0d);
-        final ListMap<String,String> filters = slurpFilters(out);
+        final ListMap<String, String> filters = slurpFilters(out);
         Assert.assertEquals(new TreeSet<String>(filters.keySet()), fails, "Failed sites did not match expected set of failed sites.");
     }
 
-    /** Utility method that takes a a VCF and a set of parameters and filters the VCF. */
+    /**
+     * Utility method that takes a a VCF and a set of parameters and filters the VCF.
+     */
     private File testFiltering(final File vcf, final String outputExtension, final double minAb, final int minDp, final int minGq, final double maxFs) throws Exception {
         final File out = VcfTestUtils.createTemporaryIndexedVcfFile("filterVcfTest.", outputExtension);
 
@@ -177,7 +202,9 @@ public class TestFilterVcf {
         return out;
     }
 
-    /** Tests that attempting to write to an uncompressed vcf fails if the input has no sequence dictionary */
+    /**
+     * Tests that attempting to write to an uncompressed vcf fails if the input has no sequence dictionary
+     */
     @Test(expectedExceptions = PicardException.class)
     public void testFilteringToVcfWithNoSequenceDictionary() throws Exception {
         final File out = File.createTempFile("filterVcfTest.", ".vcf");
@@ -195,10 +222,11 @@ public class TestFilterVcf {
         filterer.doWork();
     }
 
-
-    /** Consumes a VCF and returns a ListMap where each they keys are the IDs of filtered out sites and the values are the set of filters. */
-    private ListMap<String,String> slurpFilters(final File vcf) {
-        final ListMap<String,String> map = new ListMap<String, String>();
+    /**
+     * Consumes a VCF and returns a ListMap where each they keys are the IDs of filtered out sites and the values are the set of filters.
+     */
+    private ListMap<String, String> slurpFilters(final File vcf) {
+        final ListMap<String, String> map = new ListMap<String, String>();
         final VCFFileReader in = new VCFFileReader(vcf, false);
         for (final VariantContext ctx : in) {
             if (ctx.isNotFiltered()) continue;

--- a/testdata/picard/vcf/filter/testFilteringSitesOnly.vcf
+++ b/testdata/picard/vcf/filter/testFilteringSitesOnly.vcf
@@ -1,0 +1,146 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=LowQual,Description="Low quality">
+##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth (reads with MQ=255 or with bad mates are filtered)">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=MIN_DP,Number=1,Type=Integer,Description="Minimum DP observed within the GVCF block">
+##FORMAT=<ID=PGT,Number=1,Type=String,Description="Physical phasing haplotype information, describing how the alternate alleles are phased in relation to one another">
+##FORMAT=<ID=PID,Number=1,Type=String,Description="Physical phasing ID information, where each unique ID within a given sample (but not across samples) connects records within a phasing group">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Normalized, Phred-scaled likelihoods for genotypes as defined in the VCF specification">
+##FORMAT=<ID=SB,Number=4,Type=Integer,Description="Per-sample component statistics which comprise the Fisher's Exact Test to detect strand bias.">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=BaseQRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt Vs. Ref base qualities">
+##INFO=<ID=CCC,Number=1,Type=Integer,Description="Number of called chromosomes">
+##INFO=<ID=ClippingRankSum,Number=1,Type=Float,Description="Z-score From Wilcoxon rank sum test of Alt vs. Ref number of hard clipped bases">
+##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP Membership">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth; some reads may have been filtered">
+##INFO=<ID=DS,Number=0,Type=Flag,Description="Were any of the samples downsampled?">
+##INFO=<ID=END,Number=1,Type=Integer,Description="Stop position of the interval">
+##INFO=<ID=FS,Number=1,Type=Float,Description="Phred-scaled p-value using Fisher's exact test to detect strand bias">
+##INFO=<ID=GQ_MEAN,Number=1,Type=Float,Description="Mean of all GQ values">
+##INFO=<ID=GQ_STDDEV,Number=1,Type=Float,Description="Standard deviation of all GQ values">
+##INFO=<ID=HWP,Number=1,Type=Float,Description="P value from test of Hardy Weinberg Equilibrium">
+##INFO=<ID=HaplotypeScore,Number=1,Type=Float,Description="Consistency of the site with at most two segregating haplotypes">
+##INFO=<ID=InbreedingCoeff,Number=1,Type=Float,Description="Inbreeding coefficient as estimated from the genotype likelihoods per-sample when compared against the Hardy-Weinberg expectation">
+##INFO=<ID=MLEAC,Number=A,Type=Integer,Description="Maximum likelihood expectation (MLE) for the allele counts (not necessarily the same as the AC), for each ALT allele, in the same order as listed">
+##INFO=<ID=MLEAF,Number=A,Type=Float,Description="Maximum likelihood expectation (MLE) for the allele frequency (not necessarily the same as the AF), for each ALT allele, in the same order as listed">
+##INFO=<ID=MQ,Number=1,Type=Float,Description="RMS Mapping Quality">
+##INFO=<ID=MQ0,Number=1,Type=Integer,Description="Total Mapping Quality Zero Reads">
+##INFO=<ID=MQRankSum,Number=1,Type=Float,Description="Z-score From Wilcoxon rank sum test of Alt vs. Ref read mapping qualities">
+##INFO=<ID=NCC,Number=1,Type=Integer,Description="Number of no-called samples">
+##INFO=<ID=QD,Number=1,Type=Float,Description="Variant Confidence/Quality by Depth">
+##INFO=<ID=ReadPosRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt vs. Ref read position bias">
+##INFO=<ID=SOR,Number=1,Type=Float,Description="Symmetric Odds Ratio of 2x2 contingency table to detect strand bias">
+##contig=<ID=1,length=249250621>
+##contig=<ID=2,length=243199373>
+##contig=<ID=3,length=198022430>
+##contig=<ID=4,length=191154276>
+##contig=<ID=5,length=180915260>
+##contig=<ID=6,length=171115067>
+##contig=<ID=7,length=159138663>
+##contig=<ID=8,length=146364022>
+##contig=<ID=9,length=141213431>
+##contig=<ID=10,length=135534747>
+##contig=<ID=11,length=135006516>
+##contig=<ID=12,length=133851895>
+##contig=<ID=13,length=115169878>
+##contig=<ID=14,length=107349540>
+##contig=<ID=15,length=102531392>
+##contig=<ID=16,length=90354753>
+##contig=<ID=17,length=81195210>
+##contig=<ID=18,length=78077248>
+##contig=<ID=19,length=59128983>
+##contig=<ID=20,length=63025520>
+##contig=<ID=21,length=48129895>
+##contig=<ID=22,length=51304566>
+##contig=<ID=X,length=155270560>
+##contig=<ID=Y,length=59373566>
+##contig=<ID=MT,length=16569>
+##contig=<ID=GL000207.1,length=4262>
+##contig=<ID=GL000226.1,length=15008>
+##contig=<ID=GL000229.1,length=19913>
+##contig=<ID=GL000231.1,length=27386>
+##contig=<ID=GL000210.1,length=27682>
+##contig=<ID=GL000239.1,length=33824>
+##contig=<ID=GL000235.1,length=34474>
+##contig=<ID=GL000201.1,length=36148>
+##contig=<ID=GL000247.1,length=36422>
+##contig=<ID=GL000245.1,length=36651>
+##contig=<ID=GL000197.1,length=37175>
+##contig=<ID=GL000203.1,length=37498>
+##contig=<ID=GL000246.1,length=38154>
+##contig=<ID=GL000249.1,length=38502>
+##contig=<ID=GL000196.1,length=38914>
+##contig=<ID=GL000248.1,length=39786>
+##contig=<ID=GL000244.1,length=39929>
+##contig=<ID=GL000238.1,length=39939>
+##contig=<ID=GL000202.1,length=40103>
+##contig=<ID=GL000234.1,length=40531>
+##contig=<ID=GL000232.1,length=40652>
+##contig=<ID=GL000206.1,length=41001>
+##contig=<ID=GL000240.1,length=41933>
+##contig=<ID=GL000236.1,length=41934>
+##contig=<ID=GL000241.1,length=42152>
+##contig=<ID=GL000243.1,length=43341>
+##contig=<ID=GL000242.1,length=43523>
+##contig=<ID=GL000230.1,length=43691>
+##contig=<ID=GL000237.1,length=45867>
+##contig=<ID=GL000233.1,length=45941>
+##contig=<ID=GL000204.1,length=81310>
+##contig=<ID=GL000198.1,length=90085>
+##contig=<ID=GL000208.1,length=92689>
+##contig=<ID=GL000191.1,length=106433>
+##contig=<ID=GL000227.1,length=128374>
+##contig=<ID=GL000228.1,length=129120>
+##contig=<ID=GL000214.1,length=137718>
+##contig=<ID=GL000221.1,length=155397>
+##contig=<ID=GL000209.1,length=159169>
+##contig=<ID=GL000218.1,length=161147>
+##contig=<ID=GL000220.1,length=161802>
+##contig=<ID=GL000213.1,length=164239>
+##contig=<ID=GL000211.1,length=166566>
+##contig=<ID=GL000199.1,length=169874>
+##contig=<ID=GL000217.1,length=172149>
+##contig=<ID=GL000216.1,length=172294>
+##contig=<ID=GL000215.1,length=172545>
+##contig=<ID=GL000205.1,length=174588>
+##contig=<ID=GL000219.1,length=179198>
+##contig=<ID=GL000224.1,length=179693>
+##contig=<ID=GL000223.1,length=180455>
+##contig=<ID=GL000195.1,length=182896>
+##contig=<ID=GL000212.1,length=186858>
+##contig=<ID=GL000222.1,length=186861>
+##contig=<ID=GL000200.1,length=187035>
+##contig=<ID=GL000193.1,length=189789>
+##contig=<ID=GL000194.1,length=191469>
+##contig=<ID=GL000225.1,length=211173>
+##contig=<ID=GL000192.1,length=547496>
+##contig=<ID=NC_007605,length=171823>
+##reference=file:///seq/references/Homo_sapiens_assembly19/v1/Homo_sapiens_assembly19.fasta
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+1	324822	tf1	A	T	2213.77	.	AC=2;AF=1.00;AN=2;DP=79;FS=0.000;GQ_MEAN=234.00;MLEAC=2;MLEAF=1.00;MQ=25.61;MQ0=0;NCC=0;QD=28.38;SOR=0.855
+1	883899	rs72631890	T	G	1315.77	.	AC=1;AF=0.500;AN=2;BaseQRankSum=3.58;ClippingRankSum=-1.034e+00;DB;DP=123;FS=0.000;GQ_MEAN=1344.00;MLEAC=1;MLEAF=0.500;MQ=57.87;MQ0=0;MQRankSum=-3.820e-01;NCC=0;QD=10.70;ReadPosRankSum=0.085;SOR=0.765
+1	899942	rs71509448	G	A	172.80	.	AC=2;AF=1.00;AN=2;DB;DP=11;FS=0.000;GQ_MEAN=21.00;MLEAC=2;MLEAF=1.00;MQ=50.96;MQ0=0;NCC=0;QD=15.71;SOR=4.977
+1	900298	rs71628926	C	G	165.77	.	AC=1;AF=0.500;AN=2;BaseQRankSum=-2.793e+00;ClippingRankSum=0.135;DB;DP=12;FS=0.000;GQ_MEAN=147.00;MLEAC=1;MLEAF=0.500;MQ=56.04;MQ0=0;MQRankSum=0.135;NCC=0;QD=13.81;ReadPosRankSum=0.135;SOR=1.022
+1	909419	rs28548431	C	T	522.77	.	AC=1;AF=0.500;AN=2;BaseQRankSum=2.61;ClippingRankSum=-2.420e-01;DB;DP=54;FS=5.418;GQ_MEAN=551.00;MLEAC=1;MLEAF=0.500;MQ=60.00;MQ0=0;MQRankSum=1.28;NCC=0;QD=9.68;ReadPosRankSum=-5.110e-01;SOR=2.066
+1	912049	rs9803103	T	C	336.77	.	AC=1;AF=0.500;AN=2;BaseQRankSum=-1.522e+00;ClippingRankSum=-2.082e+00;DB;DP=41;FS=0.000;GQ_MEAN=365.00;MLEAC=1;MLEAF=0.500;MQ=58.87;MQ0=0;MQRankSum=0.612;NCC=0;QD=9.90;ReadPosRankSum=1.07;SOR=1.179
+1	914333	rs13302979	C	G	151.77	.	AC=1;AF=0.500;AN=2;BaseQRankSum=1.23;ClippingRankSum=-2.130e+00;DB;DP=14;FS=0.000;GQ_MEAN=180.00;MLEAC=1;MLEAF=0.500;MQ=60.00;MQ0=0;MQRankSum=-9.680e-01;NCC=0;QD=10.84;ReadPosRankSum=-1.226e+00;SOR=0.412
+1	914414	tf2	CGAA	C	97.77	.	AC=1;AF=0.500;AN=2;BaseQRankSum=-9.030e-01;ClippingRankSum=-2.650e-01;DP=21;FS=0.000;GQ_MEAN=126.00;MLEAC=1;MLEAF=0.500;MQ=57.06;MQ0=0;MQRankSum=-2.650e-01;NCC=0;QD=5.43;ReadPosRankSum=-6.230e-01;SOR=0.892
+1	914852	rs13303368	G	C	664.77	.	AC=1;AF=0.500;AN=2;BaseQRankSum=-9.500e-02;ClippingRankSum=1.13;DB;DP=40;FS=3.468;GQ_MEAN=546.00;MLEAC=1;MLEAF=0.500;MQ=58.36;MQ0=0;MQRankSum=0.829;NCC=0;QD=16.62;ReadPosRankSum=-9.380e-01;SOR=2.019
+1	914876	rs13302983	T	C	2241.77	.	AC=2;AF=1.00;AN=2;DB;DP=61;FS=0.000;GQ_MEAN=189.00;MLEAC=2;MLEAF=1.00;MQ=59.62;MQ0=0;NCC=0;QD=30.09;SOR=2.948
+1	914940	rs13303033	T	C	1330.77	.	AC=1;AF=0.500;AN=2;BaseQRankSum=2.60;ClippingRankSum=-1.980e-01;DB;DP=98;FS=5.001;GQ_MEAN=1170.00;MLEAC=1;MLEAF=0.500;MQ=58.76;MQ0=0;MQRankSum=0.344;NCC=0;QD=13.86;ReadPosRankSum=2.22;SOR=0.603
+1	915227	rs13303355	A	G	6323.77	.	AC=2;AF=1.00;AN=2;DB;DP=168;FS=0.000;GQ_MEAN=508.00;MLEAC=2;MLEAF=1.00;MQ=59.73;MQ0=0;NCC=0;QD=31.26;SOR=3.456
+1	916549	rs6660139	A	G	1033.77	.	AC=1;AF=0.500;AN=2;BaseQRankSum=2.85;ClippingRankSum=0.722;DB;DP=98;FS=0.000;GQ_MEAN=1062.00;MLEAC=1;MLEAF=0.500;MQ=59.34;MQ0=0;MQRankSum=-3.550e-01;NCC=0;QD=10.66;ReadPosRankSum=-7.950e-01;SOR=0.773
+1	916590	rs28566954	G	A	793.77	.	AC=1;AF=0.500;AN=2;BaseQRankSum=-4.441e+00;ClippingRankSum=-1.191e+00;DB;DP=41;FS=0.000;GQ_MEAN=372.00;MLEAC=1;MLEAF=0.500;MQ=59.44;MQ0=0;MQRankSum=0.154;NCC=0;QD=19.36;ReadPosRankSum=0.042;SOR=0.346
+1	935222	rs2298214	C	A	1381.77	.	AC=1;AF=0.500;AN=2;BaseQRankSum=-6.667e+00;ClippingRankSum=-1.069e+00;DB;DP=104;FS=2.093;GQ_MEAN=1410.00;MLEAC=1;MLEAF=0.500;MQ=59.78;MQ0=0;MQRankSum=0.595;NCC=0;QD=13.29;ReadPosRankSum=1.23;SOR=1.673
+1	948921	rs15842	T	C	1963.77	.	AC=2;AF=1.00;AN=2;DB;DP=62;FS=0.000;GQ_MEAN=186.00;MLEAC=2;MLEAF=1.00;MQ=51.79;MQ0=0;NCC=0;QD=31.67;SOR=1.057
+1	948929	tf3	GGCCCACA	G	777.77	.	AC=1;AF=0.500;AN=2;BaseQRankSum=1.94;ClippingRankSum=-5.070e-01;DP=67;FS=0.000;GQ_MEAN=806.00;MLEAC=1;MLEAF=0.500;MQ=51.26;MQ0=0;MQRankSum=-4.852e+00;NCC=0;QD=6.94;ReadPosRankSum=0.209;SOR=0.730
+1	949608	rs1921	G	A	1741.77	.	AC=1;AF=0.500;AN=2;BaseQRankSum=-6.267e+00;ClippingRankSum=-4.930e-01;DB;DP=131;FS=3.479;GQ_MEAN=1770.00;MLEAC=1;MLEAF=0.500;MQ=58.32;MQ0=0;MQRankSum=-1.115e+00;NCC=0;QD=13.50;ReadPosRankSum=0.884;SOR=1.050
+1	949654	rs8997	A	G	7066.77	.	AC=2;AF=1.00;AN=2;DB;DP=201;FS=0.000;GQ_MEAN=596.00;MLEAC=2;MLEAF=1.00;MQ=59.03;MQ0=0;NCC=0;QD=29.00;SOR=1.863
+1	977330	rs2799066	T	C	1397.77	.	AC=1;AF=0.500;AN=2;BaseQRankSum=5.53;ClippingRankSum=0.116;DB;DP=128;FS=8.556;GQ_MEAN=1426.00;MLEAC=1;MLEAF=0.500;MQ=59.23;MQ0=0;MQRankSum=1.03;NCC=0;QD=11.75;ReadPosRankSum=2.08;SOR=1.516
+1	977570	rs2710876	G	A	251.77	.	AC=1;AF=0.500;AN=2;BaseQRankSum=-1.002e+00;ClippingRankSum=-7.660e-01;DB;DP=15;FS=0.000;GQ_MEAN=174.00;MLEAC=1;MLEAF=0.500;MQ=60.00;MQ0=0;MQRankSum=0.059;NCC=0;QD=16.78;ReadPosRankSum=-1.355e+00;SOR=1.112
+1	978603	rs138543546	CCT	C	1281.77	.	AC=1;AF=0.500;AN=2;BaseQRankSum=-1.863e+00;ClippingRankSum=0.545;DB;DP=65;FS=0.000;GQ_MEAN=1253.00;MLEAC=1;MLEAF=0.500;MQ=58.98;MQ0=0;MQRankSum=-1.083e+00;NCC=0;QD=20.03;ReadPosRankSum=-2.830e-01;SOR=0.263
+1	981087	rs3128098	A	G	712.77	.	AC=1;AF=0.500;AN=2;BaseQRankSum=0.874;ClippingRankSum=-2.870e-01;DB;DP=69;FS=3.654;GQ_MEAN=741.00;MLEAC=1;MLEAF=0.500;MQ=59.39;MQ0=0;MQRankSum=0.336;NCC=0;QD=10.33;ReadPosRankSum=-1.770e-01;SOR=1.296


### PR DESCRIPTION
### Description
Currently, FilterVcf will filter entirely a sites-only vcf since "all" the genotypes are filtered (as there are no genotypes) and when a sites has all the genotypes filtered it filters out the site...This modification changes behavior so that a sites only VCF will not be filtered due to "all" its (non-existent)  genotypes.
 
----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

