### PR TITLE
Move setting of TMP_DIR prior to inflater/deflater check. 

### DIFF
--- a/src/main/java/picard/cmdline/CommandLineProgram.java
+++ b/src/main/java/picard/cmdline/CommandLineProgram.java
@@ -227,14 +227,6 @@ public abstract class CommandLineProgram {
 
         SAMFileWriterFactory.setDefaultCreateMd5File(CREATE_MD5_FILE);
 
-        if (!USE_JDK_DEFLATER) {
-            BlockCompressedOutputStream.setDefaultDeflaterFactory(new IntelDeflaterFactory());
-        }
-
-        if (!USE_JDK_INFLATER) {
-            BlockGunzipper.setDefaultInflaterFactory(new IntelInflaterFactory());
-        }
-
         for (final File f : TMP_DIR) {
             // Intentionally not checking the return values, because it may be that the program does not
             // need a tmp_dir. If this fails, the problem will be discovered downstream.
@@ -242,6 +234,14 @@ public abstract class CommandLineProgram {
             f.setReadable(true, false);
             f.setWritable(true, false);
             System.setProperty("java.io.tmpdir", f.getAbsolutePath()); // in loop so that last one takes effect
+        }
+
+        if (!USE_JDK_DEFLATER) {
+            BlockCompressedOutputStream.setDefaultDeflaterFactory(new IntelDeflaterFactory());
+        }
+
+        if (!USE_JDK_INFLATER) {
+            BlockGunzipper.setDefaultInflaterFactory(new IntelInflaterFactory());
         }
 
         PathHelper.initilizeAll();


### PR DESCRIPTION
This ensures that java.io.tmpdir is set (which is used when checking if we have space for using the intel deflater/inflater). Currently it will always check system temp dir.

_Give your PR a **concise** yet **descriptive** title_
_Please explain the changes you made here._
_Explain the **motivation** for making this change. What existing problem does the pull request solve?_
_Mention any issues fixed, addressed or otherwise related to this pull request, including issue numbers or hard links for issues in other repos._
_You can delete these instructions once you have written your PR description._

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

