### PR TITLE
Adding a LIBRARY field to the umi metrics file in UmiAwareMarkDuplica…

### DIFF
--- a/src/main/java/picard/sam/markduplicates/UmiMetrics.java
+++ b/src/main/java/picard/sam/markduplicates/UmiMetrics.java
@@ -41,6 +41,9 @@ public class UmiMetrics extends MetricBase {
     private long observedUmiWithNs = 0;
     private long totalObservedUmisWithoutNs = 0;
 
+    /** Library that was used to generate UMI data. */
+    public String LIBRARY = "";
+
     /** Number of bases in each UMI */
     public double MEAN_UMI_LENGTH = 0.0;
 

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
@@ -182,6 +182,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
             double tolerance = 1e-6;
             Assert.assertEquals(metricsOutput.getMetrics().size(), 1);
             final UmiMetrics observedMetrics = metricsOutput.getMetrics().get(0);
+            Assert.assertEquals(observedMetrics.LIBRARY, null, "LIBRARY does not match expected");
             Assert.assertEquals(observedMetrics.MEAN_UMI_LENGTH, expectedMetrics.MEAN_UMI_LENGTH, "UMI_LENGTH does not match expected");
             Assert.assertEquals(observedMetrics.OBSERVED_UNIQUE_UMIS, expectedMetrics.OBSERVED_UNIQUE_UMIS, "OBSERVED_UNIQUE_UMIS does not match expected");
             Assert.assertEquals(observedMetrics.INFERRED_UNIQUE_UMIS, expectedMetrics.INFERRED_UNIQUE_UMIS, "INFERRED_UNIQUE_UMIS does not match expected");


### PR DESCRIPTION
…tesWithMateCigar

### Description

This adds a LIBRARY field to the UMI metrics file from UmiAwareMarkDuplicatesWithMateCigar.

The reason for this change is that Zamboni expects a LIBRARY field.  For now this is a temporary fix, ideally we should aggregate the UMI metrics by library instead of simply leaving it blank.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

