### PR TITLE
RevertSam does not accept /dev/stdin - fixed.

### DIFF
--- a/src/main/java/picard/sam/RevertSam.java
+++ b/src/main/java/picard/sam/RevertSam.java
@@ -581,9 +581,9 @@ public class RevertSam extends CommandLineProgram {
 
         final Map<SAMReadGroupRecord, FastqQualityFormat> readGroupToFormat = new HashMap<>();
 
-        List<PeekableIterator<SAMRecord>> iterators = sorter.iterators();
-        for (PeekableIterator<SAMRecord> iterator : iterators) {
-            SAMReadGroupRecord readGroup = iterator.peek().getReadGroup();
+        final List<PeekableIterator<SAMRecord>> iterators = sorter.iterators();
+        for (final PeekableIterator<SAMRecord> iterator : iterators) {
+            final SAMReadGroupRecord readGroup = iterator.peek().getReadGroup();
 
             if (readGroup == null) {
                 continue;


### PR DESCRIPTION
    1 - setDestructiveIteration property of SortingCollection of SAMRecords in RevertSamSorter constructor  to 'false' value:
			singleSorter.setDestructiveIteration(false);

	2 - createReadGroupFormatMap method refactoring; // processing previously filled SortingCollections by RevertSamSorter iterators instead of reading files from /dev/stdin
		2.2 - deletion of unnecessary properties;
		2.3 - use iteration inside each of the ReadGroup;
		2.4 - readGroup NPE fix;

### Description
This pull request contains fix to the issue at https://github.com/broadinstitute/picard/issues/1008.

The problem was that **RevertSam tool didn't work with /dev/stdin in a proper way**, it couldn't define file qualities to restore the previous state of BAM-file on input.

I've **changed the structure of readGroupToFormat()** mapping in RevertSam class. Previously this map was filling by the second iteration of /dev/stdin. I **made filling this map by SortingCollection** that was build by the first iteration of /dev/stdin.
Actually the second iteration of /dev/stdin led to NullPointerException as buffer gets empty after filling sorting collection. 

**In readGroupToFormat()** method i've **changed input parameters**, replaced the unnecessary SAMReadGroupRecord iterator with iterator of Sorting Collection.

I also **changed setDestructiveIteration() parameter** of SortingCollection in RevertSamSorter constructor for the reason that iteration on SortingCOllection began from the element with 0 index that was null, instead of the element with index 1.

----

### Checklist (never delete this)

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

