### PR TITLE
Add to gradle build pre-requisites check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ jacoco {
 }
 
 final requiredJavaVersion = "8"
-final buildPrerequisitesMessage = "See https://github.com/broadinstitute/picard/blob/master/README.md for information on how to build picard"
+final buildPrerequisitesMessage = "See https://github.com/broadinstitute/picard/blob/master/README.md#building-picard for information on how to build picard"
 // Ensure that we have the right JDK version, a clone of the git repository
 def ensureBuildPrerequisites(requiredJavaVersion, largeResourcesFolder, buildPrerequisitesMessage) {
     // Make sure we can get a ToolProvider class loader. If not we may have just a JRE, or a JDK from the future.

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,23 @@ jacoco {
     toolVersion = "0.7.5.201505241946"
 }
 
+final requiredJavaVersion = "8"
+final buildPrerequisitesMessage = "See https://github.com/broadinstitute/picard/blob/master/README.md for information on how to build picard"
+// Ensure that we have the right JDK version, a clone of the git repository
+def ensureBuildPrerequisites(requiredJavaVersion, largeResourcesFolder, buildPrerequisitesMessage) {
+    // Make sure we can get a ToolProvider class loader. If not we may have just a JRE, or a JDK from the future.
+    if (ToolProvider.getSystemToolClassLoader() == null) {
+        throw new GradleException(
+                "The ClassLoader obtained from the Java ToolProvider is null. "
+                + "A Java $requiredJavaVersion JDK must be installed. $buildPrerequisitesMessage")
+    }
+    if (!file(".git").isDirectory()) {
+        throw new GradleException("The Picard Github repository must be cloned using \"git clone\" to run the build. "
+                + "$buildPrerequisitesMessage")
+    }
+}
+ensureBuildPrerequisites(requiredJavaVersion, largeResourcesFolder, buildPrerequisitesMessage)
+
 final htsjdkVersion = System.getProperty('htsjdk.version', '2.14.3')
 
 // We use a custom shaded build of the NIO library to avoid a regression in the authentication layer.

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ jacoco {
 final requiredJavaVersion = "8"
 final buildPrerequisitesMessage = "See https://github.com/broadinstitute/picard/blob/master/README.md#building-picard for information on how to build picard"
 // Ensure that we have the right JDK version, a clone of the git repository
-def ensureBuildPrerequisites(requiredJavaVersion, largeResourcesFolder, buildPrerequisitesMessage) {
+def ensureBuildPrerequisites(requiredJavaVersion, buildPrerequisitesMessage) {
     // Make sure we can get a ToolProvider class loader. If not we may have just a JRE, or a JDK from the future.
     if (ToolProvider.getSystemToolClassLoader() == null) {
         throw new GradleException(
@@ -62,7 +62,7 @@ def ensureBuildPrerequisites(requiredJavaVersion, largeResourcesFolder, buildPre
                 + "$buildPrerequisitesMessage")
     }
 }
-ensureBuildPrerequisites(requiredJavaVersion, largeResourcesFolder, buildPrerequisitesMessage)
+ensureBuildPrerequisites(requiredJavaVersion, buildPrerequisitesMessage)
 
 final htsjdkVersion = System.getProperty('htsjdk.version', '2.14.3')
 


### PR DESCRIPTION
### Description

Due to the usage of the git repository to get the version, Picard fails to build if the zipped source is downloaded. Based on the same strategy as GATK, this commit adds a check for the build pre-requisites.

This provides a better error message for cases like https://github.com/broadinstitute/picard/issues/604#issuecomment-380765514, being a temporary solution until https://github.com/broadinstitute/picard/issues/605 is implemented (adding better logging for the user).

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

