### PR TITLE
Warning message about upcoming command line syntax transition.

### DIFF
--- a/src/main/java/picard/cmdline/CommandLineProgram.java
+++ b/src/main/java/picard/cmdline/CommandLineProgram.java
@@ -203,8 +203,9 @@ public abstract class CommandLineProgram {
             Log.getInstance(this.getClass()).info(
                     String.format("\n\n********** NOTE: In a future release, the command line syntax used by Picard will change, and the existing syntax \n" +
                             "********** will no longer be accepted. In the future release, the syntax for the command line arguments would be specified as:\n" +
-                            "**********\n**********\t %s\n**********\n" +
+                            "**********\n**********\t%s %s\n**********\n" +
                             "********** See https://github.com/broadinstitute/picard/wiki/Command-Line-Syntax-Transition-For-Users-(Pre-Transition) for more information.\n\n",
+                           this.getClass().getSimpleName(),
                            Arrays.stream(CommandLineSyntaxTranslater.translatePicardStyleToPosixStyle(argv)).collect(Collectors.joining(" ")))
             );
         }

--- a/src/main/java/picard/cmdline/CommandLineProgram.java
+++ b/src/main/java/picard/cmdline/CommandLineProgram.java
@@ -195,6 +195,18 @@ public abstract class CommandLineProgram {
 
         if (System.getProperty(PROPERTY_CONVERT_LEGACY_COMMAND_LINE, "false").equals("true")) {
             actualArgs = CommandLineSyntaxTranslater.translatePicardStyleToPosixStyle(argv);
+        } else if (CommandLineSyntaxTranslater.scanForLegacyCommandLine(argv)) {
+            // Issue an informational message telling the user that legacy syntax will soon be removed, and include
+            // a link to a Picard wiki page with more detail. For now this is only an informational message letting
+            // users know a change is coming. In a future release of Picard, when the default parser is Barclay, we'll
+            // update this message to link to a different page describing the options for that release.
+            Log.getInstance(this.getClass()).info(
+                    String.format("\n\n********** NOTE: In a future release, the command line syntax used by Picard will change, and the existing syntax \n" +
+                            "********** will no longer be accepted. In the future release, the syntax for the command line arguments would be specified as:\n" +
+                            "**********\n**********\t %s\n**********\n" +
+                            "********** See https://github.com/broadinstitute/picard/wiki/Command-Line-Syntax-Transition-For-Users-(Pre-Transition) for more information.\n\n",
+                           Arrays.stream(CommandLineSyntaxTranslater.translatePicardStyleToPosixStyle(argv)).collect(Collectors.joining(" ")))
+            );
         }
         if (!parseArgs(actualArgs)) {
             return 1;

--- a/src/main/java/picard/cmdline/CommandLineSyntaxTranslater.java
+++ b/src/main/java/picard/cmdline/CommandLineSyntaxTranslater.java
@@ -9,16 +9,33 @@ import java.util.stream.Collectors;
  */
 public class CommandLineSyntaxTranslater {
 
+    // Prefixes used by the Barclay parser for short/long prefixes
+    private static final String BARCLAY_SHORT_OPTION_PREFIX = "-";
+    private static final String BARCLAY_LONG_OPTION_PREFIX = "--";
+    // Separator used by the legacy parser for name/value arguments
+    private static final String LEGACY_VALUE_SEPARATOR = "=";
+
+    // Scan the command line arguments to see if they appear to be using legacy parser syntax
+    public static boolean scanForLegacyCommandLine(final String argv[]) {
+        Arrays.stream(argv).forEach(a -> {System.out.println();});
+        return Arrays.stream(argv).anyMatch(
+                putativeLegacyArg ->
+                        !putativeLegacyArg.startsWith(BARCLAY_SHORT_OPTION_PREFIX) &&
+                           !putativeLegacyArg.startsWith(BARCLAY_LONG_OPTION_PREFIX) &&
+                                putativeLegacyArg.contains(LEGACY_VALUE_SEPARATOR)
+        );
+    }
+
     public static String[] translatePicardStyleToPosixStyle(final String argv[]) {
         final List<String> convertedArgs = Arrays.stream(argv).flatMap(
             originalArgPair -> {
-                final String[] splitArgPair = originalArgPair.split("=", -1);
+                final String[] splitArgPair = originalArgPair.split(LEGACY_VALUE_SEPARATOR, -1);
                 if (splitArgPair.length == 1) {   // assume positional arg
                     return Arrays.stream(new String[]{ originalArgPair });
                 } else if (splitArgPair.length == 2) {
                     // it doesn't matter whether we use the short short name token ("-") or the long name token
                     // ("--"), so just treat everything as if it were a short name, since the CLP will accept either
-                    return Arrays.stream(new String[]{"-" + splitArgPair[0], splitArgPair[1]});
+                    return Arrays.stream(new String[]{BARCLAY_SHORT_OPTION_PREFIX + splitArgPair[0], splitArgPair[1]});
                 }
                 else {
                     throw new RuntimeException(

--- a/src/main/java/picard/cmdline/CommandLineSyntaxTranslater.java
+++ b/src/main/java/picard/cmdline/CommandLineSyntaxTranslater.java
@@ -17,7 +17,6 @@ public class CommandLineSyntaxTranslater {
 
     // Scan the command line arguments to see if they appear to be using legacy parser syntax
     public static boolean scanForLegacyCommandLine(final String argv[]) {
-        Arrays.stream(argv).forEach(a -> {System.out.println();});
         return Arrays.stream(argv).anyMatch(
                 putativeLegacyArg ->
                         !putativeLegacyArg.startsWith(BARCLAY_SHORT_OPTION_PREFIX) &&


### PR DESCRIPTION
Once we determine a target transition date, we'll need to decide at what point we want to include this. Proposed warning message about upcoming command line syntax transition. Displays an informational message with a link to a wiki page (under construction):

![image](https://user-images.githubusercontent.com/10062863/43275366-9107cbb0-90cf-11e8-9994-a96b6be94dd1.png)

Edit: A couple of people have suggested that we do something like this warning, but it looks like it breaks PipedDataTest.testSortSam.