### PR TITLE
Yf fix scatter with overflow mode

### DIFF
--- a/src/main/java/picard/util/IntervalListScatterer.java
+++ b/src/main/java/picard/util/IntervalListScatterer.java
@@ -23,7 +23,7 @@ public class IntervalListScatterer {
          * A scatter approach that differs from {@link Mode#INTERVAL_SUBDIVISION} in a few ways:
          * <ol>
          * <li>No interval will be subdivided, and consequently, the requested {@link IntervalListTools#SCATTER_COUNT} is
-         * an upper bound of scatter count, not a guarante of the number of {@link IntervalList}s that will be produced
+         * an upper bound of scatter count, not a guarantee of the number of {@link IntervalList}s that will be produced
          * (e.g., if scatterCount = 10 but there is only one interval in the input, only 1 interval list will be emitted).</li>
          * <li>When an interval would otherwise be split, it is instead deferred to the next scatter list.</li>
          * <li>The "target width" of each scatter list may be wider than what is computed for {@link Mode#INTERVAL_SUBDIVISION}.

--- a/src/main/java/picard/util/IntervalListScatterer.java
+++ b/src/main/java/picard/util/IntervalListScatterer.java
@@ -145,7 +145,9 @@ public class IntervalListScatterer {
                 }
             }
 
-            if (runningIntervalList.getBaseCount() >= idealSplitLength) {
+            if (runningIntervalList.getBaseCount() >= idealSplitLength &&
+                    (mode != Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW ||
+                            idealSplitLength >= projectedSizeOfRemainingDivisions)) {
                 numBasesLeft -= runningIntervalList.getBaseCount(); // keep track of the number of *unique* bases left
                 accumulatedIntervalLists.add(runningIntervalList.uniqued());
                 runningIntervalList = new IntervalList(uniquedList.getHeader());

--- a/src/test/java/picard/util/IntervalListScattererTest.java
+++ b/src/test/java/picard/util/IntervalListScattererTest.java
@@ -158,6 +158,19 @@ public class IntervalListScattererTest {
         ));
 
         testcases.add(new Testcase(
+                LIST_TO_SCATTER, 2, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
+                Arrays.asList(
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30000, 30098,
+                                30100, 30150
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30200, 30249
+                        )
+                )
+        ));
+
+        testcases.add(new Testcase(
                 LIST_TO_SCATTER, 1, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION,
                 Arrays.asList(
                         composeIntervalList(LIST_TO_SCATTER, "1",
@@ -167,6 +180,7 @@ public class IntervalListScattererTest {
                         )
                 )
         ));
+
         testcases.add(new Testcase(
                 LIST_TO_SCATTER, 6, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
                 Arrays.asList(
@@ -211,27 +225,27 @@ public class IntervalListScattererTest {
                 Arrays.asList(
                         composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
                                 30000, 30000,
-                                30100, 30109
-                        ),
-                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
-                                30200, 30209,
-                                30300, 30309
-                        ),
-                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+                                30100, 30109,
+                                30200, 30209
 
+                        ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+                                30300, 30309
+
+                        ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
                                 30400, 30409
-                        ),
-                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+
+                        ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
                                 30500, 30509
 
                         ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
                                 30600, 30609
 
                         ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
-
                                 30700, 30709
+
                         ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
                                 30800, 30808
+
                         )
                 )));
 

--- a/src/test/java/picard/util/IntervalListScattererTest.java
+++ b/src/test/java/picard/util/IntervalListScattererTest.java
@@ -39,16 +39,19 @@ import java.util.NoSuchElementException;
  * Very basic test for scatter functionality in IntervalListTools
  */
 public class IntervalListScattererTest {
-    private static final IntervalList LIST_TO_SCATTER;
-    private static final IntervalList LIST_TO_SCATTER_WITH_OVERFLOW;
+    private static final File TEST_DATA_DIR = new File("testdata/picard/util");
+    private static final File INTERVAL_FILE = new File(TEST_DATA_DIR, "scatterable.interval_list");
+    private static final IntervalList LIST_TO_SCATTER = IntervalList.fromFile(INTERVAL_FILE);
+
+    private static final File INTERVAL_WITH_OVERFLOW_FILE = new File(TEST_DATA_DIR, "scatterable_with_overflow.interval_list");
+    private static final IntervalList LIST_TO_SCATTER_WITH_OVERFLOW = IntervalList.fromFile(INTERVAL_WITH_OVERFLOW_FILE);
 
     static {
-        LIST_TO_SCATTER = IntervalList.fromFile(new File("testdata/picard/util/scatterable.interval_list"));
-        LIST_TO_SCATTER_WITH_OVERFLOW = IntervalList.fromFile(new File("testdata/picard/util/scatterable_with_overflow.interval_list"));
         Assert.assertEquals(LIST_TO_SCATTER.getUniqueBaseCount(), 200, "Wrong unique base count");
     }
 
     static class Testcase {
+        final File file;
         final IntervalList source;
         final List<IntervalList> expectedScatter;
         final int scatterWidth;
@@ -62,8 +65,9 @@ public class IntervalListScattererTest {
                     '}';
         }
 
-        private Testcase(final IntervalList source, final int scatterWidth, final IntervalListScatterer.Mode mode, final List<IntervalList> expectedScatter) {
-            this.source = source;
+        private Testcase(final File file, final int scatterWidth, final IntervalListScatterer.Mode mode, final List<IntervalList> expectedScatter) {
+            this.source = IntervalList.fromFile(file);
+            this.file = file;
             this.expectedScatter = expectedScatter;
             this.scatterWidth = scatterWidth;
             this.mode = mode;
@@ -73,155 +77,155 @@ public class IntervalListScattererTest {
     static final List<Testcase> testcases = new ArrayList<Testcase>();
 
     static {
-//        testcases.add(new Testcase(
-//                LIST_TO_SCATTER, 2, IntervalListScatterer.Mode.INTERVAL_SUBDIVISION,
-//                Arrays.asList(
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30000, 30098,
-//                                30100, 30100
-//                        ),
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30101, 30150,
-//                                30200, 30249
-//                        )
-//                )
-//        ));
-//
-//        testcases.add(new Testcase(
-//                LIST_TO_SCATTER, 4, IntervalListScatterer.Mode.INTERVAL_SUBDIVISION,
-//                Arrays.asList(
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30000, 30049
-//                        ),
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30050, 30098,
-//                                30100, 30100
-//                        ),
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30101, 30150
-//                        ),
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30200, 30249
-//                        )
-//                )
-//        ));
-//
-//        testcases.add(new Testcase(
-//                LIST_TO_SCATTER, 5, IntervalListScatterer.Mode.INTERVAL_SUBDIVISION,
-//                Arrays.asList(
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30000, 30039
-//                        ),
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30040, 30079
-//                        ),
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30080, 30098,
-//                                30100, 30120
-//                        ),
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30121, 30150,
-//                                30200, 30209
-//                        ),
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30210, 30249
-//                        )
-//                )
-//        ));
-//
-//        testcases.add(new Testcase(
-//                LIST_TO_SCATTER, 6, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION,
-//                Arrays.asList(
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30000, 30098
-//                        ),
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30100, 30150
-//                        ),
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30200, 30249
-//                        )
-//                )
-//        ));
-//
-//        testcases.add(new Testcase(
-//                LIST_TO_SCATTER, 2, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION,
-//                Arrays.asList(
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30000, 30098
-//                        ),
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30100, 30150,
-//                                30200, 30249
-//                        )
-//                )
-//        ));
-//
-//        testcases.add(new Testcase(
-//                LIST_TO_SCATTER, 2, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
-//                Arrays.asList(
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30000, 30098,
-//                                30100, 30150
-//                        ),
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30200, 30249
-//                        )
-//                )
-//        ));
-//
-//        testcases.add(new Testcase(
-//                LIST_TO_SCATTER, 1, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION,
-//                Arrays.asList(
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30000, 30098,
-//                                30100, 30150,
-//                                30200, 30249
-//                        )
-//                )
-//        ));
-//
-//        testcases.add(new Testcase(
-//                LIST_TO_SCATTER, 6, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
-//                Arrays.asList(
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30000, 30098
-//                        ),
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30100, 30150
-//                        ),
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30200, 30249
-//                        )
-//                )
-//        ));
-//
-//        testcases.add(new Testcase(
-//                LIST_TO_SCATTER, 2, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
-//                Arrays.asList(
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30000, 30098,
-//                                30100, 30150
-//                        ),
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30200, 30249
-//                        )
-//                )
-//        ));
-//
-//        testcases.add(new Testcase(
-//                LIST_TO_SCATTER, 1, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
-//                Arrays.asList(
-//                        composeIntervalList(LIST_TO_SCATTER, "1",
-//                                30000, 30098,
-//                                30100, 30150,
-//                                30200, 30249
-//                        )
-//                )
-//        ));
+        testcases.add(new Testcase(
+                INTERVAL_FILE, 2, IntervalListScatterer.Mode.INTERVAL_SUBDIVISION,
+                Arrays.asList(
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30000, 30098,
+                                30100, 30100
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30101, 30150,
+                                30200, 30249
+                        )
+                )
+        ));
 
         testcases.add(new Testcase(
-                LIST_TO_SCATTER_WITH_OVERFLOW, 7, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
+                INTERVAL_FILE, 4, IntervalListScatterer.Mode.INTERVAL_SUBDIVISION,
+                Arrays.asList(
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30000, 30049
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30050, 30098,
+                                30100, 30100
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30101, 30150
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30200, 30249
+                        )
+                )
+        ));
+
+        testcases.add(new Testcase(
+                INTERVAL_FILE, 5, IntervalListScatterer.Mode.INTERVAL_SUBDIVISION,
+                Arrays.asList(
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30000, 30039
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30040, 30079
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30080, 30098,
+                                30100, 30120
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30121, 30150,
+                                30200, 30209
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30210, 30249
+                        )
+                )
+        ));
+
+        testcases.add(new Testcase(
+                INTERVAL_FILE, 6, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION,
+                Arrays.asList(
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30000, 30098
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30100, 30150
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30200, 30249
+                        )
+                )
+        ));
+
+        testcases.add(new Testcase(
+                INTERVAL_FILE, 2, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION,
+                Arrays.asList(
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30000, 30098
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30100, 30150,
+                                30200, 30249
+                        )
+                )
+        ));
+
+        testcases.add(new Testcase(
+                INTERVAL_FILE, 2, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
+                Arrays.asList(
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30000, 30098,
+                                30100, 30150
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30200, 30249
+                        )
+                )
+        ));
+
+        testcases.add(new Testcase(
+                INTERVAL_FILE, 1, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION,
+                Arrays.asList(
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30000, 30098,
+                                30100, 30150,
+                                30200, 30249
+                        )
+                )
+        ));
+
+        testcases.add(new Testcase(
+                INTERVAL_FILE, 6, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
+                Arrays.asList(
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30000, 30098
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30100, 30150
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30200, 30249
+                        )
+                )
+        ));
+
+        testcases.add(new Testcase(
+                INTERVAL_FILE, 2, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
+                Arrays.asList(
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30000, 30098,
+                                30100, 30150
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30200, 30249
+                        )
+                )
+        ));
+
+        testcases.add(new Testcase(
+                INTERVAL_FILE, 1, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
+                Arrays.asList(
+                        composeIntervalList(LIST_TO_SCATTER, "1",
+                                30000, 30098,
+                                30100, 30150,
+                                30200, 30249
+                        )
+                )
+        ));
+
+        testcases.add(new Testcase(
+                INTERVAL_WITH_OVERFLOW_FILE, 7, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
                 Arrays.asList(
                         composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
                                 30000, 30000,
@@ -249,33 +253,33 @@ public class IntervalListScattererTest {
                         )
                 )));
 
