### PR TITLE
DSDEGP-1626: Only check expected output cycles

### DIFF
--- a/src/main/java/picard/illumina/CheckIlluminaDirectory.java
+++ b/src/main/java/picard/illumina/CheckIlluminaDirectory.java
@@ -121,10 +121,10 @@ public class CheckIlluminaDirectory extends CommandLineProgram {
         final List<Integer> failingLanes = new ArrayList<>();
         int totalFailures = 0;
 
-        final int[] expectedCycles = new OutputMapping(readStructure).getOutputCycles();
+        final OutputMapping outputMapping = new OutputMapping(readStructure);
         log.info("Checking lanes(" + StringUtil.join(",", LANES) + " in basecalls directory (" + BASECALLS_DIR
                 .getAbsolutePath() + ")\n");
-        log.info("Expected cycles: " + StringUtil.intValuesToString(expectedCycles));
+        log.info("Expected cycles: " + StringUtil.intValuesToString(outputMapping.getOutputCycles()));
 
         for (final Integer lane : LANES) {
             if (IlluminaFileUtil.hasCbcls(BASECALLS_DIR, lane)) {
@@ -168,9 +168,8 @@ public class CheckIlluminaDirectory extends CommandLineProgram {
                     filterFileMap.put(fileToTile(filterFile.getName()), filterFile);
                 }
 
-                final OutputMapping outputMapping = new OutputMapping(readStructure);
-
-                final CbclReader reader = new CbclReader(cbcls, filterFileMap, readStructure.readLengths, tiles.get(0), locs, outputMapping.getOutputCycles(), true);
+                final CbclReader reader = new CbclReader(cbcls, filterFileMap, outputMapping.getOutputReadLengths(),
+                        tiles.get(0), locs, outputMapping.getOutputCycles(), true);
                 reader.getAllTiles().forEach((key, value) -> {
                     //we are looking for cycles with compressed data count of 2 bytes (standard gzip header size)
                     String emptyCycleString = value.stream()
@@ -211,7 +210,7 @@ public class CheckIlluminaDirectory extends CommandLineProgram {
                 log.info("Checking lane " + lane);
                 log.info("Expected tiles: " + StringUtil.join(", ", expectedTiles));
 
-                final int numFailures = verifyLane(fileUtil, expectedTiles, expectedCycles, DATA_TYPES, FAKE_FILES);
+                final int numFailures = verifyLane(fileUtil, expectedTiles, outputMapping.getOutputCycles(), DATA_TYPES, FAKE_FILES);
 
                 if (numFailures > 0) {
                     log.info("Lane " + lane + " FAILED " + " Total Errors: " + numFailures);
@@ -274,9 +273,9 @@ public class CheckIlluminaDirectory extends CommandLineProgram {
      * @param dataTypes     The data types we expect to be available/well-formed
      * @return The number of errors found/logged for this directory/lane
      */
-    private static final int verifyLane(final IlluminaFileUtil fileUtil, final List<Integer> expectedTiles,
-                                        final int[] cycles,
-                                        final Set<IlluminaDataType> dataTypes, final boolean fakeFiles) {
+    private static int verifyLane(final IlluminaFileUtil fileUtil, final List<Integer> expectedTiles,
+                                  final int[] cycles,
+                                  final Set<IlluminaDataType> dataTypes, final boolean fakeFiles) {
         if (expectedTiles.isEmpty()) {
             throw new PicardException(
                     "0 input tiles were specified!  Check to make sure this lane is in the InterOp file!");


### PR DESCRIPTION
DSDEGP-1626

This PR fixes the bug described here: https://gatkforums.broadinstitute.org/gatk/discussion/comment/42610

This ensures that cbcls are only checked for output cycles.
----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

