### PR TITLE
DSDEGP-2199 Switch NIO dependency to the patched version used by GATK.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,10 @@ jacoco {
 }
 
 final htsjdkVersion = System.getProperty('htsjdk.version', '2.14.3')
-final googleNioVersion= "0.28.0-alpha:shaded"
+
+// We use a custom shaded build of the NIO library to avoid a regression in the authentication layer.
+// GATK does the same, see https://github.com/broadinstitute/gatk/issues/3591
+final googleNio = 'org.broadinstitute:google-cloud-nio-GATK4-custom-patch:0.20.4-alpha-GCS-RETRY-FIX:shaded'
 
 // Get the jdk files we need to run javaDoc. We need to use these during compile, testCompile,
 // test execution, and gatkDoc generation, but we don't want them as part of the runtime
@@ -59,7 +62,7 @@ configurations {
     cloudConfiguration {
         extendsFrom runtime
         dependencies {
-            cloudConfiguration('com.google.cloud:google-cloud-nio:' + googleNioVersion)
+            cloudConfiguration(googleNio)
         }
     }
 }
@@ -71,7 +74,7 @@ dependencies {
     compile 'com.google.guava:guava:15.0'
     compile 'com.github.samtools:htsjdk:' + htsjdkVersion
     compile 'org.broadinstitute:barclay:2.0.0'
-    compileOnly 'com.google.cloud:google-cloud-nio:' + googleNioVersion
+    compileOnly googleNio
 
     // javadoc utilities; compile/test only to prevent redistribution of sdk jars
     compileOnly(javadocJDKFiles)


### PR DESCRIPTION
### Description

This change works around a known issue in the auth lib used by Google's NIO wrapper, which causes the error:
```
java.io.IOException: Error code 404 trying to get security access token from Compute Engine metadata for the default service account. This may be because the virtual machine instance does not have permission scopes specified.
```
The replacement dependency is the one used in GATK to avoid the same problem.

I ran `CrosscheckFingerprints` in a Cromwell task, using NIO for the inputs, and it worked :tada:

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

