### PR TITLE
Diagnose missing barcodes in ExtractIlluminaBarcodes instead of throwing NPE.

### DIFF
--- a/src/main/java/picard/illumina/ExtractIlluminaBarcodes.java
+++ b/src/main/java/picard/illumina/ExtractIlluminaBarcodes.java
@@ -506,14 +506,14 @@ public class ExtractIlluminaBarcodes extends CommandLineProgram {
             for (final ReadDescriptor rd : readStructure.descriptors) {
                 if (rd.type != ReadType.Barcode) continue;
                 final String header = barcodeNum == 0 ? sequenceColumn : "barcode_sequence_" + String.valueOf(1 + barcodeNum);
-                System.out.println(String.format("%d: header == '%s'", barcodeNum, header));
                 final String field = row.getField(header);
                 if (field == null) {
-                    messages.add(String.format("Null barcode in column %s of row %d in file %s", header, rowNum, BARCODE_FILE));
+                    messages.add(String.format("Null barcode in column %s of row %d.", header, rowNum));
+                    bcStrings[barcodeNum] = "";
                 } else {
                     bcStrings[barcodeNum] = field;
-                    ++barcodeNum;
                 }
+                ++barcodeNum;
             }
             if (numBarcodes == barcodeNum) {
                 final String bcStr = IlluminaUtil.barcodeSeqsToString(bcStrings);
@@ -526,7 +526,7 @@ public class ExtractIlluminaBarcodes extends CommandLineProgram {
                 final BarcodeMetric metric = new BarcodeMetric(barcodeName, libraryName, bcStr, bcStrings);
                 barcodeToMetrics.put(StringUtil.join("", bcStrings), metric);
             } else {
-                messages.add(String.format("Read structure %s specifies %d sample barcodes but found %d in %s", READ_STRUCTURE, numBarcodes, barcodeNum, BARCODE_FILE));
+                messages.add(String.format("Read structure %s specifies %d sample barcodes but found %d in row %d.", READ_STRUCTURE, numBarcodes, barcodeNum, rowNum));
             }
         }
         barcodesParser.close();

--- a/src/main/java/picard/illumina/ExtractIlluminaBarcodes.java
+++ b/src/main/java/picard/illumina/ExtractIlluminaBarcodes.java
@@ -486,35 +486,48 @@ public class ExtractIlluminaBarcodes extends CommandLineProgram {
     private void parseBarcodeFile(final ArrayList<String> messages) {
         final TabbedTextFileWithHeaderParser barcodesParser = new TabbedTextFileWithHeaderParser(BARCODE_FILE);
         final String sequenceColumn = barcodesParser.hasColumn(BARCODE_SEQUENCE_COLUMN)
-                ? BARCODE_SEQUENCE_COLUMN : barcodesParser.hasColumn(BARCODE_SEQUENCE_1_COLUMN)
-                ? BARCODE_SEQUENCE_1_COLUMN : null;
+            ? BARCODE_SEQUENCE_COLUMN : barcodesParser.hasColumn(BARCODE_SEQUENCE_1_COLUMN)
+            ? BARCODE_SEQUENCE_1_COLUMN : null;
         if (sequenceColumn == null) {
             messages.add(BARCODE_FILE + " does not have " + BARCODE_SEQUENCE_COLUMN + " or " +
                     BARCODE_SEQUENCE_1_COLUMN + " column header");
+            barcodesParser.close();
             return;
         }
         final boolean hasBarcodeName = barcodesParser.hasColumn(BARCODE_NAME_COLUMN);
         final boolean hasLibraryName = barcodesParser.hasColumn(LIBRARY_NAME_COLUMN);
         final int numBarcodes = readStructure.sampleBarcodes.length();
         final Set<String> barcodes = new HashSet<>();
+        int rowNum = 0;
         for (final TabbedTextFileWithHeaderParser.Row row : barcodesParser) {
+            ++rowNum;
             final String[] bcStrings = new String[numBarcodes];
-            int barcodeNum = 1;
+            int barcodeNum = 0;
             for (final ReadDescriptor rd : readStructure.descriptors) {
                 if (rd.type != ReadType.Barcode) continue;
-                final String header = barcodeNum == 1 ? sequenceColumn : "barcode_sequence_" + String.valueOf(barcodeNum);
-                bcStrings[barcodeNum - 1] = row.getField(header);
-                barcodeNum++;
+                final String header = barcodeNum == 0 ? sequenceColumn : "barcode_sequence_" + String.valueOf(1 + barcodeNum);
+                System.out.println(String.format("%d: header == '%s'", barcodeNum, header));
+                final String field = row.getField(header);
+                if (field == null) {
+                    messages.add(String.format("Null barcode in column %s of row %d in file %s", header, rowNum, BARCODE_FILE));
+                } else {
+                    bcStrings[barcodeNum] = field;
+                    ++barcodeNum;
+                }
             }
-            final String bcStr = IlluminaUtil.barcodeSeqsToString(bcStrings);
-            if (barcodes.contains(bcStr)) {
-                messages.add("Barcode " + bcStr + " specified more than once in " + BARCODE_FILE);
+            if (numBarcodes == barcodeNum) {
+                final String bcStr = IlluminaUtil.barcodeSeqsToString(bcStrings);
+                if (barcodes.contains(bcStr)) {
+                    messages.add("Barcode " + bcStr + " specified more than once in " + BARCODE_FILE);
+                }
+                barcodes.add(bcStr);
+                final String barcodeName = (hasBarcodeName ? row.getField(BARCODE_NAME_COLUMN) : "");
+                final String libraryName = (hasLibraryName ? row.getField(LIBRARY_NAME_COLUMN) : "");
+                final BarcodeMetric metric = new BarcodeMetric(barcodeName, libraryName, bcStr, bcStrings);
+                barcodeToMetrics.put(StringUtil.join("", bcStrings), metric);
+            } else {
+                messages.add(String.format("Read structure %s specifies %d sample barcodes but found %d in %s", READ_STRUCTURE, numBarcodes, barcodeNum, BARCODE_FILE));
             }
-            barcodes.add(bcStr);
-            final String barcodeName = (hasBarcodeName ? row.getField(BARCODE_NAME_COLUMN) : "");
-            final String libraryName = (hasLibraryName ? row.getField(LIBRARY_NAME_COLUMN) : "");
-            final BarcodeMetric metric = new BarcodeMetric(barcodeName, libraryName, bcStr, bcStrings);
-            barcodeToMetrics.put(StringUtil.join("", bcStrings), metric);
         }
         barcodesParser.close();
     }

--- a/src/main/java/picard/illumina/ExtractIlluminaBarcodes.java
+++ b/src/main/java/picard/illumina/ExtractIlluminaBarcodes.java
@@ -515,19 +515,15 @@ public class ExtractIlluminaBarcodes extends CommandLineProgram {
                 }
                 ++barcodeNum;
             }
-            if (numBarcodes == barcodeNum) {
-                final String bcStr = IlluminaUtil.barcodeSeqsToString(bcStrings);
-                if (barcodes.contains(bcStr)) {
-                    messages.add("Barcode " + bcStr + " specified more than once in " + BARCODE_FILE);
-                }
-                barcodes.add(bcStr);
-                final String barcodeName = (hasBarcodeName ? row.getField(BARCODE_NAME_COLUMN) : "");
-                final String libraryName = (hasLibraryName ? row.getField(LIBRARY_NAME_COLUMN) : "");
-                final BarcodeMetric metric = new BarcodeMetric(barcodeName, libraryName, bcStr, bcStrings);
-                barcodeToMetrics.put(StringUtil.join("", bcStrings), metric);
-            } else {
-                messages.add(String.format("Read structure %s specifies %d sample barcodes but found %d in row %d.", READ_STRUCTURE, numBarcodes, barcodeNum, rowNum));
+            final String bcStr = IlluminaUtil.barcodeSeqsToString(bcStrings);
+            if (barcodes.contains(bcStr)) {
+                messages.add("Barcode " + bcStr + " specified more than once in " + BARCODE_FILE);
             }
+            barcodes.add(bcStr);
+            final String barcodeName = (hasBarcodeName ? row.getField(BARCODE_NAME_COLUMN) : "");
+            final String libraryName = (hasLibraryName ? row.getField(LIBRARY_NAME_COLUMN) : "");
+            final BarcodeMetric metric = new BarcodeMetric(barcodeName, libraryName, bcStr, bcStrings);
+            barcodeToMetrics.put(StringUtil.join("", bcStrings), metric);
         }
         barcodesParser.close();
     }

--- a/src/main/java/picard/illumina/ExtractIlluminaBarcodes.java
+++ b/src/main/java/picard/illumina/ExtractIlluminaBarcodes.java
@@ -486,8 +486,8 @@ public class ExtractIlluminaBarcodes extends CommandLineProgram {
     private void parseBarcodeFile(final ArrayList<String> messages) {
         final TabbedTextFileWithHeaderParser barcodesParser = new TabbedTextFileWithHeaderParser(BARCODE_FILE);
         final String sequenceColumn = barcodesParser.hasColumn(BARCODE_SEQUENCE_COLUMN)
-            ? BARCODE_SEQUENCE_COLUMN : barcodesParser.hasColumn(BARCODE_SEQUENCE_1_COLUMN)
-            ? BARCODE_SEQUENCE_1_COLUMN : null;
+                ? BARCODE_SEQUENCE_COLUMN : barcodesParser.hasColumn(BARCODE_SEQUENCE_1_COLUMN)
+                ? BARCODE_SEQUENCE_1_COLUMN : null;
         if (sequenceColumn == null) {
             messages.add(BARCODE_FILE + " does not have " + BARCODE_SEQUENCE_COLUMN + " or " +
                     BARCODE_SEQUENCE_1_COLUMN + " column header");

--- a/src/main/java/picard/util/TabbedTextFileWithHeaderParser.java
+++ b/src/main/java/picard/util/TabbedTextFileWithHeaderParser.java
@@ -41,7 +41,7 @@ import java.util.Set;
  *
  * @author alecw@broadinstitute.org
  */
-public class TabbedTextFileWithHeaderParser implements Iterable<TabbedTextFileWithHeaderParser.Row> {
+public class TabbedTextFileWithHeaderParser implements Iterable<TabbedTextFileWithHeaderParser.Row>, AutoCloseable {
     public class Row {
         private final String[] fields;
         private final String currentLine;


### PR DESCRIPTION
### Description

ExtractIlluminaBarcodes throws undiagnosed NPEs when the content of a BARCODE_FILE
disagrees with the READ_STRUCTURE specified on the command line.

Instead of throwing a NullPointerException, report a null barcode field in some row
and fail from customCommandLineValidation().

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

This change adds no new function. It just replaces a generic NPE with a diagnostic.

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests