### PR TITLE
ReorderSam was having trouble when new dictionary is larger than old one

### DIFF
--- a/src/main/java/picard/sam/ReorderSam.java
+++ b/src/main/java/picard/sam/ReorderSam.java
@@ -54,7 +54,7 @@ import static htsjdk.samtools.SAMRecord.NO_ALIGNMENT_START;
 
 /**
  * Reorders a SAM/BAM input file according to the order of contigs in a second reference file.
- * <p>
+ *
  * <h3>Summary</h3>
  * Not to be confused with SortSam which sorts a SAM or BAM file with a valid sequence dictionary,
  * ReorderSam reorders reads in a SAM/BAM file to match the contig ordering in a provided reference file,

--- a/src/main/java/picard/sam/ReorderSam.java
+++ b/src/main/java/picard/sam/ReorderSam.java
@@ -33,40 +33,45 @@ import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.SAMTag;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
-import htsjdk.samtools.reference.ReferenceSequenceFile;
-import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
-import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
+import htsjdk.variant.utils.SAMSequenceDictionaryExtractor;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import picard.PicardException;
 import picard.cmdline.CommandLineProgram;
-import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import picard.cmdline.StandardOptionDefinitions;
-import picard.cmdline.argumentcollections.ReferenceArgumentCollection;
 import picard.cmdline.programgroups.ReadDataManipulationProgramGroup;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static htsjdk.samtools.SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX;
+import static htsjdk.samtools.SAMRecord.NO_ALIGNMENT_START;
+
 /**
  * Reorders a SAM/BAM input file according to the order of contigs in a second reference file.
- *
+ * <p>
  * <h3>Summary</h3>
  * Not to be confused with SortSam which sorts a SAM or BAM file with a valid sequence dictionary,
  * ReorderSam reorders reads in a SAM/BAM file to match the contig ordering in a provided reference file,
  * as determined by exact name matching of contigs.  Reads mapped to contigs absent in the new
- * reference are dropped. Runs substantially faster if the input is an indexed BAM file.
+ * reference are unmapped. Runs substantially faster if the input is an indexed BAM file.
  *
  * <h3>Example</h3>
  * <pre>
  *     java -jar picard.jar ReorderSam \
  *          INPUT=sample.bam \
  *          OUTPUT=reordered.bam \
- *          REFERENCE=reference_with_different_order.fasta
+ *          SEQUENCE_DICTIONARY=reference_with_different_order.dict
  * </pre>
+ *
+ * <h3>Caveats</h3>
+ * Note that REFERENCE_SEQUENCE is used for reading the INPUT, (e.g. when reading cram files) not for determining
+ * the order of the OUTPUT. For that you must specify the SEQUENCE_DICTIONARY argument.
  *
  * @author mdepristo
  */
@@ -74,14 +79,14 @@ import java.util.Map;
         summary = "Not to be confused with SortSam which sorts a SAM or BAM file with a valid sequence dictionary, " +
                 "ReorderSam reorders reads in a SAM/BAM file to match the contig ordering in a provided reference file, " +
                 "as determined by exact name matching of contigs.  Reads mapped to contigs absent in the new " +
-                "reference are dropped. Runs substantially faster if the input is an indexed BAM file." +
+                "reference are unmapped. Runs substantially faster if the input is an indexed BAM file." +
                 "\n" +
                 "Example\n" +
                 "\n" +
                 " java -jar picard.jar ReorderSam \\\n" +
                 "      INPUT=sample.bam \\\n" +
                 "      OUTPUT=reordered.bam \\\n" +
-                "      REFERENCE=reference_with_different_order.fasta\n",
+                "      SEQUENCE_DICTIONARY=reference_with_different_order.dict\n",
         oneLineSummary = "Reorders reads in a SAM or BAM file to match ordering in a second reference file.",
         programGroup = ReadDataManipulationProgramGroup.class)
 
