### PR TITLE
Adding a LIBRARY field to the umi metrics file in UmiAwareMarkDuplicatesWithMateCigar

### DIFF
--- a/src/main/java/picard/sam/markduplicates/UmiAwareDuplicateSetIterator.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareDuplicateSetIterator.java
@@ -58,7 +58,7 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
     private final String inferredUmiTag;
     private final boolean allowMissingUmis;
     private boolean isOpen = false;
-    private UmiMetrics metrics;
+    private Map<String, UmiMetrics> umiMetricsMap;
     private boolean haveWeSeenFirstRead = false;
 
     private long observedUmiBases = 0;
@@ -70,16 +70,18 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
      * @param maxEditDistanceToJoin The edit distance between UMIs that will be used to union UMIs into groups
      * @param umiTag                The tag used in the bam file that designates the UMI
      * @param assignedUmiTag        The tag in the bam file that designates the assigned UMI
+     * @param allowMissingUmis      Allow for SAM Records that do not have UMIs
+     * @param umiMetricsMap         Map of UMI Metrics indexed by library name
      */
     UmiAwareDuplicateSetIterator(final DuplicateSetIterator wrappedIterator, final int maxEditDistanceToJoin,
                                  final String umiTag, final String assignedUmiTag, final boolean allowMissingUmis,
-                                 final UmiMetrics metrics) {
+                                 final Map<String, UmiMetrics> umiMetricsMap) {
         this.wrappedIterator = wrappedIterator;
         this.maxEditDistanceToJoin = maxEditDistanceToJoin;
         this.umiTag = umiTag;
         this.inferredUmiTag = assignedUmiTag;
         this.allowMissingUmis = allowMissingUmis;
-        this.metrics = metrics;
+        this.umiMetricsMap = umiMetricsMap;
         isOpen = true;
         nextSetsIterator = Collections.emptyIterator();
     }
@@ -88,7 +90,11 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
     public void close() {
         isOpen = false;
         wrappedIterator.close();
-        metrics.calculateDerivedFields();
+
+        // Calculate derived fields for UMI metrics over each library
+        for (final Map.Entry<String, UmiMetrics> metric : umiMetricsMap.entrySet()) {
+           metric.getValue().calculateDerivedFields();
+        }
     }
 
     @Override
@@ -128,23 +134,31 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
 
         final UmiGraph umiGraph = new UmiGraph(set, umiTag, inferredUmiTag, allowMissingUmis);
 
-        List<DuplicateSet> duplicateSets = umiGraph.joinUmisIntoDuplicateSets(maxEditDistanceToJoin);
+        // Get the UMI metrics for the library of this duplicate set, creating a new one if necessary.
+        final String library = set.getRepresentative().getReadGroup().getLibrary();
+        UmiMetrics metrics = umiMetricsMap.get(library);
+        if (metrics == null) {
+            metrics = new UmiMetrics();
+            metrics.LIBRARY = library;
+            umiMetricsMap.put(library, metrics);
+        }
+
+        final List<DuplicateSet> duplicateSets = umiGraph.joinUmisIntoDuplicateSets(maxEditDistanceToJoin);
 
         // Collect statistics on numbers of observed and inferred UMIs
         // and total numbers of observed and inferred UMIs
