### PR TITLE
update htsjdk version to 2.14.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ jacoco {
     toolVersion = "0.7.5.201505241946"
 }
 
-final htsjdkVersion = System.getProperty('htsjdk.version', '2.13.1')
+final htsjdkVersion = System.getProperty('htsjdk.version', '2.14.0')
 
 // Get the jdk files we need to run javaDoc. We need to use these during compile, testCompile,
 // test execution, and gatkDoc generation, but we don't want them as part of the runtime

--- a/src/main/java/picard/fingerprint/CheckFingerprint.java
+++ b/src/main/java/picard/fingerprint/CheckFingerprint.java
@@ -154,8 +154,8 @@ public class CheckFingerprint extends CommandLineProgram {
         String observedSampleAlias = null;
         final boolean isBamOrSamFile = isBamOrSamFile(INPUT);
         if (isBamOrSamFile) {
-            SequenceUtil.assertSequenceDictionariesEqual(SAMSequenceDictionaryExtractor.extractDictionary(INPUT), SAMSequenceDictionaryExtractor.extractDictionary(GENOTYPES), true);
-            SequenceUtil.assertSequenceDictionariesEqual(SAMSequenceDictionaryExtractor.extractDictionary(INPUT), checker.getHeader().getSequenceDictionary(), true);
+            SequenceUtil.assertSequenceDictionariesEqual(SAMSequenceDictionaryExtractor.extractDictionary(INPUT.toPath()), SAMSequenceDictionaryExtractor.extractDictionary(GENOTYPES.toPath()), true);
+            SequenceUtil.assertSequenceDictionariesEqual(SAMSequenceDictionaryExtractor.extractDictionary(INPUT.toPath()), checker.getHeader().getSequenceDictionary(), true);
 
             // Verify that there's only one sample in the SAM/BAM.
             final SamReader in = SamReaderFactory.makeDefault().referenceSequence(REFERENCE_SEQUENCE).open(INPUT);

--- a/src/main/java/picard/sam/SamAlignmentMerger.java
+++ b/src/main/java/picard/sam/SamAlignmentMerger.java
@@ -189,7 +189,7 @@ public class SamAlignmentMerger extends AbstractAlignmentMerger {
 
     @Override
     protected SAMSequenceDictionary getDictionaryForMergedBam() {
-        SAMSequenceDictionary referenceDict = SAMSequenceDictionaryExtractor.extractDictionary(referenceFasta);
+        SAMSequenceDictionary referenceDict = SAMSequenceDictionaryExtractor.extractDictionary(referenceFasta.toPath());
         if (referenceDict == null) {
             throw new PicardException("No sequence dictionary found for " + referenceFasta.getAbsolutePath() +
                     ".  Use Picard's CreateSequenceDictionary to create a sequence dictionary.");

--- a/src/main/java/picard/util/BedToIntervalList.java
+++ b/src/main/java/picard/util/BedToIntervalList.java
@@ -117,7 +117,7 @@ public class BedToIntervalList extends CommandLineProgram {
         try {
             // create a new header that we will assign the dictionary provided by the SAMSequenceDictionaryExtractor to.
             final SAMFileHeader header = new SAMFileHeader();
-            final SAMSequenceDictionary samSequenceDictionary = SAMSequenceDictionaryExtractor.extractDictionary(SEQUENCE_DICTIONARY);
+            final SAMSequenceDictionary samSequenceDictionary = SAMSequenceDictionaryExtractor.extractDictionary(SEQUENCE_DICTIONARY.toPath());
             header.setSequenceDictionary(samSequenceDictionary);
             // set the sort order to be sorted by coordinate, which is actually done below
             // by getting the .uniqued() intervals list before we write out the file

--- a/src/main/java/picard/vcf/CollectVariantCallingMetrics.java
+++ b/src/main/java/picard/vcf/CollectVariantCallingMetrics.java
@@ -97,7 +97,7 @@ public class CollectVariantCallingMetrics extends CommandLineProgram {
         CloserUtil.close(variantReader);
 
         final SAMSequenceDictionary sequenceDictionary =
-                SAMSequenceDictionaryExtractor.extractDictionary(SEQUENCE_DICTIONARY == null ? INPUT : SEQUENCE_DICTIONARY);
+                SAMSequenceDictionaryExtractor.extractDictionary(SEQUENCE_DICTIONARY == null ? INPUT.toPath() : SEQUENCE_DICTIONARY.toPath());
 
         final IntervalList targetIntervals = (TARGET_INTERVALS == null) ? null : IntervalList.fromFile(TARGET_INTERVALS).uniqued();
 

--- a/src/main/java/picard/vcf/UpdateVcfSequenceDictionary.java
+++ b/src/main/java/picard/vcf/UpdateVcfSequenceDictionary.java
@@ -82,7 +82,7 @@ public class UpdateVcfSequenceDictionary extends CommandLineProgram {
         IOUtil.assertFileIsReadable(SEQUENCE_DICTIONARY);
         IOUtil.assertFileIsWritable(OUTPUT);
 
-        final SAMSequenceDictionary samSequenceDictionary = SAMSequenceDictionaryExtractor.extractDictionary(SEQUENCE_DICTIONARY);
+        final SAMSequenceDictionary samSequenceDictionary = SAMSequenceDictionaryExtractor.extractDictionary(SEQUENCE_DICTIONARY.toPath());
 
         final VCFFileReader fileReader = new VCFFileReader(INPUT, false);
         final VCFHeader fileHeader = fileReader.getFileHeader();

--- a/src/test/java/picard/analysis/CollectGcBiasMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectGcBiasMetricsTest.java
@@ -101,7 +101,7 @@ public class CollectGcBiasMetricsTest extends CommandLineProgramTest {
         final SAMFileHeader header = new SAMFileHeader();
 
         try {
-            header.setSequenceDictionary(SAMSequenceDictionaryExtractor.extractDictionary(dict));
+            header.setSequenceDictionary(SAMSequenceDictionaryExtractor.extractDictionary(dict.toPath()));
             header.setSortOrder(SAMFileHeader.SortOrder.unsorted);
         } catch (final SAMException e) {
             e.printStackTrace();

--- a/src/test/java/picard/analysis/CollectWgsMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectWgsMetricsTest.java
@@ -148,7 +148,7 @@ public class CollectWgsMetricsTest extends CommandLineProgramTest {
 
         //Check that dictionary file is readable and then set header dictionary
         try {
-            header.setSequenceDictionary(SAMSequenceDictionaryExtractor.extractDictionary(referenceDict));
+            header.setSequenceDictionary(SAMSequenceDictionaryExtractor.extractDictionary(referenceDict.toPath()));
             header.setSortOrder(SAMFileHeader.SortOrder.unsorted);
         } catch (final SAMException e) {
             e.printStackTrace();

--- a/src/test/java/picard/analysis/CollectWgsMetricsTestUtils.java
+++ b/src/test/java/picard/analysis/CollectWgsMetricsTestUtils.java
@@ -69,7 +69,7 @@ public class CollectWgsMetricsTestUtils {
 
         // check that dictionary file is readable and then set header dictionary
         try {
-            header.setSequenceDictionary(SAMSequenceDictionaryExtractor.extractDictionary(reference));
+            header.setSequenceDictionary(SAMSequenceDictionaryExtractor.extractDictionary(reference.toPath()));
             header.setSortOrder(SAMFileHeader.SortOrder.unsorted);
         } catch (final SAMException e) {
             e.printStackTrace();

--- a/src/test/java/picard/analysis/directed/CollectTargetedMetricsTest.java
+++ b/src/test/java/picard/analysis/directed/CollectTargetedMetricsTest.java
@@ -66,7 +66,7 @@ public class CollectTargetedMetricsTest extends CommandLineProgramTest {
 
         //Check that dictionary file is readable and then set header dictionary
         try {
-            header.setSequenceDictionary(SAMSequenceDictionaryExtractor.extractDictionary(dict));
+            header.setSequenceDictionary(SAMSequenceDictionaryExtractor.extractDictionary(dict.toPath()));
             header.setSortOrder(SAMFileHeader.SortOrder.unsorted);
         } catch (final SAMException e) {
             e.printStackTrace();

--- a/src/test/java/picard/sam/MergeBamAlignmentTest.java
+++ b/src/test/java/picard/sam/MergeBamAlignmentTest.java
@@ -953,7 +953,7 @@ public class MergeBamAlignmentTest extends CommandLineProgramTest {
         alignedSam.deleteOnExit();
 
         // Populate the header with SAMSequenceRecords
-        header.setSequenceDictionary(SAMSequenceDictionaryExtractor.extractDictionary(sequenceDict2));
+        header.setSequenceDictionary(SAMSequenceDictionaryExtractor.extractDictionary(sequenceDict2.toPath()));
 
         // Create 2 alignments for each end of pair
         final SAMFileWriter alignedWriter = factory.makeSAMWriter(header, false, alignedSam);
@@ -1107,7 +1107,7 @@ public class MergeBamAlignmentTest extends CommandLineProgramTest {
 
             final String sequence = "chr1";
             // Populate the header with SAMSequenceRecords
-            header.setSequenceDictionary(SAMSequenceDictionaryExtractor.extractDictionary(sequenceDict2));
+            header.setSequenceDictionary(SAMSequenceDictionaryExtractor.extractDictionary(sequenceDict2.toPath()));
 
             final SAMFileWriter alignedWriter = factory.makeSAMWriter(header, false, alignedSam);
             for (final MultipleAlignmentSpec spec : specs) {
@@ -1232,7 +1232,7 @@ public class MergeBamAlignmentTest extends CommandLineProgramTest {
 
         final String sequence = "chr1";
         // Populate the header with SAMSequenceRecords
-        header.setSequenceDictionary(SAMSequenceDictionaryExtractor.extractDictionary(sequenceDict2));
+        header.setSequenceDictionary(SAMSequenceDictionaryExtractor.extractDictionary(sequenceDict2.toPath()));
 
         final SAMFileWriter alignedWriter = factory.makeSAMWriter(header, false, alignedSam);
 

--- a/src/test/java/picard/vcf/UpdateVcfSequenceDictionaryTest.java
+++ b/src/test/java/picard/vcf/UpdateVcfSequenceDictionaryTest.java
@@ -97,8 +97,8 @@ public class UpdateVcfSequenceDictionaryTest {
         IOUtil.assertFilesEqual(samSequenceDictionaryVcf, outputFile);
 
         // A little extra checking.
-        Assert.assertEquals(SAMSequenceDictionaryExtractor.extractDictionary(input).size(), 84);
-        Assert.assertEquals(SAMSequenceDictionaryExtractor.extractDictionary(samSequenceDictionaryVcf).size(), 82);
-        Assert.assertEquals(SAMSequenceDictionaryExtractor.extractDictionary(outputFile).size(), 82);
+        Assert.assertEquals(SAMSequenceDictionaryExtractor.extractDictionary(input.toPath()).size(), 84);
+        Assert.assertEquals(SAMSequenceDictionaryExtractor.extractDictionary(samSequenceDictionaryVcf.toPath()).size(), 82);
+        Assert.assertEquals(SAMSequenceDictionaryExtractor.extractDictionary(outputFile.toPath()).size(), 82);
     }
 }


### PR DESCRIPTION
This htsjdk update includes  updated nio support for vcfs (more convenient), FilterTag modifications to Pass or Filter Reads, Negative/Zero protection against Histogram::getPercentile, and query parameter stripper before block compresed extension.

**Breaking Changes**
new abstract method SamReaderFactory.getFileHeader(Path samFile)

**Deprecations**
SAMSequenceDictionaryExtractor.extractDictionary(File) has been deprecated, use SAMSequenceDictionaryExtractor.extractDictionary(Path) instead

All calls to newly deprecated function have replaced in this PR as well.

Link for 2.14.0 release notes - https://github.com/samtools/htsjdk/releases/tag/2.14.0

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests


  