-//        testcases.add(new Testcase(
-//                LIST_TO_SCATTER_WITH_OVERFLOW, 7, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION,
-//                Arrays.asList(
-//                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
-//                                30000, 30000,
-//                                30100, 30109
-//                        ),
-//                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
-//                                30200, 30209
-//                        ),
-//                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
-//                                30300, 30309
-//                        ),
-//                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
-//                                30400, 30409
-//
-//                        ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
-//                                30500, 30509
-//
-//                        ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
-//                                30600, 30609
-//
-//                        ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
-//                                30700, 30709,
-//                                30800, 30808
-//                        )
-//                )));
+        testcases.add(new Testcase(
+                INTERVAL_WITH_OVERFLOW_FILE, 7, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION,
+                Arrays.asList(
+                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+                                30000, 30000,
+                                30100, 30109
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+                                30200, 30209
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+                                30300, 30309
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+                                30400, 30409
+
+                        ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+                                30500, 30509
+
+                        ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+                                30600, 30609
+
+                        ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+                                30700, 30709,
+                                30800, 30808
+                        )
+                )));
     }
 
     @DataProvider

--- a/src/test/java/picard/util/IntervalListScattererTest.java
+++ b/src/test/java/picard/util/IntervalListScattererTest.java
@@ -73,152 +73,152 @@ public class IntervalListScattererTest {
     static final List<Testcase> testcases = new ArrayList<Testcase>();
 
     static {
-        testcases.add(new Testcase(
-                LIST_TO_SCATTER, 2, IntervalListScatterer.Mode.INTERVAL_SUBDIVISION,
-                Arrays.asList(
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30000, 30098,
-                                30100, 30100
-                        ),
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30101, 30150,
-                                30200, 30249
-                        )
-                )
-        ));
-
-        testcases.add(new Testcase(
-                LIST_TO_SCATTER, 4, IntervalListScatterer.Mode.INTERVAL_SUBDIVISION,
-                Arrays.asList(
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30000, 30049
-                        ),
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30050, 30098,
-                                30100, 30100
-                        ),
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30101, 30150
-                        ),
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30200, 30249
-                        )
-                )
-        ));
-
-        testcases.add(new Testcase(
-                LIST_TO_SCATTER, 5, IntervalListScatterer.Mode.INTERVAL_SUBDIVISION,
-                Arrays.asList(
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30000, 30039
-                        ),
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30040, 30079
-                        ),
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30080, 30098,
-                                30100, 30120
-                        ),
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30121, 30150,
-                                30200, 30209
-                        ),
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30210, 30249
-                        )
-                )
-        ));
-
-        testcases.add(new Testcase(
-                LIST_TO_SCATTER, 6, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION,
-                Arrays.asList(
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30000, 30098
-                        ),
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30100, 30150
-                        ),
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30200, 30249
-                        )
-                )
-        ));
-
-        testcases.add(new Testcase(
-                LIST_TO_SCATTER, 2, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION,
-                Arrays.asList(
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30000, 30098
-                        ),
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30100, 30150,
-                                30200, 30249
-                        )
-                )
-        ));
-
-        testcases.add(new Testcase(
-                LIST_TO_SCATTER, 2, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
-                Arrays.asList(
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30000, 30098,
-                                30100, 30150
-                        ),
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30200, 30249
-                        )
-                )
-        ));
-
-        testcases.add(new Testcase(
-                LIST_TO_SCATTER, 1, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION,
-                Arrays.asList(
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30000, 30098,
-                                30100, 30150,
-                                30200, 30249
-                        )
-                )
-        ));
-
-        testcases.add(new Testcase(
-                LIST_TO_SCATTER, 6, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
-                Arrays.asList(
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30000, 30098
-                        ),
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30100, 30150
-                        ),
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30200, 30249
-                        )
-                )
-        ));
-
-        testcases.add(new Testcase(
-                LIST_TO_SCATTER, 2, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
-                Arrays.asList(
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30000, 30098,
-                                30100, 30150
-                        ),
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30200, 30249
-                        )
-                )
-        ));
-
-        testcases.add(new Testcase(
-                LIST_TO_SCATTER, 1, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
-                Arrays.asList(
-                        composeIntervalList(LIST_TO_SCATTER, "1",
-                                30000, 30098,
-                                30100, 30150,
-                                30200, 30249
-                        )
-                )
-        ));
+//        testcases.add(new Testcase(
+//                LIST_TO_SCATTER, 2, IntervalListScatterer.Mode.INTERVAL_SUBDIVISION,
+//                Arrays.asList(
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30000, 30098,
+//                                30100, 30100
+//                        ),
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30101, 30150,
+//                                30200, 30249
+//                        )
+//                )
+//        ));
+//
+//        testcases.add(new Testcase(
+//                LIST_TO_SCATTER, 4, IntervalListScatterer.Mode.INTERVAL_SUBDIVISION,
+//                Arrays.asList(
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30000, 30049
+//                        ),
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30050, 30098,
+//                                30100, 30100
+//                        ),
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30101, 30150
+//                        ),
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30200, 30249
+//                        )
+//                )
+//        ));
+//
+//        testcases.add(new Testcase(
+//                LIST_TO_SCATTER, 5, IntervalListScatterer.Mode.INTERVAL_SUBDIVISION,
+//                Arrays.asList(
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30000, 30039
+//                        ),
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30040, 30079
+//                        ),
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30080, 30098,
+//                                30100, 30120
+//                        ),
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30121, 30150,
+//                                30200, 30209
+//                        ),
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30210, 30249
+//                        )
+//                )
+//        ));
+//
+//        testcases.add(new Testcase(
+//                LIST_TO_SCATTER, 6, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION,
+//                Arrays.asList(
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30000, 30098
+//                        ),
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30100, 30150
+//                        ),
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30200, 30249
+//                        )
+//                )
+//        ));
+//
+//        testcases.add(new Testcase(
+//                LIST_TO_SCATTER, 2, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION,
+//                Arrays.asList(
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30000, 30098
+//                        ),
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30100, 30150,
+//                                30200, 30249
+//                        )
+//                )
+//        ));
+//
+//        testcases.add(new Testcase(
+//                LIST_TO_SCATTER, 2, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
+//                Arrays.asList(
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30000, 30098,
+//                                30100, 30150
+//                        ),
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30200, 30249
+//                        )
+//                )
+//        ));
+//
+//        testcases.add(new Testcase(
+//                LIST_TO_SCATTER, 1, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION,
+//                Arrays.asList(
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30000, 30098,
+//                                30100, 30150,
+//                                30200, 30249
+//                        )
+//                )
+//        ));
+//
+//        testcases.add(new Testcase(
+//                LIST_TO_SCATTER, 6, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
+//                Arrays.asList(
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30000, 30098
+//                        ),
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30100, 30150
+//                        ),
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30200, 30249
+//                        )
+//                )
+//        ));
+//
+//        testcases.add(new Testcase(
+//                LIST_TO_SCATTER, 2, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
+//                Arrays.asList(
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30000, 30098,
+//                                30100, 30150
+//                        ),
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30200, 30249
+//                        )
+//                )
+//        ));
+//
+//        testcases.add(new Testcase(
+//                LIST_TO_SCATTER, 1, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
+//                Arrays.asList(
+//                        composeIntervalList(LIST_TO_SCATTER, "1",
+//                                30000, 30098,
+//                                30100, 30150,
+//                                30200, 30249
+//                        )
+//                )
+//        ));
 
         testcases.add(new Testcase(
                 LIST_TO_SCATTER_WITH_OVERFLOW, 7, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
@@ -249,33 +249,33 @@ public class IntervalListScattererTest {
                         )
                 )));
 
