### PR TITLE
Adds option to validator to skip mate validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ jacoco {
     toolVersion = "0.7.5.201505241946"
 }
 
-final htsjdkVersion = System.getProperty('htsjdk.version', '2.12.0')
+final htsjdkVersion = System.getProperty('htsjdk.version', '2.13.0')
 
 // Get the jdk files we need to run javaDoc. We need to use these during compile, testCompile,
 // test execution, and gatkDoc generation, but we don't want them as part of the runtime

--- a/src/main/java/picard/sam/ValidateSamFile.java
+++ b/src/main/java/picard/sam/ValidateSamFile.java
@@ -210,7 +210,6 @@ public class ValidateSamFile extends CommandLineProgram {
             validator.setErrorsToIgnore(IGNORE);
             validator.setSkipMateValidation(SKIP_MATE_VALIDATION);
             validator.setBisulfiteSequenced(IS_BISULFITE_SEQUENCED);
-
             validator.setIgnoreWarnings(IGNORE_WARNINGS);
 
             if (MODE == Mode.SUMMARY) {

--- a/src/main/java/picard/sam/ValidateSamFile.java
+++ b/src/main/java/picard/sam/ValidateSamFile.java
@@ -208,20 +208,15 @@ public class ValidateSamFile extends CommandLineProgram {
 
             final SamFileValidator validator = new SamFileValidator(out, MAX_OPEN_TEMP_FILES);
             validator.setErrorsToIgnore(IGNORE);
+            validator.setSkipMateValidation(SKIP_MATE_VALIDATION);
+            validator.setBisulfiteSequenced(IS_BISULFITE_SEQUENCED);
 
-            if (IGNORE_WARNINGS) {
-                validator.setIgnoreWarnings(IGNORE_WARNINGS);
-            }
+            validator.setIgnoreWarnings(IGNORE_WARNINGS);
+
             if (MODE == Mode.SUMMARY) {
                 validator.setVerbose(false, 0);
             } else {
                 validator.setVerbose(true, MAX_OUTPUT);
-            }
-            if (SKIP_MATE_VALIDATION) {
-                validator.setSkipMateValidation(SKIP_MATE_VALIDATION);
-            }
-            if (IS_BISULFITE_SEQUENCED) {
-                validator.setBisulfiteSequenced(IS_BISULFITE_SEQUENCED);
             }
             if (VALIDATE_INDEX) {
                 validator.setIndexValidationStringency(VALIDATE_INDEX ? IndexValidationStringency.EXHAUSTIVE : IndexValidationStringency.NONE);

--- a/src/main/java/picard/sam/ValidateSamFile.java
+++ b/src/main/java/picard/sam/ValidateSamFile.java
@@ -132,6 +132,13 @@ public class ValidateSamFile extends CommandLineProgram {
             "This number can be found by executing the 'ulimit -n' command on a Unix system.")
     public int MAX_OPEN_TEMP_FILES = 8000;
 
+    @Argument(shortName = "SMV",
+            doc = "If true, this tool will not attempt to validate mate information. " +
+            "In general cases, this option should not be used.  However, in cases where samples have very " +
+            "high duplication or chimerism rates (> 10%), the mate validation process often requires extremely " +
+            "large amounts of memory to run, so this flag allows you to forego that check.")
+    public boolean SKIP_MATE_VALIDATION = false;
+
     public static void main(final String[] args) {
         System.exit(new ValidateSamFile().instanceMain(args));
     }
@@ -209,6 +216,9 @@ public class ValidateSamFile extends CommandLineProgram {
                 validator.setVerbose(false, 0);
             } else {
                 validator.setVerbose(true, MAX_OUTPUT);
+            }
+            if (SKIP_MATE_VALIDATION) {
+                validator.setSkipMateValidation(SKIP_MATE_VALIDATION);
             }
             if (IS_BISULFITE_SEQUENCED) {
                 validator.setBisulfiteSequenced(IS_BISULFITE_SEQUENCED);


### PR DESCRIPTION
### Description

I've added an option to ValidateSamFile that allows it to skip mate validation for edge case samples with high rates of duplication or chimerism (because they require a ton of memory for the mate validation).

As part of this, we need to update picard to use the latest htsjdk

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

