### PR TITLE
Fix up adapter clipping tags after an adapter is selected

### DIFF
--- a/src/main/java/picard/util/AdapterMarker.java
+++ b/src/main/java/picard/util/AdapterMarker.java
@@ -23,16 +23,22 @@
  */
 package picard.util;
 
+import htsjdk.samtools.ReservedTagConstants;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.util.CollectionUtil;
 import htsjdk.samtools.util.SequenceUtil;
 import htsjdk.samtools.util.StringUtil;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 
 /**
  * Store one or more AdapterPairs to use to mark adapter sequence of SAMRecords.  This is a very compute-intensive process, so
@@ -66,6 +72,9 @@ public class AdapterMarker {
     private int numAdaptersSeen = 0;
     private final CollectionUtil.DefaultingMap<AdapterPair, Integer> seenCounts = new CollectionUtil.DefaultingMap<AdapterPair, Integer>(0);
 
+    //Store all the sam records we have seen prior to choosing and adapter so that we can go back and fix the ones
+    //that have clipping tags for adapters that were not chosen.
+    private Map<AdapterPair, List<SAMRecord>> preAdapterPrunedRecords = new HashMap<>();
     /**
      * Truncates adapters to DEFAULT_ADAPTER_LENGTH
      * @param originalAdapters These should be in order from longest & most likely to shortest & least likely.
@@ -187,7 +196,13 @@ public class AdapterMarker {
      */
     public AdapterPair adapterTrimIlluminaSingleRead(final SAMRecord read, final int minMatchBases, final double maxErrorRate) {
         final AdapterPair ret = ClippingUtility.adapterTrimIlluminaSingleRead(read, minMatchBases, maxErrorRate, adapters.get());
-        if (ret != null) tallyFoundAdapter(ret);
+        if (ret != null && !thresholdReached) {
+            if(!preAdapterPrunedRecords.containsKey(ret)) {
+                preAdapterPrunedRecords.put(ret, new ArrayList<>());
+            }
+            preAdapterPrunedRecords.get(ret).add(read);
+            tallyFoundAdapter(ret);
+        }
         return ret;
     }
 
@@ -197,7 +212,14 @@ public class AdapterMarker {
     public AdapterPair adapterTrimIlluminaPairedReads(final SAMRecord read1, final SAMRecord read2,
                                                              final int minMatchBases, final double maxErrorRate) {
         final AdapterPair ret = ClippingUtility.adapterTrimIlluminaPairedReads(read1, read2, minMatchBases, maxErrorRate, adapters.get());
-        if (ret != null) tallyFoundAdapter(ret);
+        if (ret != null && !thresholdReached) {
+            if(!preAdapterPrunedRecords.containsKey(ret)) {
+                preAdapterPrunedRecords.put(ret, new ArrayList<>());
+            }
+            preAdapterPrunedRecords.get(ret).add(read1);
+            preAdapterPrunedRecords.get(ret).add(read2);
+            tallyFoundAdapter(ret);
+        }
         return ret;
     }
 
@@ -231,8 +253,6 @@ public class AdapterMarker {
         // If caller does not want adapter pruning, do nothing.
         if (thresholdForSelectingAdaptersToKeep < 1) return;
         synchronized (this) {
-            // Already pruned adapter list, so nothing more to do.
-            if (thresholdReached) return;
 
             // Tally this adapter
             seenCounts.put(foundAdapter, seenCounts.get(foundAdapter) + 1);
@@ -273,8 +293,21 @@ public class AdapterMarker {
                 // Replace the existing list with the pruned list.
                 thresholdReached = true;
                 adapters.set(bestAdapters.toArray(new AdapterPair[bestAdapters.size()]));
+                fixAlreadySeenReads();
             }
         }
+    }
+
+    private void fixAlreadySeenReads() {
+        //remove all the reads for the selected adapters
+        Arrays.stream(adapters.get()).forEach(adapter -> preAdapterPrunedRecords.remove(adapter));
+        //anything left is marked with the incorrect adapter and needs its XT tag removed
+        (preAdapterPrunedRecords.values()).forEach(readList -> readList.parallelStream().forEach(read -> {
+            Stream<SAMRecord.SAMTagAndValue> filterAttributes = read.getAttributes().stream().filter(tag -> !tag.tag.equals(ReservedTagConstants.XT));
+            read.clearAttributes();
+            filterAttributes.forEach(tag -> read.setAttribute(tag.tag, tag.value));
+        }));
+        preAdapterPrunedRecords.clear();
     }
 
     private static final class TruncatedAdapterPair implements AdapterPair {

--- a/src/main/java/picard/util/AdapterMarker.java
+++ b/src/main/java/picard/util/AdapterMarker.java
@@ -35,7 +35,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;


### PR DESCRIPTION
In a multi-threaded environment there is a chance that basecalls to sam is not deterministic depending on which adapters it sees prior to adapter selection and which adapter it selects. This PR is mean to cache all read seen pre adapter selection and then go back and remove XT tags from reads that were clipped due to adapters other than the selected on being found.

_Give your PR a **concise** yet **descriptive** title_
_Please explain the changes you made here._
_Explain the **motivation** for making this change. What existing problem does the pull request solve?_
_Mention any issues fixed, addressed or otherwise related to this pull request, including issue numbers or hard links for issues in other repos._
_You can delete these instructions once you have written your PR description._

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

