### PR TITLE
Make picardcloud accessible in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM broadinstitute/java-baseimage
 MAINTAINER Broad Institute DSDE <dsde-engineering@broadinstitute.org>
 
 ARG build_command=shadowJar
+ARG jar_name=picard.jar
 
 # Install ant, git for building
 RUN apt-get update && \
@@ -17,7 +18,7 @@ WORKDIR /usr/picard
 
 # Build the distribution jar, clean up everything else
 RUN ./gradlew ${build_command} && \
-    mv build/libs/picard*.jar picard.jar && \
+    mv build/libs/${jar_name} ${jar_name} && \
     mv src/main/resources/picard/docker_helper.sh docker_helper.sh && \
     ./gradlew clean && \
     rm -rf src && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ WORKDIR /usr/picard
 
 # Build the distribution jar, clean up everything else
 RUN ./gradlew shadowJar && \
+    ./gradlew cloudJar && \
     mv build/libs/picard.jar picard.jar && \
+    mv build/libs/picardcloud.jar picardcloud.jar && \
     mv src/main/resources/picard/docker_helper.sh docker_helper.sh && \
     ./gradlew clean && \
     rm -rf src && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /usr/picard
 
 # Build the distribution jar, clean up everything else
 RUN ./gradlew ${build_command} && \
-    mv build/libs/${jar_name} ${jar_name} && \
+    mv build/libs/${jar_name} picard.jar && \
     mv src/main/resources/picard/docker_helper.sh docker_helper.sh && \
     ./gradlew clean && \
     rm -rf src && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM broadinstitute/java-baseimage
 MAINTAINER Broad Institute DSDE <dsde-engineering@broadinstitute.org>
 
+ARG build_command=shadowJar
+
 # Install ant, git for building
 RUN apt-get update && \
     apt-get --no-install-recommends install -y --force-yes \
@@ -14,10 +16,8 @@ COPY / /usr/picard/
 WORKDIR /usr/picard
 
 # Build the distribution jar, clean up everything else
-RUN ./gradlew shadowJar && \
-    ./gradlew cloudJar && \
-    mv build/libs/picard.jar picard.jar && \
-    mv build/libs/picardcloud.jar picardcloud.jar && \
+RUN ./gradlew ${build_command} && \
+    mv build/libs/picard*.jar picard.jar && \
     mv src/main/resources/picard/docker_helper.sh docker_helper.sh && \
     ./gradlew clean && \
     rm -rf src && \

--- a/build_push_docker.sh
+++ b/build_push_docker.sh
@@ -10,17 +10,20 @@ fi
 
 declare -r TAG=${1}
 
+declare -r PICARD_TAG=broadinstitute/picard:${TAG}
+declare -r PICARD_CLOUD_TAG=us.gcr.io/broad-gotc-prod/picard-cloud:${TAG}
+
 echo "Will build and push the following docker images:"
-echo "broadinstitute/picard:${TAG}"
-echo "broadinstitute/picard-cloud:${TAG}"
+echo ${PICARD_TAG}
+echo ${PICARD_CLOUD_TAG}
 
 read -p "Is this really what you want to do? " -n 1 -r
 echo    # (optional) move to a new line
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-    docker build -t broadinstitute/picard:${TAG} --build-arg build_command=shadowJar --build-arg jar_name=picard.jar .
-    docker build -t us.gcr.io/broad-gotc-prod/picard-cloud:${TAG} --build-arg build_command=cloudJar --build-arg jar_name=picardcloud.jar .
+    docker build -t ${PICARD_TAG} --build-arg build_command=shadowJar --build-arg jar_name=picard.jar .
+    docker build -t ${PICARD_CLOUD_TAG} --build-arg build_command=cloudJar --build-arg jar_name=picardcloud.jar .
 
-    docker push broadinstitute/picard:${TAG}
-    docker push us.gcr.io/broad-gotc-prod/picard-cloud:${TAG}
+    docker push ${PICARD_TAG}
+    gcloud docker -- push ${PICARD_CLOUD_TAG}
 fi

--- a/build_push_docker.sh
+++ b/build_push_docker.sh
@@ -19,9 +19,8 @@ echo    # (optional) move to a new line
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
     docker build -t broadinstitute/picard:${TAG} --build-arg build_command=shadowJar --build-arg jar_name=picard.jar .
-    docker build -t broadinstitute/picard-cloud:${TAG} --build-arg build_command=cloudJar --build-arg jar_name=picardcloud.jar .
+    docker build -t us.gcr.io/broad-gotc-prod/picard-cloud:${TAG} --build-arg build_command=cloudJar --build-arg jar_name=picardcloud.jar .
 
     docker push broadinstitute/picard:${TAG}
