### PR TITLE
Remove extra newline in IntervalListTools summary line.

### DIFF
--- a/src/main/java/picard/util/IntervalListTools.java
+++ b/src/main/java/picard/util/IntervalListTools.java
@@ -112,7 +112,7 @@ import java.util.*;
 )
 @DocumentedFeature
 public class IntervalListTools extends CommandLineProgram {
-    static final String USAGE_SUMMARY ="A tool for performing various IntervalList manipulations\n";
+    static final String USAGE_SUMMARY ="A tool for performing various IntervalList manipulations";
     static final String USAGE_DETAILS =
                     " <h3>Summary</h3>" +
                     "This tool offers multiple interval list file manipulation capabilities, including: sorting, " +


### PR DESCRIPTION
Fixes this:

<img width="433" alt="screen shot 2018-01-06 at 11 44 52 am" src="https://user-images.githubusercontent.com/10062863/34641773-189c7ffe-f2d7-11e7-960e-674ed1a7fdc6.png">
