### PR TITLE
Made OpticalDuplicateFinder Serializable

### DIFF
--- a/src/main/java/picard/sam/markduplicates/util/OpticalDuplicateFinder.java
+++ b/src/main/java/picard/sam/markduplicates/util/OpticalDuplicateFinder.java
@@ -29,6 +29,7 @@ import htsjdk.samtools.util.ProgressLogger;
 import picard.sam.util.PhysicalLocation;
 import picard.sam.util.ReadNameParser;
 
+import java.io.Serializable;
 import java.util.List;
 
 /**
@@ -37,7 +38,7 @@ import java.util.List;
  * @author Tim Fennell
  * @author Nils Homer
  */
-public class OpticalDuplicateFinder extends ReadNameParser {
+public class OpticalDuplicateFinder extends ReadNameParser implements Serializable  {
 
     public int opticalDuplicatePixelDistance;
 

--- a/src/main/java/picard/sam/util/ReadNameParser.java
+++ b/src/main/java/picard/sam/util/ReadNameParser.java
@@ -2,6 +2,9 @@ package picard.sam.util;
 
 import htsjdk.samtools.util.Log;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -27,15 +30,15 @@ public class ReadNameParser implements Serializable {
      */
     public static final String DEFAULT_READ_NAME_REGEX = "<optimized capture of last three ':' separated fields as numeric values>".intern();
 
-    private final int[] tmpLocationFields = new int[3]; // for optimization of addLocationInformation
+    private transient final int[] tmpLocationFields = new int[3]; // for optimization of addLocationInformation
 
     private String readNameRegex = null;
 
-    private Pattern readNamePattern;
+    private transient Pattern readNamePattern;
 
-    private boolean warnedAboutRegexNotMatching = false;
+    private transient boolean warnedAboutRegexNotMatching = false;
 
-    private final Log log;
+    private transient final Log log;
 
     /**
      * Creates are read name parser using the default read name regex and optical duplicate distance.   See {@link #DEFAULT_READ_NAME_REGEX}
@@ -190,5 +193,20 @@ public class ReadNameParser implements Serializable {
         if (!hasDigits) throw new NumberFormatException("String '" + input + "' did not start with a parsable number.");
         if (isNegative) val = -val;
         return val;
+    }
+
+
+    private void readObject(ObjectInputStream aInputStream) throws ClassNotFoundException, IOException {
+        // perform the default de-serialization first
+        aInputStream.defaultReadObject();
+
+        // Ensure that if the regex is the default
+        if (this.readNamePattern.equals(DEFAULT_READ_NAME_REGEX)) {
+            readNamePattern.equals(DEFAULT_READ_NAME_REGEX);
+        }
+    }
+    private void writeObject(ObjectOutputStream aOutputStream) throws IOException {
+        // perform the default serialization for all non-transient, non-static fields
+        aOutputStream.defaultWriteObject();
     }
 }

--- a/src/main/java/picard/sam/util/ReadNameParser.java
+++ b/src/main/java/picard/sam/util/ReadNameParser.java
@@ -2,6 +2,7 @@ package picard.sam.util;
 
 import htsjdk.samtools.util.Log;
 
+import java.io.Serializable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -10,7 +11,7 @@ import java.util.regex.Pattern;
  * All values should be defaulted to -1 if unavailable.  ReadGroup and Tile should only allow
  * non-zero positive integers, x and y coordinates may be negative.
  */
-public class ReadNameParser {
+public class ReadNameParser implements Serializable {
 
     /**
      * The read name regular expression (regex) is used to extract three pieces of information from the read name: tile, x location,

--- a/src/test/java/picard/sam/util/ReadNameParserTests.java
+++ b/src/test/java/picard/sam/util/ReadNameParserTests.java
@@ -148,38 +148,39 @@ public class ReadNameParserTests {
         final ReadNameParser parser = new ReadNameParser(lastThreeFieldsRegex);
         final ReadNameParser defaultParser = new ReadNameParser();
         PhysicalLocationInt loc = new PhysicalLocationInt();
-        String readName = "1109ABC:22981DEF:17995GHI";
+        final String readName = "1109ABC:22981DEF:17995GHI";
+        final int expectedTile = 1109;
+        final int expectedX = 22981;
+        final int expectedY = 17995;
 
         Assert.assertTrue(parser.addLocationInformation(readName, loc));
-        Assert.assertEquals(loc.getTile(), 1109);
-        Assert.assertEquals(loc.getX(), 22981);
-        Assert.assertEquals(loc.getY(), 17995);
+        Assert.assertEquals(loc.getTile(), expectedTile);
+        Assert.assertEquals(loc.getX(), expectedX);
+        Assert.assertEquals(loc.getY(), expectedY);
 
         loc = new PhysicalLocationInt();
         Assert.assertFalse(defaultParser.addLocationInformation(readName, loc));
 
         final byte[] serializedBytes;
         try(final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            final ObjectOutputStream out = new ObjectOutputStream(baos)){
+            final ObjectOutputStream out = new ObjectOutputStream(baos)) {
             out.writeObject(parser);
             out.writeObject(defaultParser);
             serializedBytes = baos.toByteArray();
         }
-        try (final ByteArrayInputStream bais = new ByteArrayInputStream(serializedBytes);
-             final ObjectInputStream in = new ObjectInputStream(bais)){
-            ReadNameParser parserSerialized = (ReadNameParser) in.readObject();
-            ReadNameParser defaultParserSerialized = (ReadNameParser) in.readObject();
+        try(final ByteArrayInputStream bais = new ByteArrayInputStream(serializedBytes);
+            final ObjectInputStream in = new ObjectInputStream(bais)) {
+            final ReadNameParser parserSerialized = (ReadNameParser) in.readObject();
+            final ReadNameParser defaultParserSerialized = (ReadNameParser) in.readObject();
 
             loc = new PhysicalLocationInt();
             Assert.assertTrue(parserSerialized.addLocationInformation(readName, loc));
-            Assert.assertEquals(loc.getTile(), 1109);
-            Assert.assertEquals(loc.getX(), 22981);
-            Assert.assertEquals(loc.getY(), 17995);
+            Assert.assertEquals(loc.getTile(), expectedTile);
+            Assert.assertEquals(loc.getX(), expectedX);
+            Assert.assertEquals(loc.getY(), expectedY);
 
             loc = new PhysicalLocationInt();
             Assert.assertFalse(defaultParserSerialized.addLocationInformation(readName, loc));
         }
-
     }
-
 }


### PR DESCRIPTION
In tie-out for MarkDuplicatesSpark we found there were issues passing the proper read name regex arguments to the `OpticalDuplicateFinder` because the owned fields are private and the classes themselves aren't serializable resulting the fields being reset to their default value whenever they are passed around. In order to work around this it is easiest and most future proof to make the corresponding classes in Picard (which MarkDuplicatesSpark calls into) `Serializable`so the default java field serializer will take care of the fields for us. 