### PR TITLE
DSDEGP-2749: too many tokens exception in download genotypes

### DIFF
--- a/src/main/java/picard/cmdline/CommandLineProgram.java
+++ b/src/main/java/picard/cmdline/CommandLineProgram.java
@@ -142,7 +142,7 @@ public abstract class CommandLineProgram {
     private static final String[] PACKAGES_WITH_WEB_DOCUMENTATION = {"picard"};
 
     static {
-      // Register custom reader factory for reading data from Google Genomics 
+      // Register custom reader factory for reading data from Google Genomics
       // implementation of GA4GH API.
       // With this it will be possible to pass these urls as INPUT params.
       // E.g. java -jar dist/picard.jar ViewSam \
@@ -150,11 +150,11 @@ public abstract class CommandLineProgram {
       //    GA4GH_CLIENT_SECRETS=../client_secrets.json
       if (System.getProperty("samjdk.custom_reader") == null) {
         System.setProperty("samjdk.custom_reader",
-            "https://www.googleapis.com/genomics," + 
+            "https://www.googleapis.com/genomics," +
             "com.google.cloud.genomics.gatk.htsjdk.GA4GHReaderFactory");
       }
     }
-    
+
     /**
     * Initialized in parseArgs.  Subclasses may want to access this to do their
     * own validation, and then print usage using commandLineParser.
@@ -194,8 +194,8 @@ public abstract class CommandLineProgram {
         String actualArgs[] = argv;
 
         if (System.getProperty(PROPERTY_CONVERT_LEGACY_COMMAND_LINE, "false").equals("true")) {
-            actualArgs = CommandLineSyntaxTranslater.translatePicardStyleToPosixStyle(argv);
-        } else if (CommandLineSyntaxTranslater.scanForLegacyCommandLine(argv)) {
+            actualArgs = CommandLineSyntaxTranslater.convertPicardStyleToPosixStyle(argv);
+        } else if (CommandLineSyntaxTranslater.isLegacyPicardStyle(argv)) {
             // Issue an informational message telling the user that legacy syntax will soon be removed, and include
             // a link to a Picard wiki page with more detail. For now this is only an informational message letting
             // users know a change is coming. In a future release of Picard, when the default parser is Barclay, we'll
@@ -206,7 +206,7 @@ public abstract class CommandLineProgram {
                             "**********\n**********\t%s %s\n**********\n" +
                             "********** See https://github.com/broadinstitute/picard/wiki/Command-Line-Syntax-Transition-For-Users-(Pre-Transition) for more information.\n\n",
                            this.getClass().getSimpleName(),
-                           Arrays.stream(CommandLineSyntaxTranslater.translatePicardStyleToPosixStyle(argv)).collect(Collectors.joining(" ")))
+                           Arrays.stream(CommandLineSyntaxTranslater.convertPicardStyleToPosixStyle(argv)).collect(Collectors.joining(" ")))
             );
         }
         if (!parseArgs(actualArgs)) {

--- a/src/main/java/picard/cmdline/CommandLineProgram.java
+++ b/src/main/java/picard/cmdline/CommandLineProgram.java
@@ -196,18 +196,23 @@ public abstract class CommandLineProgram {
         if (System.getProperty(PROPERTY_CONVERT_LEGACY_COMMAND_LINE, "false").equals("true")) {
             actualArgs = CommandLineSyntaxTranslater.convertPicardStyleToPosixStyle(argv);
         } else if (CommandLineSyntaxTranslater.isLegacyPicardStyle(argv)) {
-            // Issue an informational message telling the user that legacy syntax will soon be removed, and include
-            // a link to a Picard wiki page with more detail. For now this is only an informational message letting
-            // users know a change is coming. In a future release of Picard, when the default parser is Barclay, we'll
-            // update this message to link to a different page describing the options for that release.
-            Log.getInstance(this.getClass()).info(
-                    String.format("\n\n********** NOTE: In a future release, the command line syntax used by Picard will change, and the existing syntax \n" +
-                            "********** will no longer be accepted. In the future release, the syntax for the command line arguments would be specified as:\n" +
-                            "**********\n**********\t%s %s\n**********\n" +
-                            "********** See https://github.com/broadinstitute/picard/wiki/Command-Line-Syntax-Transition-For-Users-(Pre-Transition) for more information.\n\n",
-                           this.getClass().getSimpleName(),
-                           Arrays.stream(CommandLineSyntaxTranslater.convertPicardStyleToPosixStyle(argv)).collect(Collectors.joining(" ")))
-            );
+            final String[] messageLines = new String[] {
+                "", "",
+                "********** NOTE: Picard's command line syntax is changing.",
+                "**********",
+                "********** For more information, please see:",
+                "********** https://github.com/broadinstitute/picard/wiki/Command-Line-Syntax-Transition-For-Users-(Pre-Transition)",
+                "**********",
+                "********** The command line looks like this in the new syntax:",
+                "**********",
+                "**********    %s %s",
+                "**********",
+                "", ""
+            };
+            final String message = String.join("\n", messageLines);
+            final String syntax  = String.join(" ", CommandLineSyntaxTranslater.convertPicardStyleToPosixStyle(argv));
+            final String info    = String.format(message, this.getClass().getSimpleName(), syntax);
+            Log.getInstance(this.getClass()).info(info);
         }
         if (!parseArgs(actualArgs)) {
             return 1;

--- a/src/main/java/picard/cmdline/CommandLineSyntaxTranslater.java
+++ b/src/main/java/picard/cmdline/CommandLineSyntaxTranslater.java
@@ -42,7 +42,5 @@ public class CommandLineSyntaxTranslater {
             }
         ).collect(Collectors.toList());
         return convertedArgs.toArray(new String[convertedArgs.size()]);
-
     }
-
 }

--- a/src/main/java/picard/cmdline/CommandLineSyntaxTranslater.java
+++ b/src/main/java/picard/cmdline/CommandLineSyntaxTranslater.java
@@ -15,8 +15,8 @@ public class CommandLineSyntaxTranslater {
     // Separator used by the legacy parser for name/value arguments
     private static final String LEGACY_VALUE_SEPARATOR = "=";
 
-    // Scan the command line arguments to see if they appear to be using legacy parser syntax
-    public static boolean scanForLegacyCommandLine(final String argv[]) {
+    // Return true when the command line arguments appear to use Picard's legacy syntax.
+    public static boolean isLegacyPicardStyle(final String argv[]) {
         return Arrays.stream(argv).anyMatch(
                 putativeLegacyArg ->
                         !putativeLegacyArg.startsWith(BARCLAY_SHORT_OPTION_PREFIX) &&
@@ -25,10 +25,10 @@ public class CommandLineSyntaxTranslater {
         );
     }
 
-    public static String[] translatePicardStyleToPosixStyle(final String argv[]) {
+    public static String[] convertPicardStyleToPosixStyle(final String argv[]) {
         final List<String> convertedArgs = Arrays.stream(argv).flatMap(
             originalArgPair -> {
-                final String[] splitArgPair = originalArgPair.split(LEGACY_VALUE_SEPARATOR, -1);
+                final String[] splitArgPair = originalArgPair.split(LEGACY_VALUE_SEPARATOR, 2);
                 if (splitArgPair.length == 1) {   // assume positional arg
                     return Arrays.stream(new String[]{ originalArgPair });
                 } else if (splitArgPair.length == 2) {
@@ -37,8 +37,7 @@ public class CommandLineSyntaxTranslater {
                     return Arrays.stream(new String[]{BARCLAY_SHORT_OPTION_PREFIX + splitArgPair[0], splitArgPair[1]});
                 }
                 else {
-                    throw new RuntimeException(
-                            "Argument syntax conversion failed. Too many \"=\" separated tokens to translate: " + originalArgPair);
+                    throw new RuntimeException("Cannot convert this argument: " + originalArgPair);
                 }
             }
         ).collect(Collectors.toList());


### PR DESCRIPTION
### Description

CommandLineSyntaxTranslater no longer throws when seeing KEY=VALUE_with_=_in_it options.

Also simplified the deprecation warning and formatted the code so the message is easier to edit.

Also renamed 2 CommandLineSyntaxTranslater methods to be more descriptive.

See Issue#1225 for more information about the problem.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [x] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests