### PR TITLE
remove non-ascii character from comment

### DIFF
--- a/src/main/java/picard/util/LiftoverUtils.java
+++ b/src/main/java/picard/util/LiftoverUtils.java
@@ -342,7 +342,7 @@ public class LiftoverUtils {
      *    Note: this will modify the start/stop and alleles of this builder.
      *    Also note: if the reference allele does not match the reference sequence, this method will throw an exception
      *
-     *    Based on Adrian Tan, Gonçalo R. Abecasis and Hyun Min Kang. (2015)
+     *    Based on Adrian Tan, Gon&ccedil;alo R. Abecasis and Hyun Min Kang. (2015)
      *    Unified Representation of Genetic Variants. Bioinformatics.
      *
      */


### PR DESCRIPTION
### Description



* Removing an accented `ç` character and replacing it with an ASCII `c`
* This character is causing problems downstream in GATK.  There's some system setup which results in exceptions when they encounter this.  See https://github.com/broadinstitute/gatk/issues/4434.

---
### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

