### PR TITLE
Add option to SamToFastq for tags

### DIFF
--- a/src/main/java/picard/sam/SamToFastq.java
+++ b/src/main/java/picard/sam/SamToFastq.java
@@ -449,14 +449,14 @@ public class SamToFastq extends CommandLineProgram {
             final String tmpTagSep = SPLIT_SEPARATOR_TAGS.get(i);
             final String[] sequenceTagsToWrite = SPLIT_SEQUENCE_TAGS.get(i);
             final String newSequence = String.join(tmpTagSep, Arrays.stream(sequenceTagsToWrite)
-                    .map(read::getStringAttribute)
+                    .map(tag -> assertTagExists(read, tag))
                     .collect(Collectors.toList()));
 
             final String tmpQualSep = StringUtils.repeat(TAG_SPLIT_DEFAULT_QUAL, tmpTagSep.length());
             final String[] qualityTagsToWrite = SPLIT_QUALITY_TAGS.get(i);
             final String newQual = QUALITY_TAG_GROUP.isEmpty() ? StringUtils.repeat(TAG_SPLIT_DEFAULT_QUAL, newSequence.length()):
                     String.join(tmpQualSep, Arrays.stream(qualityTagsToWrite)
-                    .map(read::getStringAttribute)
+                    .map(tag -> assertTagExists(read, tag))
                     .collect(Collectors.toList()));
             FastqWriter writer = tagWriters.get(i);
             writer.write(new FastqRecord(seqHeader, newSequence, "", newQual));
@@ -477,6 +477,14 @@ public class SamToFastq extends CommandLineProgram {
             SPLIT_QUALITY_TAGS.add(QUALITY_TAG_GROUP.isEmpty() ? null : QUALITY_TAG_GROUP.get(i).trim().split(","));
             SPLIT_SEPARATOR_TAGS.add(TAG_GROUP_SEPERATOR.isEmpty() ? TAG_SPLIT_DEFAULT_SEP : TAG_GROUP_SEPERATOR.get(i));
         }
+    }
+
+    private String assertTagExists(final SAMRecord record, final String tag) {
+        String value = record.getStringAttribute(tag);
+        if (value == null) {
+            throw new PicardException("Record: " + record.getReadName() + " does have a value for tag: " + tag );
+        }
+        return value;
     }
 
     /**

--- a/src/main/java/picard/sam/SamToFastq.java
+++ b/src/main/java/picard/sam/SamToFastq.java
@@ -176,10 +176,10 @@ public class SamToFastq extends CommandLineProgram {
     @Argument(shortName = "STG", doc = "List of comma separated tag values to extract from Input SAM/BAM to be used as read sequence", optional = true)
     public List<String> SEQUENCE_TAG_GROUP;
 
-    @Argument(shortName = "QTG", doc = "List of comma separated tag values to extract from Input SAM/BAM to be used as read qualities")
+    @Argument(shortName = "QTG", doc = "List of comma separated tag values to extract from Input SAM/BAM to be used as read qualities", optional = true)
     public List<String> QUALITY_TAG_GROUP;
 
-    @Argument(shortName = "SEP", doc = "List of sequences to put in between each comma separated list of sequence tags (QFT)")
+    @Argument(shortName = "SEP", doc = "List of sequences to put in between each comma separated list of sequence tags (QFT)", optional = true)
     public List<String> TAG_GROUP_SEPERATOR;
 
     @Argument(shortName = "GZOPTG", doc = "Compress output FASTQ files per Tag grouping using gzip and append a .gz extension to the file names.")
@@ -565,11 +565,11 @@ public class SamToFastq extends CommandLineProgram {
         }
 
         if (!SEQUENCE_TAG_GROUP.isEmpty() && !QUALITY_TAG_GROUP.isEmpty() && SEQUENCE_TAG_GROUP.size() != QUALITY_TAG_GROUP.size()) {
-            errors.add("QUALITY_TAG_GROUP size must be equal to SEQUENCE_TAG_GROUP or not specified at all.");
+            errors.add("QUALITY_TAG_GROUP size must be equal to SEQUENCE_TAG_GROUP or not be specified at all.");
         }
 
         if (!SEQUENCE_TAG_GROUP.isEmpty() && !TAG_GROUP_SEPERATOR.isEmpty() && SEQUENCE_TAG_GROUP.size() != TAG_GROUP_SEPERATOR.size()) {
-            errors.add("TAG_GROUP_SEPERATOR size must be equal to SEQUENCE_TAG_GROUP or not specified at all.");
+            errors.add("TAG_GROUP_SEPERATOR size must be equal to SEQUENCE_TAG_GROUP or not be specified at all.");
         }
 
         if (!errors.isEmpty()) return errors.toArray(new String[errors.size()]);

--- a/src/main/java/picard/sam/SamToFastq.java
+++ b/src/main/java/picard/sam/SamToFastq.java
@@ -91,6 +91,22 @@ public class SamToFastq extends CommandLineProgram {
             "     I=input.bam<br />" +
             "     FASTQ=output.fastq" +
             "</pre>" +
+            "<h4>Tag Usage example:</h4>" +
+            "<br />" +
+            "This will create the fastq from read sequences alongside two fastq files.  One will be converted from the " +
+            " \"CR\" tag with quality from the \"CY\" tag.  The other fastq will be converted from the \"CB\" and \"UR\" " +
+            "tags concatenated together with no separator(not specified on command line) with the qualities croming from " +
+            "the \"CY\" and \"UY\" tags concatenated together." +
+            "<br />" +
+            "<pre>" +
+            "java -jar picard.jar SamToFastq <br />" +
+            "     I=input.bam<br />" +
+            "     FASTQ=output.fastq<br />" +
+            "     SEQUENCE_TAG_GROUP=CR<br />" +
+            "     QUALITY_TAG_GROUP=CY<br />" +
+            "     SEQUENCE_TAG_GROUP=\"CB,UR\"<br />" +
+            "     QUALITY_TAG_GROUP=\"CY,UY\"" +
+            "</pre>" +
             "<hr />";
     @Argument(doc = "Input SAM/BAM file to extract reads from", shortName = StandardOptionDefinitions.INPUT_SHORT_NAME)
     public File INPUT;

--- a/src/main/java/picard/sam/SamToFastq.java
+++ b/src/main/java/picard/sam/SamToFastq.java
@@ -95,7 +95,7 @@ public class SamToFastq extends CommandLineProgram {
             "<br />" +
             "This will create the fastq from read sequences alongside two fastq files.  One will be converted from the " +
             " \"CR\" tag with quality from the \"CY\" tag.  The other fastq will be converted from the \"CB\" and \"UR\" " +
-            "tags concatenated together with no separator(not specified on command line) with the qualities croming from " +
+            "tags concatenated together with no separator (not specified on command line) with the qualities coming from " +
             "the \"CY\" and \"UY\" tags concatenated together." +
             "<br />" +
             "<pre>" +
@@ -195,7 +195,7 @@ public class SamToFastq extends CommandLineProgram {
     @Argument(shortName = "QTG", doc = "List of comma separated tag values to extract from Input SAM/BAM to be used as read qualities", optional = true)
     public List<String> QUALITY_TAG_GROUP;
 
-    @Argument(shortName = "SEP", doc = "List of sequences to put in between each comma separated list of sequence tags (QFT)", optional = true)
+    @Argument(shortName = "SEP", doc = "List of sequences to put in between each comma separated list of sequence tags in each SEQUENCE_TAG_GROUP (STG)", optional = true)
     public List<String> TAG_GROUP_SEPERATOR;
 
     @Argument(shortName = "GZOPTG", doc = "Compress output FASTQ files per Tag grouping using gzip and append a .gz extension to the file names.")


### PR DESCRIPTION
This is still a WIP and doesn't have any tests or great documentation yet but is functional.  Any feedback on what currently exists would be greatly appreciated.

This functionality gives the user the ability to create fastq files from record tags.  Some single cell sequencing (3', 5') start their pipelines with different numbers of fastqs.  One fastq being the sequenced read and then a couple of other fastqs usually for some combination of cell barcode, UMI barcode, sample index.  When converted to sam/bam, these barcode fastq files are converted to tags for each record.  These changes allow for someone to recreate the original set of fastq files from a sam/bam using tags for say a reanalysis or subsetting of data.


----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

