### PR TITLE
Made unpaired reads not fall through to paired read checks

### DIFF
--- a/src/main/java/picard/sam/RevertSam.java
+++ b/src/main/java/picard/sam/RevertSam.java
@@ -429,13 +429,15 @@ public class RevertSam extends CommandLineProgram {
                         if (unpairedRecord == null) unpairedRecord = rec;
                         ++unpaired;
                     }
-                    if (rec.getFirstOfPairFlag()) {
-                        if (firstRecord == null) firstRecord = rec;
-                        ++firsts;
-                    }
-                    if (rec.getSecondOfPairFlag()) {
-                        if (secondRecord == null) secondRecord = rec;
-                        ++seconds;
+                    else {
+                        if (rec.getFirstOfPairFlag()) {
+                            if (firstRecord == null) firstRecord = rec;
+                            ++firsts;
+                        }
+                        if (rec.getSecondOfPairFlag()) {
+                            if (secondRecord == null) secondRecord = rec;
+                            ++seconds;
+                        }
                     }
                 }
 

--- a/src/main/java/picard/sam/RevertSam.java
+++ b/src/main/java/picard/sam/RevertSam.java
@@ -426,16 +426,21 @@ public class RevertSam extends CommandLineProgram {
                 SAMRecord firstRecord = null, secondRecord = null, unpairedRecord = null;
                 for (final SAMRecord rec : recs) {
                     if (!rec.getReadPairedFlag()) {
-                        if (unpairedRecord == null) unpairedRecord = rec;
+                        if (unpairedRecord == null) {
+                            unpairedRecord = rec;
+                        }
                         ++unpaired;
-                    }
-                    else {
+                    } else {
                         if (rec.getFirstOfPairFlag()) {
-                            if (firstRecord == null) firstRecord = rec;
+                            if (firstRecord == null) {
+                                firstRecord = rec;
+                            }
                             ++firsts;
                         }
                         if (rec.getSecondOfPairFlag()) {
-                            if (secondRecord == null) secondRecord = rec;
+                            if (secondRecord == null) {
+                                secondRecord = rec;
+                            }
                             ++seconds;
                         }
                     }

--- a/src/test/java/picard/sam/RevertSamTest.java
+++ b/src/test/java/picard/sam/RevertSamTest.java
@@ -188,6 +188,14 @@ public class RevertSamTest extends CommandLineProgramTest {
         Assert.assertEquals(result, 0, "Validation of reverted single-end sample failed.");
     }
 
+    @Test
+    public void testSingleEndSanitize() throws Exception {
+        final File output = File.createTempFile("single_end_reverted", ".sam");
+        output.deleteOnExit();
+        final String args[] = { "INPUT=" + singleEndSamToRevert, "OUTPUT=" + output.getAbsolutePath(), "SANITIZE=true"};
+        Assert.assertEquals(runPicardCommandLine(args), 0, "Sanitation of single-end sample failed.");
+    }
+
     private void verifyPositiveResults(
             final File outputFile,
             final RevertSam reverter,


### PR DESCRIPTION
### Description

RevertSam had a bug in the sanitation step where unpaired records would fall through to code blocks that required paired records, which caused sanitation to fail. This PR fixes that.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

