### PR TITLE
Allowing static fields in MergableMetrics to be not annotated 

### DIFF
--- a/src/main/java/picard/analysis/MergeableMetricBase.java
+++ b/src/main/java/picard/analysis/MergeableMetricBase.java
@@ -39,30 +39,31 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * An extension of MetricBase that knows how to merge-by-adding fields that are appropriately annotated ({@link MergeByAdding}). It also provides an interface
- * for calculating derived fields {@link #calculateDerivedFields()}  (and an annotation that informs that said fields are derived {@link NoMergingIsDerived}). Finally, it also allows for an annotation
- * that suggests that a field will be used as an ID and thus merging will simply ensure that these fields are equal {@link MergeByAssertEquals}. Other annotations are available,
- * though they all currently imply that no <it>implicit</it> action will be taken {@link MergingIsManual} and {@link NoMergingKeepsValue}.
+ * An extension of MetricBase that knows how to merge-by-adding fields that are appropriately annotated ({@link MergeByAdding MergeByAdding}). It also provides an interface
+ * for calculating derived fields {@link #calculateDerivedFields}  (and an annotation that informs that said fields are derived {@link NoMergingIsDerived NoMergingIsDerived}). Finally, it also allows for an annotation
+ * that suggests that a field will be used as an ID and thus merging will simply ensure that these fields are equal {@link MergeByAssertEquals MergeByAssertEquals}. Other annotations are available,
+ * though they all currently imply that no <it>implicit</it> action will be taken {@link MergingIsManual MergingIsManual} and {@link NoMergingKeepsValue NoMergingKeepsValue}.
  *<p>
- * {@link MergeByAdding} is only enabled for the following types: int, Integer, float, Float, double, Double, short, Short, long, Long, byte, Byte.
+ * {@link MergeByAdding MergeByAdding} is only enabled for the following types: int, Integer, float, Float, double, Double, short, Short, long, Long, byte, Byte.
  * Overflow will be detected (for the short, and byte types) and an exception thrown.
- *<p><
- * Every (non-static) field in this class <it>must</it> be @Annotated by one of: {@link MergeByAdding}, {@link MergeByAssertEquals}, {@link NoMergingIsDerived}, {@link MergingIsManual}, {@link NoMergingKeepsValue}.
- * Static fields may be annotated, but not with {@link MergeByAdding}, there will be no automatic modification of static fields
+ *<p>
+ * Every (non-static) field in this class <it>must</it> be @Annotated by one of: {@link MergeByAdding MergeByAdding},
+ * {@link MergeByAssertEquals MergeByAssertEquals}, {@link NoMergingIsDerived NoMergingIsDerived}, {@link MergingIsManual MergingIsManual}, {@link NoMergingKeepsValue NoMergingKeepsValue}.
+ * Static fields may be annotated, but not with {@link MergeByAdding MergeByAdding}, there will be no automatic modification of static fields
  *
  * <dl>
- * <dt>{@link MergeByAdding}</dt>
+ * <dt>{@link MergeByAdding MergeByAdding}</dt>
  * <dd>When merging another metric into this one, the value of the field in the other class will be added to the value in this.
  * This will happen automatically!</dd>
- * <dt>{@link MergeByAssertEquals}</dt>
+ * <dt>{@link MergeByAssertEquals MergeByAssertEquals}</dt>
  * <dd>When merging another metric into this one, the code will assert that value of the field in the other class is equal to the value in this.</dd>
- * <dt>{@link NoMergingIsDerived}</dt>
+ * <dt>{@link NoMergingIsDerived NoMergingIsDerived}</dt>
  * <dd>When merging another metric into this one, no action will be taken since the value of this field should be derived from the other field.
  * This derivation should happen in the "calculateDerivedFields" method.</dd>
- * <dt>{@link MergingIsManual}</dt>
+ * <dt>{@link MergingIsManual MergingIsManual}</dt>
  * <dd>When merging another metric into this one, the resulting value will be calculated "manually", i.e. by custom code in the merge method.
  * The resulting value can depend on both this and other objects.</dd>
- * <dt>{@link NoMergingKeepsValue}</dt>
+ * <dt>{@link NoMergingKeepsValue NoMergingKeepsValue}</dt>
  * <dd>When merging another metric into this one, the value of the field in this remains unchanged by design.</dd>
  * </dl>
  *
@@ -262,9 +263,9 @@ abstract public class MergeableMetricBase extends MetricBase {
     }
 
     /**
-     * placeholder method that will calculate the derived fields from the other ones. classes that are derived from non-trivial base classes
-     * should consider calling super.calculateDerivedFields() as well. Fields whose value will change due to this method should be
-     * annotated with {@link NoMergingIsDerived}.
+     * Placeholder method that will calculate the derived fields from the other ones.
+     * Classes that are derived from non-trivial derived classes should consider calling super.calculateDerivedFields() as well.
+     * Fields whose value will change due to this method should be annotated with {@link NoMergingIsDerived NoMergingKeepsValue}.
      */
     public void calculateDerivedFields() {}
 }

--- a/src/main/java/picard/analysis/MergeableMetricBase.java
+++ b/src/main/java/picard/analysis/MergeableMetricBase.java
@@ -46,7 +46,7 @@ import java.util.List;
  * merge-by-adding is only enabled for the following types: int, Integer, float, Float, double, Double, short, Short, long, Long, byte, Byte.
  * Overflow will be detected (for the short, and byte types) and an exception thrown.
  *
- * Every (public, non-static) field in this class _must_ be @Annotated by one of: MergeByAdding, MergeByAssertEquals, NoMergingIsDerived, MergingIsManual, NoMergingKeepsValue.
+ * Every (non-static) field in this class _must_ be @Annotated by one of: MergeByAdding, MergeByAssertEquals, NoMergingIsDerived, MergingIsManual, NoMergingKeepsValue.
  * Static fields may be annotated, but not with @MergeByAdding.
  *
  * MergeByAdding: When merging another metric into this one, the value of the field in the other class will be added to the value in this.

--- a/src/main/java/picard/analysis/MergeableMetricBase.java
+++ b/src/main/java/picard/analysis/MergeableMetricBase.java
@@ -46,6 +46,18 @@ import java.util.List;
  * merge-by-adding is only enabled for the following types: int, Integer, float, Float, double, Double, short, Short, long, Long, byte, Byte.
  * Overflow will be detected (for the short, and byte types) and an exception thrown.
  *
+ * Every (public, non-static) field in this class _must_ be @Annotated by one of: MergeByAdding, MergeByAssertEquals, NoMergingIsDerived, MergingIsManual, NoMergingKeepsValue.
+ * Static fields may be annotated, but not with @MergeByAdding.
+ *
+ * MergeByAdding: When merging another metric into this one, the value of the field in the other class will be added to the value in this.
+ * This will happen automatically!
+ * MergeByAssertEquals: When merging another metric into this one, the code will assert that value of the field in the other class is equal to the value in this.
+ * NoMergingIsDerived:  When merging another metric into this one, no action will be taken since the value of this field should be derived from the other field.
+ * This derivation should happen in the "calculateDerivedFields" method.
+ * MergingIsManual:  When merging another metric into this one, the resulting value will be calculated "manually", i.e. by custom code in the merge
+ * method. The resulting value can depend on both this and other objects.
+ * NoMergingKeepsValue:  When merging another metric into this one, the value of the field in this remains unchanged by design.
+ *
  * @author Yossi Farjoun
  */
 abstract public class MergeableMetricBase extends MetricBase {
@@ -231,7 +243,7 @@ abstract public class MergeableMetricBase extends MetricBase {
         return this;
     }
 
-    private static List<Field> getAllFields(Class clazz){
+    private static List<Field> getAllFields(Class clazz) {
         final List<Field> fields = new ArrayList<>();
         fields.addAll(Arrays.asList(clazz.getDeclaredFields()));
         final Class superClass = clazz.getSuperclass();

--- a/src/main/java/picard/analysis/MergeableMetricBase.java
+++ b/src/main/java/picard/analysis/MergeableMetricBase.java
@@ -148,8 +148,8 @@ abstract public class MergeableMetricBase extends MetricBase {
             if (Modifier.isStatic(field.getModifiers())) {
                 final boolean isAnnotatedMergeByAdding = field.getAnnotationsByType(MergeByAdding.class).length != 0;
                 if (isAnnotatedMergeByAdding) {
-                    throw new IllegalStateException("All (non-static) fields of this class must be annotated with @MergeByAdding, @NoMergingIsDerived, @MergeByAssertEquals, @MergingIsManual, or @NoMergingKeepsValue. " +
-                            "Field " + field.getName() + " isn't annotated.");
+                    throw new IllegalStateException("Static fields of classes derived from MergeableMetricBase cannot be annotated with @MergeByAdding, " +
+                            "Field " + field.getName() + " has that annotation.");
                 }
             } else {
                 final boolean isAnnotated =
@@ -160,8 +160,8 @@ abstract public class MergeableMetricBase extends MetricBase {
                         field.getAnnotationsByType(NoMergingKeepsValue.class).length != 0;
                 ;
                 if (!isAnnotated) {
-                    throw new IllegalStateException("Static fields of classes derived from MergeableMetricBase cannot be annotated with @MergeByAdding, " +
-                            "Field " + field.getName() + " has that annotation.");
+                    throw new IllegalStateException("All (non-static) fields of this class must be annotated with @MergeByAdding, @NoMergingIsDerived, @MergeByAssertEquals, @MergingIsManual, or @NoMergingKeepsValue. " +
+                            "Field " + field.getName() + " isn't annotated.");
                 }
             }
 

--- a/src/main/java/picard/analysis/MergeableMetricBase.java
+++ b/src/main/java/picard/analysis/MergeableMetricBase.java
@@ -39,24 +39,32 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * An extension of MetricBase that knows how to merge-by-adding fields that are appropriately annotated. It also provides an interface
- * for calculating derived fields (and an annotation that informs that said fields are derived). Finally, it also allows for an annotation
- * that suggests that a field will be used as an ID and thus merging will simply require that these fields are equal.
+ * An extension of MetricBase that knows how to merge-by-adding fields that are appropriately annotated ({@link MergeByAdding}). It also provides an interface
+ * for calculating derived fields {@link #calculateDerivedFields()}  (and an annotation that informs that said fields are derived {@link NoMergingIsDerived}). Finally, it also allows for an annotation
+ * that suggests that a field will be used as an ID and thus merging will simply ensure that these fields are equal {@link MergeByAssertEquals}. Other annotations are available,
+ * though they all currently imply that no _implicit_ action will be taken {@link MergingIsManual} and {@link NoMergingKeepsValue}.
  *
- * merge-by-adding is only enabled for the following types: int, Integer, float, Float, double, Double, short, Short, long, Long, byte, Byte.
+ * {@link MergeByAdding} is only enabled for the following types: int, Integer, float, Float, double, Double, short, Short, long, Long, byte, Byte.
  * Overflow will be detected (for the short, and byte types) and an exception thrown.
  *
- * Every (non-static) field in this class _must_ be @Annotated by one of: MergeByAdding, MergeByAssertEquals, NoMergingIsDerived, MergingIsManual, NoMergingKeepsValue.
- * Static fields may be annotated, but not with @MergeByAdding.
+ * Every (non-static) field in this class _must_ be @Annotated by one of: {@link MergeByAdding}, {@link MergeByAssertEquals}, {@link NoMergingIsDerived}, {@link MergingIsManual}, {@link NoMergingKeepsValue}.
+ * Static fields may be annotated, but not with {@link MergeByAdding}, there will be no automatic modification of static fields
  *
- * MergeByAdding: When merging another metric into this one, the value of the field in the other class will be added to the value in this.
- * This will happen automatically!
- * MergeByAssertEquals: When merging another metric into this one, the code will assert that value of the field in the other class is equal to the value in this.
- * NoMergingIsDerived:  When merging another metric into this one, no action will be taken since the value of this field should be derived from the other field.
- * This derivation should happen in the "calculateDerivedFields" method.
- * MergingIsManual:  When merging another metric into this one, the resulting value will be calculated "manually", i.e. by custom code in the merge
- * method. The resulting value can depend on both this and other objects.
- * NoMergingKeepsValue:  When merging another metric into this one, the value of the field in this remains unchanged by design.
+ * <dl>
+ * <dt>{@link MergeByAdding}</dt>
+ * <dd>When merging another metric into this one, the value of the field in the other class will be added to the value in this.
+ * This will happen automatically!</dd>
+ * <dt>{@link MergeByAssertEquals}</dt>
+ * <dd>When merging another metric into this one, the code will assert that value of the field in the other class is equal to the value in this.</dd>
+ * <dt>{@link NoMergingIsDerived}</dt>
+ * <dd>When merging another metric into this one, no action will be taken since the value of this field should be derived from the other field.
+ * This derivation should happen in the "calculateDerivedFields" method.</dd>
+ * <dt>{@link MergingIsManual}</dt>
+ * <dd>When merging another metric into this one, the resulting value will be calculated "manually", i.e. by custom code in the merge method.
+ * The resulting value can depend on both this and other objects.</dd>
+ * <dt>{@link NoMergingKeepsValue}</dt>
+ * <dd>When merging another metric into this one, the value of the field in this remains unchanged by design.</dd>
+ * </dl>
  *
  * @author Yossi Farjoun
  */
@@ -255,7 +263,8 @@ abstract public class MergeableMetricBase extends MetricBase {
 
     /**
      * placeholder method that will calculate the derived fields from the other ones. classes that are derived from non-trivial base classes
-     * should consider calling super.calculateDerivedFields() as well.
+     * should consider calling super.calculateDerivedFields() as well. Fields whose value will change due to this method should be
+     * annotated with {@link NoMergingIsDerived}.
      */
     public void calculateDerivedFields() {}
 }

--- a/src/main/java/picard/analysis/MergeableMetricBase.java
+++ b/src/main/java/picard/analysis/MergeableMetricBase.java
@@ -42,12 +42,12 @@ import java.util.List;
  * An extension of MetricBase that knows how to merge-by-adding fields that are appropriately annotated ({@link MergeByAdding}). It also provides an interface
  * for calculating derived fields {@link #calculateDerivedFields()}  (and an annotation that informs that said fields are derived {@link NoMergingIsDerived}). Finally, it also allows for an annotation
  * that suggests that a field will be used as an ID and thus merging will simply ensure that these fields are equal {@link MergeByAssertEquals}. Other annotations are available,
- * though they all currently imply that no _implicit_ action will be taken {@link MergingIsManual} and {@link NoMergingKeepsValue}.
- *
+ * though they all currently imply that no <it>implicit</it> action will be taken {@link MergingIsManual} and {@link NoMergingKeepsValue}.
+ *<p>
  * {@link MergeByAdding} is only enabled for the following types: int, Integer, float, Float, double, Double, short, Short, long, Long, byte, Byte.
  * Overflow will be detected (for the short, and byte types) and an exception thrown.
- *
- * Every (non-static) field in this class _must_ be @Annotated by one of: {@link MergeByAdding}, {@link MergeByAssertEquals}, {@link NoMergingIsDerived}, {@link MergingIsManual}, {@link NoMergingKeepsValue}.
+ *<p><
+ * Every (non-static) field in this class <it>must</it> be @Annotated by one of: {@link MergeByAdding}, {@link MergeByAssertEquals}, {@link NoMergingIsDerived}, {@link MergingIsManual}, {@link NoMergingKeepsValue}.
  * Static fields may be annotated, but not with {@link MergeByAdding}, there will be no automatic modification of static fields
  *
  * <dl>
@@ -98,7 +98,7 @@ abstract public class MergeableMetricBase extends MetricBase {
     protected @interface NoMergingKeepsValue {}
 
 
-    /** checks if this instance can be merged with another
+    /** Checks if this instance can be merged with another
      *
      * Other must have all the fields that this instance has, and
      * the fields that are annotated as MergeByAssertEquals must contain the same value

--- a/src/main/java/picard/analysis/MergeableMetricBase.java
+++ b/src/main/java/picard/analysis/MergeableMetricBase.java
@@ -145,24 +145,24 @@ abstract public class MergeableMetricBase extends MetricBase {
         for (final Field field : getAllFields(this.getClass())) {
             if (field.isSynthetic()) continue;
 
-            final boolean isAnnotated =
-                    field.getAnnotationsByType(MergeByAdding.class).length +
-                    field.getAnnotationsByType(MergeByAssertEquals.class).length +
-                    field.getAnnotationsByType(NoMergingIsDerived.class).length +
-                    field.getAnnotationsByType(MergingIsManual.class).length +
-                    field.getAnnotationsByType(NoMergingKeepsValue.class).length != 0;
-
-            final boolean isStatic = Modifier.isStatic(field.getModifiers());
-            final boolean isAnnotatedActive = field.getAnnotationsByType(MergeByAdding.class).length != 0;
-
-            if (!isAnnotated && !isStatic) {
-                throw new IllegalStateException("All (non-static) fields of this class must be annotated with @MergeByAdding, @NoMergingIsDerived, @MergeByAssertEquals, @MergingIsManual, or @NoMergingKeepsValue. " +
-                        "Field " + field.getName() + " isn't annotated.");
-            }
-
-            if (isStatic && isAnnotatedActive) {
-                throw new IllegalStateException("Static fields of classes derived from MergeableMetricBase cannot be annotated with @MergeByAdding, " +
-                        "Field " + field.getName() + " has that annotation.");
+            if (Modifier.isStatic(field.getModifiers())) {
+                final boolean isAnnotatedMergeByAdding = field.getAnnotationsByType(MergeByAdding.class).length != 0;
+                if (isAnnotatedMergeByAdding) {
+                    throw new IllegalStateException("All (non-static) fields of this class must be annotated with @MergeByAdding, @NoMergingIsDerived, @MergeByAssertEquals, @MergingIsManual, or @NoMergingKeepsValue. " +
+                            "Field " + field.getName() + " isn't annotated.");
+                }
+            } else {
+                final boolean isAnnotated =
+                        field.getAnnotationsByType(MergeByAdding.class).length +
+                        field.getAnnotationsByType(MergeByAssertEquals.class).length +
+                        field.getAnnotationsByType(NoMergingIsDerived.class).length +
+                        field.getAnnotationsByType(MergingIsManual.class).length +
+                        field.getAnnotationsByType(NoMergingKeepsValue.class).length != 0;
+                ;
+                if (!isAnnotated) {
+                    throw new IllegalStateException("Static fields of classes derived from MergeableMetricBase cannot be annotated with @MergeByAdding, " +
+                            "Field " + field.getName() + " has that annotation.");
+                }
             }
 
             final Annotation[] summableAnnotations = field.getAnnotationsByType(MergeByAdding.class);

--- a/src/test/java/picard/analysis/MergeableMetricBaseTest.java
+++ b/src/test/java/picard/analysis/MergeableMetricBaseTest.java
@@ -30,7 +30,7 @@ import org.testng.annotations.Test;
 
 public class MergeableMetricBaseTest {
 
-    class TestMergeableMetric extends MergeableMetricBase {
+    static class TestMergeableMetric extends MergeableMetricBase {
         @MergeByAdding
         public Integer boxedInt = 1;
         @MergeByAdding
@@ -85,7 +85,7 @@ public class MergeableMetricBaseTest {
         }
     }
 
-     class TestMergeableMetricWithRestrictedMembers extends TestMergeableMetric {
+     static class TestMergeableMetricWithRestrictedMembers extends TestMergeableMetric {
 
         @MergeByAdding
         private Integer privateIntDerived = 1;
@@ -100,9 +100,73 @@ public class MergeableMetricBaseTest {
         public void calculateDerivedFields() {}
     }
 
+
+    static class TestMergeableMetricWithStaticMembers extends TestMergeableMetric {
+
+        public static int staticInteger = 1;
+
+        protected static String staticString = "hi!";
+        @MergeByAssertEquals
+        protected static String staticEqualsString = "hi!";
+        @NoMergingIsDerived
+        protected static String staticDerivedString = "hi!";
+        @MergingIsManual
+        protected static String staticManualString = "hi!";
+
+        @MergeByAdding
+        private Integer privateIntDerived = 1;
+
+        @MergeByAdding
+        protected Integer protectedIntDerived = 1;
+
+        @MergeByAssertEquals
+        private String privateString = "hi!";
+
+        @Override
+        public void calculateDerivedFields() {}
+    }
+
+
+
+    @Test
+    public void testMergingWithStaticMembers() {
+        final TestMergeableMetricWithStaticMembers metric1 = new TestMergeableMetricWithStaticMembers();
+        final TestMergeableMetricWithStaticMembers metric2 = new TestMergeableMetricWithStaticMembers();
+
+        metric1.merge(metric2);
+        Assert.assertEquals(metric1.boxedInt, (Integer) 2);
+        Assert.assertEquals(metric1.unboxedInt, 4);
+        Assert.assertEquals(metric1.privateIntDerived, (Integer) 2);
+        Assert.assertEquals(metric1.protectedIntDerived, (Integer) 2);
+        Assert.assertEquals(metric1.protectedIntBase, (Integer) 2);
+        Assert.assertEquals(((TestMergeableMetric)metric1).privateIntBase, (Integer) 2);
+        Assert.assertEquals(metric1.privateString, "hi!");
+
+        Assert.assertEquals(metric1.staticInteger,1);
+        Assert.assertEquals(metric1.staticString, "hi!");
+    }
+
+    static class TestMergeableMetricWithStaticAnnotatedMembers extends TestMergeableMetric {
+        // should fail
+        @MergeByAdding
+        public static int staticInteger = 1;
+    }
+
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void testMergingWithStaticAnnotatedMembers() {
+        final TestMergeableMetricWithStaticAnnotatedMembers metric1 = new TestMergeableMetricWithStaticAnnotatedMembers();
+        final TestMergeableMetricWithStaticAnnotatedMembers metric2 = new TestMergeableMetricWithStaticAnnotatedMembers();
+
+        metric1.merge(metric2);
+
+    }
+
+
     @Test
     public void testMergingWithRestrictedMembers() {
-        final TestMergeableMetricWithRestrictedMembers metric1 = new TestMergeableMetricWithRestrictedMembers(), metric2 = new TestMergeableMetricWithRestrictedMembers();
+        final TestMergeableMetricWithRestrictedMembers metric1 = new TestMergeableMetricWithRestrictedMembers();
+        final TestMergeableMetricWithRestrictedMembers metric2 = new TestMergeableMetricWithRestrictedMembers();
         metric1.merge(metric2);
 
         Assert.assertEquals(metric1.boxedInt, (Integer) 2);
@@ -116,7 +180,8 @@ public class MergeableMetricBaseTest {
 
     @Test
     public void testMergingWithRestrictedMembersUsingBaseClass() {
-        final MergeableMetricBase metric1 = new TestMergeableMetricWithRestrictedMembers(), metric2 = new TestMergeableMetricWithRestrictedMembers();
+        final MergeableMetricBase metric1 = new TestMergeableMetricWithRestrictedMembers();
+        final MergeableMetricBase metric2 = new TestMergeableMetricWithRestrictedMembers();
         metric1.merge(metric2);
 
         Assert.assertEquals(((TestMergeableMetricWithRestrictedMembers)metric1).boxedInt, (Integer) 2);
@@ -128,7 +193,8 @@ public class MergeableMetricBaseTest {
 
     @Test
     public void testMerging() {
-        final TestMergeableMetric metric1 = new TestMergeableMetric(), metric2 = new TestMergeableMetric();
+        final TestMergeableMetric metric1 = new TestMergeableMetric();
+        final TestMergeableMetric metric2 = new TestMergeableMetric();
         metric1.merge(metric2);
 
         Assert.assertEquals(metric1.boxedInt, (Integer) 2);
@@ -161,7 +227,8 @@ public class MergeableMetricBaseTest {
     @Test(expectedExceptions = IllegalStateException.class)
     public void testMergingUnequalString() {
 
-        final TestMergeableMetric metric1 = new TestMergeableMetric(), metric2 = new TestMergeableMetric();
+        final TestMergeableMetric metric1 = new TestMergeableMetric();
+        final TestMergeableMetric metric2 = new TestMergeableMetric();
         metric1.mustBeEqualString = "goodbye";
 
         Assert.assertFalse(metric1.canMerge(metric2));
@@ -171,7 +238,8 @@ public class MergeableMetricBaseTest {
     @Test
     public void testMergingANull() {
 
-        final TestMergeableMetric metric1 = new TestMergeableMetric(), metric2 = new TestMergeableMetric();
+        final TestMergeableMetric metric1 = new TestMergeableMetric();
+        final TestMergeableMetric metric2 = new TestMergeableMetric();
         metric1.mustBeEqualString = "goodbye";
         metric2.mustBeEqualString = null;
 
@@ -188,7 +256,8 @@ public class MergeableMetricBaseTest {
     @Test(expectedExceptions = IllegalStateException.class)
     public void testMergingUnequalDouble() {
 
-        final TestMergeableMetric metric1 = new TestMergeableMetric(), metric2 = new TestMergeableMetric();
+        final TestMergeableMetric metric1 = new TestMergeableMetric();
+        final TestMergeableMetric metric2 = new TestMergeableMetric();
         metric1.mustBeEqualDouble = 1D;
 
         Assert.assertFalse(metric1.canMerge(metric2));
@@ -198,7 +267,8 @@ public class MergeableMetricBaseTest {
     @Test(expectedExceptions = IllegalStateException.class)
     public void testMergingUnequalBoolean() {
 
-        final TestMergeableMetric metric1 = new TestMergeableMetric(), metric2 = new TestMergeableMetric();
+        final TestMergeableMetric metric1 = new TestMergeableMetric();
+        final TestMergeableMetric metric2 = new TestMergeableMetric();
         metric1.mustBeEqualUnboxedBoolean = true;
 
         Assert.assertFalse(metric1.canMerge(metric2));
@@ -214,7 +284,8 @@ public class MergeableMetricBaseTest {
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testIllegalClass() {
-        final TestMergeableMetricIllegal illegal1 = new TestMergeableMetricIllegal(), illegal2 = new TestMergeableMetricIllegal();
+        final TestMergeableMetricIllegal illegal1 = new TestMergeableMetricIllegal();
+        final TestMergeableMetricIllegal illegal2 = new TestMergeableMetricIllegal();
 
         illegal1.merge(illegal2);
     }


### PR DESCRIPTION
or they can be annotated but not with @MergeByAdding...

fixes #1172 

