### PR TITLE
Jc base dir fix

### DIFF
--- a/src/main/java/picard/illumina/parser/PerTileFileUtil.java
+++ b/src/main/java/picard/illumina/parser/PerTileFileUtil.java
@@ -18,7 +18,7 @@ public class PerTileFileUtil extends ParameterizedFileUtil {
     }
 
     public PerTileFileUtil(final String extension, final File base,
-        final FileFaker faker, final int lane, final boolean skipEmptyFiles) {
+                           final FileFaker faker, final int lane, final boolean skipEmptyFiles) {
         super(true, extension, base, faker, lane, skipEmptyFiles);
         this.fileMap = getTiledFiles(base, matchPattern);
         if (!fileMap.isEmpty()) {
@@ -43,16 +43,19 @@ public class PerTileFileUtil extends ParameterizedFileUtil {
 
     @Override
     public List<String> verify(final List<Integer> expectedTiles, final int[] expectedCycles) {
-        final List<String> failures = new LinkedList<String>();
+        return verifyPerTile(this.base, expectedTiles);
+    }
 
-        if (!base.exists()) {
-            failures.add("Base directory(" + base.getAbsolutePath() + ") does not exist!");
+    List<String> verifyPerTile(File baseDir, List<Integer> expectedTiles) {
+        final List<String> failures = new LinkedList<>();
+        if (!baseDir.exists()) {
+            failures.add("Base directory(" + baseDir.getAbsolutePath() + ") does not exist!");
         } else {
-                if (!tiles.containsAll(expectedTiles)) {
-                    final List<Integer> missing = new ArrayList<Integer>(expectedTiles);
-                    missing.removeAll(tiles);
-                    failures.add("Missing tile " + missing + " for file type " + extension + ".");
-                }
+            if (!tiles.containsAll(expectedTiles)) {
+                final List<Integer> missing = new ArrayList<>(expectedTiles);
+                missing.removeAll(tiles);
+                failures.add("Missing tile " + missing + " for file type " + extension + ".");
+            }
         }
         return failures;
     }
@@ -60,7 +63,7 @@ public class PerTileFileUtil extends ParameterizedFileUtil {
     @Override
     public List<String> fakeFiles(final List<Integer> expectedTiles, final int[] cycles,
                                   final IlluminaFileUtil.SupportedIlluminaFormat format) {
-        final List<String> failures = new LinkedList<String>();
+        final List<String> failures = new LinkedList<>();
         if (!base.exists()) {
             failures.add("Base directory(" + base.getAbsolutePath() + ") does not exist!");
         } else {

--- a/src/main/java/picard/illumina/parser/PerTileOrPerRunFileUtil.java
+++ b/src/main/java/picard/illumina/parser/PerTileOrPerRunFileUtil.java
@@ -3,6 +3,7 @@ package picard.illumina.parser;
 import picard.illumina.parser.fakers.FileFaker;
 
 import java.io.File;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -31,5 +32,13 @@ public class PerTileOrPerRunFileUtil extends PerTileFileUtil {
     @Override
     public boolean checkTileCount() {
         return runFile == null;
+    }
+
+    @Override
+    public List<String> verify(final List<Integer> expectedTiles, final int[] expectedCycles) {
+        // if we have a runFile the base should be the parent directory of that file and not
+        // the lane base directory of a per tile file.
+        final File baseDir = runFile != null ? runFile.getParentFile() : this.base;
+        return verifyPerTile(baseDir, expectedTiles);
     }
 }

--- a/src/test/java/picard/illumina/CheckIlluminaDirectoryTest.java
+++ b/src/test/java/picard/illumina/CheckIlluminaDirectoryTest.java
@@ -370,8 +370,11 @@ public class CheckIlluminaDirectoryTest extends CommandLineProgramTest {
         writeTileMetricsOutFile(makeMap(makeList(lane), makeList(tileList)));
 
         createSingleLocsFile();
-        final File intensityLaneDir = new File(intensityDir, IlluminaFileUtil.longLaneStr(lane));
-        intensityLaneDir.mkdirs();
+        // if we aren't creating symlinks we shouldn't create lane dirs
+        if(createSymlinks) {
+            final File intensityLaneDir = new File(intensityDir, IlluminaFileUtil.longLaneStr(lane));
+            intensityLaneDir.mkdirs();
+        }
         Assert.assertEquals(runPicardCommandLine(args), 0);
         //now that we have created the loc files lets test to make sure they are there
         args = makeCheckerArgs(basecallDir, lane, "50T", new IlluminaDataType[]{IlluminaDataType.Position},


### PR DESCRIPTION
Per run file check still looks for the lane base directory which doesn't exist in most cases. This change fixes the check to look at the run files parent directory instead.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

