### PR TITLE
Tag for 6 tools for documentation and add beta and experimental categorization to 3

### DIFF
--- a/src/main/java/picard/analysis/CollectWgsMetricsWithNonZeroCoverage.java
+++ b/src/main/java/picard/analysis/CollectWgsMetricsWithNonZeroCoverage.java
@@ -32,6 +32,8 @@ import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.IntervalList;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.StringUtil;
+import org.broadinstitute.barclay.argparser.BetaFeature;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import picard.PicardException;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
@@ -43,6 +45,8 @@ import picard.util.RExecutor;
 import java.io.File;
 import java.util.List;
 
+@DocumentedFeature
+@BetaFeature
 @CommandLineProgramProperties(
         summary = CollectWgsMetricsWithNonZeroCoverage.USAGE_SUMMARY + CollectWgsMetricsWithNonZeroCoverage.USAGE_DETAILS,
         oneLineSummary = CollectWgsMetricsWithNonZeroCoverage.USAGE_SUMMARY,
@@ -50,7 +54,7 @@ import java.util.List;
 )
 public class CollectWgsMetricsWithNonZeroCoverage extends CollectWgsMetrics {
 
-    static final String USAGE_SUMMARY = "Collect metrics about coverage and performance of whole genome sequencing (WGS) experiments.  ";
+    static final String USAGE_SUMMARY = "(Experimental) Collect metrics about coverage and performance of whole genome sequencing (WGS) experiments.  ";
     static final String USAGE_DETAILS = "This tool collects metrics about the percentages of reads that pass base- and mapping- quality " +
             "filters as well as coverage (read-depth) levels. Both minimum base- and mapping-quality values as well as the maximum " +
             "read depths (coverage cap) are user defined.  This extends CollectWgsMetrics by including metrics related only to sites" +

--- a/src/main/java/picard/analysis/replicates/CollectIndependentReplicateMetrics.java
+++ b/src/main/java/picard/analysis/replicates/CollectIndependentReplicateMetrics.java
@@ -58,6 +58,8 @@ import htsjdk.variant.vcf.VCFContigHeaderLine;
 import htsjdk.variant.vcf.VCFFileReader;
 import htsjdk.variant.vcf.VCFHeader;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.BetaFeature;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import picard.cmdline.CommandLineProgram;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import picard.cmdline.StandardOptionDefinitions;
@@ -100,12 +102,13 @@ import static picard.cmdline.StandardOptionDefinitions.MINIMUM_MAPPING_QUALITY_S
  * @author Yossi Farjoun
  *
  */
-
+@DocumentedFeature
+@BetaFeature
 @CommandLineProgramProperties(
         summary = "Estimates the rate of independent replication rate of reads within a bam. \n" +
                 "That is, it estimates the fraction of the reads which would be marked as duplicates but " +
                 "are actually biological replicates, independent observations of the data. ",
-        oneLineSummary = "Estimates the rate of independent replication of reads within a bam.",
+        oneLineSummary = "(Experimental) Estimates the rate of independent replication of reads within a bam.",
         programGroup = Alpha.class
 )
 public class CollectIndependentReplicateMetrics extends CommandLineProgram {

--- a/src/main/java/picard/fingerprint/CrosscheckReadGroupFingerprints.java
+++ b/src/main/java/picard/fingerprint/CrosscheckReadGroupFingerprints.java
@@ -27,6 +27,7 @@ package picard.fingerprint;
 
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import picard.cmdline.programgroups.Fingerprinting;
 
 import java.io.File;
@@ -41,6 +42,7 @@ import java.util.List;
  *
  * @deprecated 6/6/2017 Use {@link CrosscheckFingerprints} instead.
  */
+@DocumentedFeature
 @CommandLineProgramProperties(
         summary = "DEPRECATED: USE CrosscheckFingerprints. Checks if all read groups within a set of BAM files appear to come from the same individual",
         oneLineSummary = "DEPRECATED: USE CrosscheckFingerprints. Checks if all read groups appear to come from the same individual.",

--- a/src/main/java/picard/sam/SetNmAndUqTags.java
+++ b/src/main/java/picard/sam/SetNmAndUqTags.java
@@ -25,12 +25,14 @@
 package picard.sam;
 
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import picard.cmdline.programgroups.SamOrBam;
 
 /**
  * @author Yossi Farjoun
  */
 @Deprecated
+@DocumentedFeature
 @CommandLineProgramProperties(
         summary = SetNmAndUqTags.USAGE_SUMMARY + SetNmMdAndUqTags.USAGE_DETAILS,
         oneLineSummary = SetNmAndUqTags.USAGE_SUMMARY,

--- a/src/main/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigar.java
@@ -33,6 +33,8 @@ import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecordDuplicateComparator;
 import htsjdk.samtools.SAMTag;
 import htsjdk.samtools.util.*;
+import org.broadinstitute.barclay.argparser.BetaFeature;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import picard.PicardException;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import picard.cmdline.programgroups.Testing;
@@ -61,10 +63,12 @@ import java.util.Set;
  *
  * @author nhomer
  */
+@DocumentedFeature
+@BetaFeature
 @CommandLineProgramProperties(
         summary = "Examines aligned records in the supplied SAM or BAM file to locate duplicate molecules. " +
                 "All records are then written to the output file with the duplicate records flagged.",
-        oneLineSummary = "Examines aligned records in the supplied SAM or BAM file to locate duplicate molecules.",
+        oneLineSummary = "(Experimental) Examines aligned records in the supplied SAM or BAM file to locate duplicate molecules.",
         programGroup = Testing.class
 )
 public class SimpleMarkDuplicatesWithMateCigar extends MarkDuplicates {

--- a/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
@@ -31,6 +31,7 @@ import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.util.*;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import picard.cmdline.programgroups.Alpha;
 
 import java.io.File;
@@ -48,6 +49,7 @@ import java.io.File;
  *
  * @author fleharty
  */
+@DocumentedFeature
 @CommandLineProgramProperties(
         summary = UmiAwareMarkDuplicatesWithMateCigar.USAGE_SUMMARY + UmiAwareMarkDuplicatesWithMateCigar.USAGE_DETAILS,
         oneLineSummary = UmiAwareMarkDuplicatesWithMateCigar.USAGE_SUMMARY,


### PR DESCRIPTION
### Description
Added `@DocumentedFeature` and `@BetaFeature` tags appropriately to six tool docs that were not showing up in gatkDocs. 

- Three tools categorized under "Alpha Tools" got the BETA and (Experimental) labels, consistent with how we treat GATK tools.
- Two of these are deprecated tools.
- One is a unit testing tool.

In https://github.com/broadinstitute/dsde-docs/issues/2639, @vdauwera asks that we tag _all_ tools for documentation.

Related issues:
https://github.com/broadinstitute/gatk/issues/3847
https://github.com/broadinstitute/gatk/pull/3850

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

