### PR TITLE
CreateSequenceDictionary support for alternative names (@SQ-AN)

### DIFF
--- a/src/main/java/picard/sam/CreateSequenceDictionary.java
+++ b/src/main/java/picard/sam/CreateSequenceDictionary.java
@@ -112,7 +112,9 @@ public class CreateSequenceDictionary extends CommandLineProgram {
 
     @Argument(shortName = "AN", doc = "Optional file containing the alternative names for the contigs. "
     		+ "Tools may use this information to consider different contig notations as identical (e.g: 'chr1' and '1'). "
-            + "First column is the original name, the second column is an alternative name. "
+    		+ "The alternative names will be put into the appropriate @AN annotation for each contig. "
+    		+ "No header. "
+    		+ "First column is the original name, the second column is an alternative name. "
             + "One contig may have more than one alternative name." ,
             optional=true)
     public File ALT_NAMES = null;

--- a/src/main/java/picard/sam/CreateSequenceDictionary.java
+++ b/src/main/java/picard/sam/CreateSequenceDictionary.java
@@ -48,7 +48,6 @@ import picard.cmdline.StandardOptionDefinitions;
 
 import java.io.*;
 import java.math.BigInteger;
-import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -59,7 +58,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * Create a SAM/BAM file from a fasta containing reference sequence. The output SAM file contains a header but no
@@ -113,8 +111,9 @@ public class CreateSequenceDictionary extends CommandLineProgram {
     public int NUM_SEQUENCES = Integer.MAX_VALUE;
 
     @Argument(shortName = "AN", doc = "Optional file containing the alternative names for the contigs. "
+    		+ "Tools may use this information to consider different contig notations as identical (e.g: 'chr1' and '1'). "
             + "First column is the original name, the second column is an alternative name. "
-            + "One contig may have more than one alternative name. " ,
+            + "One contig may have more than one alternative name." ,
             optional=true)
     public File ALT_NAMES = null;
 
@@ -331,15 +330,15 @@ public class CreateSequenceDictionary extends CommandLineProgram {
         // the map returned by the function
         final Map<String, Set<String>> aliasesByContig = new HashMap<>();
         try {
-            for (final String line :IOUtil.slurpLines(this.ALT_NAMES)) {
-            if (StringUtil.isBlank(line)) {
-                    continue;
-                }
+            for (final String line : IOUtil.slurpLines(this.ALT_NAMES)) {
+                if (StringUtil.isBlank(line)) {
+                        continue;
+                    }
                 final int tab = line.indexOf('\t');
-                if (tab == -1 ) {
+                if (tab == -1) {
                     throw new IOException("tabulation missing in " + line);
                 }
-                final String contigName = line.substring(0,tab);
+                final String contigName = line.substring(0, tab);
                 final String altName = line.substring(tab + 1);
                 // check for empty values
                 if (StringUtil.isBlank(contigName)) {
@@ -359,15 +358,15 @@ public class CreateSequenceDictionary extends CommandLineProgram {
                 // check alias not previously defined as contig
                 if (aliasesByContig.containsKey(altName)) {
                     throw new IOException("alternate name  " + altName +
-                            "previously defined as a contig in " + line);
+                            " previously defined as a contig in " + line);
                 }
                 // check contig not previously defined as alias
                 if (aliasesByContig.keySet().stream().
                         // not an error if defined twice for same contig
-                        filter(K->!K.equals(contigName)). 
-                        anyMatch(K->aliasesByContig.get(K).contains(contigName))) {
-                        throw new IOException("contig  " + contigName +
-                            "previously defined as an alternate name in " + line);
+                        filter(K -> !K.equals(contigName)). 
+                        anyMatch(K -> aliasesByContig.get(K).contains(contigName))) {
+                            throw new IOException("contig  " + contigName +
+                                " previously defined as an alternate name in " + line);
                 }
                 // add alias
                 if (!aliasesByContig.containsKey(contigName)) {

--- a/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
+++ b/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
@@ -126,7 +126,7 @@ public class CreateSequenceDictionaryTest extends CommandLineProgramTest {
     
     @Test
     public void testAltNames() throws Exception {
-        final File altFile = File.createTempFile("CreateSequenceDictionaryTest.", ".alt");
+        final File altFile = File.createTempFile("CreateSequenceDictionaryTest", ".alt");
         final PrintWriter pw = new PrintWriter(altFile);
         pw.println("chr1\t1");
         pw.println("chr1\t01");
@@ -168,7 +168,7 @@ public class CreateSequenceDictionaryTest extends CommandLineProgramTest {
         
         // check chrM
         ssr = dict.getSequence("chrM");
-        Assert.assertNull(ssr, "chrM presnt in dictionary");
+        Assert.assertNull(ssr, "chrM present in dictionary");
     }
 
 }

--- a/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
+++ b/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
@@ -25,13 +25,21 @@ package picard.sam;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.variant.utils.SAMSequenceDictionaryExtractor;
 import picard.cmdline.CommandLineProgramTest;
 import picard.PicardException;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -114,4 +122,53 @@ public class CreateSequenceDictionaryTest extends CommandLineProgramTest {
         Assert.assertEquals(runPicardCommandLine(argv), 0);
         Assert.fail("Exception should have been thrown.");
     }
+    
+    
+    @Test
+    public void testAltNames() throws Exception {
+        final File altFile = File.createTempFile("CreateSequenceDictionaryTest.", ".alt");
+        final PrintWriter pw = new PrintWriter(altFile);
+        pw.println("chr1\t1");
+        pw.println("chr1\t01");
+        pw.println("chr1\tk1");
+        pw.println("chrMT\tM");
+        pw.flush();
+        pw.close();
+        altFile.deleteOnExit();
+        
+        final File outputDict = File.createTempFile("CreateSequenceDictionaryTest.", ".dict");
+        outputDict.delete();
+        outputDict.deleteOnExit();
+        final String[] argv = {
+                "REFERENCE=" + BASIC_FASTA,
+                "AN=" + altFile,
+                "OUTPUT=" + outputDict,
+                "TRUNCATE_NAMES_AT_WHITESPACE=true"
+        };
+        Assert.assertEquals(runPicardCommandLine(argv), 0);
+        final SAMSequenceDictionary dict = SAMSequenceDictionaryExtractor.extractDictionary(outputDict);
+        Assert.assertNotNull(dict, "dictionary is null");
+       
+        // check chr1
+        SAMSequenceRecord ssr = dict.getSequence("chr1");
+        Assert.assertNotNull(ssr, "chr1 missing in dictionary");
+        String an = ssr.getAttribute("AN");
+        Assert.assertNotNull(ssr, "AN Missing");
+        Set<String> anSet = new HashSet<>(Arrays.asList(an.split("[,]")));
+        Assert.assertTrue(anSet.contains("1"));
+        Assert.assertTrue(anSet.contains("01"));
+        Assert.assertTrue(anSet.contains("k1"));
+        Assert.assertFalse(anSet.contains("M"));
+        
+        // check chr2
+        ssr = dict.getSequence("chr2");
+        Assert.assertNotNull(ssr, "chr2 missing in dictionary");
+        an = ssr.getAttribute("AN");
+        Assert.assertNull(an, "AN Present");
+        
+        // check chrM
+        ssr = dict.getSequence("chrM");
+        Assert.assertNull(ssr, "chrM presnt in dictionary");
+    }
+
 }


### PR DESCRIPTION
### Description

this PR add a new option **AN** in **CreateSequenceDictionary** to support the alternative name in a dictionary, as defined in the sam spec  https://github.com/samtools/hts-specs/blob/master/SAMv1.tex#L212

```
ALT_NAMES=File
AN=File                       Optional file containing the alternative names for the contigs. First column is the
                              original name, the second column is an alternative name. One contig may have more than one
                              alternative name.   Default value: null. 
```

In the code, I added a` Map<String,Set<String>>`  mapping the contigs to a set of aliases. This map is then used when a SamSequenceRecord is serialized.

a test was added in CreateSequenceDictionaryTest

Related PR  in htsjdk : https://github.com/samtools/htsjdk/pull/956/files

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

