### PR TITLE
Fix output file naming in SplitSamByNumberOfReads

### DIFF
--- a/src/main/java/picard/sam/SplitSamByNumberOfReads.java
+++ b/src/main/java/picard/sam/SplitSamByNumberOfReads.java
@@ -124,14 +124,14 @@ public class SplitSamByNumberOfReads extends CommandLineProgram {
         final long totalReads = TOTAL_READS_IN_INPUT == 0 ? firstPassProgress.getCount() : TOTAL_READS_IN_INPUT;
 
         final SAMFileWriterFactory writerFactory = new SAMFileWriterFactory();
-        final DecimalFormat fileNameFormatter = new DecimalFormat(OUT_PREFIX + "_" + String.format("0000") + BamFileIoUtils.BAM_FILE_EXTENSION);
+        final DecimalFormat fileNameFormatter = new DecimalFormat(String.format("0000"));
 
         final int splitToNFiles = SPLIT_TO_N_FILES != 0 ? SPLIT_TO_N_FILES : (int) Math.ceil(totalReads / (double) SPLIT_TO_N_READS);
         final int readsPerFile = (int) Math.ceil(totalReads / (double) splitToNFiles);
 
         int readsWritten = 0;
         int fileIndex = 1;
-        SAMFileWriter currentWriter = writerFactory.makeSAMOrBAMWriter(header, true, new File(OUTPUT, fileNameFormatter.format(fileIndex++)));
+        SAMFileWriter currentWriter = writerFactory.makeSAMOrBAMWriter(header, true, new File(OUTPUT, OUT_PREFIX + "_" + fileNameFormatter.format(fileIndex++) + BamFileIoUtils.BAM_FILE_EXTENSION));
         String lastReadName = "";
         final ProgressLogger progress = new ProgressLogger(log);
         for (SAMRecord currentRecord : reader) {


### PR DESCRIPTION
### Description
Moved the OUT_PREFIX String out of the DecimalFormat and into the File name creation. This means if the user adds any of the DecimalFormat Special Pattern Characters in the prefix it won't mess up the pattern. 

For example
If OUT_PREFIX contains any zeroes then the file name gets messed up

if OUT_PREFIX is "test01"
then output filename is "test00001.1_bam"
with this fix filename is "test01_0001.bam"

The default of "shard" as the prefix means that this behaviour wasn't covered by tests.

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [no] Added or modified tests to cover changes and any new functionality
sorry I don't know how to write tests and run them. 
- [n/a] Edited the README / documentation (if applicable)
- [probably] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

