### PR TITLE
Tidy up TileMetricsOutReader a bit.

### DIFF
--- a/src/main/java/picard/illumina/parser/readers/TileMetricsOutReader.java
+++ b/src/main/java/picard/illumina/parser/readers/TileMetricsOutReader.java
@@ -14,7 +14,7 @@ import java.util.NoSuchElementException;
  * is essentially a struct.
  *
  * File Format:
- * byte 0 (unsigned byte) = The version number which MUST be 2 or an exception will be thrown
+ * byte 0 (unsigned byte) = The version number which MUST agree with the constructor parameter or an exception will be thrown
  * byte 1 (unsigned byte) = The record size which must be 10 or an exception will be thrown
  * bytes 3 + (current_record * 10) to (current_record * 10 + 10) (TileMetrics Record) = The actual records each of size 10 that
  *          get converted into IlluminaPhasingMetrics objects

--- a/src/main/java/picard/illumina/parser/readers/TileMetricsOutReader.java
+++ b/src/main/java/picard/illumina/parser/readers/TileMetricsOutReader.java
@@ -14,7 +14,7 @@ import java.util.NoSuchElementException;
  * is essentially a struct.
  *
  * File Format:
- * byte 0 (unsigned byte) = The version number which MUST agree with the constructor parameter or an exception will be thrown
+ * byte 0 (unsigned byte) = The version number which must agree with the constructor parameter or an exception will be thrown
  * byte 1 (unsigned byte) = The record size which must be 10 or an exception will be thrown
  * bytes 3 + (current_record * 10) to (current_record * 10 + 10) (TileMetrics Record) = The actual records each of size 10 that
  *          get converted into IlluminaPhasingMetrics objects
@@ -45,12 +45,12 @@ public class TileMetricsOutReader implements Iterator<TileMetricsOutReader.Illum
 
         final int actualVersion = UnsignedTypeUtil.uByteToInt(header.get());
         if (actualVersion != version.version) {
-            throw new PicardException("TileMetricsOutReader expects the version number to be " + version.version + ".  Actual Version in Header( " + actualVersion + ")");
+            throw new PicardException("TileMetricsOutReader expects the version number to be " + version.version + ".  Actual Version in Header(" + actualVersion + ")");
         }
 
         final int actualRecordSize = UnsignedTypeUtil.uByteToInt(header.get());
         if (version.recordSize != actualRecordSize) {
-            throw new PicardException("TileMetricsOutReader expects the record size to be " + version.recordSize + ".  Actual Record Size in Header( " + actualRecordSize + ")");
+            throw new PicardException("TileMetricsOutReader expects the record size to be " + version.recordSize + ".  Actual Record Size in Header(" + actualRecordSize + ")");
         }
         if (version == TileMetricsVersion.THREE) {
             this.density = UnsignedTypeUtil.uIntToFloat(header.getInt());

--- a/src/main/java/picard/illumina/parser/readers/TileMetricsOutReader.java
+++ b/src/main/java/picard/illumina/parser/readers/TileMetricsOutReader.java
@@ -82,7 +82,6 @@ public class TileMetricsOutReader implements Iterator<TileMetricsOutReader.Illum
     public static class IlluminaTileMetrics {
         private final IlluminaLaneTileCode laneTileCode;
         private final float metricValue;
-        private float metricValue2;
         private byte type;
 
         public IlluminaTileMetrics(final ByteBuffer bb, TileMetricsVersion version) {
@@ -91,7 +90,6 @@ public class TileMetricsOutReader implements Iterator<TileMetricsOutReader.Illum
                 //need to dump 9 bytes
                 this.type = bb.get();
                 this.metricValue = bb.getFloat();
-                this.metricValue2 = bb.getFloat();
             } else {
                 this.laneTileCode = new IlluminaLaneTileCode(UnsignedTypeUtil.uShortToInt(bb.getShort()), UnsignedTypeUtil.uShortToInt(bb.getShort()),
                         UnsignedTypeUtil.uShortToInt(bb.getShort()));
@@ -133,7 +131,7 @@ public class TileMetricsOutReader implements Iterator<TileMetricsOutReader.Illum
                 return false;
             }
         }
-        
+
         @Override
         public int hashCode() {
             return String.format("%s:%s:%s:%s", laneTileCode.getLaneNumber(), laneTileCode.getTileNumber(), laneTileCode.getMetricCode(), metricValue).hashCode(); // Slow but adequate.


### PR DESCRIPTION
### Description

Tidy TileMetricsOutReader up.

Fix File Format comment description for byte 0 now there is version 3.
Remove asymmetric spaces from PicardException messages.
Remove unused metricValue2 field from IlluminaTileMetrics.

I noticed these while debugging something else.
There should be no operational differences or change in function.

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable