### PR TITLE
Adding error in LiftoverVcf if reference dictionary does not exist (Issue #1157)

### DIFF
--- a/src/main/java/picard/vcf/LiftoverVcf.java
+++ b/src/main/java/picard/vcf/LiftoverVcf.java
@@ -286,7 +286,7 @@ public class LiftoverVcf extends CommandLineProgram {
         final Map<String, ReferenceSequence> refSeqs = new HashMap<>();
         // check if sequence dictionary exists
         if (walker.getSequenceDictionary() == null) {
-            log.error("Reference " + REFERENCE_SEQUENCE.getAbsolutePath() + " must have associated Dictionary .dict file in same directory");
+            log.error("Reference " + REFERENCE_SEQUENCE.getAbsolutePath() + " must have an associated Dictionary .dict file in the same directory.");
             return 1;
         }
         for (final SAMSequenceRecord rec : walker.getSequenceDictionary().getSequences()) {

--- a/src/main/java/picard/vcf/LiftoverVcf.java
+++ b/src/main/java/picard/vcf/LiftoverVcf.java
@@ -284,6 +284,11 @@ public class LiftoverVcf extends CommandLineProgram {
         log.info("Loading up the target reference genome.");
         final ReferenceSequenceFileWalker walker = new ReferenceSequenceFileWalker(REFERENCE_SEQUENCE);
         final Map<String, ReferenceSequence> refSeqs = new HashMap<>();
+        //check if sequence dictionary exists
+        if (walker.getSequenceDictionary() == null) {
+            log.error("Reference " + REFERENCE_SEQUENCE.getAbsolutePath() + " must have associated Dictionary .dict file in same directory");
+            return 1;
+        }
         for (final SAMSequenceRecord rec : walker.getSequenceDictionary().getSequences()) {
             refSeqs.put(rec.getSequenceName(), walker.get(rec.getSequenceIndex()));
         }

--- a/src/main/java/picard/vcf/LiftoverVcf.java
+++ b/src/main/java/picard/vcf/LiftoverVcf.java
@@ -284,7 +284,7 @@ public class LiftoverVcf extends CommandLineProgram {
         log.info("Loading up the target reference genome.");
         final ReferenceSequenceFileWalker walker = new ReferenceSequenceFileWalker(REFERENCE_SEQUENCE);
         final Map<String, ReferenceSequence> refSeqs = new HashMap<>();
-        //check if sequence dictionary exists
+        // check if sequence dictionary exists
         if (walker.getSequenceDictionary() == null) {
             log.error("Reference " + REFERENCE_SEQUENCE.getAbsolutePath() + " must have associated Dictionary .dict file in same directory");
             return 1;

--- a/src/test/java/picard/util/LiftoverVcfTest.java
+++ b/src/test/java/picard/util/LiftoverVcfTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.*;
 import java.nio.file.Path;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 /**
  * Test class for LiftoverVcf.
  * <p>
@@ -1180,21 +1181,17 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         final Path rejectOutput = Files.createTempFile("tmpreject", ".vcf");
         rejectOutput.toFile().deleteOnExit();
         final Path input = TEST_DATA_PATH.toPath().resolve("testLiftoverBiallelicIndels.vcf");
+        final Path referenceCopy = Files.createTempFile("ref", ".fasta");
+        referenceCopy.toFile().deleteOnExit();
+        Files.copy(REFERENCE_FILE.toPath(), referenceCopy, StandardCopyOption.REPLACE_EXISTING);
         final String[] args = new String[]{
                 "INPUT=" + input.toString(),
                 "OUTPUT=" + liftOutput.toString(),
                 "REJECT=" + rejectOutput.toString(),
                 "CHAIN=" + CHAIN_FILE,
-                "REFERENCE_SEQUENCE=" + REFERENCE_FILE,
+                "REFERENCE_SEQUENCE=" + referenceCopy.toString(),
         };
-        Path dictionary = REFERENCE_FILE.toPath().resolveSibling(REFERENCE_FILE.getName().replace("fasta", "dict"));
-        dictionary.toFile().renameTo(new File(dictionary.toString().replace("dict", "dict.tmp")));
-        dictionary = REFERENCE_FILE.toPath().resolveSibling(REFERENCE_FILE.getName().replace("fasta", "dict.tmp"));
-        try {
-            Assert.assertEquals(runPicardCommandLine(args), 1);
-        } finally {//return dictionary name to previous
-            dictionary.toFile().renameTo(new File(dictionary.toString().replace("dict.tmp", "dict")));
-        }
+        Assert.assertEquals(runPicardCommandLine(args), 1);
     }
 
     @Test(expectedExceptions = SAMException.class)
@@ -1211,11 +1208,11 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
                 "CHAIN=" + CHAIN_FILE,
                 "REFERENCE_SEQUENCE=" + REFERENCE_FILE,
         };
-        final Path dictionary = REFERENCE_FILE.toPath().resolveSibling(REFERENCE_FILE.getName().replace("fasta", "dict"));
+        final Path dictionary = REFERENCE_FILE.toPath().resolveSibling(REFERENCE_FILE.getName().replaceAll("fasta$", "dict"));
         dictionary.toFile().setReadable(false);
         try {
             runPicardCommandLine(args);
-        } finally {//return dictionary to readable
+        } finally {// return dictionary to readable
             dictionary.toFile().setReadable(true);
         }
     }

--- a/src/test/java/picard/util/LiftoverVcfTest.java
+++ b/src/test/java/picard/util/LiftoverVcfTest.java
@@ -1194,7 +1194,7 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         Assert.assertEquals(runPicardCommandLine(args), 1);
     }
 
-    @Test(expectedExceptions = SAMException.class)
+    @Test(expectedExceptions = SAMException.class, expectedExceptionsMessageRegExp = "File exists but is not readable:.*")
     public void testUnreadableDictionary() throws IOException {
         final Path liftOutput = Files.createTempFile("tmpouput", ".vcf");
         liftOutput.toFile().deleteOnExit();
@@ -1206,7 +1206,7 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         Files.copy(REFERENCE_FILE.toPath(), referenceCopy, StandardCopyOption.REPLACE_EXISTING);
         final Path dictCopy = referenceCopy.resolveSibling(referenceCopy.toFile().getName().replaceAll("fasta$", "dict"));
         final Path dictionary = REFERENCE_FILE.toPath().resolveSibling(REFERENCE_FILE.getName().replaceAll("fasta$", "dict"));
-        Files.copy(dictionary, dictCopy, StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(dictionary, dictCopy);
         dictCopy.toFile().deleteOnExit();
         dictCopy.toFile().setReadable(false);
         final String[] args = new String[]{

--- a/src/test/java/picard/util/LiftoverVcfTest.java
+++ b/src/test/java/picard/util/LiftoverVcfTest.java
@@ -1181,15 +1181,17 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         final Path rejectOutput = Files.createTempFile("tmpreject", ".vcf");
         rejectOutput.toFile().deleteOnExit();
         final Path input = TEST_DATA_PATH.toPath().resolve("testLiftoverBiallelicIndels.vcf");
-        final Path referenceCopy = Files.createTempFile("ref", ".fasta");
+        final Path tmpCopyDir = Files.createTempDirectory("copy");
+        tmpCopyDir.toFile().deleteOnExit();
+        final Path referenceCopy = tmpCopyDir.resolve("refCopy.fasta");
         referenceCopy.toFile().deleteOnExit();
-        Files.copy(REFERENCE_FILE.toPath(), referenceCopy, StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(REFERENCE_FILE.toPath(), referenceCopy);
         final String[] args = new String[]{
-                "INPUT=" + input.toString(),
-                "OUTPUT=" + liftOutput.toString(),
-                "REJECT=" + rejectOutput.toString(),
+                "INPUT=" + input,
+                "OUTPUT=" + liftOutput,
+                "REJECT=" + rejectOutput,
                 "CHAIN=" + CHAIN_FILE,
-                "REFERENCE_SEQUENCE=" + referenceCopy.toString(),
+                "REFERENCE_SEQUENCE=" + referenceCopy,
         };
         Assert.assertEquals(runPicardCommandLine(args), 1);
     }
@@ -1201,20 +1203,22 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         final Path rejectOutput = Files.createTempFile("tmpreject", ".vcf");
         rejectOutput.toFile().deleteOnExit();
         final Path input = TEST_DATA_PATH.toPath().resolve("testLiftoverBiallelicIndels.vcf");
-        final Path referenceCopy = Files.createTempFile("ref", ".fasta");
+        final Path tmpCopyDir = Files.createTempDirectory("copy");
+        tmpCopyDir.toFile().deleteOnExit();
+        final Path referenceCopy = tmpCopyDir.resolve("refCopy.fasta");
         referenceCopy.toFile().deleteOnExit();
-        Files.copy(REFERENCE_FILE.toPath(), referenceCopy, StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(REFERENCE_FILE.toPath(), referenceCopy);
         final Path dictCopy = referenceCopy.resolveSibling(referenceCopy.toFile().getName().replaceAll("fasta$", "dict"));
+        dictCopy.toFile().deleteOnExit();
         final Path dictionary = REFERENCE_FILE.toPath().resolveSibling(REFERENCE_FILE.getName().replaceAll("fasta$", "dict"));
         Files.copy(dictionary, dictCopy);
-        dictCopy.toFile().deleteOnExit();
         dictCopy.toFile().setReadable(false);
         final String[] args = new String[]{
-                "INPUT=" + input.toString(),
-                "OUTPUT=" + liftOutput.toString(),
-                "REJECT=" + rejectOutput.toString(),
+                "INPUT=" + input,
+                "OUTPUT=" + liftOutput,
+                "REJECT=" + rejectOutput,
                 "CHAIN=" + CHAIN_FILE,
-                "REFERENCE_SEQUENCE=" + referenceCopy.toString(),
+                "REFERENCE_SEQUENCE=" + referenceCopy,
         };
         runPicardCommandLine(args);
     }

--- a/src/test/java/picard/util/LiftoverVcfTest.java
+++ b/src/test/java/picard/util/LiftoverVcfTest.java
@@ -1201,19 +1201,21 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         final Path rejectOutput = Files.createTempFile("tmpreject", ".vcf");
         rejectOutput.toFile().deleteOnExit();
         final Path input = TEST_DATA_PATH.toPath().resolve("testLiftoverBiallelicIndels.vcf");
+        final Path referenceCopy = Files.createTempFile("ref", ".fasta");
+        referenceCopy.toFile().deleteOnExit();
+        Files.copy(REFERENCE_FILE.toPath(), referenceCopy, StandardCopyOption.REPLACE_EXISTING);
+        final Path dictCopy = referenceCopy.resolveSibling(referenceCopy.toFile().getName().replaceAll("fasta$", "dict"));
+        final Path dictionary = REFERENCE_FILE.toPath().resolveSibling(REFERENCE_FILE.getName().replaceAll("fasta$", "dict"));
+        Files.copy(dictionary, dictCopy, StandardCopyOption.REPLACE_EXISTING);
+        dictCopy.toFile().deleteOnExit();
+        dictCopy.toFile().setReadable(false);
         final String[] args = new String[]{
                 "INPUT=" + input.toString(),
                 "OUTPUT=" + liftOutput.toString(),
                 "REJECT=" + rejectOutput.toString(),
                 "CHAIN=" + CHAIN_FILE,
-                "REFERENCE_SEQUENCE=" + REFERENCE_FILE,
+                "REFERENCE_SEQUENCE=" + referenceCopy.toString(),
         };
-        final Path dictionary = REFERENCE_FILE.toPath().resolveSibling(REFERENCE_FILE.getName().replaceAll("fasta$", "dict"));
-        dictionary.toFile().setReadable(false);
-        try {
-            runPicardCommandLine(args);
-        } finally {// return dictionary to readable
-            dictionary.toFile().setReadable(true);
-        }
+        runPicardCommandLine(args);
     }
 }


### PR DESCRIPTION
### Description

- In LiftoverVCF, checking if dictionary associated with reference .fast exists.  If not, logging error and returning 1 from doWork().
- Fixes Issue #1157 
- Adding tests for nonexistent dictionary, and non-readable dictionary  

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

