### PR TITLE
Integrate @ExperimentalFeature and @BetaFeature tags

### DIFF
--- a/src/main/java/picard/analysis/CollectWgsMetricsWithNonZeroCoverage.java
+++ b/src/main/java/picard/analysis/CollectWgsMetricsWithNonZeroCoverage.java
@@ -54,7 +54,7 @@ import java.util.List;
 )
 public class CollectWgsMetricsWithNonZeroCoverage extends CollectWgsMetrics {
 
-    static final String USAGE_SUMMARY = "(Experimental) Collect metrics about coverage and performance of whole genome sequencing (WGS) experiments.  ";
+    static final String USAGE_SUMMARY = "Collect metrics about coverage and performance of whole genome sequencing (WGS) experiments.  ";
     static final String USAGE_DETAILS = "This tool collects metrics about the percentages of reads that pass base- and mapping- quality " +
             "filters as well as coverage (read-depth) levels. Both minimum base- and mapping-quality values as well as the maximum " +
             "read depths (coverage cap) are user defined.  This extends CollectWgsMetrics by including metrics related only to sites" +

--- a/src/main/java/picard/analysis/replicates/CollectIndependentReplicateMetrics.java
+++ b/src/main/java/picard/analysis/replicates/CollectIndependentReplicateMetrics.java
@@ -108,7 +108,7 @@ import static picard.cmdline.StandardOptionDefinitions.MINIMUM_MAPPING_QUALITY_S
         summary = "Estimates the rate of independent replication rate of reads within a bam. \n" +
                 "That is, it estimates the fraction of the reads which would be marked as duplicates but " +
                 "are actually biological replicates, independent observations of the data. ",
-        oneLineSummary = "(Experimental) Estimates the rate of independent replication of reads within a bam.",
+        oneLineSummary = "Estimates the rate of independent replication of reads within a bam.",
         programGroup = DiagnosticsAndQCProgramGroup.class
 )
 public class CollectIndependentReplicateMetrics extends CommandLineProgram {

--- a/src/main/java/picard/cmdline/PicardCommandLine.java
+++ b/src/main/java/picard/cmdline/PicardCommandLine.java
@@ -2,8 +2,10 @@ package picard.cmdline;
 
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.StringUtil;
+import org.broadinstitute.barclay.argparser.BetaFeature;
 import org.broadinstitute.barclay.argparser.CommandLineProgramGroup;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.ExperimentalFeature;
 
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -55,7 +57,7 @@ import java.util.stream.Collectors;
  */
 public class PicardCommandLine {
     private static final Log log = Log.getInstance(PicardCommandLine.class);
-    
+
     private static String initializeColor(final String color) {
         if (CommandLineDefaults.COLOR_STATUS) return color;
         else return "";
@@ -75,6 +77,10 @@ public class PicardCommandLine {
 
     /** The name of this unified command line program **/
     private final static String COMMAND_LINE_NAME = PicardCommandLine.class.getSimpleName();
+
+    /** Prefixes for class that annotated by @ExperimentalFeature and @BetaFeature **/
+    private final static String BETA_PREFIX = "**BETA FEATURE - WORK IN PROGRESS** ";
+    private final static String EXPERIMENTAL_PREFIX = "**EXPERIMENTAL FEATURE - USE AT YOUR OWN RISK** ";
 
     /** The packages we wish to include in our command line **/
     protected static List<String> getPackageList() {
@@ -258,9 +264,9 @@ public class PicardCommandLine {
                 }
                 if (!commandListOnly) {
                     if (clazz.getSimpleName().length() >= 45) {
-                        builder.append(String.format("%s    %s    %s%s%s\n", KGRN, clazz.getSimpleName(), KCYN, property.oneLineSummary(), KNRM));
+                        builder.append(String.format("%s    %s    %s%s%s%s\n", KGRN, clazz.getSimpleName(), KCYN, getFeaturePrefix(clazz), property.oneLineSummary(), KNRM));
                     } else {
-                        builder.append(String.format("%s    %-45s%s%s%s\n", KGRN, clazz.getSimpleName(), KCYN, property.oneLineSummary(), KNRM));
+                        builder.append(String.format("%s    %-45s%s%s%s\n", KGRN, clazz.getSimpleName(), KCYN, getFeaturePrefix(clazz), property.oneLineSummary(), KNRM));
                     }
                 }
                 else {
@@ -277,6 +283,20 @@ public class PicardCommandLine {
             System.err.print(builder.toString());
         }
     }
+
+    public static String getFeaturePrefix(Class clazz){
+        if (clazz.getAnnotation(ExperimentalFeature.class) != null){
+            return EXPERIMENTAL_PREFIX;
+        }
+
+        if (clazz.getAnnotation(BetaFeature.class) != null){
+            return BETA_PREFIX;
+        }
+
+        return "";
+    }
+
+
 
     /** similarity floor for matching in printUnknown **/
     private final static int HELP_SIMILARITY_FLOOR = 7;

--- a/src/main/java/picard/cmdline/PicardCommandLine.java
+++ b/src/main/java/picard/cmdline/PicardCommandLine.java
@@ -264,9 +264,17 @@ public class PicardCommandLine {
                 }
                 if (!commandListOnly) {
                     if (clazz.getSimpleName().length() >= 45) {
-                        builder.append(String.format("%s    %s    %s%s%s%s\n", KGRN, clazz.getSimpleName(), KCYN, getFeaturePrefix(clazz), property.oneLineSummary(), KNRM));
+                        builder.append(
+                                String.format("%s    %s    %s%s%s%s\n",
+                                        KGRN, clazz.getSimpleName(),
+                                        KCYN, getFeaturePrefix(clazz), property.oneLineSummary(),
+                                        KNRM));
                     } else {
-                        builder.append(String.format("%s    %-45s%s%s%s\n", KGRN, clazz.getSimpleName(), KCYN, getFeaturePrefix(clazz), property.oneLineSummary(), KNRM));
+                        builder.append(
+                                String.format("%s    %-45s%s%s%s\n",
+                                        KGRN, clazz.getSimpleName(),
+                                        KCYN, getFeaturePrefix(clazz), property.oneLineSummary(),
+                                        KNRM));
                     }
                 }
                 else {

--- a/src/main/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigar.java
@@ -68,7 +68,7 @@ import java.util.Set;
 @CommandLineProgramProperties(
         summary = "Examines aligned records in the supplied SAM or BAM file to locate duplicate molecules. " +
                 "All records are then written to the output file with the duplicate records flagged.",
-        oneLineSummary = "(Experimental) Examines aligned records in the supplied SAM or BAM file to locate duplicate molecules.",
+        oneLineSummary = "Examines aligned records in the supplied SAM or BAM file to locate duplicate molecules.",
         programGroup = ReadDataManipulationProgramGroup.class
 )
 public class SimpleMarkDuplicatesWithMateCigar extends MarkDuplicates {


### PR DESCRIPTION
### Description
Associated issue: https://github.com/broadinstitute/picard/issues/1072

#### Motivation: 
Tools marked with annotations @BetaFeature and @ExperimentalFeature should display related information in their description. 

#### Solution: 
I`ve created helper method getFeaturePrefix(Class clazz) that checks @BetaFeature and @ExperimentalFeature existence and adds corresponding prefix. Also I`ve changed PicardCommandLine.printUsage() by adding new method call.

----

### Checklist 

- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

