### PR TITLE
Added missing validation for SECOND_INPUT that was causing errors.

### DIFF
--- a/src/main/java/picard/util/IntervalListTools.java
+++ b/src/main/java/picard/util/IntervalListTools.java
@@ -427,7 +427,8 @@ public class IntervalListTools extends CommandLineProgram {
             errorMsgs.add("BREAK_BANDS_AT_MULTIPLES_OF must be greater than or equal to 0.");
         }
 
-        if (CollectionUtil.makeSet(Action.CONCAT, Action.UNION, Action.INTERSECT).contains(ACTION)) {
+        if (CollectionUtil.makeSet(Action.CONCAT, Action.UNION, Action.INTERSECT).contains(ACTION)
+                && SECOND_INPUT != null && !SECOND_INPUT.isEmpty()) {
             errorMsgs.add(String.format("SECOND_LIST must be null when ACTION is %s, found %s. " +
                             "Please put all the inputs in INPUT for this ACTION.", ACTION.name(), SECOND_INPUT));
         }

--- a/src/test/java/picard/util/IntervalListToolsTest.java
+++ b/src/test/java/picard/util/IntervalListToolsTest.java
@@ -1,0 +1,24 @@
+package picard.util;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+
+public class IntervalListToolsTest {
+    @Test
+    public void testSecondInputValidation(){
+        IntervalListTools intervalListTools = new IntervalListTools();
+        String[] errors = intervalListTools.customCommandLineValidation();
+        Assert.assertNull(errors);
+
+        intervalListTools.SECOND_INPUT = new ArrayList<>();
+        errors = intervalListTools.customCommandLineValidation();
+        Assert.assertNull(errors);
+
+        intervalListTools.SECOND_INPUT.add(new File("fakefile"));
+        errors = intervalListTools.customCommandLineValidation();
+        Assert.assertTrue(errors.length == 1);
+    }
+}


### PR DESCRIPTION
Currently IntevalListTools wants to validate that on certain actions SECOND_INPUT is null or empty. However this check was never implemented.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

