### PR TITLE
Fix for SplitSamByNumberOfReads when OUTPUT_PREFIX has a zero

### DIFF
--- a/src/main/java/picard/sam/SplitSamByNumberOfReads.java
+++ b/src/main/java/picard/sam/SplitSamByNumberOfReads.java
@@ -124,14 +124,14 @@ public class SplitSamByNumberOfReads extends CommandLineProgram {
         final long totalReads = TOTAL_READS_IN_INPUT == 0 ? firstPassProgress.getCount() : TOTAL_READS_IN_INPUT;
 
         final SAMFileWriterFactory writerFactory = new SAMFileWriterFactory();
-        final DecimalFormat fileNameFormatter = new DecimalFormat(OUT_PREFIX + "_" + String.format("0000") + BamFileIoUtils.BAM_FILE_EXTENSION);
+        final DecimalFormat fileNameFormatter = new DecimalFormat(String.format("0000"));
 
         final int splitToNFiles = SPLIT_TO_N_FILES != 0 ? SPLIT_TO_N_FILES : (int) Math.ceil(totalReads / (double) SPLIT_TO_N_READS);
         final int readsPerFile = (int) Math.ceil(totalReads / (double) splitToNFiles);
 
         int readsWritten = 0;
         int fileIndex = 1;
-        SAMFileWriter currentWriter = writerFactory.makeSAMOrBAMWriter(header, true, new File(OUTPUT, fileNameFormatter.format(fileIndex++)));
+        SAMFileWriter currentWriter = writerFactory.makeSAMOrBAMWriter(header, true, new File(OUTPUT, OUT_PREFIX + "_" + fileNameFormatter.format(fileIndex++) + BamFileIoUtils.BAM_FILE_EXTENSION));
         String lastReadName = "";
         final ProgressLogger progress = new ProgressLogger(log);
         for (SAMRecord currentRecord : reader) {

--- a/src/test/java/picard/sam/SplitSamByNumberOfReadsTest.java
+++ b/src/test/java/picard/sam/SplitSamByNumberOfReadsTest.java
@@ -24,7 +24,6 @@
 package picard.sam;
 
 import htsjdk.samtools.*;
-import htsjdk.samtools.util.IOUtil;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import picard.cmdline.CommandLineProgramTest;
@@ -33,6 +32,7 @@ import com.google.common.collect.Iterators;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 /**
  * Tests for SAMSplitter
@@ -42,6 +42,7 @@ public class SplitSamByNumberOfReadsTest extends CommandLineProgramTest {
     private static final File PAIRED_FILE = new File(TEST_DATA_DIR + "/sorted-pair.sam");
     private static final File THREE_READ_TEMPLATE = new File(TEST_DATA_DIR + "/sorted-triplet.sam");
     private final ValidateSamTester VALIDATE_SAM_TESTER = new ValidateSamTester();
+    private final String TMP_DIR_NAME = "temp_dir";
 
     public String getCommandLineProgramName() {
         return SplitSamByNumberOfReads.class.getSimpleName();
@@ -49,10 +50,10 @@ public class SplitSamByNumberOfReadsTest extends CommandLineProgramTest {
 
     @Test
     public void testOkFile() throws IOException {
-        final String tmpDir = IOUtil.getDefaultTmpDir().getAbsolutePath();
+        final File tmpDir = Files.createTempDirectory(TMP_DIR_NAME).toFile();
 
-        final String[] args = new String[]{
-                "INPUT=" + PAIRED_FILE.getAbsolutePath(),
+        final String[] args = {
+                "INPUT=" + PAIRED_FILE.getPath(),
                 "TOTAL_READS_IN_INPUT=10",
                 "SPLIT_TO_N_READS=5",
                 "OUTPUT=" + tmpDir
@@ -84,10 +85,10 @@ public class SplitSamByNumberOfReadsTest extends CommandLineProgramTest {
 
     @Test
     public void testNoTotalReads() throws IOException {
-        final String tmpDir = IOUtil.getDefaultTmpDir().getAbsolutePath();
+        final File tmpDir = Files.createTempDirectory(TMP_DIR_NAME).toFile();
 
-        final String[] args = new String[]{
-                "INPUT=" + PAIRED_FILE.getAbsolutePath(),
+        final String[] args = {
+                "INPUT=" + PAIRED_FILE.getPath(),
                 "SPLIT_TO_N_READS=5",
                 "OUTPUT=" + tmpDir
         };
@@ -118,10 +119,10 @@ public class SplitSamByNumberOfReadsTest extends CommandLineProgramTest {
 
     @Test
     public void testNFiles() throws IOException {
-        final String tmpDir = IOUtil.getDefaultTmpDir().getAbsolutePath();
+        final File tmpDir = Files.createTempDirectory(TMP_DIR_NAME).toFile();
 
-        final String[] args = new String[]{
-                "INPUT=" + PAIRED_FILE.getAbsolutePath(),
+        final String[] args = {
+                "INPUT=" + PAIRED_FILE.getPath(),
                 "TOTAL_READS_IN_INPUT=10",
                 "SPLIT_TO_N_FILES=2",
                 "OUTPUT=" + tmpDir
@@ -146,10 +147,10 @@ public class SplitSamByNumberOfReadsTest extends CommandLineProgramTest {
 
     @Test
     public void testOneOutput() throws IOException {
-        final String tmpDir = IOUtil.getDefaultTmpDir().getAbsolutePath();
+        final File tmpDir = Files.createTempDirectory(TMP_DIR_NAME).toFile();
 
-        final String[] args = new String[]{
-                "INPUT=" + PAIRED_FILE.getAbsolutePath(),
+        final String[] args = {
+                "INPUT=" + PAIRED_FILE.getPath(),
                 "TOTAL_READS_IN_INPUT=10",
                 "SPLIT_TO_N_READS=10",
                 "OUTPUT=" + tmpDir
@@ -167,10 +168,10 @@ public class SplitSamByNumberOfReadsTest extends CommandLineProgramTest {
 
     @Test
     public void testWrongTotalReads() throws IOException {
-        final String tmpDir = IOUtil.getDefaultTmpDir().getAbsolutePath();
+        final File tmpDir = Files.createTempDirectory(TMP_DIR_NAME).toFile();
 
-        final String[] args = new String[]{
-                "INPUT=" + PAIRED_FILE.getAbsolutePath(),
+        final String[] args = {
+                "INPUT=" + PAIRED_FILE.getPath(),
                 "TOTAL_READS_IN_INPUT=20",
                 "SPLIT_TO_N_READS=5",
                 "OUTPUT=" + tmpDir
@@ -195,9 +196,9 @@ public class SplitSamByNumberOfReadsTest extends CommandLineProgramTest {
 
     @Test
     public void testStreamWithoutTotalReads() throws IOException {
-        final String tmpDir = IOUtil.getDefaultTmpDir().getAbsolutePath();
+        final File tmpDir = Files.createTempDirectory(TMP_DIR_NAME).toFile();
 
-        final String[] args = new String[]{
+        final String[] args = {
                 "INPUT=/dev/stdin",
                 "SPLIT_TO_N_READS=5",
                 "OUTPUT=" + tmpDir
@@ -209,10 +210,10 @@ public class SplitSamByNumberOfReadsTest extends CommandLineProgramTest {
 
     @Test
     public void testThreeReadTemplate() throws IOException {
-        final String tmpDir = IOUtil.getDefaultTmpDir().getAbsolutePath();
+        final File tmpDir = Files.createTempDirectory(TMP_DIR_NAME).toFile();
 
-        final String[] args = new String[]{
-                "INPUT=" + THREE_READ_TEMPLATE.getAbsolutePath(),
+        final String[] args = {
+                "INPUT=" + THREE_READ_TEMPLATE.getPath(),
                 "TOTAL_READS_IN_INPUT=11",
                 "SPLIT_TO_N_READS=2",
                 "OUTPUT=" + tmpDir
@@ -250,5 +251,25 @@ public class SplitSamByNumberOfReadsTest extends CommandLineProgramTest {
             SAMRecord inputRec = inputIterator.next();
             Assert.assertEquals(rec.getReadName(), inputRec.getReadName());
         }
+    }
+
+    @Test
+    public void testOutPrefixWithZeros() throws IOException {
+        final File tmpDir = Files.createTempDirectory(TMP_DIR_NAME).toFile();
+
+        final String[] args = {
+                "INPUT=" + PAIRED_FILE,
+                "SPLIT_TO_N_READS=5",
+                "OUTPUT=" + tmpDir,
+                "OUT_PREFIX=Sample01"
+        };
+
+        runPicardCommandLine(args);
+        final File out1 = new File(tmpDir, "Sample01_0001.bam");
+        out1.deleteOnExit();
+        VALIDATE_SAM_TESTER.assertSamValid(out1);
+        final File out2 = new File(tmpDir, "Sample01_0002.bam");
+        out2.deleteOnExit();
+        VALIDATE_SAM_TESTER.assertSamValid(out2);
     }
 }


### PR DESCRIPTION
### Description

This adds a test to the PR #1207. 

When a `0` is included in OUTPUT_PREFIX the file names get messed up. The included test fails with the current version but will now pass.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

