### PR TITLE
Pull out some of the metrics being fixed in HsMetricsCollector into a separate method

### DIFF
--- a/src/main/java/picard/analysis/directed/HsMetricCollector.java
+++ b/src/main/java/picard/analysis/directed/HsMetricCollector.java
@@ -86,10 +86,7 @@ public class HsMetricCollector extends TargetMetricsCollector<HsMetrics> {
                 new String[]{"BAIT_SET",  "BAIT_TERRITORY",  "ON_BAIT_BASES",  "NEAR_BAIT_BASES",  "OFF_BAIT_BASES",  "PCT_OFF_BAIT",  "ON_BAIT_VS_SELECTED",  "MEAN_BAIT_COVERAGE"}
         );
 
-        hsMetrics.BAIT_DESIGN_EFFICIENCY = (double) hsMetrics.TARGET_TERRITORY / (double) hsMetrics.BAIT_TERRITORY;
-        hsMetrics.PCT_USABLE_BASES_ON_BAIT   = hsMetrics.ON_BAIT_BASES   / (double) targetMetrics.PF_BASES;
-        hsMetrics.PCT_USABLE_BASES_ON_TARGET = hsMetrics.ON_TARGET_BASES / (double) targetMetrics.PF_BASES;
-        hsMetrics.HS_LIBRARY_SIZE = DuplicationMetrics.estimateLibrarySize(targetMetrics.PF_SELECTED_PAIRS, targetMetrics.PF_SELECTED_UNIQUE_PAIRS);
+        updateMetrics(hsMetrics, targetMetrics.PF_BASES, targetMetrics.PF_SELECTED_PAIRS, targetMetrics.PF_SELECTED_UNIQUE_PAIRS);
 
         //need HSLIBRARY_SIZE
         hsMetrics.HS_PENALTY_10X = calculateHsPenalty(hsMetrics.HS_LIBRARY_SIZE, targetMetrics, 10);
@@ -102,6 +99,21 @@ public class HsMetricCollector extends TargetMetricsCollector<HsMetrics> {
     }
 
     /**
+     * Updates several of the metrics in the provided Metrics object so that they better reflect the particular target strategy
+     *
+     * @param hsMetrics the metrics object to fix
+     * @param bases the total number of bases
+     * @param selectedPairs the total number of selected pairs
+     * @param selectedUniquePairs the number of selected pairs that are unique
+     */
+    protected void updateMetrics(final HsMetrics hsMetrics, final long bases, final long selectedPairs, final long selectedUniquePairs) {
+        hsMetrics.BAIT_DESIGN_EFFICIENCY = (double) hsMetrics.TARGET_TERRITORY / (double) hsMetrics.BAIT_TERRITORY;
+        hsMetrics.PCT_USABLE_BASES_ON_BAIT   = hsMetrics.ON_BAIT_BASES   / (double) bases;
+        hsMetrics.PCT_USABLE_BASES_ON_TARGET = hsMetrics.ON_TARGET_BASES / (double) bases;
+        hsMetrics.HS_LIBRARY_SIZE = DuplicationMetrics.estimateLibrarySize(selectedPairs, selectedUniquePairs);
+    }
+
+    /**
      * Attempts to calculate the HS penalty incurred by the library in order to get 80%
      * of target bases (in non-zero-covered targets) to a specific target coverage (e.g. 20X).
      *
@@ -109,7 +121,7 @@ public class HsMetricCollector extends TargetMetricsCollector<HsMetrics> {
      * @return the hs penalty - a multiplier that tells if you want, e.g. 20X coverage, then you will
      *         need to produce this many PF aligned bases per target bases in your design!
      */
-    private double calculateHsPenalty(final Long librarySize, final TargetMetrics targetMetrics, final int coverageGoal) {
+    protected double calculateHsPenalty(final Long librarySize, final TargetMetrics targetMetrics, final int coverageGoal) {
         if (librarySize == null) return 0;
 
         final double meanCoverage  = targetMetrics.ON_TARGET_FROM_PAIR_BASES / (double) targetMetrics.TARGET_TERRITORY;

--- a/src/main/java/picard/analysis/directed/HsMetricCollector.java
+++ b/src/main/java/picard/analysis/directed/HsMetricCollector.java
@@ -117,18 +117,37 @@ public class HsMetricCollector extends TargetMetricsCollector<HsMetrics> {
      * Attempts to calculate the HS penalty incurred by the library in order to get 80%
      * of target bases (in non-zero-covered targets) to a specific target coverage (e.g. 20X).
      *
+     * @param librarySize  the estimated library size
+     * @param targetMetrics the target metrics class
      * @param coverageGoal the desired coverage target (e.g. 20X)
      * @return the hs penalty - a multiplier that tells if you want, e.g. 20X coverage, then you will
      *         need to produce this many PF aligned bases per target bases in your design!
      */
-    protected double calculateHsPenalty(final Long librarySize, final TargetMetrics targetMetrics, final int coverageGoal) {
-        if (librarySize == null) return 0;
-
+    private double calculateHsPenalty(final Long librarySize, final TargetMetrics targetMetrics, final int coverageGoal) {
         final double meanCoverage  = targetMetrics.ON_TARGET_FROM_PAIR_BASES / (double) targetMetrics.TARGET_TERRITORY;
         final double fold80        = targetMetrics.FOLD_80_BASE_PENALTY;
         final long pairs           = targetMetrics.PF_SELECTED_PAIRS;
         final long uniquePairs     = targetMetrics.PF_SELECTED_UNIQUE_PAIRS;
         final double onTargetPct   = (double) targetMetrics.ON_TARGET_BASES / (double) targetMetrics.PF_UQ_BASES_ALIGNED;
+        return calculateHsPenalty(librarySize, meanCoverage, fold80, pairs, uniquePairs, onTargetPct, coverageGoal);
+    }
+
+    /**
+     * Attempts to calculate the HS penalty incurred by the library in order to get 80%
+     * of target bases (in non-zero-covered targets) to a specific target coverage (e.g. 20X).
+     *
+     * @param librarySize  the estimated library size
+     * @param meanCoverage  the mean coverage
+     * @param pairs  the total number of read pairs
+     * @param uniquePairs  the number of unique read pairs
+     * @param onTargetPct  the percentage of on-target bases
+     * @param coverageGoal the desired coverage target (e.g. 20X)
+     * @return the hs penalty - a multiplier that tells if you want, e.g. 20X coverage, then you will
+     *         need to produce this many PF aligned bases per target bases in your design!
+     */
+    protected double calculateHsPenalty(final Long librarySize, final double meanCoverage, final double fold80, final long pairs, final long uniquePairs, final double onTargetPct, final int coverageGoal) {
+
+        if (librarySize == null) return 0;
 
         final double uniquePairGoalMultiplier = (coverageGoal / meanCoverage) * fold80;
         double pairMultiplier = uniquePairGoalMultiplier;
@@ -163,5 +182,4 @@ public class HsMetricCollector extends TargetMetricsCollector<HsMetrics> {
             return (1 / uniqueFraction) * fold80 * (1 / onTargetPct);
         }
     }
-
 }


### PR DESCRIPTION
### Description

This minor change is needed so that a class that extends HsMetricsCollector can update these metrics differently.  Nothing is really changed in this PR.

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

