### PR TITLE
Allow command line option to suppress LiftOver logging of every failed interval

### DIFF
--- a/src/main/java/picard/vcf/LiftoverVcf.java
+++ b/src/main/java/picard/vcf/LiftoverVcf.java
@@ -148,6 +148,9 @@ public class LiftoverVcf extends CommandLineProgram {
     @Argument(shortName = "WMC", doc = "Warn on missing contig.", optional = true)
     public boolean WARN_ON_MISSING_CONTIG = false;
 
+    @Argument(shortName = "LFI", doc = "If true, intervals failing due to match below LIFTOVER_MIN_MATCH will be logged to the console.", optional = true)
+    public boolean LOG_FAILED_INTERVALS = false;
+
     // Option on whether or not to write the original contig/position of the variant to the INFO field
     @Argument(doc = "Write the original contig/position for lifted variants to the INFO field.", optional = true)
     public boolean WRITE_ORIGINAL_POSITION = false;
@@ -255,6 +258,8 @@ public class LiftoverVcf extends CommandLineProgram {
         // Setup the inputs
         ////////////////////////////////////////////////////////////////////////
         final LiftOver liftOver = new LiftOver(CHAIN);
+        liftOver.setShouldLogFailedIntervalsBelowThreshold(LOG_FAILED_INTERVALS);
+
         final VCFFileReader in = new VCFFileReader(INPUT, false);
 
         log.info("Loading up the target reference genome.");

--- a/src/main/java/picard/vcf/LiftoverVcf.java
+++ b/src/main/java/picard/vcf/LiftoverVcf.java
@@ -148,8 +148,8 @@ public class LiftoverVcf extends CommandLineProgram {
     @Argument(shortName = "WMC", doc = "Warn on missing contig.", optional = true)
     public boolean WARN_ON_MISSING_CONTIG = false;
 
-    @Argument(shortName = "LFI", doc = "If true, intervals failing due to match below LIFTOVER_MIN_MATCH will be logged to the console.", optional = true)
-    public boolean LOG_FAILED_INTERVALS = false;
+    @Argument(shortName = "LFI", doc = "If true, intervals failing due to match below LIFTOVER_MIN_MATCH will be logged as a warning to the console.", optional = true)
+    public boolean LOG_FAILED_INTERVALS = true;
 
     // Option on whether or not to write the original contig/position of the variant to the INFO field
     @Argument(doc = "Write the original contig/position for lifted variants to the INFO field.", optional = true)


### PR DESCRIPTION

### Description

LiftOver in HTSJDK defaults to logging every single time an interval falls below the minimum match threshold.  This becomes excessive when lifting a large VCF file.  I recently had a PR approved in HTSJDK to add a setter on Liftover to turn this off (samtools/htsjdk#995).  

This PR stems from that.  I'd like to add a command line option in LiftOverVcf that enables/disables this logging behavior.  This is a really straightforward patch.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

