### PR TITLE
Installation of r-base in Docker Image allows RExecutor to work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG jar_name=picard.jar
 RUN apt-get update && \
     apt-get --no-install-recommends install -y --force-yes \
         git \
-	r-base \
+        r-base \
         ant && \
     apt-get clean autoclean && \
     apt-get autoremove -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ARG jar_name=picard.jar
 RUN apt-get update && \
     apt-get --no-install-recommends install -y --force-yes \
         git \
+	r-base \
         ant && \
     apt-get clean autoclean && \
     apt-get autoremove -y


### PR DESCRIPTION
### Description

A number of the Picard Metrics tools generate R code and run it by calling picard RExecutor method. That method runs  ```Rscript``` to generate graphics/PDFs.  This would work fine in many installations since R/Rscript is available on the user's PATH, but the docker image distributed at docker.io (broadinstitute/picard) does not include R, and nor does the image that one can build using the Dockerfile distributed here on github.  When invoked using a regular docker run command, the tools that use RExecutor crash and do not generate the requested graphics if they are run.

All this patch does is add ```r-base``` to the ```apt-get install ...``` command in the Dockerfile.  It does increase the size of the image by about 214 MB at the moment, which is ~22% larger.  On the other hand, it allows CollectInsertSizeMetrics, QualityScoreDistribution, MeanQualityByCycle, CollectBaseDistributionByCycle, CollectGcBiasMetrics, CollectRnaSeqMetrics, CollectRrbsMetrics, and CollectWgsMetricsWithNonZeroCoverage to work inside a Docker container.  

This pull request fixes issue #1197

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

