### PR TITLE
Increment of RIBOSOMAL_BASES logic changed, new test checking PCT_RIB…

### DIFF
--- a/src/main/java/picard/analysis/directed/RnaSeqMetricsCollector.java
+++ b/src/main/java/picard/analysis/directed/RnaSeqMetricsCollector.java
@@ -40,7 +40,7 @@ public class RnaSeqMetricsCollector extends SAMRecordMultiLevelCollector<RnaSeqM
     private final OverlapDetector<Gene> geneOverlapDetector;
     private final OverlapDetector<Interval> ribosomalSequenceOverlapDetector;
     private final boolean collectCoverageStatistics;
-    
+
     public RnaSeqMetricsCollector(final Set<MetricAccumulationLevel> accumulationLevels, final List<SAMReadGroupRecord> samRgRecords,
                                   final Long ribosomalBasesInitialValue, OverlapDetector<Gene> geneOverlapDetector, OverlapDetector<Interval> ribosomalSequenceOverlapDetector,
                                   final HashSet<Integer> ignoredSequenceIndices, final int minimumLength, final StrandSpecificity strandSpecificity,
@@ -168,7 +168,7 @@ public class RnaSeqMetricsCollector extends SAMRecordMultiLevelCollector<RnaSeqM
                 if (intersectionLength/(double)fragmentInterval.length() >= rrnaFragmentPercentage) {
                     // Assume entire read is ribosomal.
                     // TODO: Should count reads, not bases?
-                    metrics.RIBOSOMAL_BASES += rec.getReadLength();
+                    metrics.RIBOSOMAL_BASES += getNumAlignedBases(rec);
                     metrics.PF_ALIGNED_BASES += getNumAlignedBases(rec);
                     return;
                 }

--- a/src/main/java/picard/analysis/directed/RnaSeqMetricsCollector.java
+++ b/src/main/java/picard/analysis/directed/RnaSeqMetricsCollector.java
@@ -167,7 +167,6 @@ public class RnaSeqMetricsCollector extends SAMRecordMultiLevelCollector<RnaSeqM
                 }
                 if (intersectionLength/(double)fragmentInterval.length() >= rrnaFragmentPercentage) {
                     // Assume entire read is ribosomal.
-                    // TODO: Should count reads, not bases?
                     metrics.RIBOSOMAL_BASES += getNumAlignedBases(rec);
                     metrics.PF_ALIGNED_BASES += getNumAlignedBases(rec);
                     return;

--- a/src/test/java/picard/analysis/CollectRnaSeqMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectRnaSeqMetricsTest.java
@@ -394,17 +394,16 @@ public class CollectRnaSeqMetricsTest extends CommandLineProgramTest {
         final int sequenceIndex = builder.getHeader().getSequenceIndex(sequence);
 
         builder.addPair("rrnaPair", sequenceIndex, 400, 500, false, false, "35I1M", "35I1M", true, true, -1);
-        builder.addFrag("frag1", sequenceIndex, 150, true,false,"34I2M","*",-1);
-        builder.addFrag("frag2", sequenceIndex, 190, true,false,"35I1M","*",-1);
+        builder.addFrag("frag1", sequenceIndex, 150, true, false, "34I2M", "*", -1);
+        builder.addFrag("frag2", sequenceIndex, 190, true, false, "35I1M", "*", -1);
         builder.addFrag("ignoredFrag", builder.getHeader().getSequenceIndex(ignoredSequence), 1, false);
         final File samFile = File.createTempFile("tmp.collectRnaSeqMetrics.", ".sam");
         samFile.deleteOnExit();
-
-        final SAMFileWriter samWriter = new SAMFileWriterFactory().makeSAMWriter(builder.getHeader(), false, samFile);
-        for (final SAMRecord rec : builder.getRecords()) {
-            samWriter.addAlignment(rec);
+        try (SAMFileWriter samWriter = new SAMFileWriterFactory().makeSAMWriter(builder.getHeader(), false, samFile)) {
+            for (final SAMRecord rec : builder.getRecords()) {
+                samWriter.addAlignment(rec);
+            }
         }
-        samWriter.close();
 
         // Create an interval list with one ribosomal interval.
         final Interval rRnaInterval = new Interval(sequence, 300, 520, true, "rRNA");
@@ -418,7 +417,7 @@ public class CollectRnaSeqMetricsTest extends CommandLineProgramTest {
         final File metricsFile = File.createTempFile("tmp.", ".rna_metrics");
         metricsFile.deleteOnExit();
 
-        final String[] args = new String[] {
+        final String[] args = new String[]{
                 "INPUT=" + samFile.getAbsolutePath(),
                 "OUTPUT=" + metricsFile.getAbsolutePath(),
                 "REF_FLAT=" + getRefFlatFile(sequence).getAbsolutePath(),


### PR DESCRIPTION
# Description
Current implementation fixes bug when PCT_RIBOSOMAL_BASES metric value can be more than 1.
Resolves #1091 
PCT_RIBOSOMAL_BASES  is computed as RIBOSOMAL_BASES/PF_ALIGNED_BASES,
where RIBOSOMAL BASES is comuted as 
metrics.RIBOSOMAL_BASES += rec.getReadLength() for each ribisomal read.
 However, in this code, RIBOSOMAL_BASES can be incremented by more than PF_ALIGNED_BASES, resulting in PCT_RIBOSOMAL_BASES that is too large and has value more than 1. 
## Proof
### Input file
![input file](https://user-images.githubusercontent.com/19429157/37903539-fc840ca2-3100-11e8-97d0-7a49dbffb053.PNG)
### Result ( Metric value)
![metric value](https://user-images.githubusercontent.com/19429157/37903559-0a6812a0-3101-11e8-8449-6ddbc3254318.png)


The proposed solution was to change the increment  to
RIBOSOMAL_BASES+=getNumAlignedBases(rec). 

So I made such changes.
# Motivation :
bug fix.
# Changes:
RIBOSOMAL_BASES increment logic was changed
# Test supporting changes:
New test for CollectRnaMetrics, checking the PCT_RIBOSOMAL_BASES value, added 

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