-        for (DuplicateSet ds : duplicateSets) {
-            List<SAMRecord> records = ds.getRecords();
-            SAMRecord representativeRead = ds.getRepresentative();
-            String inferredUmi = representativeRead.getStringAttribute(inferredUmiTag);
+        for (final DuplicateSet ds : duplicateSets) {
+             final List<SAMRecord> records = ds.getRecords();
+             final SAMRecord representativeRead = ds.getRepresentative();
+             final String inferredUmi = representativeRead.getStringAttribute(inferredUmiTag);
 
-            for (SAMRecord rec : records) {
-                String currentUmi = UmiUtil.getSanitizedUMI(rec, umiTag);
+            for (final SAMRecord rec : records) {
+                final String currentUmi = UmiUtil.getSanitizedUMI(rec, umiTag);
 
                 if (currentUmi != null) {
-                    // All UMIs should be the same length, the code presently does not support variable length UMIs
-                    // TODO: Add support for variable length UMIs
-                    // If the UMI contains a N, we don't want to include it in our other metrics
-                    // but still want to keep track of it
+                    // All UMIs should be the same length, the code presently does not support variable length UMIs.
+                    // If the UMI contains a N, we don't want to include it in our other metrics but we still want
+                    // to keep track of it.
                     if (currentUmi.contains("N")) {
                         metrics.addUmiObservationN();
                     } else {

--- a/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
@@ -35,6 +35,8 @@ import org.broadinstitute.barclay.help.DocumentedFeature;
 import picard.cmdline.programgroups.ReadDataManipulationProgramGroup;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  *
@@ -128,7 +130,7 @@ public class UmiAwareMarkDuplicatesWithMateCigar extends SimpleMarkDuplicatesWit
     public boolean ALLOW_MISSING_UMIS = false;
 
     private final Log log = Log.getInstance(UmiAwareMarkDuplicatesWithMateCigar.class);
-    private UmiMetrics metrics = new UmiMetrics();
+    private final Map<String, UmiMetrics> metrics = new HashMap<>();
 
     @Override
     protected int doWork() {
@@ -136,11 +138,14 @@ public class UmiAwareMarkDuplicatesWithMateCigar extends SimpleMarkDuplicatesWit
         IOUtil.assertFileIsWritable(UMI_METRICS_FILE);
 
         // Perform Mark Duplicates work
-        int retval = super.doWork();
+        final int retval = super.doWork();
 
-        // Write metrics specific to UMIs
-        MetricsFile<UmiMetrics, Double> metricsFile = getMetricsFile();
-        metricsFile.addMetric(metrics);
+        // Add results in metrics to the metricsFile
+        final MetricsFile<UmiMetrics, Double> metricsFile = getMetricsFile();
+        for (final Map.Entry<String, UmiMetrics> metric : metrics.entrySet()) {
+            metricsFile.addMetric(metric.getValue());
+        }
+
         metricsFile.write(UMI_METRICS_FILE);
         return retval;
     }

--- a/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
@@ -142,8 +142,8 @@ public class UmiAwareMarkDuplicatesWithMateCigar extends SimpleMarkDuplicatesWit
 
         // Add results in metrics to the metricsFile
         final MetricsFile<UmiMetrics, Double> metricsFile = getMetricsFile();
-        for (final Map.Entry<String, UmiMetrics> metric : metrics.entrySet()) {
-            metricsFile.addMetric(metric.getValue());
+        for (final UmiMetrics metric : metrics.values()) {
+            metricsFile.addMetric(metric);
         }
 
         metricsFile.write(UMI_METRICS_FILE);

--- a/src/main/java/picard/sam/markduplicates/UmiMetrics.java
+++ b/src/main/java/picard/sam/markduplicates/UmiMetrics.java
@@ -41,6 +41,9 @@ public class UmiMetrics extends MetricBase {
     private long observedUmiWithNs = 0;
     private long totalObservedUmisWithoutNs = 0;
 
+    /** Library that was used to generate UMI data. */
+    public String LIBRARY = null;
+
     /** Number of bases in each UMI */
     public double MEAN_UMI_LENGTH = 0.0;
 
@@ -82,12 +85,13 @@ public class UmiMetrics extends MetricBase {
 
     public UmiMetrics() {}
 
-    public UmiMetrics(final double length, final int observedUniqueUmis, final int inferredUniqueUmis,
+    public UmiMetrics(final String library, final double length, final int observedUniqueUmis, final int inferredUniqueUmis,
                       final int observedBaseErrors, final int duplicateSetsWithoutUmi,
                       final int duplicateSetsWithUmi, final double effectiveLengthOfInferredUmis,
                       final double effectiveLengthOfObservedUmis, final double estimatedBaseQualityOfUmis,
                       final double percentUmiWithN) {
 
+        LIBRARY = library;
         MEAN_UMI_LENGTH = length;
         OBSERVED_UNIQUE_UMIS = observedUniqueUmis;
         INFERRED_UNIQUE_UMIS = inferredUniqueUmis;

--- a/src/main/java/picard/sam/markduplicates/UmiMetrics.java
+++ b/src/main/java/picard/sam/markduplicates/UmiMetrics.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import htsjdk.samtools.metrics.MetricBase;
 import htsjdk.samtools.util.Histogram;
 import htsjdk.samtools.util.QualityUtil;
+import picard.PicardException;
 import picard.util.MathUtil;
 
 /**
@@ -42,7 +43,7 @@ public class UmiMetrics extends MetricBase {
     private long totalObservedUmisWithoutNs = 0;
 
     /** Library that was used to generate UMI data. */
-    public String LIBRARY = null;
+    public String LIBRARY;
 
     /** Number of bases in each UMI */
     public double MEAN_UMI_LENGTH = 0.0;
@@ -83,7 +84,11 @@ public class UmiMetrics extends MetricBase {
     /** The percentage of reads that contain an UMI that contains at least one N */
     public double PCT_UMI_WITH_N = 0.0;
 
-    public UmiMetrics() {}
+    public UmiMetrics() { }
+
+    public UmiMetrics(final String library) {
+        LIBRARY = library;
+    }
 
     public UmiMetrics(final String library, final double length, final int observedUniqueUmis, final int inferredUniqueUmis,
                       final int observedBaseErrors, final int duplicateSetsWithoutUmi,

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
@@ -37,6 +37,7 @@ import java.util.*;
 /**
  * This class defines the individual test cases to run. The actual running of the test is done
  * by UmiAwareMarkDuplicatesWithMateCigarTester (see getTester).
+ *
  * @author fleharty
  */
 public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicatesWithMateCigarTest {
@@ -52,49 +53,49 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
 
     @DataProvider(name = "testUmiSetsDataProvider")
     private Object[][] testUmiSetsDataProvider() {
-        return new Object[][] {{
+        return new Object[][]{{
                 // Test basic error correction using edit distance of 1
-                Arrays.asList(new String[] {"AAAA", "AAAA", "ATTA", "AAAA", "AAAT"}), // Observed UMI
-                Arrays.asList(new String[] {"AAAA", "AAAA", "ATTA", "AAAA", "AAAA"}), // Expected inferred UMI
-                Arrays.asList(new Boolean[] {false, true, false, true, true}), // Should it be marked as duplicate?
+                Arrays.asList("AAAA", "AAAA", "ATTA", "AAAA", "AAAT"), // Observed UMI
+                Arrays.asList("AAAA", "AAAA", "ATTA", "AAAA", "AAAA"), // Expected inferred UMI
+                Arrays.asList(false, true, false, true, true), // Should it be marked as duplicate?
                 1 // Edit Distance to Join
         }, {
                 // Test basic error correction using edit distance of 1 including dashes
-                Arrays.asList(new String[] {"AA-AA", "--AAAA", "A-T-TA", "-AAAA----", "A-AA-T"}), // Observed UMI
-                Arrays.asList(new String[] {"AAAA", "AAAA", "ATTA", "AAAA", "AAAA"}), // Expected inferred UMI
-                Arrays.asList(new Boolean[] {false, true, false, true, true}), // Should it be marked as duplicate?
+                Arrays.asList("AA-AA", "--AAAA", "A-T-TA", "-AAAA----", "A-AA-T"), // Observed UMI
+                Arrays.asList("AAAA", "AAAA", "ATTA", "AAAA", "AAAA"), // Expected inferred UMI
+                Arrays.asList(false, true, false, true, true), // Should it be marked as duplicate?
                 1 // Edit Distance to Join
         }, {
                 // Test basic error correction using edit distance of 2
-                Arrays.asList(new String[] {"AAAA", "AAAA", "ATTA", "AAAA", "AAAT"}),
-                Arrays.asList(new String[] {"AAAA", "AAAA", "AAAA", "AAAA", "AAAA"}),
-                Arrays.asList(new Boolean[] {false, true, true, true, true}),
+                Arrays.asList("AAAA", "AAAA", "ATTA", "AAAA", "AAAT"),
+                Arrays.asList("AAAA", "AAAA", "AAAA", "AAAA", "AAAA"),
+                Arrays.asList(false, true, true, true, true),
                 2
         }, {
                 // Test basic error correction using edit distance of 2 including dashes
-                Arrays.asList(new String[] {"AAA-A", "A--AAA", "A---TT-A", "----AAAA", "A-AAT"}),
-                Arrays.asList(new String[] {"AAAA", "AAAA", "AAAA", "AAAA", "AAAA"}),
-                Arrays.asList(new Boolean[] {false, true, true, true, true}),
+                Arrays.asList("AAA-A", "A--AAA", "A---TT-A", "----AAAA", "A-AAT"),
+                Arrays.asList("AAAA", "AAAA", "AAAA", "AAAA", "AAAA"),
+                Arrays.asList(false, true, true, true, true),
                 2
         }, {
                 // Test basic error correction using edit distance of 1 where UMIs
                 // form a chain in edit distance space so that a UMI with large
                 // edit distance will get error corrected to a distant but linked (in edit space) UMI
-                Arrays.asList(new String[] {"AAAA", "AAAA", "AAAT", "AAGT", "ACGT", "TCGT", "CCCC"}),
-                Arrays.asList(new String[] {"AAAA", "AAAA", "AAAA", "AAAA", "AAAA", "AAAA", "CCCC"}),
-                Arrays.asList(new Boolean[] {false, true, true, true, true, true, false}),
+                Arrays.asList("AAAA", "AAAA", "AAAT", "AAGT", "ACGT", "TCGT", "CCCC"),
+                Arrays.asList("AAAA", "AAAA", "AAAA", "AAAA", "AAAA", "AAAA", "CCCC"),
+                Arrays.asList(false, true, true, true, true, true, false),
                 1
         }, {
                 // Test short UMIs
-                Arrays.asList(new String[] {"A", "A", "T", "G", "G", "C", "C", "A"}),
-                Arrays.asList(new String[] {"A", "A", "A", "A", "A", "A", "A", "A"}), // All UMIs should get corrected to A
-                Arrays.asList(new Boolean[] {false, true, true, true, true, true, true, true}), // All mate pairs should be duplicates except the first
+                Arrays.asList("A", "A", "T", "G", "G", "C", "C", "A"),
+                Arrays.asList("A", "A", "A", "A", "A", "A", "A", "A"), // All UMIs should get corrected to A
+                Arrays.asList(false, true, true, true, true, true, true, true), // All mate pairs should be duplicates except the first
                 1
         }, {
                 // Test short UMIs with no allowance for errors
-                Arrays.asList(new String[] {"A", "A", "T", "G", "G", "C", "C", "A"}),
-                Arrays.asList(new String[] {"A", "A", "T", "G", "G", "C", "C", "A"}), // No UMIs should get corrected
-                Arrays.asList(new Boolean[] {false, true, false, false, true, false, true, true}), // Only exactly duplicated UMIs will give rise to a new duplicate set
+                Arrays.asList("A", "A", "T", "G", "G", "C", "C", "A"),
+                Arrays.asList("A", "A", "T", "G", "G", "C", "C", "A"), // No UMIs should get corrected
+                Arrays.asList(false, true, false, false, true, false, true, true), // Only exactly duplicated UMIs will give rise to a new duplicate set
                 0
         }, {
                 // Test longish UMIs with relatively large allowance for error
@@ -102,65 +103,65 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
                 // they are within edit distance of 4 of each other.  TTGACATCCA should be chosen as the inferred
                 // UMI even though it only occurs once.  Since all UMIs only occur once, we choose the UMI that
                 // is not marked as duplicate to be the inferred UMI.
-                Arrays.asList(new String[] {"TTGACATCCA", "ATGCCATCGA", "AAGTCACCGT"}),
-                Arrays.asList(new String[] {"TTGACATCCA", "TTGACATCCA", "TTGACATCCA"}), // All UMIs should get corrected to TTGACATCCA
-                Arrays.asList(new Boolean[] {false, true, true}), // All mate pairs should be duplicates except the first
+                Arrays.asList("TTGACATCCA", "ATGCCATCGA", "AAGTCACCGT"),
+                Arrays.asList("TTGACATCCA", "TTGACATCCA", "TTGACATCCA"), // All UMIs should get corrected to TTGACATCCA
+                Arrays.asList(false, true, true), // All mate pairs should be duplicates except the first
                 4
         }, {
                 // Test that the inferred UMI is correct with N
-                Arrays.asList(new String[] {"AAAN", "AANN"}),
-                Arrays.asList(new String[] {"AAAN", "AAAN"}), // Only N containing UMI
-                Arrays.asList(new Boolean[] {false, true}), // All mate pairs should be duplicates except the first
+                Arrays.asList("AAAN", "AANN"),
+                Arrays.asList("AAAN", "AAAN"), // Only N containing UMI
+                Arrays.asList(false, true), // All mate pairs should be duplicates except the first
                 1
         }, {
                 // Test that the majority with no Ns wins
-                Arrays.asList(new String[] {"AAAN", "AAAN", "AAAA", "AAAA", "AAAN" }),
-                Arrays.asList(new String[] {"AAAA", "AAAA", "AAAA", "AAAA", "AAAA"}), // Even though AAAN is majority, AAAA is represented
-                Arrays.asList(new Boolean[] {false, true, true, true, true}), // All mate pairs should be duplicates except the first
+                Arrays.asList("AAAN", "AAAN", "AAAA", "AAAA", "AAAN"),
+                Arrays.asList("AAAA", "AAAA", "AAAA", "AAAA", "AAAA"), // Even though AAAN is majority, AAAA is represented
+                Arrays.asList(false, true, true, true, true), // All mate pairs should be duplicates except the first
                 1
         }, {
                 // Test that the majority with the fewest N wins when both have Ns
-                Arrays.asList(new String[] {"AAAN", "AAAN", "AANN", "AANN", "AANN" }),
-                Arrays.asList(new String[] {"AAAN", "AAAN", "AAAN", "AAAN", "AAAN"}), // Even though AANN is majority, AAAN is represented
-                Arrays.asList(new Boolean[] {false, true, true, true, true, true}), // All mate pairs should be duplicates except the first
+                Arrays.asList("AAAN", "AAAN", "AANN", "AANN", "AANN"),
+                Arrays.asList("AAAN", "AAAN", "AAAN", "AAAN", "AAAN"), // Even though AANN is majority, AAAN is represented
+                Arrays.asList(false, true, true, true, true, true), // All mate pairs should be duplicates except the first
                 1
-        } };
+        }};
     }
 
     @DataProvider(name = "testBadUmiSetsDataProvider")
     private Object[][] testBadUmiSetsDataProvider() {
-        return new Object[][] {{
+        return new Object[][]{{
                 // The code should not support variable length UMIs, if we observe variable length UMIs
                 // ensure that an exception is thrown.
-                Arrays.asList(new String[] {"AAAA", "A"}),
-                Arrays.asList(new String[] {"AAAA", "A"}),
-                Arrays.asList(new Boolean[] {false, false}),
+                Arrays.asList("AAAA", "A"),
+                Arrays.asList("AAAA", "A"),
+                Arrays.asList(false, false),
                 4
         }, {
                 // The code should not support variable length UMIs, if we observe variable length UMIs
                 // ensure that an exception is thrown.
                 // Arrays.asList(new String[] {"T", "GG"}),
-                Arrays.asList(new String[] {"T", "GG"}),
-                Arrays.asList(new String[] {"T", "GG"}),
-                Arrays.asList(new Boolean[] {false, false}),
+                Arrays.asList("T", "GG"),
+                Arrays.asList("T", "GG"),
+                Arrays.asList(false, false),
                 1
         }, {
                 // Test to make sure that we throw an exception with missing UMIs when allowMissingUmis is false
                 // This throws an exception because the UMIs have differing lengths.
-                Arrays.asList(new String[] {"TTGA", "TTAT", null}),
-                Arrays.asList(new String[] {"TTGA", "TTAT", null}),
-                Arrays.asList(new Boolean[] {false, false, false}),
+                Arrays.asList("TTGA", "TTAT", null),
+                Arrays.asList("TTGA", "TTAT", null),
+                Arrays.asList(false, false, false),
                 4
         }};
     }
 
     @DataProvider(name = "testEmptyUmiDataProvider")
     private Object[][] testEmptyUmiDataProvider() {
-        return new Object[][] {{
+        return new Object[][]{{
                 // Test to make sure we treat empty UMIs correctly when they are allowed
-                Arrays.asList(new String[] {null, null, null}),
-                Arrays.asList(new String[] {null, null, null}),
-                Arrays.asList(new Boolean[] {false, true, true}),
+                Arrays.asList(null, null, null),
+                Arrays.asList(null, null, null),
+                Arrays.asList(false, true, true),
                 4
         }};
     }
@@ -171,7 +172,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
         tester.addArg("MAX_EDIT_DISTANCE_TO_JOIN=" + editDistanceToJoin);
         final String dummyLibraryName = "A";
 
-        for(int i = 0;i < umis.size();i++) {
+        for (int i = 0; i < umis.size(); i++) {
             tester.addMatePairWithUmi(dummyLibraryName, umis.get(i), assignedUmi.get(i), isDuplicate.get(i), isDuplicate.get(i));
         }
         tester.setExpectedAssignedUmis(assignedUmi).runTest();
@@ -183,7 +184,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
         tester.addArg("MAX_EDIT_DISTANCE_TO_JOIN=" + editDistanceToJoin);
         final String dummyLibraryName = "A";
 
-        for(int i = 0;i < umis.size();i++) {
+        for (int i = 0; i < umis.size(); i++) {
             tester.addMatePairWithUmi(dummyLibraryName, umis.get(i), assignedUmi.get(i), isDuplicate.get(i), isDuplicate.get(i));
         }
         tester.setExpectedAssignedUmis(assignedUmi).runTest();
@@ -195,7 +196,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
         tester.addArg("MAX_EDIT_DISTANCE_TO_JOIN=" + editDistanceToJoin);
         final String dummyLibraryName = "A";
 
-        for(int i = 0;i < umis.size();i++) {
+        for (int i = 0; i < umis.size(); i++) {
             tester.addMatePairWithUmi(dummyLibraryName, umis.get(i), assignedUmi.get(i), isDuplicate.get(i), isDuplicate.get(i));
         }
         tester.setExpectedAssignedUmis(assignedUmi).runTest();
@@ -206,122 +207,122 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
 
         // Calculate values of metrics by hand to ensure they are right
         // effectiveLength4_1 is the effective UMI length observing 5 UMIs where 4 are the same
-        double effectiveLength4_1 = -(4./5.)*Math.log(4./5.)/Math.log(4.) -(1./5.)*Math.log(1./5.)/Math.log(4.);
-        // effectiveLength4_1 is the effective UMI length observing 5 UMIs where 3 are the same and the other two are
+        double effectiveLength4_1 = -(4. / 5.) * Math.log(4. / 5.) / Math.log(4.) - (1. / 5.) * Math.log(1. / 5.) / Math.log(4.);
+        // effectiveLength3_1_1 is the effective UMI length observing 5 UMIs where 3 are the same and the other two are
         // unique
-        double effectiveLength3_1_1 = -(3./5.)*Math.log(3./5.)/Math.log(4.) -2*(1./5.)*Math.log(1./5.)/Math.log(4.);
+        double effectiveLength3_1_1 = -(3. / 5.) * Math.log(3. / 5.) / Math.log(4.) - 2 * (1. / 5.) * Math.log(1. / 5.) / Math.log(4.);
 
-        double effectiveLength_N = -(3./4.)*Math.log(3./4.)/Math.log(4.) -(1./4.)*Math.log(1./4.)/Math.log(4.);
+        double effectiveLength_N = -(3. / 4.) * Math.log(3. / 4.) / Math.log(4.) - (1. / 4.) * Math.log(1. / 4.) / Math.log(4.);
 
         // estimatedBaseQualityk_n is the phred scaled base quality score where k of n bases are incorrect
-        double estimatedBaseQuality1_20 = QualityUtil.getPhredScoreFromErrorProbability(1./20.);
-        double estimatedBaseQuality3_20 = QualityUtil.getPhredScoreFromErrorProbability(3./20.);
-        double estimatedBaseQuality_N = QualityUtil.getPhredScoreFromErrorProbability(2./16.);
+        double estimatedBaseQuality1_20 = QualityUtil.getPhredScoreFromErrorProbability(1. / 20.);
+        double estimatedBaseQuality3_20 = QualityUtil.getPhredScoreFromErrorProbability(3. / 20.);
+        double estimatedBaseQuality_N = QualityUtil.getPhredScoreFromErrorProbability(2. / 16.);
 
-        double estimatedPercentWithN3_7 = 3./7.;
+        double estimatedPercentWithN3_7 = 3. / 7.;
 
         return new Object[][]{{
                 // Test basic error correction using edit distance of 1
-                Arrays.asList(new String[]{"AAAA", "AAAA", "ATTA", "AAAA", "AAAT"}), // Observed UMI
-                Arrays.asList(new String[]{"AAAA", "AAAA", "ATTA", "AAAA", "AAAA"}), // Expected inferred UMI
-                Arrays.asList(new Boolean[]{false, true, false, true, true}), // Should it be marked as duplicate?
+                Arrays.asList("AAAA", "AAAA", "ATTA", "AAAA", "AAAT"), // Observed UMI
+                Arrays.asList("AAAA", "AAAA", "ATTA", "AAAA", "AAAA"), // Expected inferred UMI
+                Arrays.asList(false, true, false, true, true), // Should it be marked as duplicate?
                 1, // Edit Distance to Join
-                new UmiMetrics("A",                         // LIBRARY
-                               4.0,                         // MEAN_UMI_LENGTH
-                               3,                           // OBSERVED_UNIQUE_UMIS
-                               2,                           // INFERRED_UNIQUE_UMIS
-                               2,                           // OBSERVED_BASE_ERRORS (Note: This is 2 rather than 1 because we are using paired end reads)
-                               2,                           // DUPLICATE_SETS_WITHOUT_UMI
-                               4,                           // DUPLICATE_SETS_WITH_UMI
-                               effectiveLength4_1,          // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
-                               effectiveLength3_1_1,        // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
-                               estimatedBaseQuality1_20,    // ESTIMATED_BASE_QUALITY_OF_UMIS
-                               0)                           // UMI_WITH_N
+                new UmiMetrics("A",                  // LIBRARY
+                        4.0,                         // MEAN_UMI_LENGTH
+                        3,                           // OBSERVED_UNIQUE_UMIS
+                        2,                           // INFERRED_UNIQUE_UMIS
+                        2,                           // OBSERVED_BASE_ERRORS (Note: This is 2 rather than 1 because we are using paired end reads)
+                        2,                           // DUPLICATE_SETS_WITHOUT_UMI
+                        4,                           // DUPLICATE_SETS_WITH_UMI
+                        effectiveLength4_1,          // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
+                        effectiveLength3_1_1,        // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
+                        estimatedBaseQuality1_20,    // ESTIMATED_BASE_QUALITY_OF_UMIS
+                        0)                           // UMI_WITH_N
         }, {
                 // Test basic error correction using edit distance of 2
-                Arrays.asList(new String[]{"AAAA", "AAAA", "ATTA", "AAAA", "AAAT"}),
-                Arrays.asList(new String[]{"AAAA", "AAAA", "AAAA", "AAAA", "AAAA"}),
-                Arrays.asList(new Boolean[]{false, true, true, true, true}),
+                Arrays.asList("AAAA", "AAAA", "ATTA", "AAAA", "AAAT"),
+                Arrays.asList("AAAA", "AAAA", "AAAA", "AAAA", "AAAA"),
+                Arrays.asList(false, true, true, true, true),
                 2,
-                new UmiMetrics("A",                         // LIBRARY
-                               4.0,                         // MEAN_UMI_LENGTH
-                               3,                           // OBSERVED_UNIQUE_UMIS
-                               1,                           // INFERRED_UNIQUE_UMIS
-                               6,                           // OBSERVED_BASE_ERRORS
-                               2,                           // DUPLICATE_SETS_WITHOUT_UMI
-                               2,                           // DUPLICATE_SETS_WITH_UMI
-                               0.0,                         // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
-                                effectiveLength3_1_1,       // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
-                                estimatedBaseQuality3_20,   // ESTIMATED_BASE_QUALITY_OF_UMIS
-                               0)                           // UMI_WITH_N
+                new UmiMetrics("A",                  // LIBRARY
+                        4.0,                         // MEAN_UMI_LENGTH
+                        3,                           // OBSERVED_UNIQUE_UMIS
+                        1,                           // INFERRED_UNIQUE_UMIS
+                        6,                           // OBSERVED_BASE_ERRORS
+                        2,                           // DUPLICATE_SETS_WITHOUT_UMI
+                        2,                           // DUPLICATE_SETS_WITH_UMI
+                        0.0,                         // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
+                        effectiveLength3_1_1,        // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
+                        estimatedBaseQuality3_20,    // ESTIMATED_BASE_QUALITY_OF_UMIS
+                        0)                           // UMI_WITH_N
         }, {
                 // Test basic error correction using edit distance of 2 including dashes
-                Arrays.asList(new String[]{"AAAA", "AAA-A", "A-TTA", "--AAA-A", "AAA-T"}),
-                Arrays.asList(new String[]{"AAAA", "AAAA", "AAAA", "AAAA", "AAAA"}),
-                Arrays.asList(new Boolean[]{false, true, true, true, true}),
+                Arrays.asList("AAAA", "AAA-A", "A-TTA", "--AAA-A", "AAA-T"),
+                Arrays.asList("AAAA", "AAAA", "AAAA", "AAAA", "AAAA"),
+                Arrays.asList(false, true, true, true, true),
                 2,
-                new UmiMetrics("A",                      // LIBRARY
-                               4.0,                      // MEAN_UMI_LENGTH
-                               3,                        // OBSERVED_UNIQUE_UMIS
-                               1,                        // INFERRED_UNIQUE_UMIS
-                               6,                        // OBSERVED_BASE_ERRORS
-                               2,                        // DUPLICATE_SETS_WITHOUT_UMI
-                               2,                        // DUPLICATE_SETS_WITH_UMI
-                               0.0,                      // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
-                               effectiveLength3_1_1,     // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
-                               estimatedBaseQuality3_20, // ESTIMATED_BASE_QUALITY_OF_UMIS
-                               0)                        // UMI_WITH_N
-        },{
+                new UmiMetrics("A",               // LIBRARY
+                        4.0,                      // MEAN_UMI_LENGTH
+                        3,                        // OBSERVED_UNIQUE_UMIS
+                        1,                        // INFERRED_UNIQUE_UMIS
+                        6,                        // OBSERVED_BASE_ERRORS
+                        2,                        // DUPLICATE_SETS_WITHOUT_UMI
+                        2,                        // DUPLICATE_SETS_WITH_UMI
+                        0.0,                      // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
+                        effectiveLength3_1_1,     // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
+                        estimatedBaseQuality3_20, // ESTIMATED_BASE_QUALITY_OF_UMIS
+                        0)                        // UMI_WITH_N
+        }, {
                 // Test basic error correction using edit distance of 2 - Ns metrics should not include the umis with Ns
-                Arrays.asList(new String[]{"AAAA", "AAAA","AANA","ANNA", "ATTA", "AAAA", "ANAT"}),
-                Arrays.asList(new String[]{"AAAA", "AAAA","AAAA","AAAA","AAAA", "AAAA", "AAAA"}),
-                Arrays.asList(new Boolean[]{false, true, true, true, true, true, true}),
+                Arrays.asList("AAAA", "AAAA", "AANA", "ANNA", "ATTA", "AAAA", "ANAT"),
+                Arrays.asList("AAAA", "AAAA", "AAAA", "AAAA", "AAAA", "AAAA", "AAAA"),
+                Arrays.asList(false, true, true, true, true, true, true),
                 2,
-                new UmiMetrics("A",                        // LIBRARY
-                               4.0,                        // MEAN_UMI_LENGTH
-                               2,                          // OBSERVED_UNIQUE_UMIS
-                               1,                          // INFERRED_UNIQUE_UMIS
-                               4,                          // OBSERVED_BASE_ERRORS
-                               2,                          // DUPLICATE_SETS_WITHOUT_UMI
-                               2,                          // DUPLICATE_SETS_WITH_UMI
-                               0.0,                        // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
-                               effectiveLength_N,          // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
-                               estimatedBaseQuality_N,     // ESTIMATED_BASE_QUALITY_OF_UMIS
-                               estimatedPercentWithN3_7)   // UMI_WITH_N
+                new UmiMetrics("A",                 // LIBRARY
+                        4.0,                        // MEAN_UMI_LENGTH
+                        2,                          // OBSERVED_UNIQUE_UMIS
+                        1,                          // INFERRED_UNIQUE_UMIS
+                        4,                          // OBSERVED_BASE_ERRORS
+                        2,                          // DUPLICATE_SETS_WITHOUT_UMI
+                        2,                          // DUPLICATE_SETS_WITH_UMI
+                        0.0,                        // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
+                        effectiveLength_N,          // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
+                        estimatedBaseQuality_N,     // ESTIMATED_BASE_QUALITY_OF_UMIS
+                        estimatedPercentWithN3_7)   // UMI_WITH_N
         }, {
                 // Test basic error correction using edit distance of 2 including Ns and dashes
-                Arrays.asList(new String[]{"AAAA-", "AA-AA","AAN-A","ANNA", "AT-TA", "AAA-A-", "A--NAT-"}),
-                Arrays.asList(new String[]{"AAAA", "AAAA","AAAA","AAAA","AAAA", "AAAA", "AAAA"}),
-                Arrays.asList(new Boolean[]{false, true, true, true, true, true, true}),
+                Arrays.asList("AAAA-", "AA-AA", "AAN-A", "ANNA", "AT-TA", "AAA-A-", "A--NAT-"),
+                Arrays.asList("AAAA", "AAAA", "AAAA", "AAAA", "AAAA", "AAAA", "AAAA"),
+                Arrays.asList(false, true, true, true, true, true, true),
                 2,
-                new UmiMetrics("A",                        // LIBRARY
-                               4.0,                        // MEAN_UMI_LENGTH
-                               2,                          // OBSERVED_UNIQUE_UMIS
-                               1,                          // INFERRED_UNIQUE_UMIS
-                               4,                          // OBSERVED_BASE_ERRORS
-                               2,                          // DUPLICATE_SETS_WITHOUT_UMI
-                               2,                          // DUPLICATE_SETS_WITH_UMI
-                               0.0,                        // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
-                               effectiveLength_N,          // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
-                               estimatedBaseQuality_N,     // ESTIMATED_BASE_QUALITY_OF_UMIS
-                               estimatedPercentWithN3_7)   // UMI_WITH_N
+                new UmiMetrics("A",                 // LIBRARY
+                        4.0,                        // MEAN_UMI_LENGTH
+                        2,                          // OBSERVED_UNIQUE_UMIS
+                        1,                          // INFERRED_UNIQUE_UMIS
+                        4,                          // OBSERVED_BASE_ERRORS
+                        2,                          // DUPLICATE_SETS_WITHOUT_UMI
+                        2,                          // DUPLICATE_SETS_WITH_UMI
+                        0.0,                        // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
+                        effectiveLength_N,          // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
+                        estimatedBaseQuality_N,     // ESTIMATED_BASE_QUALITY_OF_UMIS
+                        estimatedPercentWithN3_7)   // UMI_WITH_N
         }, {
                 // Test maximum entropy (EFFECTIVE_LENGTH_OF_INFERRED_UMIS)
-                Arrays.asList(new String[]{"AA", "AT", "AC", "AG", "TA", "TT", "TC", "TG", "CA", "CT", "CC", "CG", "GA", "GT", "GC", "GG"}),
-                Arrays.asList(new String[]{"AA", "AT", "AC", "AG", "TA", "TT", "TC", "TG", "CA", "CT", "CC", "CG", "GA", "GT", "GC", "GG"}),
-                Arrays.asList(new Boolean[]{false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false}),
+                Arrays.asList("AA", "AT", "AC", "AG", "TA", "TT", "TC", "TG", "CA", "CT", "CC", "CG", "GA", "GT", "GC", "GG"),
+                Arrays.asList("AA", "AT", "AC", "AG", "TA", "TT", "TC", "TG", "CA", "CT", "CC", "CG", "GA", "GT", "GC", "GG"),
+                Arrays.asList(false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false),
                 0,
                 new UmiMetrics("A",    // LIBRARY
-                               2.0,    // MEAN_UMI_LENGTH
-                               16,     // OBSERVED_UNIQUE_UMIS
-                               16,     // INFERRED_UNIQUE_UMIS
-                               0,      // OBSERVED_BASE_ERRORS
-                               2,      // DUPLICATE_SETS_WITHOUT_UMI
-                               32,     // DUPLICATE_SETS_WITH_UMI
-                               2.0,    // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
-                               2,      // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
-                               -1,     // ESTIMATED_BASE_QUALITY_OF_UMIS
-                               0)      // UMI_WITH_N
+                        2.0,           // MEAN_UMI_LENGTH
+                        16,            // OBSERVED_UNIQUE_UMIS
+                        16,            // INFERRED_UNIQUE_UMIS
+                        0,             // OBSERVED_BASE_ERRORS
+                        2,             // DUPLICATE_SETS_WITHOUT_UMI
+                        32,            // DUPLICATE_SETS_WITH_UMI
+                        2.0,           // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
+                        2,             // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
+                        -1,            // ESTIMATED_BASE_QUALITY_OF_UMIS
+                        0)             // UMI_WITH_N
         }};
     }
 
@@ -331,7 +332,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
         UmiAwareMarkDuplicatesWithMateCigarTester tester = getTester(false);
         tester.addArg("MAX_EDIT_DISTANCE_TO_JOIN=" + editDistanceToJoin);
 
-        for (int i = 0;i < umis.size();i++) {
+        for (int i = 0; i < umis.size(); i++) {
             tester.addMatePairWithUmi("A", umis.get(i), assignedUmi.get(i), isDuplicate.get(i), isDuplicate.get(i));
         }
         tester.setExpectedAssignedUmis(assignedUmi);
@@ -342,52 +343,99 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
     @DataProvider(name = "testMultipleLibraryUmiMetricsDataProvider")
     private Object[][] testMultipleLibraryUmiMetricsDataProvider() {
 
-        final double effectiveLength2_1 = -(2./3.)*Math.log(2./3.)/Math.log(4.) -(1./3.)*Math.log(1./3.)/Math.log(4.);
-        final double effectiveLength1_1_1 = -3*(1./3.)*Math.log(1./3.)/Math.log(4.);
-        final double estimatedBaseQuality1_12 = QualityUtil.getPhredScoreFromErrorProbability(1./12.);
+        // The effectiveLength is the number of UMIs belonging to each group, 2_1 means there is a group of 2 that are the same,
+        // and a group of 1 for a total of 3.   1_1_1 means there are 3 groups of 1 UMI each.
+        final double effectiveLength2_1 = -(2. / 3.) * Math.log(2. / 3.) / Math.log(4.) - (1. / 3.) * Math.log(1. / 3.) / Math.log(4.);
+        final double effectiveLength1_1_1 = -3 * (1. / 3.) * Math.log(1. / 3.) / Math.log(4.);
+        
+        final double estimatedBaseQuality1_12 = QualityUtil.getPhredScoreFromErrorProbability(1. / 12.);
+        final double estimatedBaseQuality1_9 = QualityUtil.getPhredScoreFromErrorProbability(1. / 9.);
 
-        return new Object[][] {{
-                // Test basic error correction using edit distance of 1
-                Arrays.asList("A", "B", "A", "B", "A"),
-                Arrays.asList("AAAA", "AAAA", "ATTA", "AAAA", "AAAT"), // Observed UMI
-                Arrays.asList("AAAA", "AAAA", "ATTA", "AAAA", "AAAA"),  // Inferred UMIs
-                Arrays.asList(false, false, false, true, true), // Should it be marked as duplicate?
-                1, // Edit Distance to Join
-                Arrays.asList(
-                   new UmiMetrics("A",           // LIBRARY
-                      4.0,                       // MEAN_UMI_LENGTH
-                      3,                         // OBSERVED_UNIQUE_UMIS
-                      2,                         // INFERRED_UNIQUE_UMIS
-                      2,                         // OBSERVED_BASE_ERRORS (Note: This is 2 rather than 1 because we are using paired end reads)
-                      2,                         // DUPLICATE_SETS_WITHOUT_UMI
-                      4,                         // DUPLICATE_SETS_WITH_UMI
-                      effectiveLength2_1,        // INFERRED_UMI_ENTROPY
-                      effectiveLength1_1_1,      // OBSERVED_UMI_ENTROPY
-                      estimatedBaseQuality1_12,  // ESTIMATED_BASE_QUALITY_OF_UMIS
-                      0),                        // UMI_WITH_N
+        return new Object[][]{{
+            // Test basic error correction using edit distance of 1
+            Arrays.asList("A", "B", "A", "B", "A"), // Adding reads belonging to different libraries in no particular order
+            Arrays.asList("AAAA", "AAAA", "ATTA", "AAAA", "AAAT"),  // Observed UMI
+            Arrays.asList("AAAA", "AAAA", "ATTA", "AAAA", "AAAA"),  // Inferred UMIs
+            Arrays.asList(false, false, false, true, true), // Should it be marked as duplicate?
+            1, // Edit Distance to Join
+            Arrays.asList(
+                new UmiMetrics("A",            // LIBRARY
+                    4.0,                       // MEAN_UMI_LENGTH
+                    3,                         // OBSERVED_UNIQUE_UMIS
+                    2,                         // INFERRED_UNIQUE_UMIS
+                    2,                         // OBSERVED_BASE_ERRORS (Note: This is 2 rather than 1 because we are using paired end reads)
+                    2,                         // DUPLICATE_SETS_WITHOUT_UMI
+                    4,                         // DUPLICATE_SETS_WITH_UMI
+                    effectiveLength2_1,        // INFERRED_UMI_ENTROPY
+                    effectiveLength1_1_1,      // OBSERVED_UMI_ENTROPY
+                    estimatedBaseQuality1_12,  // ESTIMATED_BASE_QUALITY_OF_UMIS
+                    0),                        // UMI_WITH_N
 
-                   new UmiMetrics("B",           // LIBRARY
-                      4.0,                       // MEAN_UMI_LENGTH
-                      1,                         // OBSERVED_UNIQUE_UMIS
-                      1,                         // INFERRED_UNIQUE_UMIS
-                      0,                         // OBSERVED_BASE_ERRORS
-                      2,                         // DUPLICATE_SETS_WITHOUT_UMI
-                      2,                         // DUPLICATE_SETS_WITH_UMI
-                      0.0,                       // INFERRED_UMI_ENTROPY
-                      0.0,                       // OBSERVED_UMI_ENTROPY
-                      -1,                        // ESTIMATED_BASE_QUALITY_OF_UMIS
-                      0)                         // UMI_WITH_N
+                new UmiMetrics("B",            // LIBRARY
+                    4.0,                       // MEAN_UMI_LENGTH
+                    1,                         // OBSERVED_UNIQUE_UMIS
+                    1,                         // INFERRED_UNIQUE_UMIS
+                    0,                         // OBSERVED_BASE_ERRORS
+                    2,                         // DUPLICATE_SETS_WITHOUT_UMI
+                    2,                         // DUPLICATE_SETS_WITH_UMI
+                    0.0,                       // INFERRED_UMI_ENTROPY
+                    0.0,                       // OBSERVED_UMI_ENTROPY
+                    -1,                        // ESTIMATED_BASE_QUALITY_OF_UMIS
+                    0)                         // UMI_WITH_N
                 )
+        }, {
+            // Test basic error correction using edit distance of 1
+            Arrays.asList("A", "B", "C", "C", "C"),
+            Arrays.asList("AAA", "AAA", "TTA", "AAA", "AAT"),  // Observed UMI
+            Arrays.asList("AAA", "AAA", "TTA", "AAA", "AAA"),  // Inferred UMIs
+            Arrays.asList(false, false, false, false, true), // Should it be marked as duplicate?
+            1, // Edit Distance to Join
+            Arrays.asList(
+                new UmiMetrics("A",            // LIBRARY
+                    3.0,                       // MEAN_UMI_LENGTH
+                    1,                         // OBSERVED_UNIQUE_UMIS
+                    1,                         // INFERRED_UNIQUE_UMIS
+                    0,                         // OBSERVED_BASE_ERRORS (Note: This is 2 rather than 1 because we are using paired end reads)
+                    2,                         // DUPLICATE_SETS_WITHOUT_UMI
+                    2,                         // DUPLICATE_SETS_WITH_UMI
+                    0.0,                       // INFERRED_UMI_ENTROPY
+                    0.0,                       // OBSERVED_UMI_ENTROPY
+                    -1,                        // ESTIMATED_BASE_QUALITY_OF_UMIS
+                    0),                        // UMI_WITH_N
+
+                new UmiMetrics("B",            // LIBRARY
+                    3.0,                       // MEAN_UMI_LENGTH
+                    1,                         // OBSERVED_UNIQUE_UMIS
+                    1,                         // INFERRED_UNIQUE_UMIS
+                    0,                         // OBSERVED_BASE_ERRORS
+                    2,                         // DUPLICATE_SETS_WITHOUT_UMI
+                    2,                         // DUPLICATE_SETS_WITH_UMI
+                    0.0,                       // INFERRED_UMI_ENTROPY
+                    0.0,                       // OBSERVED_UMI_ENTROPY
+                    -1,                        // ESTIMATED_BASE_QUALITY_OF_UMIS
+                    0),                        // UMI_WITH_N
+
+                new UmiMetrics("C",            // LIBRARY
+                    3.0,                       // MEAN_UMI_LENGTH
+                    3,                         // OBSERVED_UNIQUE_UMIS
+                    2,                         // INFERRED_UNIQUE_UMIS
+                    2,                         // OBSERVED_BASE_ERRORS
+                    2,                         // DUPLICATE_SETS_WITHOUT_UMI
+                    4,                         // DUPLICATE_SETS_WITH_UMI
+                    effectiveLength2_1,        // INFERRED_UMI_ENTROPY
+                    effectiveLength1_1_1,      // OBSERVED_UMI_ENTROPY
+                    estimatedBaseQuality1_9,   // ESTIMATED_BASE_QUALITY_OF_UMIS
+                    0))                        // UMI_WITH_N
         }};
     }
 
     @Test(dataProvider = "testMultipleLibraryUmiMetricsDataProvider")
     public void testMultipleLibraryUmiMetrics(final List<String> libraries, final List<String> umis, final List<String> assignedUmi, final List<Boolean> isDuplicate,
-                               final int editDistanceToJoin, final List<UmiMetrics> expectedMetricsList) {
+                                              final int editDistanceToJoin, final List<UmiMetrics> expectedMetricsList) {
 
         // Test collection of UMI metrics across multiple libraries
         final Map<String, List<String>> expectedAssignedUmis = new HashMap<>();
-        for (int i = 0;i < umis.size();i++) {
+        for (int i = 0; i < umis.size(); i++) {
             // Get assigned UMIs for each particular library
             expectedAssignedUmis.putIfAbsent(libraries.get(i), new ArrayList<>());
             expectedAssignedUmis.get(libraries.get(i)).add(assignedUmi.get(i));
@@ -397,8 +445,8 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
         for (final UmiMetrics expectedMetrics : expectedMetricsList) {
             final UmiAwareMarkDuplicatesWithMateCigarTester tester = getTester(false);
             tester.addArg("MAX_EDIT_DISTANCE_TO_JOIN=" + editDistanceToJoin);
-            for (int i = 0;i < umis.size();i++) {
-                if(expectedMetrics.LIBRARY.equals(libraries.get(i))) {
+            for (int i = 0; i < umis.size(); i++) {
+                if (expectedMetrics.LIBRARY.equals(libraries.get(i))) {
                     tester.addMatePairWithUmi(libraries.get(i), umis.get(i), assignedUmi.get(i), isDuplicate.get(i), isDuplicate.get(i));
                 }
             }
@@ -412,14 +460,14 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
     @DataProvider(name = "testUmiUtilDataProvider")
     private Object[][] testUmiUtilDataProvider() {
         return new Object[][]{{
-                Arrays.asList(new String[]{"AAAA", "AA-AA", "-A-T-A", "AAAAA--", "---A", "---", ""}), // Observed UMI
-                Arrays.asList(new String[]{"AAAA", "AAAA", "ATA", "AAAAA", "A", "", ""}) // Sanitized UMI
+            Arrays.asList("AAAA", "AA-AA", "-A-T-A", "AAAAA--", "---A", "---", ""), // Observed UMI
+            Arrays.asList("AAAA", "AAAA", "ATA", "AAAAA", "A", "", "")              // Sanitized UMI
         }};
     }
 
     @Test(dataProvider = "testUmiUtilDataProvider")
     public void testUmiUtil(List<String> observed, List<String> expected) {
-        for( int i = 0;i < observed.size();i++ ) {
+        for (int i = 0; i < observed.size(); i++) {
             SAMRecord rec = new SAMRecord(new SAMFileHeader());
             rec.setAttribute("RX", observed.get(i));
             Assert.assertEquals(UmiUtil.getSanitizedUMI(rec, "RX"), expected.get(i));

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
@@ -169,9 +169,10 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
     public void testUmi(List<String> umis, List<String> assignedUmi, final List<Boolean> isDuplicate, final int editDistanceToJoin) {
         UmiAwareMarkDuplicatesWithMateCigarTester tester = getTester(false);
         tester.addArg("MAX_EDIT_DISTANCE_TO_JOIN=" + editDistanceToJoin);
+        final String dummyLibraryName = "A";
 
         for(int i = 0;i < umis.size();i++) {
-            tester.addMatePairWithUmi(umis.get(i), assignedUmi.get(i), isDuplicate.get(i), isDuplicate.get(i));
+            tester.addMatePairWithUmi(dummyLibraryName, umis.get(i), assignedUmi.get(i), isDuplicate.get(i), isDuplicate.get(i));
         }
         tester.setExpectedAssignedUmis(assignedUmi).runTest();
     }
@@ -180,9 +181,10 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
     public void testEmptyUmis(List<String> umis, List<String> assignedUmi, final List<Boolean> isDuplicate, final int editDistanceToJoin) {
         UmiAwareMarkDuplicatesWithMateCigarTester tester = getTester(true);
         tester.addArg("MAX_EDIT_DISTANCE_TO_JOIN=" + editDistanceToJoin);
+        final String dummyLibraryName = "A";
 
         for(int i = 0;i < umis.size();i++) {
-            tester.addMatePairWithUmi(umis.get(i), assignedUmi.get(i), isDuplicate.get(i), isDuplicate.get(i));
+            tester.addMatePairWithUmi(dummyLibraryName, umis.get(i), assignedUmi.get(i), isDuplicate.get(i), isDuplicate.get(i));
         }
         tester.setExpectedAssignedUmis(assignedUmi).runTest();
     }
@@ -191,9 +193,10 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
     public void testBadUmis(List<String> umis, List<String> assignedUmi, final List<Boolean> isDuplicate, final int editDistanceToJoin) {
         UmiAwareMarkDuplicatesWithMateCigarTester tester = getTester(false);
         tester.addArg("MAX_EDIT_DISTANCE_TO_JOIN=" + editDistanceToJoin);
+        final String dummyLibraryName = "A";
 
         for(int i = 0;i < umis.size();i++) {
-            tester.addMatePairWithUmi(umis.get(i), assignedUmi.get(i), isDuplicate.get(i), isDuplicate.get(i));
+            tester.addMatePairWithUmi(dummyLibraryName, umis.get(i), assignedUmi.get(i), isDuplicate.get(i), isDuplicate.get(i));
         }
         tester.setExpectedAssignedUmis(assignedUmi).runTest();
     }
@@ -223,15 +226,16 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
                 Arrays.asList(new String[]{"AAAA", "AAAA", "ATTA", "AAAA", "AAAA"}), // Expected inferred UMI
                 Arrays.asList(new Boolean[]{false, true, false, true, true}), // Should it be marked as duplicate?
                 1, // Edit Distance to Join
-                new UmiMetrics(4.0,                         // MEAN_UMI_LENGTH
+                new UmiMetrics("A",                         // LIBRARY
+                               4.0,                         // MEAN_UMI_LENGTH
                                3,                           // OBSERVED_UNIQUE_UMIS
                                2,                           // INFERRED_UNIQUE_UMIS
                                2,                           // OBSERVED_BASE_ERRORS (Note: This is 2 rather than 1 because we are using paired end reads)
                                2,                           // DUPLICATE_SETS_WITHOUT_UMI
                                4,                           // DUPLICATE_SETS_WITH_UMI
-                                effectiveLength4_1,         // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
-                                effectiveLength3_1_1,       // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
-                                estimatedBaseQuality1_20,   // ESTIMATED_BASE_QUALITY_OF_UMIS
+                               effectiveLength4_1,          // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
+                               effectiveLength3_1_1,        // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
+                               estimatedBaseQuality1_20,    // ESTIMATED_BASE_QUALITY_OF_UMIS
                                0)                           // UMI_WITH_N
         }, {
                 // Test basic error correction using edit distance of 2
@@ -239,7 +243,8 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
                 Arrays.asList(new String[]{"AAAA", "AAAA", "AAAA", "AAAA", "AAAA"}),
                 Arrays.asList(new Boolean[]{false, true, true, true, true}),
                 2,
-                new UmiMetrics(4.0,                         // MEAN_UMI_LENGTH
+                new UmiMetrics("A",                         // LIBRARY
+                               4.0,                         // MEAN_UMI_LENGTH
                                3,                           // OBSERVED_UNIQUE_UMIS
                                1,                           // INFERRED_UNIQUE_UMIS
                                6,                           // OBSERVED_BASE_ERRORS
@@ -255,55 +260,59 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
                 Arrays.asList(new String[]{"AAAA", "AAAA", "AAAA", "AAAA", "AAAA"}),
                 Arrays.asList(new Boolean[]{false, true, true, true, true}),
                 2,
-                new UmiMetrics(4.0,                     // MEAN_UMI_LENGTH
-                        3,                              // OBSERVED_UNIQUE_UMIS
-                        1,                              // INFERRED_UNIQUE_UMIS
-                        6,                              // OBSERVED_BASE_ERRORS
-                        2,                              // DUPLICATE_SETS_WITHOUT_UMI
-                        2,                              // DUPLICATE_SETS_WITH_UMI
-                        0.0,                            // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
-                         effectiveLength3_1_1,          // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
-                         estimatedBaseQuality3_20,      // ESTIMATED_BASE_QUALITY_OF_UMIS
-                        0)                              // UMI_WITH_N
+                new UmiMetrics("A",                      // LIBRARY
+                               4.0,                      // MEAN_UMI_LENGTH
+                               3,                        // OBSERVED_UNIQUE_UMIS
+                               1,                        // INFERRED_UNIQUE_UMIS
+                               6,                        // OBSERVED_BASE_ERRORS
+                               2,                        // DUPLICATE_SETS_WITHOUT_UMI
+                               2,                        // DUPLICATE_SETS_WITH_UMI
+                               0.0,                      // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
+                               effectiveLength3_1_1,     // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
+                               estimatedBaseQuality3_20, // ESTIMATED_BASE_QUALITY_OF_UMIS
+                               0)                        // UMI_WITH_N
         },{
                 // Test basic error correction using edit distance of 2 - Ns metrics should not include the umis with Ns
                 Arrays.asList(new String[]{"AAAA", "AAAA","AANA","ANNA", "ATTA", "AAAA", "ANAT"}),
                 Arrays.asList(new String[]{"AAAA", "AAAA","AAAA","AAAA","AAAA", "AAAA", "AAAA"}),
                 Arrays.asList(new Boolean[]{false, true, true, true, true, true, true}),
                 2,
-                new UmiMetrics(4.0,                 // MEAN_UMI_LENGTH
-                        2,                          // OBSERVED_UNIQUE_UMIS
-                        1,                          // INFERRED_UNIQUE_UMIS
-                        4,                          // OBSERVED_BASE_ERRORS
-                        2,                          // DUPLICATE_SETS_WITHOUT_UMI
-                        2,                          // DUPLICATE_SETS_WITH_UMI
-                        0.0,                        // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
-                         effectiveLength_N,         // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
-                         estimatedBaseQuality_N,    // ESTIMATED_BASE_QUALITY_OF_UMIS
-                        estimatedPercentWithN3_7)   // UMI_WITH_N
+                new UmiMetrics("A",                        // LIBRARY
+                               4.0,                        // MEAN_UMI_LENGTH
+                               2,                          // OBSERVED_UNIQUE_UMIS
+                               1,                          // INFERRED_UNIQUE_UMIS
+                               4,                          // OBSERVED_BASE_ERRORS
+                               2,                          // DUPLICATE_SETS_WITHOUT_UMI
+                               2,                          // DUPLICATE_SETS_WITH_UMI
+                               0.0,                        // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
+                               effectiveLength_N,          // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
+                               estimatedBaseQuality_N,     // ESTIMATED_BASE_QUALITY_OF_UMIS
+                               estimatedPercentWithN3_7)   // UMI_WITH_N
         }, {
                 // Test basic error correction using edit distance of 2 including Ns and dashes
                 Arrays.asList(new String[]{"AAAA-", "AA-AA","AAN-A","ANNA", "AT-TA", "AAA-A-", "A--NAT-"}),
                 Arrays.asList(new String[]{"AAAA", "AAAA","AAAA","AAAA","AAAA", "AAAA", "AAAA"}),
                 Arrays.asList(new Boolean[]{false, true, true, true, true, true, true}),
                 2,
-                new UmiMetrics(4.0,                 // MEAN_UMI_LENGTH
-                        2,                          // OBSERVED_UNIQUE_UMIS
-                        1,                          // INFERRED_UNIQUE_UMIS
-                        4,                          // OBSERVED_BASE_ERRORS
-                        2,                          // DUPLICATE_SETS_WITHOUT_UMI
-                        2,                          // DUPLICATE_SETS_WITH_UMI
-                        0.0,                        // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
-                        effectiveLength_N,         // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
-                        estimatedBaseQuality_N,    // ESTIMATED_BASE_QUALITY_OF_UMIS
-                        estimatedPercentWithN3_7)   // UMI_WITH_N
+                new UmiMetrics("A",                        // LIBRARY
+                               4.0,                        // MEAN_UMI_LENGTH
+                               2,                          // OBSERVED_UNIQUE_UMIS
+                               1,                          // INFERRED_UNIQUE_UMIS
+                               4,                          // OBSERVED_BASE_ERRORS
+                               2,                          // DUPLICATE_SETS_WITHOUT_UMI
+                               2,                          // DUPLICATE_SETS_WITH_UMI
+                               0.0,                        // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
+                               effectiveLength_N,          // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
+                               estimatedBaseQuality_N,     // ESTIMATED_BASE_QUALITY_OF_UMIS
+                               estimatedPercentWithN3_7)   // UMI_WITH_N
         }, {
                 // Test maximum entropy (EFFECTIVE_LENGTH_OF_INFERRED_UMIS)
                 Arrays.asList(new String[]{"AA", "AT", "AC", "AG", "TA", "TT", "TC", "TG", "CA", "CT", "CC", "CG", "GA", "GT", "GC", "GG"}),
                 Arrays.asList(new String[]{"AA", "AT", "AC", "AG", "TA", "TT", "TC", "TG", "CA", "CT", "CC", "CG", "GA", "GT", "GC", "GG"}),
                 Arrays.asList(new Boolean[]{false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false}),
                 0,
-                new UmiMetrics(2.0,    // MEAN_UMI_LENGTH
+                new UmiMetrics("A",    // LIBRARY
+                               2.0,    // MEAN_UMI_LENGTH
                                16,     // OBSERVED_UNIQUE_UMIS
                                16,     // INFERRED_UNIQUE_UMIS
                                0,      // OBSERVED_BASE_ERRORS
@@ -322,12 +331,82 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
         UmiAwareMarkDuplicatesWithMateCigarTester tester = getTester(false);
         tester.addArg("MAX_EDIT_DISTANCE_TO_JOIN=" + editDistanceToJoin);
 
-        for( int i = 0;i < umis.size();i++ ) {
-            tester.addMatePairWithUmi(umis.get(i), assignedUmi.get(i), isDuplicate.get(i), isDuplicate.get(i));
+        for (int i = 0;i < umis.size();i++) {
+            tester.addMatePairWithUmi("A", umis.get(i), assignedUmi.get(i), isDuplicate.get(i), isDuplicate.get(i));
         }
         tester.setExpectedAssignedUmis(assignedUmi);
         tester.setExpectedMetrics(expectedMetrics);
         tester.runTest();
+    }
+
+    @DataProvider(name = "testMultipleLibraryUmiMetricsDataProvider")
+    private Object[][] testMultipleLibraryUmiMetricsDataProvider() {
+
+        final double effectiveLength2_1 = -(2./3.)*Math.log(2./3.)/Math.log(4.) -(1./3.)*Math.log(1./3.)/Math.log(4.);
+        final double effectiveLength1_1_1 = -3*(1./3.)*Math.log(1./3.)/Math.log(4.);
+        final double estimatedBaseQuality1_12 = QualityUtil.getPhredScoreFromErrorProbability(1./12.);
+
+        return new Object[][] {{
+                // Test basic error correction using edit distance of 1
+                Arrays.asList("A", "B", "A", "B", "A"),
+                Arrays.asList("AAAA", "AAAA", "ATTA", "AAAA", "AAAT"), // Observed UMI
+                Arrays.asList("AAAA", "AAAA", "ATTA", "AAAA", "AAAA"),  // Inferred UMIs
+                Arrays.asList(false, false, false, true, true), // Should it be marked as duplicate?
+                1, // Edit Distance to Join
+                Arrays.asList(
+                   new UmiMetrics("A",           // LIBRARY
+                      4.0,                       // MEAN_UMI_LENGTH
+                      3,                         // OBSERVED_UNIQUE_UMIS
+                      2,                         // INFERRED_UNIQUE_UMIS
+                      2,                         // OBSERVED_BASE_ERRORS (Note: This is 2 rather than 1 because we are using paired end reads)
+                      2,                         // DUPLICATE_SETS_WITHOUT_UMI
+                      4,                         // DUPLICATE_SETS_WITH_UMI
+                      effectiveLength2_1,        // INFERRED_UMI_ENTROPY
+                      effectiveLength1_1_1,      // OBSERVED_UMI_ENTROPY
+                      estimatedBaseQuality1_12,  // ESTIMATED_BASE_QUALITY_OF_UMIS
+                      0),                        // UMI_WITH_N
+
+                   new UmiMetrics("B",           // LIBRARY
+                      4.0,                       // MEAN_UMI_LENGTH
+                      1,                         // OBSERVED_UNIQUE_UMIS
+                      1,                         // INFERRED_UNIQUE_UMIS
+                      0,                         // OBSERVED_BASE_ERRORS
+                      2,                         // DUPLICATE_SETS_WITHOUT_UMI
+                      2,                         // DUPLICATE_SETS_WITH_UMI
+                      0.0,                       // INFERRED_UMI_ENTROPY
+                      0.0,                       // OBSERVED_UMI_ENTROPY
+                      -1,                        // ESTIMATED_BASE_QUALITY_OF_UMIS
+                      0)                         // UMI_WITH_N
+                )
+        }};
+    }
+
+    @Test(dataProvider = "testMultipleLibraryUmiMetricsDataProvider")
+    public void testMultipleLibraryUmiMetrics(final List<String> libraries, final List<String> umis, final List<String> assignedUmi, final List<Boolean> isDuplicate,
+                               final int editDistanceToJoin, final List<UmiMetrics> expectedMetricsList) {
+
+        // Test collection of UMI metrics across multiple libraries
+        final Map<String, List<String>> expectedAssignedUmis = new HashMap<>();
+        for (int i = 0;i < umis.size();i++) {
+            // Get assigned UMIs for each particular library
+            expectedAssignedUmis.putIfAbsent(libraries.get(i), new ArrayList<>());
+            expectedAssignedUmis.get(libraries.get(i)).add(assignedUmi.get(i));
+        }
+
+        // Evaluate UMI metrics over each library
+        for (final UmiMetrics expectedMetrics : expectedMetricsList) {
+            final UmiAwareMarkDuplicatesWithMateCigarTester tester = getTester(false);
+            tester.addArg("MAX_EDIT_DISTANCE_TO_JOIN=" + editDistanceToJoin);
+            for (int i = 0;i < umis.size();i++) {
+                if(expectedMetrics.LIBRARY.equals(libraries.get(i))) {
+                    tester.addMatePairWithUmi(libraries.get(i), umis.get(i), assignedUmi.get(i), isDuplicate.get(i), isDuplicate.get(i));
+                }
+            }
+
+            tester.setExpectedAssignedUmis(expectedAssignedUmis.get(expectedMetrics.LIBRARY));
+            tester.setExpectedMetrics(expectedMetrics);
+            tester.runTest();
+        }
     }
 
     @DataProvider(name = "testUmiUtilDataProvider")

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
@@ -68,7 +68,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
         }
     }
 
-    public void addMatePairWithUmi(final String umi, final String assignedUMI, final boolean isDuplicate1, final boolean isDuplicate2) {
+    public void addMatePairWithUmi(final String library, final String umi, final String assignedUMI, final boolean isDuplicate1, final boolean isDuplicate2) {
 
         final String readName = "READ" + readNameCounter++;
         final String cigar1 = null;
@@ -90,37 +90,40 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
 
         final int defaultQuality = 10;
 
-        addMatePairWithUmi(readName, referenceSequenceIndex1, referenceSequenceIndex2, alignmentStart1, alignmentStart2, record1Unmapped,
+        addMatePairWithUmi(library, readName, referenceSequenceIndex1, referenceSequenceIndex2, alignmentStart1, alignmentStart2, record1Unmapped,
                 record2Unmapped, isDuplicate1, isDuplicate2, cigar1, cigar2, strand1, strand2, firstOnly, record1NonPrimary, record2NonPrimary,
                 defaultQuality, umi, assignedUMI);
 
     }
 
-    public void addMatePairWithUmi(final String readName,
-                            final int referenceSequenceIndex1,
-                            final int referenceSequenceIndex2,
-                            final int alignmentStart1,
-                            final int alignmentStart2,
-                            final boolean record1Unmapped,
-                            final boolean record2Unmapped,
-                            final boolean isDuplicate1,
-                            final boolean isDuplicate2,
-                            final String cigar1,
-                            final String cigar2,
-                            final boolean strand1,
-                            final boolean strand2,
-                            final boolean firstOnly,
-                            final boolean record1NonPrimary,
-                            final boolean record2NonPrimary,
-                            final int defaultQuality,
-                            final String umi,
-                            final String assignedUMI) {
+    public void addMatePairWithUmi(final String library,
+                                   final String readName,
+                                   final int referenceSequenceIndex1,
+                                   final int referenceSequenceIndex2,
+                                   final int alignmentStart1,
+                                   final int alignmentStart2,
+                                   final boolean record1Unmapped,
+                                   final boolean record2Unmapped,
+                                   final boolean isDuplicate1,
+                                   final boolean isDuplicate2,
+                                   final String cigar1,
+                                   final String cigar2,
+                                   final boolean strand1,
+                                   final boolean strand2,
+                                   final boolean firstOnly,
+                                   final boolean record1NonPrimary,
+                                   final boolean record2NonPrimary,
+                                   final int defaultQuality,
+                                   final String umi,
+                                   final String assignedUMI) {
         final List<SAMRecord> samRecordList = samRecordSetBuilder.addPair(readName, referenceSequenceIndex1, referenceSequenceIndex2, alignmentStart1, alignmentStart2,
                 record1Unmapped, record2Unmapped, cigar1, cigar2, strand1, strand2, record1NonPrimary, record2NonPrimary, defaultQuality);
 
         final SAMRecord record1 = samRecordList.get(0);
         final SAMRecord record2 = samRecordList.get(1);
 
+        record1.getReadGroup().setLibrary(library);
+        record2.getReadGroup().setLibrary(library);
         if (this.noMateCigars) {
             record1.setAttribute("MC", null);
             record2.setAttribute("MC", null);
@@ -182,6 +185,8 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
             double tolerance = 1e-6;
             Assert.assertEquals(metricsOutput.getMetrics().size(), 1);
             final UmiMetrics observedMetrics = metricsOutput.getMetrics().get(0);
+
+            Assert.assertEquals(observedMetrics.LIBRARY, expectedMetrics.LIBRARY, "LIBRARY does not match expected");
             Assert.assertEquals(observedMetrics.MEAN_UMI_LENGTH, expectedMetrics.MEAN_UMI_LENGTH, "UMI_LENGTH does not match expected");
             Assert.assertEquals(observedMetrics.OBSERVED_UNIQUE_UMIS, expectedMetrics.OBSERVED_UNIQUE_UMIS, "OBSERVED_UNIQUE_UMIS does not match expected");
             Assert.assertEquals(observedMetrics.INFERRED_UNIQUE_UMIS, expectedMetrics.INFERRED_UNIQUE_UMIS, "INFERRED_UNIQUE_UMIS does not match expected");


### PR DESCRIPTION
### Description

Adds a LIBRARY field to the UMI_METRICS file.  This allows for the metrics in UMI_METRICS to be stratified by library.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

