### PR TITLE
Added forgotten (test) class that tests MarkDuplicates on queryname sorted input

### DIFF
--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesTestQueryNameSorted.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesTestQueryNameSorted.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam.markduplicates;
+
+/**
+ * The purpose of this class is to show that MarkDuplicates gives (almost) the same results when run on files that
+ * are queryname sorted.
+ *
+ */
+public class MarkDuplicatesTestQueryNameSorted extends MarkDuplicatesTest {
+    @Override
+    protected boolean markUnmappedRecordsLikeTheirMates() {
+        return true;
+    }
+
+    @Override
+    protected boolean markSecondaryAndSupplementaryRecordsLikeTheCanonical() {
+        return true;
+    }
+
+    @Override
+    protected AbstractMarkDuplicatesCommandLineProgramTester getTester() {
+        return new QuerySortedMarkDuplicatesTester();
+    }
+}


### PR DESCRIPTION
This shows that in this case the program marks all the reads (umapped mates, secondary and supplementary) from the same template (i.e. with the same queryname) in the same way. This is possible to do when the input is queryname sorted, and thus it is done.


