### PR TITLE
Avoid overflow when computing barcode metrics.

### DIFF
--- a/src/main/java/picard/illumina/ExtractIlluminaBarcodes.java
+++ b/src/main/java/picard/illumina/ExtractIlluminaBarcodes.java
@@ -371,9 +371,9 @@ public class ExtractIlluminaBarcodes extends CommandLineProgram {
     public static void finalizeMetrics(final Map<String, BarcodeMetric> barcodeToMetrics,
                                        final BarcodeMetric noMatchMetric) {
         // Finish metrics tallying.
-        int totalReads = noMatchMetric.READS;
-        int totalPfReads = noMatchMetric.PF_READS;
-        int totalPfReadsAssigned = 0;
+        long totalReads = noMatchMetric.READS;
+        long totalPfReads = noMatchMetric.PF_READS;
+        long totalPfReadsAssigned = 0;
         for (final BarcodeMetric barcodeMetric : barcodeToMetrics.values()) {
             totalReads += barcodeMetric.READS;
             totalPfReads += barcodeMetric.PF_READS;
@@ -548,27 +548,27 @@ public class ExtractIlluminaBarcodes extends CommandLineProgram {
         /**
          * The total number of reads matching the barcode.
          */
-        public int READS = 0;
+        public long READS = 0;
         /**
          * The number of PF reads matching this barcode (always less than or equal to READS).
          */
-        public int PF_READS = 0;
+        public long PF_READS = 0;
         /**
          * The number of all reads matching this barcode that matched with 0 errors or no-calls.
          */
-        public int PERFECT_MATCHES = 0;
+        public long PERFECT_MATCHES = 0;
         /**
          * The number of PF reads matching this barcode that matched with 0 errors or no-calls.
          */
-        public int PF_PERFECT_MATCHES = 0;
+        public long PF_PERFECT_MATCHES = 0;
         /**
          * The number of all reads matching this barcode that matched with 1 error or no-call.
          */
-        public int ONE_MISMATCH_MATCHES = 0;
+        public long ONE_MISMATCH_MATCHES = 0;
         /**
          * The number of PF reads matching this barcode that matched with 1 error or no-call.
          */
-        public int PF_ONE_MISMATCH_MATCHES = 0;
+        public long PF_ONE_MISMATCH_MATCHES = 0;
         /**
          * The fraction of all reads in the lane that matched to this barcode.
          */


### PR DESCRIPTION
### Description

For instruments like NovaSeq, total number of reads in a lane can be greater than will fit into a 32-bit signed int, causing count of reads to be negative.  This causes various PCT metrics in BarcodeMetric to be 0.  Changing these counters from int to long solves the problem.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

