### PR TITLE
ExtractIlluminaBarcodes should fail when sample barcode lengths mismatch

### DIFF
--- a/src/main/java/picard/illumina/ExtractIlluminaBarcodes.java
+++ b/src/main/java/picard/illumina/ExtractIlluminaBarcodes.java
@@ -228,9 +228,17 @@ public class ExtractIlluminaBarcodes extends CommandLineProgram {
         // Create BarcodeMetric for counting reads that don't match any barcode
         final String[] noMatchBarcode = new String[readStructure.sampleBarcodes.length()];
         int index = 0;
+        int barcodeLength = 0;
         for (final ReadDescriptor d : readStructure.descriptors) {
             if (d.type == ReadType.Barcode) {
                 noMatchBarcode[index++] = StringUtil.repeatCharNTimes('N', d.length);
+                barcodeLength += d.length;
+            }
+        }
+
+        for (final String barcode : barcodeToMetrics.keySet()) {
+            if (barcode.length() != barcodeLength) {
+                throw new PicardException("Barcode '" + barcode + "' with length '" + barcode.length() + "' in the barcodes file did not match the expected number of sample barcode bases '" + barcodeLength + "'");
             }
         }
 

--- a/src/test/java/picard/illumina/ExtractIlluminaBarcodesTest.java
+++ b/src/test/java/picard/illumina/ExtractIlluminaBarcodesTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import picard.PicardException;
 import picard.cmdline.CommandLineProgramTest;
 import picard.illumina.parser.BaseIlluminaDataProvider;
 import picard.illumina.parser.ClusterData;
@@ -333,5 +334,21 @@ public class ExtractIlluminaBarcodesTest extends CommandLineProgramTest {
         final MetricsFile<ExtractIlluminaBarcodes.BarcodeMetric, Integer> retval = new MetricsFile<ExtractIlluminaBarcodes.BarcodeMetric, Integer>();
         retval.read(new FileReader(metricsFile));
         return retval;
+    }
+
+    @Test(expectedExceptions=PicardException.class)
+    public void testBarcodeLengthMismatch() throws Exception {
+        final File metricsFile = File.createTempFile("dual.", ".metrics");
+        metricsFile.deleteOnExit();
+
+        final String[] args = new String[]{
+                "BASECALLS_DIR=" + dual.getAbsolutePath(),
+                "LANE=" + 1,
+                "METRICS_FILE=" + metricsFile.getPath(),
+                "READ_STRUCTURE=" + "25T8B9B25T",
+                "BARCODE=" + "CAATAGTCCGACTCTC"
+        };
+
+        runPicardCommandLine(args);
     }
 }


### PR DESCRIPTION
`ExtractIlluminaBarcodes` should fail when the # of sample barcodes does not match between the read structure and the barcodes file.