### PR TITLE
DSDEGP-2354 id correct tile metrics file in parser for novaseq

### DIFF
--- a/src/main/java/picard/illumina/CollectIlluminaLaneMetrics.java
+++ b/src/main/java/picard/illumina/CollectIlluminaLaneMetrics.java
@@ -159,8 +159,8 @@ public class CollectIlluminaLaneMetrics extends CommandLineProgram {
                     tiles = TileMetricsUtil.parseClusterRecordsFromTileMetricsV3(
                             tileMetricsOutFiles,
                             TileMetricsUtil.renderPhasingMetricsFilesFromBasecallingDirectory(illuminaRunDirectory),
-                            readStructure,
-                            validationStringency);
+                            readStructure
+                    );
                 } else {
                     tiles = TileMetricsUtil.parseTileMetrics(tileMetricsOutFiles.get(0),
                             readStructure,

--- a/src/main/java/picard/illumina/CollectIlluminaLaneMetrics.java
+++ b/src/main/java/picard/illumina/CollectIlluminaLaneMetrics.java
@@ -154,15 +154,15 @@ public class CollectIlluminaLaneMetrics extends CommandLineProgram {
                                                                              final boolean isNovaSeq) {
             final Collection<Tile> tiles;
             try {
-                File tileMetricsOutFile = TileMetricsUtil.renderTileMetricsFileFromBasecallingDirectory(illuminaRunDirectory, readStructure.totalCycles, isNovaSeq);
+                List<File> tileMetricsOutFiles = TileMetricsUtil.renderTileMetricsFileFromBasecallingDirectory(illuminaRunDirectory, readStructure.totalCycles, isNovaSeq);
                 if (isNovaSeq) {
-                    tiles = TileMetricsUtil.parseTileMetrics(
-                            tileMetricsOutFile,
+                    tiles = TileMetricsUtil.parseClusterRecordsFromTileMetricsV3(
+                            tileMetricsOutFiles,
                             TileMetricsUtil.renderPhasingMetricsFilesFromBasecallingDirectory(illuminaRunDirectory),
                             readStructure,
                             validationStringency);
                 } else {
-                    tiles = TileMetricsUtil.parseTileMetrics(tileMetricsOutFile,
+                    tiles = TileMetricsUtil.parseTileMetrics(tileMetricsOutFiles.get(0),
                             readStructure,
                             validationStringency
                     );

--- a/src/main/java/picard/illumina/CollectIlluminaLaneMetrics.java
+++ b/src/main/java/picard/illumina/CollectIlluminaLaneMetrics.java
@@ -154,7 +154,7 @@ public class CollectIlluminaLaneMetrics extends CommandLineProgram {
                                                                              final boolean isNovaSeq) {
             final Collection<Tile> tiles;
             try {
-                List<File> tileMetricsOutFiles = TileMetricsUtil.renderTileMetricsFileFromBasecallingDirectory(illuminaRunDirectory, readStructure.totalCycles, isNovaSeq);
+                List<File> tileMetricsOutFiles = TileMetricsUtil.renderTileMetricsFilesFromBasecallingDirectory(illuminaRunDirectory, readStructure.totalCycles, isNovaSeq);
                 if (isNovaSeq) {
                     tiles = TileMetricsUtil.parseClusterRecordsFromTileMetricsV3(
                             tileMetricsOutFiles,

--- a/src/main/java/picard/illumina/CollectIlluminaLaneMetrics.java
+++ b/src/main/java/picard/illumina/CollectIlluminaLaneMetrics.java
@@ -154,7 +154,7 @@ public class CollectIlluminaLaneMetrics extends CommandLineProgram {
                                                                              final boolean isNovaSeq) {
             final Collection<Tile> tiles;
             try {
-                List<File> tileMetricsOutFiles = TileMetricsUtil.findTileMetricsFiles(illuminaRunDirectory, readStructure.totalCycles, isNovaSeq);
+                final List<File> tileMetricsOutFiles = TileMetricsUtil.findTileMetricsFiles(illuminaRunDirectory, readStructure.totalCycles, isNovaSeq);
                 if (isNovaSeq) {
                     tiles = TileMetricsUtil.parseClusterRecordsFromTileMetricsV3(
                             tileMetricsOutFiles,
@@ -162,7 +162,8 @@ public class CollectIlluminaLaneMetrics extends CommandLineProgram {
                             readStructure
                     );
                 } else {
-                    tiles = TileMetricsUtil.parseTileMetrics(tileMetricsOutFiles.get(0),
+                    tiles = TileMetricsUtil.parseTileMetrics(
+                            tileMetricsOutFiles.get(0),
                             readStructure,
                             validationStringency
                     );

--- a/src/main/java/picard/illumina/CollectIlluminaLaneMetrics.java
+++ b/src/main/java/picard/illumina/CollectIlluminaLaneMetrics.java
@@ -154,7 +154,7 @@ public class CollectIlluminaLaneMetrics extends CommandLineProgram {
                                                                              final boolean isNovaSeq) {
             final Collection<Tile> tiles;
             try {
-                List<File> tileMetricsOutFiles = TileMetricsUtil.renderTileMetricsFilesFromBasecallingDirectory(illuminaRunDirectory, readStructure.totalCycles, isNovaSeq);
+                List<File> tileMetricsOutFiles = TileMetricsUtil.findTileMetricsFiles(illuminaRunDirectory, readStructure.totalCycles, isNovaSeq);
                 if (isNovaSeq) {
                     tiles = TileMetricsUtil.parseClusterRecordsFromTileMetricsV3(
                             tileMetricsOutFiles,

--- a/src/main/java/picard/illumina/parser/TileMetricsUtil.java
+++ b/src/main/java/picard/illumina/parser/TileMetricsUtil.java
@@ -130,27 +130,12 @@ public class TileMetricsUtil {
         return Collections.unmodifiableCollection(tiles);
     }
 
-    private static boolean v3TileMetricsHasClusterRecordsFirstPass(Map<String, ? extends Collection<IlluminaTileMetrics>> locationToMetricsMap) {
-        final Map.Entry<String, ? extends Collection<IlluminaTileMetrics>> entry = locationToMetricsMap.entrySet().iterator().next();
-        final IlluminaTileMetrics record = CollectionUtil.getSoleElement(entry.getValue());
-        return record.isClusterRecord();
-    }
-
     public static Collection<Tile> parseClusterRecordsFromTileMetricsV3(
             final Collection<File> tileMetricsOutFiles,
             final Map<Integer, File> phasingMetricsFiles,
             final ReadStructure readStructure
     ) throws FileNotFoundException {
         Map<Integer, Map<Integer, Collection<TilePhasingValue>>> phasingValues = getTilePhasingValues(phasingMetricsFiles, readStructure);
-        for (File tileMetricsOutFile : tileMetricsOutFiles) {
-            TileMetricsOutReader tileMetricsIterator = new TileMetricsOutReader(tileMetricsOutFile, TileMetricsOutReader.TileMetricsVersion.THREE);
-            final Collection<IlluminaTileMetrics> tileMetrics = determineLastValueForLaneTileMetricsCode(tileMetricsIterator);
-            final Map<String, ? extends Collection<IlluminaTileMetrics>> locationToMetricsMap = partitionTileMetricsByLocation(tileMetrics);
-            if (v3TileMetricsHasClusterRecordsFirstPass(locationToMetricsMap)) {
-                final float density = tileMetricsIterator.getDensity();
-                return getTileClusterRecordsV3(locationToMetricsMap, phasingValues, density);
-            }
-        }
         for (File tileMetricsOutFile : tileMetricsOutFiles) {
             TileMetricsOutReader tileMetricsIterator = new TileMetricsOutReader(tileMetricsOutFile, TileMetricsOutReader.TileMetricsVersion.THREE);
             final float density = tileMetricsIterator.getDensity();

--- a/src/main/java/picard/illumina/parser/TileMetricsUtil.java
+++ b/src/main/java/picard/illumina/parser/TileMetricsUtil.java
@@ -155,6 +155,7 @@ public class TileMetricsUtil {
         throw new RuntimeException("None of the following input files contained cluster records:" + pathsString);
     }
 
+    @Deprecated // Use parseClusterRecordsFromTileMetricsV3 instead
     public static Collection<Tile> parseTileMetrics(final File tileMetricsOutFile,
                                                     final Map<Integer, File> phasingMetricsFiles,
                                                     final ReadStructure readStructure,

--- a/src/main/java/picard/illumina/parser/TileMetricsUtil.java
+++ b/src/main/java/picard/illumina/parser/TileMetricsUtil.java
@@ -74,11 +74,12 @@ public class TileMetricsUtil {
     /**
      * Returns the path to the TileMetrics file given the basecalling directory.
      */
-    public static List<File> renderTileMetricsFilesFromBasecallingDirectory(final File illuminaRunDirectory, Integer numCycles, boolean isNovaSeq) {
-        return findTileMetricsFiles(illuminaRunDirectory, numCycles, isNovaSeq);
+    @Deprecated // Use findTileMetricsFiles instead; the illumina directory hierarchy for novaSeq is unreliable.
+    public static File renderTileMetricsFileFromBasecallingDirectory(final File illuminaRunDirectory, Integer numCycles, boolean isNovaSeq) {
+        return findTileMetricsFiles(illuminaRunDirectory, numCycles, isNovaSeq).get(0);
     }
 
-    private static List<File> findTileMetricsFiles(File illuminaRunDirectory, Integer numCycles, boolean isNovaSeq) {
+    public static List<File> findTileMetricsFiles(File illuminaRunDirectory, Integer numCycles, boolean isNovaSeq) {
         Path interOpDir = illuminaRunDirectory.toPath().resolve(INTEROP_SUBDIRECTORY_NAME);
         final List<Path> pathsToTest = new ArrayList<>();
 

--- a/src/main/java/picard/illumina/parser/TileMetricsUtil.java
+++ b/src/main/java/picard/illumina/parser/TileMetricsUtil.java
@@ -135,7 +135,7 @@ public class TileMetricsUtil {
             final Map<Integer, File> phasingMetricsFiles,
             final ReadStructure readStructure
     ) throws FileNotFoundException {
-        Map<Integer, Map<Integer, Collection<TilePhasingValue>>> phasingValues = getTilePhasingValues(phasingMetricsFiles, readStructure);
+        final Map<Integer, Map<Integer, Collection<TilePhasingValue>>> phasingValues = getTilePhasingValues(phasingMetricsFiles, readStructure);
         for (File tileMetricsOutFile : tileMetricsOutFiles) {
             final TileMetricsOutReader tileMetricsIterator = new TileMetricsOutReader(tileMetricsOutFile, TileMetricsOutReader.TileMetricsVersion.THREE);
             final float density = tileMetricsIterator.getDensity();
@@ -150,7 +150,7 @@ public class TileMetricsUtil {
                 .stream()
                 .map(File::getAbsolutePath)
                 .collect(Collectors.joining(", "));
-        throw new RuntimeException("None of the following input files contained cluster records:" + pathsString);
+        throw new RuntimeException("None of the following input files contained cluster records: " + pathsString);
     }
 
     /**

--- a/src/main/java/picard/illumina/parser/TileMetricsUtil.java
+++ b/src/main/java/picard/illumina/parser/TileMetricsUtil.java
@@ -74,7 +74,7 @@ public class TileMetricsUtil {
     /**
      * Returns the path to the TileMetrics file given the basecalling directory.
      */
-    public static List<File> renderTileMetricsFileFromBasecallingDirectory(final File illuminaRunDirectory, Integer numCycles, boolean isNovaSeq) {
+    public static List<File> renderTileMetricsFilesFromBasecallingDirectory(final File illuminaRunDirectory, Integer numCycles, boolean isNovaSeq) {
         return findTileMetricsFiles(illuminaRunDirectory, numCycles, isNovaSeq);
     }
 
@@ -101,16 +101,18 @@ public class TileMetricsUtil {
             if (isNovaSeq) {
                 message.append(" or any of its cycle directories.");
             }
-            throw new IllegalArgumentException(message.toString());
+            throw new IllegalStateException(message.toString());
         }
         return files;
     }
 
-    private static Collection<Tile> getTileClusterRecordsV3(Map<String, ? extends Collection<IlluminaTileMetrics>> locationToMetricsMap,
-                                            final Map<Integer, File> phasingMetricsFiles,
-                                            final ReadStructure readStructure,
-                                            final ValidationStringency validationStringency,
-                                            final Float density) {
+    private static Collection<Tile> getTileClusterRecordsV3(
+            Map<String, ? extends Collection<IlluminaTileMetrics>> locationToMetricsMap,
+            final Map<Integer, File> phasingMetricsFiles,
+            final ReadStructure readStructure,
+            final ValidationStringency validationStringency,
+            final Float density) {
+
         final Collection<Tile> tiles = new LinkedList<>();
         for (final Map.Entry<String, ? extends Collection<IlluminaTileMetrics>> entry : locationToMetricsMap.entrySet()) {
             final Collection<IlluminaTileMetrics> tileRecords = entry.getValue();
@@ -130,11 +132,12 @@ public class TileMetricsUtil {
         return Collections.unmodifiableCollection(tiles);
     }
 
-    public static Collection<Tile> parseClusterRecordsFromTileMetricsV3(final Collection<File> tileMetricsOutFiles,
-                                                        final Map<Integer, File> phasingMetricsFiles,
-                                                        final ReadStructure readStructure,
-                                                        final ValidationStringency validationStringency)
-            throws FileNotFoundException {
+    public static Collection<Tile> parseClusterRecordsFromTileMetricsV3(
+            final Collection<File> tileMetricsOutFiles,
+            final Map<Integer, File> phasingMetricsFiles,
+            final ReadStructure readStructure,
+            final ValidationStringency validationStringency
+    ) throws FileNotFoundException {
         for (File tileMetricsOutfile : tileMetricsOutFiles) {
             TileMetricsOutReader tileMetricsIterator = new TileMetricsOutReader(tileMetricsOutfile, TileMetricsOutReader.TileMetricsVersion.THREE);
             final float density = tileMetricsIterator.getDensity();

--- a/src/main/java/picard/illumina/parser/TileMetricsUtil.java
+++ b/src/main/java/picard/illumina/parser/TileMetricsUtil.java
@@ -110,7 +110,7 @@ public class TileMetricsUtil {
     }
 
     private static Collection<Tile> getTileClusterRecordsV3(
-            Map<String, ? extends Collection<IlluminaTileMetrics>> locationToMetricsMap,
+            final Map<String, ? extends Collection<IlluminaTileMetrics>> locationToMetricsMap,
             final Map<Integer, Map<Integer, Collection<TilePhasingValue>>> phasingValues,
             final float density) {
 
@@ -137,7 +137,7 @@ public class TileMetricsUtil {
     ) throws FileNotFoundException {
         Map<Integer, Map<Integer, Collection<TilePhasingValue>>> phasingValues = getTilePhasingValues(phasingMetricsFiles, readStructure);
         for (File tileMetricsOutFile : tileMetricsOutFiles) {
-            TileMetricsOutReader tileMetricsIterator = new TileMetricsOutReader(tileMetricsOutFile, TileMetricsOutReader.TileMetricsVersion.THREE);
+            final TileMetricsOutReader tileMetricsIterator = new TileMetricsOutReader(tileMetricsOutFile, TileMetricsOutReader.TileMetricsVersion.THREE);
             final float density = tileMetricsIterator.getDensity();
             final Collection<IlluminaTileMetrics> tileMetrics = determineLastValueForLaneTileMetricsCode(tileMetricsIterator);
             final Map<String, ? extends Collection<IlluminaTileMetrics>> locationToMetricsMap = partitionTileMetricsByLocation(tileMetrics);
@@ -162,8 +162,8 @@ public class TileMetricsUtil {
                                                     final ReadStructure readStructure,
                                                     final ValidationStringency validationStringency)
             throws FileNotFoundException {
-        Map<Integer, Map<Integer, Collection<TilePhasingValue>>> phasingValues = getTilePhasingValues(phasingMetricsFiles, readStructure);
-        TileMetricsOutReader tileMetricsIterator = new TileMetricsOutReader(tileMetricsOutFile, TileMetricsOutReader.TileMetricsVersion.THREE);
+        final Map<Integer, Map<Integer, Collection<TilePhasingValue>>> phasingValues = getTilePhasingValues(phasingMetricsFiles, readStructure);
+        final TileMetricsOutReader tileMetricsIterator = new TileMetricsOutReader(tileMetricsOutFile, TileMetricsOutReader.TileMetricsVersion.THREE);
         final Collection<IlluminaTileMetrics> tileMetrics = determineLastValueForLaneTileMetricsCode(tileMetricsIterator);
         final Map<String, ? extends Collection<IlluminaTileMetrics>> locationToMetricsMap = partitionTileMetricsByLocation(tileMetrics);
         return getTileClusterRecordsV3(locationToMetricsMap, phasingValues, tileMetricsIterator.getDensity());

--- a/src/main/java/picard/illumina/parser/TileMetricsUtil.java
+++ b/src/main/java/picard/illumina/parser/TileMetricsUtil.java
@@ -73,13 +73,15 @@ public class TileMetricsUtil {
 
     /**
      * Returns the path to the TileMetrics file given the basecalling directory.
+     *
+     * @deprecated use {@link #findTileMetricsFiles(File, int, boolean)} instead
      */
-    @Deprecated // Use findTileMetricsFiles instead; the illumina directory hierarchy for novaSeq is unreliable.
-    public static File renderTileMetricsFileFromBasecallingDirectory(final File illuminaRunDirectory, Integer numCycles, boolean isNovaSeq) {
+    @Deprecated
+    public static File renderTileMetricsFileFromBasecallingDirectory(final File illuminaRunDirectory, int numCycles, boolean isNovaSeq) {
         return findTileMetricsFiles(illuminaRunDirectory, numCycles, isNovaSeq).get(0);
     }
 
-    public static List<File> findTileMetricsFiles(File illuminaRunDirectory, Integer numCycles, boolean isNovaSeq) {
+    public static List<File> findTileMetricsFiles(File illuminaRunDirectory, int numCycles, boolean isNovaSeq) {
         Path interOpDir = illuminaRunDirectory.toPath().resolve(INTEROP_SUBDIRECTORY_NAME);
         final List<Path> pathsToTest = new ArrayList<>();
 
@@ -112,7 +114,7 @@ public class TileMetricsUtil {
             final Map<Integer, File> phasingMetricsFiles,
             final ReadStructure readStructure,
             final ValidationStringency validationStringency,
-            final Float density) {
+            final float density) {
 
         final Collection<Tile> tiles = new LinkedList<>();
         for (final Map.Entry<String, ? extends Collection<IlluminaTileMetrics>> entry : locationToMetricsMap.entrySet()) {
@@ -155,7 +157,10 @@ public class TileMetricsUtil {
         throw new RuntimeException("None of the following input files contained cluster records:" + pathsString);
     }
 
-    @Deprecated // Use parseClusterRecordsFromTileMetricsV3 instead
+    /**
+     * @deprecated use {@link #parseClusterRecordsFromTileMetricsV3(Collection, Map, ReadStructure, ValidationStringency)} instead
+     */
+    @Deprecated
     public static Collection<Tile> parseTileMetrics(final File tileMetricsOutFile,
                                                     final Map<Integer, File> phasingMetricsFiles,
                                                     final ReadStructure readStructure,

--- a/src/main/java/picard/illumina/parser/TileMetricsUtil.java
+++ b/src/main/java/picard/illumina/parser/TileMetricsUtil.java
@@ -50,8 +50,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static java.lang.Float.NaN;
-
 /**
  * Utility for reading the tile data from an Illumina run directory's TileMetricsOut.bin file
  *

--- a/src/main/java/picard/illumina/parser/TileMetricsUtil.java
+++ b/src/main/java/picard/illumina/parser/TileMetricsUtil.java
@@ -135,19 +135,35 @@ public class TileMetricsUtil {
         return Collections.unmodifiableCollection(tiles);
     }
 
+    private static boolean v3TileMetricsHasClusterRecordsFirstPass(Map<String, ? extends Collection<IlluminaTileMetrics>> locationToMetricsMap) {
+        final Map.Entry<String, ? extends Collection<IlluminaTileMetrics>> entry = locationToMetricsMap.entrySet().iterator().next();
+        final IlluminaTileMetrics record = CollectionUtil.getSoleElement(entry.getValue());
+        return record.isClusterRecord();
+    }
+
     public static Collection<Tile> parseClusterRecordsFromTileMetricsV3(
             final Collection<File> tileMetricsOutFiles,
             final Map<Integer, File> phasingMetricsFiles,
             final ReadStructure readStructure,
             final ValidationStringency validationStringency
     ) throws FileNotFoundException {
-        for (File tileMetricsOutfile : tileMetricsOutFiles) {
-            TileMetricsOutReader tileMetricsIterator = new TileMetricsOutReader(tileMetricsOutfile, TileMetricsOutReader.TileMetricsVersion.THREE);
-            final float density = tileMetricsIterator.getDensity();
-            if (density > 0 ) {
-                final Collection<IlluminaTileMetrics> tileMetrics = determineLastValueForLaneTileMetricsCode(tileMetricsIterator);
-                final Map<String, ? extends Collection<IlluminaTileMetrics>> locationToMetricsMap = partitionTileMetricsByLocation(tileMetrics);
+        for (File tileMetricsOutFile : tileMetricsOutFiles) {
+            TileMetricsOutReader tileMetricsIterator = new TileMetricsOutReader(tileMetricsOutFile, TileMetricsOutReader.TileMetricsVersion.THREE);
+            final Collection<IlluminaTileMetrics> tileMetrics = determineLastValueForLaneTileMetricsCode(tileMetricsIterator);
+            final Map<String, ? extends Collection<IlluminaTileMetrics>> locationToMetricsMap = partitionTileMetricsByLocation(tileMetrics);
+            if (v3TileMetricsHasClusterRecordsFirstPass(locationToMetricsMap)) {
+                final float density = tileMetricsIterator.getDensity();
                 return getTileClusterRecordsV3(locationToMetricsMap, phasingMetricsFiles, readStructure, validationStringency, density);
+            }
+        }
+        for (File tileMetricsOutFile : tileMetricsOutFiles) {
+            TileMetricsOutReader tileMetricsIterator = new TileMetricsOutReader(tileMetricsOutFile, TileMetricsOutReader.TileMetricsVersion.THREE);
+            final float density = tileMetricsIterator.getDensity();
+            final Collection<IlluminaTileMetrics> tileMetrics = determineLastValueForLaneTileMetricsCode(tileMetricsIterator);
+            final Map<String, ? extends Collection<IlluminaTileMetrics>> locationToMetricsMap = partitionTileMetricsByLocation(tileMetrics);
+            final Collection<Tile> tiles = getTileClusterRecordsV3(locationToMetricsMap, phasingMetricsFiles, readStructure, validationStringency, density);
+            if (!tiles.isEmpty()) {
+                return tiles;
             }
         }
         final String pathsString = tileMetricsOutFiles

--- a/src/test/java/picard/illumina/parser/TileMetricsUtilTest.java
+++ b/src/test/java/picard/illumina/parser/TileMetricsUtilTest.java
@@ -50,7 +50,7 @@ public class TileMetricsUtilTest {
     @Test(expectedExceptions = IllegalStateException.class)
     public void testMissingTileMetrics() throws IOException {
         List<Integer> populatedCycleDirs = Collections.emptyList();
-        Path baseDir = createTestDirs("missingTileMetrics",0, populatedCycleDirs, false);
+        Path baseDir = createTestDirs("missingTileMetrics", 0, populatedCycleDirs, false);
         TileMetricsUtil.findTileMetricsFiles(
                 baseDir.toFile(), 0, false);
     }

--- a/src/test/java/picard/illumina/parser/TileMetricsUtilTest.java
+++ b/src/test/java/picard/illumina/parser/TileMetricsUtilTest.java
@@ -19,7 +19,7 @@ public class TileMetricsUtilTest {
     public void testFindTileMetrics() throws IOException {
         List<Integer> populatedCycleDirs = new ArrayList<>();
         Path baseDir = createTestDirs(0, populatedCycleDirs, true);
-        List<File> tileMetricsFiles = TileMetricsUtil.renderTileMetricsFilesFromBasecallingDirectory(
+        List<File> tileMetricsFiles = TileMetricsUtil.findTileMetricsFiles(
                 baseDir.toFile(), 0, false);
 
         List<File> expected = generateFindTileMetricsExpected(baseDir, populatedCycleDirs, true);
@@ -31,7 +31,7 @@ public class TileMetricsUtilTest {
     public void testMissingTileMetrics() throws IOException {
         List<Integer> populatedCycleDirs = new ArrayList<>();
         Path baseDir = createTestDirs(0, populatedCycleDirs, false);
-        TileMetricsUtil.renderTileMetricsFilesFromBasecallingDirectory(
+        TileMetricsUtil.findTileMetricsFiles(
                 baseDir.toFile(), 0, false);
 
         IOUtil.deleteDirectoryTree(baseDir.toFile());
@@ -57,7 +57,7 @@ public class TileMetricsUtilTest {
     ) throws IOException {
 
         Path baseDir = createTestDirs(numCycles, populatedCycleDirs, baseMetricsFile);
-        List<File> tileMetricsFiles = TileMetricsUtil.renderTileMetricsFilesFromBasecallingDirectory(
+        List<File> tileMetricsFiles = TileMetricsUtil.findTileMetricsFiles(
             baseDir.toFile(), numCycles, true);
 
         List<File> expected = generateFindTileMetricsExpected(baseDir, populatedCycleDirs, baseMetricsFile);
@@ -86,7 +86,7 @@ public class TileMetricsUtilTest {
             boolean baseMetricsFile
     ) throws IOException {
         Path baseDir = Files.createTempDirectory("TileMetricsUtilTest");
-        // create numCylcleMetricsFiles cycle dirs put tile metrics in those indicated by populatedCycleDirs
+        // create numCycleMetricsFiles cycle dirs put tile metrics in those indicated by populatedCycleDirs
         Path baseOpDir = Files.createDirectory(getBaseOpDir(baseDir));
         IntStream.range(1, numCycleMetricsFiles + 1).forEach(i -> {
             try {


### PR DESCRIPTION
### Description

TileMetricsUtil was relying on a hierarchy in the Illumina directory structure to determine which TileMetricsOut.bin to use when collecting lane metrics. This hierarchy has turned out to be unreliable. The correct TileMetricsOut.bin to use should be the one with cluster records. This change has the collector parse all of the TileMetricsOut.bin files in hierarchical order until it finds one with cluster records.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

