### PR TITLE
Fix to ValidateSamFile to warn when NM validation occurs without reference (#258)

### DIFF
--- a/src/main/java/picard/sam/ValidateSamFile.java
+++ b/src/main/java/picard/sam/ValidateSamFile.java
@@ -206,7 +206,7 @@ public class ValidateSamFile extends CommandLineProgram {
                 reference = ReferenceSequenceFileFactory.getReferenceSequenceFile(REFERENCE_SEQUENCE);
 
             } else {
-                log.warn("NM validation cannot be performed without the reference");
+                log.warn("NM validation cannot be performed without the reference. All other validations will still occur.");
             }
             final PrintWriter out;
             if (OUTPUT != null) {

--- a/src/main/java/picard/sam/ValidateSamFile.java
+++ b/src/main/java/picard/sam/ValidateSamFile.java
@@ -205,6 +205,8 @@ public class ValidateSamFile extends CommandLineProgram {
                 IOUtil.assertFileIsReadable(REFERENCE_SEQUENCE);
                 reference = ReferenceSequenceFileFactory.getReferenceSequenceFile(REFERENCE_SEQUENCE);
 
+            } else {
+                log.warn("NM validation cannot be performed without the reference.");
             }
             final PrintWriter out;
             if (OUTPUT != null) {

--- a/src/main/java/picard/sam/ValidateSamFile.java
+++ b/src/main/java/picard/sam/ValidateSamFile.java
@@ -206,7 +206,7 @@ public class ValidateSamFile extends CommandLineProgram {
                 reference = ReferenceSequenceFileFactory.getReferenceSequenceFile(REFERENCE_SEQUENCE);
 
             } else {
-                log.warn("NM validation cannot be performed without the reference.");
+                log.warn("NM validation cannot be performed without the reference");
             }
             final PrintWriter out;
             if (OUTPUT != null) {


### PR DESCRIPTION
This addresses #258 https://github.com/broadinstitute/picard/issues/258.

Gives warning if REFERENCE_SEQUENCE is null.