-    docker push broadinstitute/picard-cloud:${TAG}
+    docker push us.gcr.io/broad-gotc-prod/picard-cloud:${TAG}
 fi
-

--- a/build_push_docker.sh
+++ b/build_push_docker.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# This script is used to build and deploy docker images for Picard
+
+if [[ "$1" == "" ]]
+then
+    echo "Usage: build_push_docker.sh <git-tag>"
+    exit 1
+fi
+
+declare -r TAG=${1}
+
+echo "Will build and push the following docker images:"
+echo "broadinstitute/picard:${TAG}"
+echo "broadinstitute/picard-cloud:${TAG}"
+
+read -p "Is this really what you want to do? " -n 1 -r
+echo    # (optional) move to a new line
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    docker build -t broadinstitute/picard:${TAG} --build-arg build_command=shadowJar --build-arg jar_name=picard.jar .
+    docker build -t broadinstitute/picard-cloud:${TAG} --build-arg build_command=cloudJar --build-arg jar_name=picardcloud.jar .
+
+    docker push broadinstitute/picard:${TAG}
+    docker push broadinstitute/picard-cloud:${TAG}
+fi
+

--- a/src/main/resources/picard/docker_helper.sh
+++ b/src/main/resources/picard/docker_helper.sh
@@ -24,4 +24,4 @@ done
 shift $(expr $OPTIND - 1)
 TOOL_WITH_ARGS=$@
 
-java ${JVM_ARGS} -jar /usr/picard/picard.jar ${TOOL_WITH_ARGS}
+java ${JVM_ARGS} -jar /usr/picard/picard*.jar ${TOOL_WITH_ARGS}

--- a/src/main/resources/picard/docker_helper.sh
+++ b/src/main/resources/picard/docker_helper.sh
@@ -8,15 +8,20 @@ Usage: $0 [-j <JVM arguments>] tool_name tool_arguments
 Run Picard with JVM args and program args if present. Assumes picard.jar lives in the same directory.
 JVM arguments should be a quoted, space separated list.
 
+To run picardcloud.jar, use the '-c' argument.
+
 Example Usage:
 ./docker_helper.sh -j "-XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10 -Xmx4000m" MarkDuplicates INPUT=fake.bam ...
 
 EOF
   exit 1
 }
-while getopts "j:h" OPTION; do
+
+JAR=picard.jar
+while getopts "j:ch" OPTION; do
   case $OPTION in
     j) JVM_ARGS=$OPTARG;;
+    c) JAR=picardcloud.jar;;
     h) usage; exit 0;;
     [?]) usage; exit 1;;
   esac
@@ -24,4 +29,4 @@ done
 shift $(expr $OPTIND - 1)
 TOOL_WITH_ARGS=$@
 
-java ${JVM_ARGS} -jar /usr/picard/picard.jar ${TOOL_WITH_ARGS}
+java ${JVM_ARGS} -jar /usr/picard/${JAR} ${TOOL_WITH_ARGS}

--- a/src/main/resources/picard/docker_helper.sh
+++ b/src/main/resources/picard/docker_helper.sh
@@ -8,20 +8,15 @@ Usage: $0 [-j <JVM arguments>] tool_name tool_arguments
 Run Picard with JVM args and program args if present. Assumes picard.jar lives in the same directory.
 JVM arguments should be a quoted, space separated list.
 
-To run picardcloud.jar, use the '-c' argument.
-
 Example Usage:
 ./docker_helper.sh -j "-XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10 -Xmx4000m" MarkDuplicates INPUT=fake.bam ...
 
 EOF
   exit 1
 }
-
-JAR=picard.jar
-while getopts "j:ch" OPTION; do
+while getopts "j:h" OPTION; do
   case $OPTION in
     j) JVM_ARGS=$OPTARG;;
-    c) JAR=picardcloud.jar;;
     h) usage; exit 0;;
     [?]) usage; exit 1;;
   esac
@@ -29,4 +24,4 @@ done
 shift $(expr $OPTIND - 1)
 TOOL_WITH_ARGS=$@
 
-java ${JVM_ARGS} -jar /usr/picard/${JAR} ${TOOL_WITH_ARGS}
+java ${JVM_ARGS} -jar /usr/picard/picard.jar ${TOOL_WITH_ARGS}


### PR DESCRIPTION
### Description

The cloud version of Picard should be accessible from the docker image. By using the `-c` option when invoking the docker image, the picardcloud jar is now run instead of the normal picard jar

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

