### PR TITLE
Un-deprecate method VcfTestUtils.createTemporaryIndexedVcfFromInput(File, String)

### DIFF
--- a/src/test/java/picard/vcf/VcfTestUtils.java
+++ b/src/test/java/picard/vcf/VcfTestUtils.java
@@ -43,26 +43,25 @@ public class VcfTestUtils {
     }
 
     /**
+     * Given a VCF file, create a temporary VCF file with an index file. Both the temporary file and its index are
+     * deleted when the JVM exits.
      *
-     * @param vcfFile
-     * @param tempFilePrefix
-     * @return
-     * @throws IOException
-     *
-     * @deprecated use createTemporaryIndexedFile instead
+     * @param vcfFile the file to use as a source
+     * @param tempFilePrefix a prefix name for the temporary file
+     * @return the temporary VCF file
      */
-    @Deprecated
     public static File createTemporaryIndexedVcfFromInput(final File vcfFile, final String tempFilePrefix) throws IOException {
         return createTemporaryIndexedVcfFromInput(vcfFile, tempFilePrefix, null);
     }
 
-        /**
-         * This method makes a copy of the input VCF and creates an index file for it in the same location.
-         * This is done so that we don't need to store the index file in the same repo
-         * The copy of the input is done so that it and its index are in the same directory which is typically required.
-         * @param vcfFile the vcf file to index
-         * @return File a vcf file (index file is created in same path).
-         */
+    /**
+     * This method makes a copy of the input VCF and creates an index file for it in the same location.
+     * This is done so that we don't need to store the index file in the same repo
+     * The copy of the input is done so that it and its index are in the same directory which is typically required.
+     *
+     * @param vcfFile the vcf file to index
+     * @return File a vcf file (index file is created in same path).
+     */
     public static File createTemporaryIndexedVcfFromInput(final File vcfFile, final String tempFilePrefix, final String suffix) throws IOException {
         final String extension;
 
@@ -73,27 +72,27 @@ public class VcfTestUtils {
         } else if (vcfFile.getAbsolutePath().endsWith(".vcf.gz") ) {
             extension = ".vcf.gz";
         } else {
-            extension = "nope!";
+            extension = "";
         }
 
-        if (!extension.equals(".vcf") && !extension.equals(".vcf.gz"))
+        if (!extension.equals(".vcf") && !extension.equals(".vcf.gz")) {
             throw new IllegalArgumentException("couldn't find a .vcf or .vcf.gz ending for input file " + vcfFile.getAbsolutePath());
+        }
 
         File output = createTemporaryIndexedFile(tempFilePrefix, extension);
 
-        final VCFFileReader in = new VCFFileReader(vcfFile, false);
-        final VCFHeader header = in.getFileHeader();
-
-        final VariantContextWriter out = new VariantContextWriterBuilder().
-                setReferenceDictionary(header.getSequenceDictionary()).
-                setOptions(EnumSet.of(Options.INDEX_ON_THE_FLY)).
-                setOutputFile(output).build();
-        out.writeHeader(header);
-        for (final VariantContext ctx : in) {
-            out.add(ctx);
+        try (final VCFFileReader in = new VCFFileReader(vcfFile, false)) {
+            final VCFHeader header = in.getFileHeader();
+            try (final VariantContextWriter out = new VariantContextWriterBuilder().
+                    setReferenceDictionary(header.getSequenceDictionary()).
+                    setOptions(EnumSet.of(Options.INDEX_ON_THE_FLY)).
+                    setOutputFile(output).build()) {
+                out.writeHeader(header);
+                for (final VariantContext ctx : in) {
+                    out.add(ctx);
+                }
+            }
         }
-        out.close();
-        in.close();
         return output;
     }
 
@@ -130,7 +129,7 @@ public class VcfTestUtils {
 
         Assert.assertEquals(actual.getID(), expected.getID());
         Assert.assertEquals(actual.getFilters(), expected.getFilters());
-        Assert.assertEquals(actual.getAttributes(), expected.getAttributes(), "");
+        Assert.assertEquals(actual.getAttributes(), expected.getAttributes());
     }
 
     public static void assertEquals(final GenotypesContext actual, final GenotypesContext expected) {
@@ -152,10 +151,9 @@ public class VcfTestUtils {
         final File indexedActual = createTemporaryIndexedVcfFromInput(actual, "assert");
         final File indexedExpected = createTemporaryIndexedVcfFromInput(expected, "assert");
 
-        try (
-                final VCFFileReader vcfReaderActual = new VCFFileReader(indexedActual);
-                final VCFFileReader vcfReaderExpected = new VCFFileReader(indexedExpected)) {
-            VcfTestUtils.assertEquals(vcfReaderActual, vcfReaderExpected);
+        try (final VCFFileReader vcfReaderActual = new VCFFileReader(indexedActual);
+             final VCFFileReader vcfReaderExpected = new VCFFileReader(indexedExpected)) {
+            assertEquals(vcfReaderActual, vcfReaderExpected);
         }
     }
 }


### PR DESCRIPTION
The method `createTemporaryIndexedVcfFromInput(File, String)` was changed to `deprecated` but the referenced method is not a valid substitute.

- removed deprecated tag from `createTemporaryIndexedVcfFromInput(File, String)`
- added javadoc
- other minor cleanups


----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