-        testcases.add(new Testcase(
-                LIST_TO_SCATTER_WITH_OVERFLOW, 7, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION,
-                Arrays.asList(
-                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
-                                30000, 30000,
-                                30100, 30109
-                        ),
-                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
-                                30200, 30209
-                        ),
-                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
-                                30300, 30309
-                        ),
-                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
-                                30400, 30409
-
-                        ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
-                                30500, 30509
-
-                        ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
-                                30600, 30609
-
-                        ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
-                                30700, 30709,
-                                30800, 30808
-                        )
-                )));
+//        testcases.add(new Testcase(
+//                LIST_TO_SCATTER_WITH_OVERFLOW, 7, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION,
+//                Arrays.asList(
+//                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+//                                30000, 30000,
+//                                30100, 30109
+//                        ),
+//                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+//                                30200, 30209
+//                        ),
+//                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+//                                30300, 30309
+//                        ),
+//                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+//                                30400, 30409
+//
+//                        ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+//                                30500, 30509
+//
+//                        ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+//                                30600, 30609
+//
+//                        ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+//                                30700, 30709,
+//                                30800, 30808
+//                        )
+//                )));
     }
 
     @DataProvider

--- a/src/test/java/picard/util/IntervalListScattererTest.java
+++ b/src/test/java/picard/util/IntervalListScattererTest.java
@@ -40,9 +40,11 @@ import java.util.NoSuchElementException;
  */
 public class IntervalListScattererTest {
     private static final IntervalList LIST_TO_SCATTER;
+    private static final IntervalList LIST_TO_SCATTER_WITH_OVERFLOW;
 
     static {
         LIST_TO_SCATTER = IntervalList.fromFile(new File("testdata/picard/util/scatterable.interval_list"));
+        LIST_TO_SCATTER_WITH_OVERFLOW = IntervalList.fromFile(new File("testdata/picard/util/scatterable_with_overflow.interval_list"));
         Assert.assertEquals(LIST_TO_SCATTER.getUniqueBaseCount(), 200, "Wrong unique base count");
     }
 
@@ -84,7 +86,7 @@ public class IntervalListScattererTest {
                         )
                 )
         ));
-        
+
         testcases.add(new Testcase(
                 LIST_TO_SCATTER, 4, IntervalListScatterer.Mode.INTERVAL_SUBDIVISION,
                 Arrays.asList(
@@ -164,7 +166,8 @@ public class IntervalListScattererTest {
                                 30200, 30249
                         )
                 )
-        ));  testcases.add(new Testcase(
+        ));
+        testcases.add(new Testcase(
                 LIST_TO_SCATTER, 6, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
                 Arrays.asList(
                         composeIntervalList(LIST_TO_SCATTER, "1",
@@ -202,6 +205,63 @@ public class IntervalListScattererTest {
                         )
                 )
         ));
+
+        testcases.add(new Testcase(
+                LIST_TO_SCATTER_WITH_OVERFLOW, 7, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW,
+                Arrays.asList(
+                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+                                30000, 30000,
+                                30100, 30109
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+                                30200, 30209,
+                                30300, 30309
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+
+                                30400, 30409
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+                                30500, 30509
+
+                        ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+                                30600, 30609
+
+                        ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+
+                                30700, 30709
+                        ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+                                30800, 30808
+                        )
+                )));
+
+        testcases.add(new Testcase(
+                LIST_TO_SCATTER_WITH_OVERFLOW, 7, IntervalListScatterer.Mode.BALANCING_WITHOUT_INTERVAL_SUBDIVISION,
+                Arrays.asList(
+                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+                                30000, 30000,
+                                30100, 30109
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+                                30200, 30209
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+                                30300, 30309
+                        ),
+                        composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+                                30400, 30409
+
+                        ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+                                30500, 30509
+
+                        ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+                                30600, 30609
+
+                        ), composeIntervalList(LIST_TO_SCATTER_WITH_OVERFLOW, "1",
+                                30700, 30709,
+                                30800, 30808
+                        )
+                )));
     }
 
     @DataProvider
