### PR TITLE
Add arguments and reporting around recovering REF/ALT swapped alleles

### DIFF
--- a/src/main/java/picard/util/LiftoverUtils.java
+++ b/src/main/java/picard/util/LiftoverUtils.java
@@ -63,7 +63,7 @@ public class LiftoverUtils {
      * @param target The target interval
      * @param refSeq The reference sequence, which should match the target interval
      * @param writeOriginalPosition If true, INFO field annotations will be added to store the original position and contig
-     * @param writeOriginalAlleles If true, INFO an field annotation will be added to store the original alleles in order.  This can be useful in the case of more complex liftovers, like reverse complements, left aligned indels or swapped REF/ALT
+     * @param writeOriginalAlleles If true, an INFO field annotation will be added to store the original alleles in order.  This can be useful in the case of more complex liftovers, like reverse complements, left aligned indels or swapped REF/ALT
      * @return The lifted VariantContext.  This will be null if the input VariantContext could not be lifted.
      */
     public static VariantContext liftVariant(final VariantContext source, final Interval target, final ReferenceSequence refSeq, final boolean writeOriginalPosition, final boolean writeOriginalAlleles){
@@ -102,7 +102,7 @@ public class LiftoverUtils {
         }
 
         if (writeOriginalAlleles && !source.getAlleles().equals(builder.getAlleles())) {
-            List<String> alleles = new ArrayList<>();
+            final List<String> alleles = new ArrayList<>();
             source.getAlleles().forEach(a -> alleles.add(a.getDisplayString()));
             builder.attribute(LiftoverVcf.ORIGINAL_ALLELES, alleles);
         }

--- a/src/main/java/picard/util/LiftoverUtils.java
+++ b/src/main/java/picard/util/LiftoverUtils.java
@@ -108,9 +108,16 @@ public class LiftoverUtils {
         return builder.make();
     }
 
+    /**
+     * This is a utility method that will convert a list of alleles into a list of base strings.  Reference status
+     * is ignored when creating these strings (i.e. 'A', not 'A*').  These strings should be sufficient
+     * to recreate an Allele using Allele.create()
+     * @param alleles The list of alleles
+     * @return A list of strings representing the bases of the input alleles.
+     */
     protected static List<String> allelesToStringList(final List<Allele> alleles) {
         final List<String> ret = new ArrayList<>();
-        alleles.forEach(a -> ret.add(a.getDisplayString()));
+        alleles.forEach(a -> ret.add(a.isNoCall() ? Allele.NO_CALL_STRING : a.getDisplayString()));
         return ret;
     }
 

--- a/src/main/java/picard/util/LiftoverUtils.java
+++ b/src/main/java/picard/util/LiftoverUtils.java
@@ -63,9 +63,10 @@ public class LiftoverUtils {
      * @param target The target interval
      * @param refSeq The reference sequence, which should match the target interval
      * @param writeOriginalPosition If true, INFO field annotations will be added to store the original position and contig
+     * @param writeOriginalAlleles If true, INFO an field annotation will be added to store the original alleles in order.  This can be useful in the case of more complex liftovers, like reverse complements, left aligned indels or swapped REF/ALT
      * @return The lifted VariantContext.  This will be null if the input VariantContext could not be lifted.
      */
-    public static VariantContext liftVariant(final VariantContext source, final Interval target, final ReferenceSequence refSeq, final boolean writeOriginalPosition){
+    public static VariantContext liftVariant(final VariantContext source, final Interval target, final ReferenceSequence refSeq, final boolean writeOriginalPosition, final boolean writeOriginalAlleles){
         if (target == null) {
             return null;
         }
@@ -98,6 +99,12 @@ public class LiftoverUtils {
         if (writeOriginalPosition) {
             builder.attribute(LiftoverVcf.ORIGINAL_CONTIG, source.getContig());
             builder.attribute(LiftoverVcf.ORIGINAL_START, source.getStart());
+        }
+
+        if (writeOriginalAlleles && !source.getAlleles().equals(builder.getAlleles())) {
+            List<String> alleles = new ArrayList<>();
+            source.getAlleles().forEach(a -> alleles.add(a.getDisplayString()));
+            builder.attribute(LiftoverVcf.ORIGINAL_ALLELES, alleles);
         }
 
         return builder.make();

--- a/src/main/java/picard/util/LiftoverUtils.java
+++ b/src/main/java/picard/util/LiftoverUtils.java
@@ -102,12 +102,16 @@ public class LiftoverUtils {
         }
 
         if (writeOriginalAlleles && !source.getAlleles().equals(builder.getAlleles())) {
-            final List<String> alleles = new ArrayList<>();
-            source.getAlleles().forEach(a -> alleles.add(a.getDisplayString()));
-            builder.attribute(LiftoverVcf.ORIGINAL_ALLELES, alleles);
+            builder.attribute(LiftoverVcf.ORIGINAL_ALLELES, allelesToStringList(source.getAlleles()));
         }
 
         return builder.make();
+    }
+
+    protected static List<String> allelesToStringList(final List<Allele> alleles) {
+        final List<String> ret = new ArrayList<>();
+        alleles.forEach(a -> ret.add(a.getDisplayString()));
+        return ret;
     }
 
     protected static VariantContextBuilder liftSimpleVariantContext(VariantContext source, Interval target){

--- a/src/main/java/picard/vcf/LiftoverVcf.java
+++ b/src/main/java/picard/vcf/LiftoverVcf.java
@@ -238,7 +238,7 @@ public class LiftoverVcf extends CommandLineProgram {
     private static final List<VCFInfoHeaderLine> ATTRS = CollectionUtil.makeList(
             new VCFInfoHeaderLine(ORIGINAL_CONTIG, 1, VCFHeaderLineType.String, "The name of the source contig/chromosome prior to liftover."),
             new VCFInfoHeaderLine(ORIGINAL_START, 1, VCFHeaderLineType.String, "The position of the variant on the source contig prior to liftover."),
-            new VCFInfoHeaderLine(ORIGINAL_ALLELES, VCFHeaderLineCount.R, VCFHeaderLineType.String, "A list of the original alleles (including REF) of the variant prior to liftover.  If the alleles are identical, this attribute will be omitted.")
+            new VCFInfoHeaderLine(ORIGINAL_ALLELES, VCFHeaderLineCount.R, VCFHeaderLineType.String, "A list of the original alleles (including REF) of the variant prior to liftover.  If the alleles were not changed during liftover, this attribute will be omitted.")
             );
 
     private VariantContextWriter rejects;

--- a/src/main/java/picard/vcf/LiftoverVcf.java
+++ b/src/main/java/picard/vcf/LiftoverVcf.java
@@ -238,7 +238,7 @@ public class LiftoverVcf extends CommandLineProgram {
     private static final List<VCFInfoHeaderLine> ATTRS = CollectionUtil.makeList(
             new VCFInfoHeaderLine(ORIGINAL_CONTIG, 1, VCFHeaderLineType.String, "The name of the source contig/chromosome prior to liftover."),
             new VCFInfoHeaderLine(ORIGINAL_START, 1, VCFHeaderLineType.String, "The position of the variant on the source contig prior to liftover."),
-            new VCFInfoHeaderLine(ORIGINAL_ALLELES, VCFHeaderLineCount.R, VCFHeaderLineType.String, "The position of the variant on the source contig prior to liftover.")
+            new VCFInfoHeaderLine(ORIGINAL_ALLELES, VCFHeaderLineCount.R, VCFHeaderLineType.String, "A list of the original alleles (including REF) of the variant prior to liftover.")
             );
 
     private VariantContextWriter rejects;
@@ -463,7 +463,7 @@ public class LiftoverVcf extends CommandLineProgram {
         map.put(contig, ++val);
     }
 
-    private void addAndTrack(VariantContext toAdd, VariantContext source){
+    private void addAndTrack(final VariantContext toAdd, final VariantContext source){
         trackLiftedVariantContig(liftedBySourceContig, source.getContig());
         trackLiftedVariantContig(liftedByDestContig, toAdd.getContig());
         sorter.add(toAdd);

--- a/src/main/java/picard/vcf/LiftoverVcf.java
+++ b/src/main/java/picard/vcf/LiftoverVcf.java
@@ -420,10 +420,9 @@ public class LiftoverVcf extends CommandLineProgram {
             log.info("no successfully lifted variants");
         }
 
-        if (RECOVER_SWAPPED_REF_ALT){
+        if (RECOVER_SWAPPED_REF_ALT) {
             log.info(totalRecoveredBySwapRefAlt, " variants were lifted by swapping REF/ALT alleles.");
-        }
-        else {
+        } else {
             log.info(totalNotRecoveredSwapRefAlt, " variants with a swapped REF/ALT were identified, but were not recovered.  See RECOVER_SWAPPED_REF_ALT.");
         }
 
@@ -463,7 +462,7 @@ public class LiftoverVcf extends CommandLineProgram {
         map.put(contig, ++val);
     }
 
-    private void addAndTrack(final VariantContext toAdd, final VariantContext source){
+    private void addAndTrack(final VariantContext toAdd, final VariantContext source) {
         trackLiftedVariantContig(liftedBySourceContig, source.getContig());
         trackLiftedVariantContig(liftedByDestContig, toAdd.getContig());
         sorter.add(toAdd);
@@ -492,12 +491,11 @@ public class LiftoverVcf extends CommandLineProgram {
                 if (!refString.equalsIgnoreCase(allele.getBaseString())) {
                     // consider that the ref and the alt may have been swapped in a simple biallelic SNP
                     if (vc.isBiallelic() && vc.isSNP() && refString.equalsIgnoreCase(vc.getAlternateAllele(0).getBaseString())) {
-                        if (RECOVER_SWAPPED_REF_ALT){
+                        if (RECOVER_SWAPPED_REF_ALT) {
                             totalRecoveredBySwapRefAlt++;
                             addAndTrack(LiftoverUtils.swapRefAlt(vc, TAGS_TO_REVERSE, TAGS_TO_DROP), source);
                             return;
-                        }
-                        else {
+                        } else {
                             totalNotRecoveredSwapRefAlt++;
                         }
                     }

--- a/src/test/java/picard/util/LiftoverVcfTest.java
+++ b/src/test/java/picard/util/LiftoverVcfTest.java
@@ -558,13 +558,12 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
     public Iterator<Object[]> indelFlipDataWithOriginalAllele() {
         final List<Object[]> tests = new ArrayList<>();
         indelFlipData().forEachRemaining(x -> {
-            if (x[2] == null){
+            if (x[2] == null) {
                 tests.add(x);
-            }
-            else {
+            } else {
                 VariantContext source = (VariantContext)x[0];
                 VariantContextBuilder result_builder = new VariantContextBuilder((VariantContext)x[2]);
-                result_builder.attribute(LiftoverVcf.ORIGINAL_ALLELES, allelesToStringList(source.getAlleles()));
+                result_builder.attribute(LiftoverVcf.ORIGINAL_ALLELES, LiftoverUtils.allelesToStringList(source.getAlleles()));
                 tests.add(new Object[]{x[0], x[1], result_builder.make()});
             }
         });
@@ -1073,12 +1072,6 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         VcfTestUtils.assertEquals(vcb == null ? null : vcb.make(), result);
     }
 
-    private List<String> allelesToStringList(final List<Allele> alleles) {
-        final List<String> ret = new ArrayList<>();
-        alleles.forEach(a -> ret.add(a.getDisplayString()));
-        return ret;
-    }
-
     @DataProvider(name = "noCallAndSymbolicData")
     public Iterator<Object[]> noCallAndSymbolicData() {
 
@@ -1129,7 +1122,7 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         builder.start(start).stop(start).alleles(CollectionUtil.makeList(CRef, T, DEL));
         result_builder.start(liftedStart).stop(liftedStart).alleles(CollectionUtil.makeList(GRef, A, DEL));
         result_builder.attribute(LiftoverVcf.ORIGINAL_START, start);
-        result_builder.attribute(LiftoverVcf.ORIGINAL_ALLELES, allelesToStringList(builder.getAlleles()));
+        result_builder.attribute(LiftoverVcf.ORIGINAL_ALLELES, LiftoverUtils.allelesToStringList(builder.getAlleles()));
         result_builder.attribute(LiftoverUtils.REV_COMPED_ALLELES, true);
 
         genotypeBuilder.alleles(CollectionUtil.makeList(T, DEL));
@@ -1146,7 +1139,7 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         builder.start(start).stop(start).alleles(CollectionUtil.makeList(CRef, T));
         result_builder.start(liftedStart).stop(liftedStart).alleles(CollectionUtil.makeList(GRef, A));
         result_builder.attribute(LiftoverVcf.ORIGINAL_START, start);
-        result_builder.attribute(LiftoverVcf.ORIGINAL_ALLELES, allelesToStringList(builder.getAlleles()));
+        result_builder.attribute(LiftoverVcf.ORIGINAL_ALLELES, LiftoverUtils.allelesToStringList(builder.getAlleles()));
         genotypeBuilder.alleles(CollectionUtil.makeList(T, Allele.NO_CALL));
         resultGenotypeBuilder.alleles(CollectionUtil.makeList(A, Allele.NO_CALL));
         builder.genotypes(genotypeBuilder.make());
@@ -1170,7 +1163,7 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         Assert.assertEquals(vc.getAttribute(LiftoverVcf.ORIGINAL_CONTIG), source.getContig());
         Assert.assertEquals(vc.getAttribute(LiftoverVcf.ORIGINAL_START), source.getStart());
         Assert.assertTrue(source.getAlleles().equals(result.getAlleles()) != result.hasAttribute(LiftoverVcf.ORIGINAL_ALLELES));
-        if (!source.getAlleles().equals(result.getAlleles())){
+        if (!source.getAlleles().equals(result.getAlleles())) {
             List<String> resultAlleles = new ArrayList<>();
             source.getAlleles().forEach(a -> resultAlleles.add(a.getDisplayString()));
             Assert.assertEquals(resultAlleles, result.getAttributeAsStringList(LiftoverVcf.ORIGINAL_ALLELES, null));


### PR DESCRIPTION
### Description

Relatively recently LiftoverVcf has a feature added to automatically recover lifted variants with swapped REF/ALT alleles.  See #1149 for some discussion around this.  This PR:

1) Adds an argument to LiftoverVcf to allow users to disable that feature, due to the problems it can cause with allele-based annotations.

2) Adds a new opt-in feature to record the ORIGINAL_ALLELES, in addition to ORIGINAL_START and ORIGINAL_CONTIG.  This is something not directly related to the swapping feature, but as the allele-level modifications get more complicated, simply stashing the original alleles can be useful.  For example, reverse complemented indels might get left-aligned, and reversing that whole process isnt simple.  

3) This is perhaps the one controversial thing I propose: I'd like to see the allele swapping feature default to false, for the reasons noted in #1149, since I think that can cause subtle but real problems in VCFs and there isnt a good solution in LiftoverVcf to handle that.  Generally speaking, it seems like public tools such as Picard should err on the more conservative side, and therefore I believe that's where the default should be unless the feature becomes more robust.

4) I added/augmented tests

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

