### PR TITLE
Include google-cloud-nio only in the cloudJar, not in the shadowJar.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ final javadocJDKFiles = files(((URLClassLoader) ToolProvider.getSystemToolClassL
 configurations {
     cloudConfiguration {
         extendsFrom runtime
+        dependencies {
+            cloudConfiguration('com.google.cloud:google-cloud-nio:' + googleNioVersion)
+        }
     }
 }
 
@@ -68,10 +71,6 @@ dependencies {
     compile 'com.google.guava:guava:15.0'
     compile 'com.github.samtools:htsjdk:' + htsjdkVersion
     compile 'org.broadinstitute:barclay:2.0.0'
-    configurations.cloudConfiguration {
-        compile ('com.google.cloud:google-cloud-nio:' + googleNioVersion)
-    }
-
     compileOnly 'com.google.cloud:google-cloud-nio:' + googleNioVersion
 
     // javadoc utilities; compile/test only to prevent redistribution of sdk jars
@@ -80,8 +79,6 @@ dependencies {
 
     testCompile 'org.testng:testng:6.9.10'
     testCompile 'org.apache.commons:commons-lang3:3.6'
-
-
 }
 
 configurations.all {


### PR DESCRIPTION
google-cloud-nio is currently being included in the shadowJar (picard.jar) but should only be included in the cloudJar configuration. Before this change the two jars (picard.jar and picardcloud.jar) were the about the same size. With this:

-rw-r--r--  1 cnorman  CHARLES\Domain Users  13257211 Mar 22 11:34 picard.jar
-rw-r--r--  1 cnorman  CHARLES\Domain Users  30166495 Mar 22 11:34 picardcloud.jar

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable
