### PR TITLE
Tl dsdegp 1641 check illumina directory return code

### DIFF
--- a/src/main/java/picard/illumina/CheckIlluminaDirectory.java
+++ b/src/main/java/picard/illumina/CheckIlluminaDirectory.java
@@ -23,6 +23,7 @@ import picard.illumina.parser.readers.CbclReader;
 import picard.illumina.parser.readers.LocsFileReader;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -56,7 +57,8 @@ public class CheckIlluminaDirectory extends CommandLineProgram {
             "and are reasonably sized for every tile and cycle.  Reasonably sized means non-zero sized for files that exist per tile and " +
             "equal size for binary files that exist per cycle or per tile. If DATA_TYPES {Position, BaseCalls, QualityScores, PF," +
             " or Barcodes} are not specified, then the default data types used by IlluminaBasecallsToSam are used.  " +
-            "CheckIlluminaDirectory DOES NOT check that the individual records in a file are well-formed.</p>" +
+            "CheckIlluminaDirectory DOES NOT check that the individual records in a file are well-formed. If there are errors, " +
+            "the number of errors is written in a file called 'errors.count' in the working directory</p>" +
             "" +
             "<h4>Usage example:</h4> " +
             "<pre>" +
@@ -233,6 +235,12 @@ public class CheckIlluminaDirectory extends CommandLineProgram {
             log.info("SUCCEEDED!  All required files are present and non-empty.");
         } else {
             status = 1;
+            try {
+                Files.write(Paths.get(".", "errors.count"), Integer.toString(totalFailures).getBytes());
+            }
+            catch (IOException e) {
+                log.error("Unable to write number off errors to file");
+            }
             log.info("FAILED! There were " + totalFailures + " in the following lanes: " + StringUtil
                     .join(", ", failingLanes));
         }

--- a/src/main/java/picard/illumina/CheckIlluminaDirectory.java
+++ b/src/main/java/picard/illumina/CheckIlluminaDirectory.java
@@ -165,16 +165,13 @@ public class CheckIlluminaDirectory extends CommandLineProgram {
 
                 //check s.locs
                 final File locsFile = new File(BASECALLS_DIR.getParentFile(), AbstractIlluminaPositionFileReader.S_LOCS_FILE);
-                final List<AbstractIlluminaPositionFileReader.PositionInfo> locs;
-                final Map<Integer, File> filterFileMap;
+                final List<AbstractIlluminaPositionFileReader.PositionInfo> locs = new ArrayList<>();
+                final Map<Integer, File> filterFileMap = new HashMap<>();
                 try (LocsFileReader locsFileReader = new LocsFileReader(locsFile)) {
-                    locs = new ArrayList<>();
                     while (locsFileReader.hasNext()) {
                         locs.add(locsFileReader.next());
                     }
                 }
-
-                filterFileMap = new HashMap<>();
                 for (final File filterFile : filterFiles) {
                     filterFileMap.put(fileToTile(filterFile.getName()), filterFile);
                 }

--- a/src/main/java/picard/illumina/CheckIlluminaDirectory.java
+++ b/src/main/java/picard/illumina/CheckIlluminaDirectory.java
@@ -165,8 +165,8 @@ public class CheckIlluminaDirectory extends CommandLineProgram {
 
                 //check s.locs
                 final File locsFile = new File(BASECALLS_DIR.getParentFile(), AbstractIlluminaPositionFileReader.S_LOCS_FILE);
-                List<AbstractIlluminaPositionFileReader.PositionInfo> locs;
-                Map<Integer, File> filterFileMap;
+                final List<AbstractIlluminaPositionFileReader.PositionInfo> locs;
+                final Map<Integer, File> filterFileMap;
                 try (LocsFileReader locsFileReader = new LocsFileReader(locsFile)) {
                     locs = new ArrayList<>();
                     while (locsFileReader.hasNext()) {
@@ -238,9 +238,9 @@ public class CheckIlluminaDirectory extends CommandLineProgram {
         } else {
             status = 1;
             try {
-                Files.write(Paths.get(".", "errors.count"), Integer.toString(totalFailures).getBytes());
+                Files.write(Paths.get("./errors.count"), Integer.toString(totalFailures).getBytes());
             } catch (IOException e) {
-                log.error("Unable to write number off errors to file");
+                log.error("Unable to write number of errors to file", e);
             }
             log.info("FAILED! There were " + totalFailures + " in the following lanes: " + StringUtil
                     .join(", ", failingLanes));

--- a/src/main/java/picard/illumina/CheckIlluminaDirectory.java
+++ b/src/main/java/picard/illumina/CheckIlluminaDirectory.java
@@ -23,6 +23,8 @@ import picard.illumina.parser.readers.CbclReader;
 import picard.illumina.parser.readers.LocsFileReader;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -230,7 +232,7 @@ public class CheckIlluminaDirectory extends CommandLineProgram {
         if (totalFailures == 0) {
             log.info("SUCCEEDED!  All required files are present and non-empty.");
         } else {
-            status = totalFailures;
+            status = 1;
             log.info("FAILED! There were " + totalFailures + " in the following lanes: " + StringUtil
                     .join(", ", failingLanes));
         }

--- a/src/test/java/picard/illumina/CheckIlluminaDirectoryTest.java
+++ b/src/test/java/picard/illumina/CheckIlluminaDirectoryTest.java
@@ -24,6 +24,9 @@ import java.io.RandomAccessFile;
 import java.nio.ByteOrder;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -296,7 +299,18 @@ public class CheckIlluminaDirectoryTest extends CommandLineProgramTest {
         writeTileMetricsOutFile(makeMap(makeList(lane - 1, lane + 1, lane), makeList(makeList(1, 2, 3), tiles, tiles)));
 
         final String[] args = makeCheckerArgs(basecallDir, lane, readStructure, dataTypes, filterTiles, makeFakeFiles, false);
-        Assert.assertEquals(runPicardCommandLine(args), expectedNumErrors);
+        final int returnCode = runPicardCommandLine(args);
+        Assert.assertEquals(returnCode, 1);
+
+        try {
+            final int numErrors = Integer.parseInt(new String(Files.readAllBytes(Paths.get("./errors.count"))));
+            Assert.assertEquals(numErrors, expectedNumErrors);
+            Files.deleteIfExists(Paths.get("./errors.count"));
+        }
+        catch (IOException e) {
+            Assert.fail("Could not read the number of errors from file", e);
+        }
+
         //if we previously faked files make sure CheckIlluminaDirectory returns with no failures
         if (makeFakeFiles) {
             Assert.assertEquals(runPicardCommandLine(args), 0);

--- a/src/test/java/picard/illumina/CheckIlluminaDirectoryTest.java
+++ b/src/test/java/picard/illumina/CheckIlluminaDirectoryTest.java
@@ -303,9 +303,10 @@ public class CheckIlluminaDirectoryTest extends CommandLineProgramTest {
         Assert.assertEquals(returnCode, 1);
 
         try {
-            final int numErrors = Integer.parseInt(new String(Files.readAllBytes(Paths.get("./errors.count"))));
+            final Path errorPath = Paths.get("./errors.count");
+            final int numErrors = Integer.parseInt(new String(Files.readAllBytes(errorPath)));
             Assert.assertEquals(numErrors, expectedNumErrors);
-            Files.deleteIfExists(Paths.get("./errors.count"));
+            Files.deleteIfExists(errorPath);
         }
         catch (IOException e) {
             Assert.fail("Could not read the number of errors from file", e);


### PR DESCRIPTION
### Description
`CheckIlluminaDirectory` currently returns the number of errors encountered as its return code. The problem with this is that the standard is that only 8 bits (255) are used for return codes, and some return codes have special meanings. For example, there was recently a situation where the return code, modulus 255, meant that Sun GridEngine retried the job thousands of times because a failing return code was interpreted as something else. 

This PR changes `CheckIlluminaDirectory` to return `1` on error and `0` on success. If there are errors, the number of errors is written to `errors.count` in the current working directory. 

While I was in there, I replaced some unsafe operations with try with resources to make things safer.
----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

