### PR TITLE
Get set of genes from OverlapDetector once rather than over and over, for speed.

### DIFF
--- a/src/main/java/picard/analysis/directed/RnaSeqMetricsCollector.java
+++ b/src/main/java/picard/analysis/directed/RnaSeqMetricsCollector.java
@@ -38,6 +38,7 @@ public class RnaSeqMetricsCollector extends SAMRecordMultiLevelCollector<RnaSeqM
     final private Set<Integer> ignoredSequenceIndices;
 
     private final OverlapDetector<Gene> geneOverlapDetector;
+    private final Set<Gene> allGenes;
     private final OverlapDetector<Interval> ribosomalSequenceOverlapDetector;
     private final boolean collectCoverageStatistics;
     
@@ -48,6 +49,8 @@ public class RnaSeqMetricsCollector extends SAMRecordMultiLevelCollector<RnaSeqM
         this.ribosomalInitialValue  = ribosomalBasesInitialValue;
         this.ignoredSequenceIndices = ignoredSequenceIndices;
         this.geneOverlapDetector    = geneOverlapDetector;
+        // This is an expensive operation, so do it once up front.
+        this.allGenes               = geneOverlapDetector.getAll();
         this.ribosomalSequenceOverlapDetector = ribosomalSequenceOverlapDetector;
         this.minimumLength          = minimumLength;
         this.strandSpecificity      = strandSpecificity;
@@ -435,7 +438,7 @@ public class RnaSeqMetricsCollector extends SAMRecordMultiLevelCollector<RnaSeqM
             final Map<Gene.Transcript, Double> bestPerGene = new HashMap<Gene.Transcript, Double>();
 
             // Make a map of the best transcript per gene to it's mean coverage
-            for (final Gene gene : geneOverlapDetector.getAll()) {
+            for (final Gene gene : allGenes) {
                 Gene.Transcript best = null;
                 double bestMean = 0;
 


### PR DESCRIPTION
### Description

Change: Compute set of genes (return value of overlapDetector.getAll()) once in RnaSeqMetricsCollector ctor, rather than over and over again in pickTranscripts().

Motivation: For Drop-seq data, there can be tens of thousands of libraries rather than the handful of libraries in a convention Rna-seq experiment, so computing this over and over is very time-consuming.

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

