### PR TITLE
Simple tracking/logging of liftover success by contig

### DIFF
--- a/src/main/java/picard/vcf/LiftoverVcf.java
+++ b/src/main/java/picard/vcf/LiftoverVcf.java
@@ -388,7 +388,7 @@ public class LiftoverVcf extends CommandLineProgram {
         contigUnion.addAll(rejectsByContig.keySet());
 
         log.info("liftover success by source contig:");
-        for (String contig : contigUnion){
+        for (String contig : contigUnion) {
             final long success = liftedBySourceContig.getOrDefault(contig, 0L);
             final long fail = rejectsByContig.getOrDefault(contig, 0L);
             final String liftPct = pfmt.format((double)success / (double)(success + fail));
@@ -397,10 +397,10 @@ public class LiftoverVcf extends CommandLineProgram {
         }
 
         log.info("lifted variants by target contig:");
-        for (String contig : liftedByDestContig.keySet()){
+        for (String contig : liftedByDestContig.keySet()) {
             log.info(contig, ": ", liftedByDestContig.get(contig));
         }
-        if (liftedByDestContig.isEmpty()){
+        if (liftedByDestContig.isEmpty()) {
             log.info("no successfully lifted variants");
         }
 
@@ -433,13 +433,11 @@ public class LiftoverVcf extends CommandLineProgram {
 
     private void trackLiftedVariantContig(Map<String, Long> map, String contig) {
         Long val = map.get(contig);
-        if (val == null){
+        if (val == null) {
             val = 0L;
         }
 
-        val++;
-
-        map.put(contig, val);
+        map.put(contig, ++val);
     }
 
     /**


### PR DESCRIPTION
### Description

When performing liftovers, especially from more dissimilar genomes, it can be useful to understand liftover success/failure by contig.  This patch adds fairly simple tracking within LiftoverVcf based on source/target contig for variants that pass/failed liftover, and then logs this information on completion.  we already logged total passing/failed variants - this is just slightly more information.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