@@ -94,7 +99,12 @@ public class ReorderSam extends CommandLineProgram {
     @Argument(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "Output file (SAM or BAM) to write extracted reads to.")
     public File OUTPUT;
 
-    @Argument(shortName = "S", doc = "If true, then allows only a partial overlap of the original contigs with the new reference " +
+    @Argument(shortName = StandardOptionDefinitions.SEQUENCE_DICTIONARY_SHORT_NAME,
+            doc = "A Sequence Dictionary for the OUTPUT file (can be read from one of the " +
+                    "following file types (SAM, BAM, VCF, BCF, Interval List, Fasta, or Dict)")
+    public File SEQUENCE_DICTIONARY;
+
+    @Argument(shortName = "S", doc = "If true, allows only a partial overlap of the original contigs with the new reference " +
             "sequence contigs.  By default, this tool requires a corresponding contig in the new " +
             "reference for each read contig")
     public boolean ALLOW_INCOMPLETE_DICT_CONCORDANCE = false;
@@ -106,69 +116,55 @@ public class ReorderSam extends CommandLineProgram {
 
     private final Log log = Log.getInstance(ReorderSam.class);
 
-    // return a custom argument collection because this tool uses the (required) argument name
-    // "REFERENCE" instead of "REFERENCE_SEQUENCE" which is not a required argument.
-    @Override
-    protected ReferenceArgumentCollection makeReferenceArgumentCollection() {
-        return new ReorderSamReferenceArgumentCollection();
-    }
-
-    public static class ReorderSamReferenceArgumentCollection implements ReferenceArgumentCollection {
-        @Argument(shortName = StandardOptionDefinitions.REFERENCE_SHORT_NAME, common=false,
-                doc = "Reference sequence to reorder reads to match.  " +
-                        "A sequence dictionary corresponding to the reference fasta is required.  Create one with CreateSequenceDictionary.")
-        public File REFERENCE;
-
-        @Override
-        public File getReferenceFile() {
-            return REFERENCE;
-        };
-    }
-
     protected int doWork() {
         IOUtil.assertFileIsReadable(INPUT);
-        IOUtil.assertFileIsReadable(REFERENCE_SEQUENCE);
+        IOUtil.assertFileIsReadable(SEQUENCE_DICTIONARY);
         IOUtil.assertFileIsWritable(OUTPUT);
 
-        final SamReader in = SamReaderFactory.makeDefault().referenceSequence(REFERENCE_SEQUENCE).open(INPUT);
+        try (final SamReader in = SamReaderFactory.makeDefault().referenceSequence(REFERENCE_SEQUENCE).open(INPUT)) {
 
-        final ReferenceSequenceFile reference = ReferenceSequenceFileFactory.getReferenceSequenceFile(REFERENCE_SEQUENCE);
-        final SAMSequenceDictionary refDict = reference.getSequenceDictionary();
+            final SAMSequenceDictionary outputDictionary = SAMSequenceDictionaryExtractor.extractDictionary(SEQUENCE_DICTIONARY.toPath());
 
-        if (refDict == null) {
-            log.error("No reference sequence dictionary found. Aborting.  You can create a sequence dictionary for the reference fasta using CreateSequenceDictionary.jar.");
-            CloserUtil.close(in);
-            return 1;
-        }
+            if (outputDictionary == null) {
+                log.error("No reference sequence dictionary found. Aborting.  You can create a sequence dictionary for the reference fasta using the CreateSequenceDictionary command.");
+                return 1;
+            }
 
-        printDictionary("SAM/BAM file", in.getFileHeader().getSequenceDictionary());
-        printDictionary("Reference", refDict);
-        final Map<Integer, Integer> newOrder = buildSequenceDictionaryMap(refDict, in.getFileHeader().getSequenceDictionary());
+            printDictionary("SAM/BAM file", in.getFileHeader().getSequenceDictionary());
+            printDictionary("Reference", outputDictionary);
+            final Map<Integer, Integer> newOrder;
+            try {
+                newOrder = buildSequenceDictionaryMap(outputDictionary, in.getFileHeader().getSequenceDictionary());
+            } catch (PicardException e) {
+                log.error(e);
+                return 1;
+            }
+            // has to be after we create the newOrder
+            final SAMFileHeader outHeader = in.getFileHeader().clone();
+            outHeader.setSequenceDictionary(outputDictionary);
 
-        // has to be after we create the newOrder
-        final SAMFileHeader outHeader = in.getFileHeader().clone();
-        outHeader.setSequenceDictionary(refDict);
+            log.info("Writing reads...");
+            if (in.hasIndex()) {
+                try (final SAMFileWriter out = new SAMFileWriterFactory().makeSAMOrBAMWriter(outHeader, false, OUTPUT)) {
 
-        log.info("Writing reads...");
-        if (in.hasIndex()) {
-            try( final SAMFileWriter out = new SAMFileWriterFactory().makeSAMOrBAMWriter(outHeader, true, OUTPUT)) {
+                    // write the reads in contig order
+                    for (final SAMSequenceRecord contig : in.getFileHeader().getSequenceDictionary().getSequences()) {
+                        log.info("writing the reads from " + contig.getSequenceName());
+                        final SAMRecordIterator it = in.query(contig.getSequenceName(), 0, 0, false);
+                        writeReads(out, it, newOrder, contig.getSequenceName());
+                    }
 
-                // write the reads in contig order
-                for (final SAMSequenceRecord contig : refDict.getSequences()) {
-                    final SAMRecordIterator it = in.query(contig.getSequenceName(), 0, 0, false);
-                    writeReads(out, it, newOrder, contig.getSequenceName());
+                    // don't forget the unmapped reads
+                    writeReads(out, in.queryUnmapped(), newOrder, "unmapped");
                 }
-                // don't forget the unmapped reads
-                writeReads(out, in.queryUnmapped(), newOrder, "unmapped");
+            } else {
+                try (final SAMFileWriter out = new SAMFileWriterFactory().makeSAMOrBAMWriter(outHeader, false, OUTPUT)) {
+                    writeReads(out, in.iterator(), newOrder, "All reads");
+                }
             }
-        } else {
-            try (final SAMFileWriter out = new SAMFileWriterFactory().makeSAMOrBAMWriter(outHeader, false, OUTPUT)) {
-                writeReads(out, in.iterator(), newOrder, "All reads");
-            }
+        } catch (IOException e) {
+            e.printStackTrace();
         }
-
-        // cleanup
-        CloserUtil.close(in);
         return 0;
     }
 
@@ -178,13 +174,16 @@ public class ReorderSam extends CommandLineProgram {
      * can be made.
      */
     private int newOrderIndex(SAMRecord read, int oldIndex, Map<Integer, Integer> newOrder) {
-        if (oldIndex == -1)
-            return -1; // unmapped read
-        else {
+        if (oldIndex == NO_ALIGNMENT_REFERENCE_INDEX) {
+            return NO_ALIGNMENT_REFERENCE_INDEX; // unmapped read
+        } else {
             final Integer n = newOrder.get(oldIndex);
 
-            if (n == null) throw new PicardException("BUG: no mapping found for read " + read.getSAMString());
-            else return n;
+            if (n == null) {
+                throw new PicardException("BUG: no mapping found for read " + read.getSAMString());
+            } else {
+                return n;
+            }
         }
     }
 
@@ -209,9 +208,19 @@ public class ReorderSam extends CommandLineProgram {
             read.setHeader(out.getFileHeader());
             read.setReferenceIndex(newRefIndex);
 
+            // read becoming unmapped
+            if (oldRefIndex != NO_ALIGNMENT_REFERENCE_INDEX &&
+                    newRefIndex == NO_ALIGNMENT_REFERENCE_INDEX) {
+                read.setAlignmentStart(NO_ALIGNMENT_START);
+                read.setReadUnmappedFlag(true);
+                read.setCigarString(SAMRecord.NO_ALIGNMENT_CIGAR);
+                read.setMappingQuality(SAMRecord.NO_MAPPING_QUALITY);
+            }
+
             final int newMateIndex = newOrderIndex(read, oldMateIndex, newOrder);
-            if (oldMateIndex != -1 && newMateIndex == -1) { // becoming unmapped
-                read.setMateAlignmentStart(0);
+            if (oldMateIndex != NO_ALIGNMENT_REFERENCE_INDEX &&
+                    newMateIndex == NO_ALIGNMENT_REFERENCE_INDEX) { // mate becoming unmapped
+                read.setMateAlignmentStart(NO_ALIGNMENT_START);
                 read.setMateUnmappedFlag(true);
                 read.setAttribute(SAMTag.MC.name(), null);      // Set the Mate Cigar String to null
             }
@@ -226,11 +235,12 @@ public class ReorderSam extends CommandLineProgram {
 
     /**
      * Constructs a mapping from read sequence records index -> new sequence dictionary index for use in
-     * reordering the reference index and mate reference index in each read.  -1 means unmapped.
+     * reordering the reference index and mate reference index in each read.  -1 (SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX)
+     * means unmapped.
      */
     private Map<Integer, Integer> buildSequenceDictionaryMap(final SAMSequenceDictionary refDict,
                                                              final SAMSequenceDictionary readsDict) {
-        Map<Integer, Integer> newOrder = new HashMap<Integer, Integer>();
+        Map<Integer, Integer> newOrder = new HashMap<>();
 
         log.info("Reordering SAM/BAM file:");
         for (final SAMSequenceRecord refRec : refDict.getSequences()) {
@@ -257,10 +267,11 @@ public class ReorderSam extends CommandLineProgram {
 
         for (SAMSequenceRecord readsRec : readsDict.getSequences()) {
             if (!newOrder.containsKey(readsRec.getSequenceIndex())) {
-                if (ALLOW_INCOMPLETE_DICT_CONCORDANCE)
-                    newOrder.put(readsRec.getSequenceIndex(), -1);
-                else
+                if (ALLOW_INCOMPLETE_DICT_CONCORDANCE) {
+                    newOrder.put(readsRec.getSequenceIndex(), NO_ALIGNMENT_REFERENCE_INDEX);
+                } else {
                     throw new PicardException("New reference sequence does not contain a matching contig for " + readsRec.getSequenceName());
+                }
             }
         }
 
@@ -273,7 +284,7 @@ public class ReorderSam extends CommandLineProgram {
     private void printDictionary(String name, SAMSequenceDictionary dict) {
         log.info(name);
         for (final SAMSequenceRecord contig : dict.getSequences()) {
-            log.info("  SN=%s LN=%d%n", contig.getSequenceName(), contig.getSequenceLength());
+            log.info(String.format("   SN=%s LN=%d%n", contig.getSequenceName(), contig.getSequenceLength()));
         }
     }
 }

--- a/src/main/java/picard/sam/ValidateSamFile.java
+++ b/src/main/java/picard/sam/ValidateSamFile.java
@@ -66,15 +66,15 @@ import java.util.List;
  *
  * This tool is a wrapper for {@link SamFileValidator}.
  *
- * <h4>Usage example:</h4>
+ * <h3>Usage example:</h3>
  * <pre>
- * java -jar picard.jar ValidateSamFile \\<br />
- *       I=input.bam \\<br />
+ * java -jar picard.jar ValidateSamFile \<br />
+ *       I=input.bam \<br />
  *       MODE=SUMMARY
  * </pre>
  * <p>To obtain a complete list with descriptions of both 'ERROR' and 'WARNING' messages, please see our additional
  *  <a href='https://www.broadinstitute.org/gatk/guide/article?id=7571'>documentation</a> for this tool.</p>
- * "<hr />
+ * <hr />
  *
  * @author Doug Voet
  */
@@ -100,14 +100,14 @@ public class ValidateSamFile extends CommandLineProgram {
 
             "<p>After identifying and fixing your 'warnings/errors', we recommend that you rerun this tool to validate your SAM/BAM " +
             "file prior to proceeding with your downstream analysis.  This will verify that all problems in your file have been addressed.</p>" +
-            "<h4>Usage example:</h4>" +
+            "<h3>Usage example:</h3>" +
             "<pre>" +
             "java -jar picard.jar ValidateSamFile \\<br />" +
             "      I=input.bam \\<br />" +
             "      MODE=SUMMARY" +
             "</pre>" +
             "<p>To obtain a complete list with descriptions of both 'ERROR' and 'WARNING' messages, please see our additional " +
-            " <a href='https://www.broadinstitute.org/gatk/guide/article?id=7571'>documentation</a> for this tool.</p>" +
+            "<a href='https://www.broadinstitute.org/gatk/guide/article?id=7571'>documentation</a> for this tool.</p>" +
             ""+
             "<hr />"+
             "Return codes depend on the errors/warnings discovered:" +
@@ -135,7 +135,7 @@ public class ValidateSamFile extends CommandLineProgram {
     public Mode MODE = Mode.VERBOSE;
 
     @Argument(doc = "List of validation error types to ignore.", optional = true)
-    public List<SAMValidationError.Type> IGNORE = new ArrayList<SAMValidationError.Type>();
+    public List<SAMValidationError.Type> IGNORE = new ArrayList<>();
 
     @Argument(shortName = "MO",
             doc = "The maximum number of lines output in verbose mode")

--- a/src/main/java/picard/util/SequenceDictionaryUtils.java
+++ b/src/main/java/picard/util/SequenceDictionaryUtils.java
@@ -1,0 +1,229 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package picard.util;
+
+import htsjdk.samtools.SAMSequenceDictionaryCodec;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.reference.ReferenceSequence;
+import htsjdk.samtools.reference.ReferenceSequenceFile;
+import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
+import htsjdk.samtools.util.CloseableIterator;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.RuntimeIOException;
+import htsjdk.samtools.util.SortingCollection;
+import htsjdk.samtools.util.StringUtil;
+import picard.PicardException;
+
+import java.io.BufferedWriter;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Class with helper methods for generating and writing SequenceDictionary objects.
+ */
+public class SequenceDictionaryUtils {
+
+    static public class SamSequenceRecordsIterator implements Iterator<SAMSequenceRecord> {
+        final private boolean truncateNamesAtWhitespace;
+        final private ReferenceSequenceFile refSeqFile;
+        private String genomeAssembly;
+        private String uri;
+
+        public void setGenomeAssembly(final String genomeAssembly) {
+            this.genomeAssembly = genomeAssembly;
+        }
+
+        public void setUri(final String uri) {
+            this.uri = uri;
+        }
+
+        public void setSpecies(final String species) {
+            this.species = species;
+        }
+
+        private String species;
+        private ReferenceSequence nextRefSeq;
+        private final MessageDigest md5;
+
+        public SamSequenceRecordsIterator(File referenceSequence, boolean truncateNamesAtWhitespace) {
+            this.truncateNamesAtWhitespace = truncateNamesAtWhitespace;
+            this.refSeqFile = ReferenceSequenceFileFactory.
+                    getReferenceSequenceFile(referenceSequence, truncateNamesAtWhitespace);
+
+            this.nextRefSeq = refSeqFile.nextSequence();
+            try {
+                md5 = MessageDigest.getInstance("MD5");
+            } catch (NoSuchAlgorithmException e) {
+                throw new PicardException("MD5 algorithm not found", e);
+            }
+        }
+
+        private String md5Hash(final byte[] bytes) {
+            md5.reset();
+            md5.update(bytes);
+            String s = new BigInteger(1, md5.digest()).toString(16);
+            if (s.length() != 32) {
+                final String zeros = "00000000000000000000000000000000";
+                s = zeros.substring(0, 32 - s.length()) + s;
+            }
+            return s;
+        }
+
+        /**
+         * Create one SAMSequenceRecord from a single fasta sequence
+         */
+        private SAMSequenceRecord makeSequenceRecord(final ReferenceSequence refSeq) {
+            final SAMSequenceRecord ret = new SAMSequenceRecord(refSeq.getName(), refSeq.length());
+
+            // Compute MD5 of upcased bases
+            final byte[] bases = refSeq.getBases();
+            for (int i = 0; i < bases.length; ++i) {
+                bases[i] = StringUtil.toUpperCase(bases[i]);
+            }
+
+            ret.setAttribute(SAMSequenceRecord.MD5_TAG, md5Hash(bases));
+            if (genomeAssembly != null) {
+                ret.setAttribute(SAMSequenceRecord.ASSEMBLY_TAG, genomeAssembly);
+            }
+            ret.setAttribute(SAMSequenceRecord.URI_TAG, uri);
+            if (species != null) {
+                ret.setAttribute(SAMSequenceRecord.SPECIES_TAG, species);
+            }
+            return ret;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return nextRefSeq != null;
+        }
+
+        @Override
+        public SAMSequenceRecord next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException("next() was called when hasNext() was false.");
+            }
+            final SAMSequenceRecord samSequenceRecord = makeSequenceRecord(nextRefSeq);
+            nextRefSeq = refSeqFile.nextSequence();
+            return samSequenceRecord;
+        }
+    }
+
+    /**
+     * Encodes a sequence dictionary
+     *
+     * @param writer                    a Buffered writer into which the dictionary will be written
+     * @param samSequenceRecordIterator an iterator that produces SAMSequenceRecords
+     * @throws IllegalArgumentException if the iterator produces two SAMSequenceRecord with the same name
+     */
+    public static void encodeDictionary(final BufferedWriter writer, Iterator<SAMSequenceRecord> samSequenceRecordIterator) {
+        final SAMSequenceDictionaryCodec samDictCodec = new SAMSequenceDictionaryCodec(writer);
+
+        samDictCodec.encodeHeaderLine(false);
+        // SortingCollection is used to check uniqueness of sequence names
+        final SortingCollection<String> sequenceNames = makeSortingCollection();
+
+        // read reference sequence one by one and write its metadata
+        while (samSequenceRecordIterator.hasNext()) {
+            final SAMSequenceRecord samSequenceRecord = samSequenceRecordIterator.next();
+            samDictCodec.encodeSequenceRecord(samSequenceRecord);
+            sequenceNames.add(samSequenceRecord.getSequenceName());
+        }
+
+        // check uniqueness of sequences names
+        final CloseableIterator<String> iterator = sequenceNames.iterator();
+
+        if (!iterator.hasNext()) {
+            return;
+        }
+
+        String current = iterator.next();
+        while (iterator.hasNext()) {
+            final String next = iterator.next();
+            if (current.equals(next)) {
+                throw new PicardException("Sequence name " + current +
+                        " appears more than once in reference file");
+            }
+            current = next;
+        }
+    }
+
+    public static SortingCollection<String> makeSortingCollection() {
+        final File tmpDir = IOUtil.createTempDir("SamDictionaryNames", null);
+        tmpDir.deleteOnExit();
+        // 256 byte for one name, and 1/10 part of all memory for this, rough estimate
+        long maxNamesInRam = Runtime.getRuntime().maxMemory() / 256 / 10;
+        return SortingCollection.newInstance(
+                String.class,
+                new StringCodec(),
+                String::compareTo,
+                (int) Math.min(maxNamesInRam, Integer.MAX_VALUE),
+                tmpDir.toPath()
+        );
+    }
+
+    private static class StringCodec implements SortingCollection.Codec<String> {
+        private DataInputStream dis;
+        private DataOutputStream dos;
+
+        public StringCodec clone() {
+            return new StringCodec();
+        }
+
+        public void setOutputStream(final OutputStream os) {
+            dos = new DataOutputStream(os);
+        }
+
+        public void setInputStream(final InputStream is) {
+            dis = new DataInputStream(is);
+        }
+
+        public void encode(final String str) {
+            try {
+                dos.writeUTF(str);
+            } catch (IOException e) {
+                throw new RuntimeIOException(e);
+            }
+        }
+
+        public String decode() {
+            try {
+                return dis.readUTF();
+            } catch (EOFException e) {
+                return null;
+            } catch (IOException e) {
+                throw new PicardException("Exception reading sequence name from temporary file.", e);
+            }
+        }
+    }
+}

--- a/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
+++ b/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
@@ -45,12 +45,13 @@ import java.util.stream.Collectors;
  * @author alecw@broadinstitute.org
  */
 public class CreateSequenceDictionaryTest extends CommandLineProgramTest {
-    private static File TEST_DATA_DIR = new File("testdata/picard");
-    private static File BASIC_FASTA = new File(TEST_DATA_DIR + "/sam", "basic.fasta");
-    private static File SPECIAL_FASTA = new File(TEST_DATA_DIR + "/sam", "special.fasta");
-    private static File SPECIAL_ALT = new File(TEST_DATA_DIR + "/sam", "special.alt");
-    private static File EQUIVALENCE_TEST_FASTA = new File(TEST_DATA_DIR + "/reference", "test.fasta");
-    private static File DUPLICATE_FASTA = new File(TEST_DATA_DIR + "/sam", "duplicate_sequence_names.fasta");
+    private static final File TEST_DATA_DIR = new File("testdata/picard");
+    private static final File BASIC_FASTA = new File(TEST_DATA_DIR + "/sam", "basic.fasta");
+    private static final File EQUIVALENCE_TEST_FASTA = new File(TEST_DATA_DIR + "/reference", "test.fasta");
+    private static final File DUPLICATE_FASTA = new File(TEST_DATA_DIR + "/sam", "duplicate_sequence_names.fasta");
+
+    private static final File SPECIAL_FASTA = new File(TEST_DATA_DIR + "/sam", "special.fasta");
+    private static final File SPECIAL_ALT = new File(TEST_DATA_DIR + "/sam", "special.alt");
 
     public String getCommandLineProgramName() {
         return CreateSequenceDictionary.class.getSimpleName();
@@ -93,13 +94,13 @@ public class CreateSequenceDictionaryTest extends CommandLineProgramTest {
         };
         Assert.assertEquals(runPicardCommandLine(argv), 0);
 
-        List<String> currentDict = new BufferedReader(new FileReader(outputDict))
+        final List<String> currentDict = new BufferedReader(new FileReader(outputDict))
                 .lines()
                 //remove info about location fasta file
                 .map(s -> s.replaceAll("UR:.*", ""))
                 .collect(Collectors.toList());
 
-        List<String> expectedDict = new BufferedReader(new FileReader(TEST_DATA_DIR + "/reference/csd_dict.dict"))
+        final List<String> expectedDict = new BufferedReader(new FileReader(TEST_DATA_DIR + "/reference/csd_dict.dict"))
                 .lines()
                 //remove info about location fasta file
                 .map(s -> s.replaceAll("UR:.*", ""))
@@ -147,29 +148,31 @@ public class CreateSequenceDictionaryTest extends CommandLineProgramTest {
                 "TRUNCATE_NAMES_AT_WHITESPACE=true"
         };
         Assert.assertEquals(runPicardCommandLine(argv), 0);
-        final SAMSequenceDictionary dict = SAMSequenceDictionaryExtractor.extractDictionary(outputDict);
+        final SAMSequenceDictionary dict = SAMSequenceDictionaryExtractor.extractDictionary(outputDict.toPath());
         Assert.assertNotNull(dict, "dictionary is null");
        
         // check chr1
-        SAMSequenceRecord ssr = dict.getSequence("chr1");
-        Assert.assertNotNull(ssr, "chr1 missing in dictionary");
-        String an = ssr.getAttribute("AN");
-        Assert.assertNotNull(an, "AN Missing");
-        Set<String> anSet = new HashSet<>(Arrays.asList(an.split("[,]")));
+
+        final SAMSequenceRecord ssr1 = dict.getSequence("chr1");
+        Assert.assertNotNull(ssr1, "chr1 missing in dictionary");
+        final String an1 = ssr1.getAttribute("AN");
+        Assert.assertNotNull(ssr1, "AN Missing");
+        Set<String> anSet = new HashSet<>(Arrays.asList(an1.split("[,]")));
+
         Assert.assertTrue(anSet.contains("1"));
         Assert.assertTrue(anSet.contains("01"));
         Assert.assertTrue(anSet.contains("k1"));
         Assert.assertFalse(anSet.contains("M"));
         
         // check chr2
-        ssr = dict.getSequence("chr2");
-        Assert.assertNotNull(ssr, "chr2 missing in dictionary");
-        an = ssr.getAttribute("AN");
-        Assert.assertNull(an, "AN Present");
+        SAMSequenceRecord ssr2 = dict.getSequence("chr2");
+        Assert.assertNotNull(ssr2, "chr2 missing in dictionary");
+        final String an2 = ssr2.getAttribute("AN");
+        Assert.assertNull(an2, "AN Present");
         
         // check chrM
-        ssr = dict.getSequence("chrM");
-        Assert.assertNull(ssr, "chrM present in dictionary");
+        final SAMSequenceRecord ssrM = dict.getSequence("chrM");
+        Assert.assertNull(ssrM, "chrM present in dictionary");
     }
 
     @Test

--- a/src/test/java/picard/sam/ReorderSamTest.java
+++ b/src/test/java/picard/sam/ReorderSamTest.java
@@ -1,0 +1,203 @@
+package picard.sam;
+
+import htsjdk.samtools.*;
+import htsjdk.variant.utils.SAMSequenceDictionaryExtractor;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import picard.cmdline.CommandLineProgramTest;
+import picard.sam.testers.ValidateSamTester;
+import picard.util.SequenceDictionaryUtils;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.*;
+
+
+public class ReorderSamTest extends CommandLineProgramTest {
+
+    @Override
+    public String getCommandLineProgramName() {
+        return ReorderSam.class.getSimpleName();
+    }
+
+    @DataProvider(name = "testDictionaryData")
+    public Iterator<Object[]> testDictionaryData() throws IOException {
+        List<Object[]> tests = new ArrayList<>();
+
+        final SAMRecordSetBuilder setBuilder = new SAMRecordSetBuilder();
+
+        setBuilder.addPair("pair1", setBuilder.getHeader().getSequenceIndex("chr1"), 1, 100);
+        setBuilder.addPair("pair2", setBuilder.getHeader().getSequenceIndex("chr2"), 1, 100);
+        setBuilder.addPair("pair3", setBuilder.getHeader().getSequenceIndex("chr3"), 1, 100);
+        setBuilder.addPair("pair4", setBuilder.getHeader().getSequenceIndex("chr4"), 1, 100);
+        setBuilder.addPair("pair5", setBuilder.getHeader().getSequenceIndex("chr5"), 1, 100);
+
+        setBuilder.addUnmappedFragment("unmapped_frag");
+        setBuilder.addUnmappedPair("unmapped_pair");
+
+        setBuilder.addPair("split_pair1",
+                setBuilder.getHeader().getSequenceIndex("chr1"),
+                setBuilder.getHeader().getSequenceIndex("chr6"),
+                100, 200,
+                false, false, "36M",
+                "36M", true, false, false,
+                false, 30);
+
+        setBuilder.addPair("split_pair2",
+                setBuilder.getHeader().getSequenceIndex("chr1"),
+                setBuilder.getHeader().getSequenceIndex("chr6"),
+                100, 200,
+                false, true, "36M",
+                "*", true, false, false,
+                false, 30);
+
+        { // same dictionary, but different order
+            final List<SAMSequenceRecord> sequences = new ArrayList<>(new SAMRecordSetBuilder().getHeader().getSequenceDictionary().getSequences());
+            Collections.shuffle(sequences, new Random(42));
+
+            tests.add(new Object[]{setBuilder, sequences, true, 0});
+            tests.add(new Object[]{setBuilder, sequences, false, 0});
+        }
+        { // same dictionary, but different lengths
+            final List<SAMSequenceRecord> sequences = new ArrayList<>(new SAMRecordSetBuilder().getHeader().getSequenceDictionary().getSequences());
+            sequences.forEach(s -> s.setSequenceLength(s.getSequenceLength() + 1));
+
+            tests.add(new Object[]{setBuilder, sequences, false, 1});
+            tests.add(new Object[]{setBuilder, sequences, true, 1});
+        }
+
+        { // dropped contigs with split reads
+
+            final List<SAMSequenceRecord> sequences = new ArrayList<>(new SAMRecordSetBuilder().getHeader().getSequenceDictionary().getSequences());
+            sequences.remove(setBuilder.getHeader().getSequenceDictionary().getSequence("chr6"));
+            sequences.remove(setBuilder.getHeader().getSequenceDictionary().getSequence("chr7"));
+            sequences.remove(setBuilder.getHeader().getSequenceDictionary().getSequence("chr8"));
+            sequences.remove(setBuilder.getHeader().getSequenceDictionary().getSequence("chr9"));
+
+            Collections.shuffle(sequences, new Random(42));
+
+            tests.add(new Object[]{setBuilder, sequences, true, 0});
+            tests.add(new Object[]{setBuilder, sequences, false, 1});
+        }
+
+        { // dropped contigs with no reads
+
+            final List<SAMSequenceRecord> sequences = new ArrayList<>(new SAMRecordSetBuilder().getHeader().getSequenceDictionary().getSequences());
+            sequences.remove(setBuilder.getHeader().getSequenceDictionary().getSequence("chr7"));
+            sequences.remove(setBuilder.getHeader().getSequenceDictionary().getSequence("chr8"));
+            sequences.remove(setBuilder.getHeader().getSequenceDictionary().getSequence("chr9"));
+
+            Collections.shuffle(sequences, new Random(42));
+
+            tests.add(new Object[]{setBuilder, sequences, true, 0});
+            tests.add(new Object[]{setBuilder, sequences, false, 1});
+        }
+
+        { // added contigs
+
+            final List<SAMSequenceRecord> sequences = new ArrayList<>(new SAMRecordSetBuilder().getHeader().getSequenceDictionary().getSequences());
+            sequences.add(new SAMSequenceRecord("test1", 100));
+            sequences.add(new SAMSequenceRecord("test2", 100));
+            sequences.add(new SAMSequenceRecord("test3", 100));
+            sequences.add(new SAMSequenceRecord("test4", 100));
+            Collections.shuffle(sequences, new Random(42));
+
+            tests.add(new Object[]{setBuilder, sequences, true, 0});
+            tests.add(new Object[]{setBuilder, sequences, false, 0});
+        }
+
+        { //dropped contigs with reads
+
+            final List<SAMSequenceRecord> sequences = new ArrayList<>(new SAMRecordSetBuilder().getHeader().getSequenceDictionary().getSequences());
+            sequences.remove(setBuilder.getHeader().getSequenceDictionary().getSequence("chr1"));
+            sequences.remove(setBuilder.getHeader().getSequenceDictionary().getSequence("chr2"));
+
+            tests.add(new Object[]{setBuilder, sequences, true, 0});
+            tests.add(new Object[]{setBuilder, sequences, false, 1});
+
+        }
+        return tests.iterator();
+    }
+
+    @Test(dataProvider = "testDictionaryData")
+    public void TestsWithIndex(final SAMRecordSetBuilder builder, final List<SAMSequenceRecord> sequences, final boolean allowIncomplete, final int expected) throws IOException {
+
+        final File dictionary = File.createTempFile("reorder", ".dict");
+        dictionary.deleteOnExit();
+        writeDictionary(dictionary, sequences);
+
+        final File bam = File.createTempFile("reorderIN" , ".bam");
+        bam.deleteOnExit();
+        final File bamIndex = new File(bam + ".bai");
+        bamIndex.deleteOnExit();
+
+        final File bamOut = File.createTempFile("reorderOUT", ".bam");
+        bamOut.deleteOnExit();
+        final File bamOutIndex = new File(bamOut + ".bai");
+        bamOutIndex.deleteOnExit();
+
+        tester(bam, bamOut, builder, dictionary, allowIncomplete, expected);
+    }
+
+    @Test(dataProvider = "testDictionaryData")
+    public void TestsWithoutIndex(final SAMRecordSetBuilder builder, final List<SAMSequenceRecord> sequences, final boolean allowIncomplete, final int expected) throws IOException {
+        final File sam = File.createTempFile("reorder", ".sam");
+        sam.deleteOnExit();
+
+        final File dictionary = File.createTempFile("reorder", ".dict");
+        dictionary.deleteOnExit();
+        writeDictionary(dictionary, sequences);
+
+        final File bamOut = File.createTempFile("reorder", ".bam");
+        bamOut.deleteOnExit();
+        final File bamOutIndex = new File(bamOut + ".bai");
+        bamOutIndex.deleteOnExit();
+
+        tester(sam, bamOut, builder, dictionary, allowIncomplete, expected);
+    }
+
+    private void tester(File input, File output, final SAMRecordSetBuilder builder, final File dictionary, final boolean allowIncomplete, final int expected) {
+
+        try (SAMFileWriter writer = new SAMFileWriterFactory()
+                .setCreateIndex(true).makeWriter(builder.getHeader(), false, input, null)) {
+            for (final SAMRecord record : builder) {
+                writer.addAlignment(record);
+            }
+        }
+
+        final ValidateSamTester inputValidator = new ValidateSamTester();
+        final List<SAMValidationError.Type> ignoreList = Collections.singletonList(SAMValidationError.Type.MISSING_TAG_NM);
+        inputValidator.setIgnoreError(ignoreList);
+        inputValidator.assertSamValid(input);
+
+        final String[] args = new String[]{
+                "INPUT=" + input.getAbsolutePath(),
+                "OUTPUT=" + output.getAbsolutePath(),
+                "SEQUENCE_DICTIONARY=" + dictionary.getAbsolutePath(),
+                "ALLOW_INCOMPLETE_DICT_CONCORDANCE=" + allowIncomplete
+        };
+
+        Assert.assertEquals(runPicardCommandLine(args), expected);
+
+        if (expected == 0) {
+            Assert.assertTrue(SAMSequenceDictionaryExtractor.extractDictionary(output.toPath()).isSameDictionary(
+                    SAMSequenceDictionaryExtractor.extractDictionary(dictionary.toPath())));
+
+            Assert.assertFalse(SAMSequenceDictionaryExtractor.extractDictionary(output.toPath()).isSameDictionary(
+                    SAMSequenceDictionaryExtractor.extractDictionary(input.toPath())));
+
+            final ValidateSamTester outputValidator = new ValidateSamTester();
+            outputValidator.setIgnoreError(ignoreList);
+            outputValidator.assertSamValid(output);
+        }
+    }
+
+    private static void writeDictionary(final File dictionary, Collection<SAMSequenceRecord> sequences) throws IOException {
+        try (BufferedWriter bufWriter = new BufferedWriter(new FileWriter(dictionary))) {
+            SequenceDictionaryUtils.encodeDictionary(bufWriter, sequences.iterator());
+        }
+    }
+}

--- a/src/test/java/picard/sam/testers/ValidateSamTester.java
+++ b/src/test/java/picard/sam/testers/ValidateSamTester.java
@@ -1,21 +1,34 @@
 package picard.sam.testers;
 
+import htsjdk.samtools.SAMValidationError;
 import org.testng.Assert;
 import picard.cmdline.CommandLineProgramTest;
 import picard.sam.ValidateSamFile;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Created by ggrant on 6/12/14.
  */
 public class ValidateSamTester extends CommandLineProgramTest {
+    private Collection<SAMValidationError.Type> ignoreErrors = Collections.emptyList();
     public String getCommandLineProgramName() {
         return ValidateSamFile.class.getSimpleName();
     }
 
+    public void setIgnoreError(final Collection<SAMValidationError.Type> errorsToIgnore){
+        ignoreErrors = new ArrayList<>(errorsToIgnore);
+    }
+
     public void assertSamValid(final File samFile) {
-        final int validateExitStatus = runPicardCommandLine(new String[]{"I=" + samFile.getAbsolutePath()});
-        Assert.assertEquals(validateExitStatus, 0);
+        final List<String> args = new ArrayList<>();
+        args.add("I=" + samFile.getAbsolutePath());
+        ignoreErrors.forEach(s -> args.add("IGNORE=" + s));
+        final int validateExitStatus = runPicardCommandLine(args.toArray(new String[0]));
+        Assert.assertEquals(validateExitStatus, 0, "There were problems in file: " + samFile.getAbsolutePath());
     }
 }


### PR DESCRIPTION
....and input type is BAM.

Also fixed logical problem that Reference was used both to open input (e.g. for cram) and to use as dictionary for new file.

Added a required input SEQUENCE_DICTIONARY and made REFERENCE_SEQUENCE not required.
This changes the API!

Added tests (was untested).

Refactored the code that writes a dictionary (using it in the test)

fixes #974.
supercedes #1073 

### Description

_Give your PR a **concise** yet **descriptive** title_
_Please explain the changes you made here._
_Explain the **motivation** for making this change. What existing problem does the pull request solve?_
_Mention any issues fixed, addressed or otherwise related to this pull request, including issue numbers or hard links for issues in other repos._
_You can delete these instructions once you have written your PR description._

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