@@ -221,7 +281,7 @@ public class IntervalListScattererTest {
         Assert.assertEquals(scatter.size(), tc.expectedScatter.size());
         Assert.assertEquals(scatter, tc.expectedScatter);
     }
-    
+
     private static IntervalList composeIntervalList(final IntervalList source, final String chromosome, final int... segmentsByPair) {
         final IntervalList intervals = new IntervalList(source.getHeader());
         for (int i = 0; i < segmentsByPair.length; i += 2) {
@@ -230,7 +290,7 @@ public class IntervalListScattererTest {
         }
         return intervals;
     }
-    
+
     private static Interval lookupIntervalContainingLocus(final IntervalList source, final String chromosome, final int startIndex) {
         for (final Interval interval : source) {
             if (interval.getContig().equals(chromosome) && startIndex >= interval.getStart() && startIndex <= interval.getEnd()) {

--- a/src/test/java/picard/util/IntervalListToolsTest.java
+++ b/src/test/java/picard/util/IntervalListToolsTest.java
@@ -167,7 +167,7 @@ public class IntervalListToolsTest extends CommandLineProgramTest {
         final List<String> args = new ArrayList<>();
 
         args.add("ACTION=UNION");
-        args.add("INPUT=" + scatterable);
+        args.add("INPUT=" + tc.file.getAbsolutePath());
 
         args.add("SUBDIVISION_MODE=" + tc.mode);
 

--- a/testdata/picard/util/scatterable_with_overflow.interval_list
+++ b/testdata/picard/util/scatterable_with_overflow.interval_list
@@ -1,0 +1,95 @@
+@HD	VN:1.5	SO:coordinate
+@SQ	SN:1	LN:249250621	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:1b22b98cdeb4a9304cb5d48026a85128	SP:Homo Sapiens
+@SQ	SN:2	LN:243199373	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:a0d9851da00400dec1098a9255ac712e	SP:Homo Sapiens
+@SQ	SN:3	LN:198022430	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:fdfd811849cc2fadebc929bb925902e5	SP:Homo Sapiens
+@SQ	SN:4	LN:191154276	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:23dccd106897542ad87d2765d28a19a1	SP:Homo Sapiens
+@SQ	SN:5	LN:180915260	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:0740173db9ffd264d728f32784845cd7	SP:Homo Sapiens
+@SQ	SN:6	LN:171115067	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:1d3a93a248d92a729ee764823acbbc6b	SP:Homo Sapiens
+@SQ	SN:7	LN:159138663	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:618366e953d6aaad97dbe4777c29375e	SP:Homo Sapiens
+@SQ	SN:8	LN:146364022	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:96f514a9929e410c6651697bded59aec	SP:Homo Sapiens
+@SQ	SN:9	LN:141213431	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:3e273117f15e0a400f01055d9f393768	SP:Homo Sapiens
+@SQ	SN:10	LN:135534747	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:988c28e000e84c26d552359af1ea2e1d	SP:Homo Sapiens
+@SQ	SN:11	LN:135006516	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:98c59049a2df285c76ffb1c6db8f8b96	SP:Homo Sapiens
+@SQ	SN:12	LN:133851895	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:51851ac0e1a115847ad36449b0015864	SP:Homo Sapiens
+@SQ	SN:13	LN:115169878	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:283f8d7892baa81b510a015719ca7b0b	SP:Homo Sapiens
+@SQ	SN:14	LN:107349540	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:98f3cae32b2a2e9524bc19813927542e	SP:Homo Sapiens
+@SQ	SN:15	LN:102531392	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:e5645a794a8238215b2cd77acb95a078	SP:Homo Sapiens
+@SQ	SN:16	LN:90354753	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:fc9b1a7b42b97a864f56b348b06095e6	SP:Homo Sapiens
+@SQ	SN:17	LN:81195210	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:351f64d4f4f9ddd45b35336ad97aa6de	SP:Homo Sapiens
+@SQ	SN:18	LN:78077248	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:b15d4b2d29dde9d3e4f93d1d0f2cbc9c	SP:Homo Sapiens
+@SQ	SN:19	LN:59128983	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:1aacd71f30db8e561810913e0b72636d	SP:Homo Sapiens
+@SQ	SN:20	LN:63025520	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:0dec9660ec1efaaf33281c0d5ea2560f	SP:Homo Sapiens
+@SQ	SN:21	LN:48129895	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:2979a6085bfe28e3ad6f552f361ed74d	SP:Homo Sapiens
+@SQ	SN:22	LN:51304566	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:a718acaa6135fdca8357d5bfe94211dd	SP:Homo Sapiens
+@SQ	SN:X	LN:155270560	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:7e0e2e580297b7764e31dbc80c2540dd	SP:Homo Sapiens
+@SQ	SN:Y	LN:59373566	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:1fa3474750af0948bdf97d5a0ee52e51	SP:Homo Sapiens
+@SQ	SN:MT	LN:16569	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:c68f52674c9fb33aef52dcf399755519	SP:Homo Sapiens
+@SQ	SN:GL000207.1	LN:4262	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:f3814841f1939d3ca19072d9e89f3fd7	SP:Homo Sapiens
+@SQ	SN:GL000226.1	LN:15008	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:1c1b2cd1fccbc0a99b6a447fa24d1504	SP:Homo Sapiens
+@SQ	SN:GL000229.1	LN:19913	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:d0f40ec87de311d8e715b52e4c7062e1	SP:Homo Sapiens
+@SQ	SN:GL000231.1	LN:27386	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:ba8882ce3a1efa2080e5d29b956568a4	SP:Homo Sapiens
+@SQ	SN:GL000210.1	LN:27682	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:851106a74238044126131ce2a8e5847c	SP:Homo Sapiens
+@SQ	SN:GL000239.1	LN:33824	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:99795f15702caec4fa1c4e15f8a29c07	SP:Homo Sapiens
+@SQ	SN:GL000235.1	LN:34474	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:118a25ca210cfbcdfb6c2ebb249f9680	SP:Homo Sapiens
+@SQ	SN:GL000201.1	LN:36148	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:dfb7e7ec60ffdcb85cb359ea28454ee9	SP:Homo Sapiens
+@SQ	SN:GL000247.1	LN:36422	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:7de00226bb7df1c57276ca6baabafd15	SP:Homo Sapiens
+@SQ	SN:GL000245.1	LN:36651	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:89bc61960f37d94abf0df2d481ada0ec	SP:Homo Sapiens
+@SQ	SN:GL000197.1	LN:37175	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:6f5efdd36643a9b8c8ccad6f2f1edc7b	SP:Homo Sapiens
+@SQ	SN:GL000203.1	LN:37498	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:96358c325fe0e70bee73436e8bb14dbd	SP:Homo Sapiens
+@SQ	SN:GL000246.1	LN:38154	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:e4afcd31912af9d9c2546acf1cb23af2	SP:Homo Sapiens
+@SQ	SN:GL000249.1	LN:38502	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:1d78abec37c15fe29a275eb08d5af236	SP:Homo Sapiens
+@SQ	SN:GL000196.1	LN:38914	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:d92206d1bb4c3b4019c43c0875c06dc0	SP:Homo Sapiens
+@SQ	SN:GL000248.1	LN:39786	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:5a8e43bec9be36c7b49c84d585107776	SP:Homo Sapiens
+@SQ	SN:GL000244.1	LN:39929	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:0996b4475f353ca98bacb756ac479140	SP:Homo Sapiens
+@SQ	SN:GL000238.1	LN:39939	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:131b1efc3270cc838686b54e7c34b17b	SP:Homo Sapiens
+@SQ	SN:GL000202.1	LN:40103	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:06cbf126247d89664a4faebad130fe9c	SP:Homo Sapiens
+@SQ	SN:GL000234.1	LN:40531	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:93f998536b61a56fd0ff47322a911d4b	SP:Homo Sapiens
+@SQ	SN:GL000232.1	LN:40652	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:3e06b6741061ad93a8587531307057d8	SP:Homo Sapiens
+@SQ	SN:GL000206.1	LN:41001	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:43f69e423533e948bfae5ce1d45bd3f1	SP:Homo Sapiens
+@SQ	SN:GL000240.1	LN:41933	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:445a86173da9f237d7bcf41c6cb8cc62	SP:Homo Sapiens
+@SQ	SN:GL000236.1	LN:41934	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:fdcd739913efa1fdc64b6c0cd7016779	SP:Homo Sapiens
+@SQ	SN:GL000241.1	LN:42152	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:ef4258cdc5a45c206cea8fc3e1d858cf	SP:Homo Sapiens
+@SQ	SN:GL000243.1	LN:43341	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:cc34279a7e353136741c9fce79bc4396	SP:Homo Sapiens
+@SQ	SN:GL000242.1	LN:43523	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:2f8694fc47576bc81b5fe9e7de0ba49e	SP:Homo Sapiens
+@SQ	SN:GL000230.1	LN:43691	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:b4eb71ee878d3706246b7c1dbef69299	SP:Homo Sapiens
+@SQ	SN:GL000237.1	LN:45867	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:e0c82e7751df73f4f6d0ed30cdc853c0	SP:Homo Sapiens
+@SQ	SN:GL000233.1	LN:45941	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:7fed60298a8d62ff808b74b6ce820001	SP:Homo Sapiens
+@SQ	SN:GL000204.1	LN:81310	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:efc49c871536fa8d79cb0a06fa739722	SP:Homo Sapiens
+@SQ	SN:GL000198.1	LN:90085	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:868e7784040da90d900d2d1b667a1383	SP:Homo Sapiens
+@SQ	SN:GL000208.1	LN:92689	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:aa81be49bf3fe63a79bdc6a6f279abf6	SP:Homo Sapiens
+@SQ	SN:GL000191.1	LN:106433	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:d75b436f50a8214ee9c2a51d30b2c2cc	SP:Homo Sapiens
+@SQ	SN:GL000227.1	LN:128374	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:a4aead23f8053f2655e468bcc6ecdceb	SP:Homo Sapiens
+@SQ	SN:GL000228.1	LN:129120	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:c5a17c97e2c1a0b6a9cc5a6b064b714f	SP:Homo Sapiens
+@SQ	SN:GL000214.1	LN:137718	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:46c2032c37f2ed899eb41c0473319a69	SP:Homo Sapiens
+@SQ	SN:GL000221.1	LN:155397	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:3238fb74ea87ae857f9c7508d315babb	SP:Homo Sapiens
+@SQ	SN:GL000209.1	LN:159169	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:f40598e2a5a6b26e84a3775e0d1e2c81	SP:Homo Sapiens
+@SQ	SN:GL000218.1	LN:161147	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:1d708b54644c26c7e01c2dad5426d38c	SP:Homo Sapiens
+@SQ	SN:GL000220.1	LN:161802	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:fc35de963c57bf7648429e6454f1c9db	SP:Homo Sapiens
+@SQ	SN:GL000213.1	LN:164239	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:9d424fdcc98866650b58f004080a992a	SP:Homo Sapiens
+@SQ	SN:GL000211.1	LN:166566	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:7daaa45c66b288847b9b32b964e623d3	SP:Homo Sapiens
+@SQ	SN:GL000199.1	LN:169874	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:569af3b73522fab4b40995ae4944e78e	SP:Homo Sapiens
+@SQ	SN:GL000217.1	LN:172149	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:6d243e18dea1945fb7f2517615b8f52e	SP:Homo Sapiens
+@SQ	SN:GL000216.1	LN:172294	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:642a232d91c486ac339263820aef7fe0	SP:Homo Sapiens
+@SQ	SN:GL000215.1	LN:172545	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:5eb3b418480ae67a997957c909375a73	SP:Homo Sapiens
+@SQ	SN:GL000205.1	LN:174588	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:d22441398d99caf673e9afb9a1908ec5	SP:Homo Sapiens
+@SQ	SN:GL000219.1	LN:179198	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:f977edd13bac459cb2ed4a5457dba1b3	SP:Homo Sapiens
+@SQ	SN:GL000224.1	LN:179693	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:d5b2fc04f6b41b212a4198a07f450e20	SP:Homo Sapiens
+@SQ	SN:GL000223.1	LN:180455	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:399dfa03bf32022ab52a846f7ca35b30	SP:Homo Sapiens
+@SQ	SN:GL000195.1	LN:182896	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:5d9ec007868d517e73543b005ba48535	SP:Homo Sapiens
+@SQ	SN:GL000212.1	LN:186858	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:563531689f3dbd691331fd6c5730a88b	SP:Homo Sapiens
+@SQ	SN:GL000222.1	LN:186861	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:6fe9abac455169f50470f5a6b01d0f59	SP:Homo Sapiens
+@SQ	SN:GL000200.1	LN:187035	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:75e4c8d17cd4addf3917d1703cacaf25	SP:Homo Sapiens
+@SQ	SN:GL000193.1	LN:189789	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:dbb6e8ece0b5de29da56601613007c2a	SP:Homo Sapiens
+@SQ	SN:GL000194.1	LN:191469	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:6ac8f815bf8e845bb3031b73f812c012	SP:Homo Sapiens
+@SQ	SN:GL000225.1	LN:211173	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:63945c3e6962f28ffd469719a747e73c	SP:Homo Sapiens
+@SQ	SN:GL000192.1	LN:547496	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:325ba9e808f669dfeee210fdd7b470ac	SP:Homo Sapiens
+@SQ	SN:NC_007605	LN:171823	AS:NC_007605.1	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:6743bd63b3ff2b5b8985d8933c53290a	SP:Epstein-Barr virus
+1	30000	30000	+	target_1
+1	30100	30109	+	target_2
+1	30200	30209	+	target_3
+1	30300	30309	+	target_4
+1	30400	30409	+	target_5
+1	30500	30509	+	target_6
+1	30600	30609	+	target_7
+1	30700	30709	+	target_8
+1	30800	30808	+	target_9


### PR DESCRIPTION
### Description

While refactoring the scattering code in a different branch I noticed this bug. it seems that sometime OVERFLOW mode "forgets" to overflow.

fixed and  added some tests. 

Not sure if there's a point in merging this, but it can serve as an explanation for my other PR (coming up)
