### PR TITLE
Adds DUPLEX_UMI argument to UmiAwareMarkDuplicatesWithMateCigar

### DIFF
--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -37,6 +37,7 @@ import picard.sam.markduplicates.util.*;
 import picard.sam.util.RepresentativeReadIndexer;
 
 import java.io.File;
+import java.util.Objects;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -208,9 +209,14 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
             "definition, have identical normalized UMIs.  A UMI from the 'bottom' strand is normalized by swapping its content " +
             "around the hyphen (eg. ATC-GTC becomes GTC-ATC).  A UMI from the 'top' strand is already normalized as it is. " +
             "Both reads from a read pair considered top strand if the read 1 unclipped 5' coordinate is less than the read " +
-            "2 unclipped 5' coordinate. All chimeric reads and read fragments are treated as having come from the ttop strand. " +
+            "2 unclipped 5' coordinate. All chimeric reads and read fragments are treated as having come from the top strand. " +
             "With this option is it required that the BARCODE_TAG hold non-normalized UMIs. Default false.")
     public boolean DUPLEX_UMI = false;
+
+    @Argument(doc = "By default, UMIs are only allowed to contain characters that correspond to common DNA bases (e.g. upper " +
+            "and lower-case 'A','T', 'C', 'G', 'N') and '-'.  When set to true, this option allows for the use of UMIs with " +
+            "characters outside this set.  Default false.")
+    public boolean ALLOW_NON_DNA_UMI = false;
 
     private SortingCollection<ReadEndsForMarkDuplicates> pairSort;
     private SortingCollection<ReadEndsForMarkDuplicates> fragSort;
@@ -411,7 +417,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
                     }
                 }
             if (DUPLEX_UMI) {
-                rec.setAttribute(MOLECULAR_IDENTIFIER_TAG, UmiUtil.molecularIdentifierString(rec, MOLECULAR_IDENTIFIER_TAG));
+                rec.setAttribute(MOLECULAR_IDENTIFIER_TAG, UmiUtil.molecularIdentifierString(rec, MOLECULAR_IDENTIFIER_TAG, ALLOW_NON_DNA_UMI));
             }
 
             // Tag any read pair that was in a duplicate set with the duplicate set size and a representative read name
@@ -581,7 +587,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
                     key.append(ReservedTagConstants.READ_GROUP_ID);
                     key.append(rec.getReadName());
                     if (DUPLEX_UMI) {
-                        key.append(UmiUtil.getTopStrandNormalizedUmi(rec, BARCODE_TAG, DUPLEX_UMI));
+                        key.append(UmiUtil.getTopStrandNormalizedUmi(rec, BARCODE_TAG, DUPLEX_UMI, ALLOW_NON_DNA_UMI));
                     }
                     ReadEndsForMarkDuplicates pairedEnds = tmp.remove(rec.getReferenceIndex(), key.toString());
 
@@ -704,7 +710,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
 
         if (useBarcodes) {
             final ReadEndsForMarkDuplicatesWithBarcodes endsWithBarcode = (ReadEndsForMarkDuplicatesWithBarcodes) ends;
-            final String topStrandNormalizedUmi = UmiUtil.getTopStrandNormalizedUmi(rec, BARCODE_TAG, DUPLEX_UMI);
+            final String topStrandNormalizedUmi = UmiUtil.getTopStrandNormalizedUmi(rec, BARCODE_TAG, DUPLEX_UMI, ALLOW_NON_DNA_UMI);
             endsWithBarcode.barcode = Objects.hash(topStrandNormalizedUmi);
 
             if (!rec.getReadPairedFlag() || rec.getFirstOfPairFlag()) {

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -218,11 +218,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
     protected LibraryIdGenerator libraryIdGenerator = null; // this is initialized in buildSortedReadEndLists
 
     private int getBarcodeValue(final SAMRecord record) {
-        if (DUPLEX_UMI) {
-            return UmiUtil.getTopStrandNormalizedDuplexUMI(record, BARCODE_TAG).hashCode();
-        } else {
-            return EstimateLibraryComplexity.getReadBarcodeValue(record, BARCODE_TAG);
-        }
+        return UmiUtil.getTopStrandNormalizedDuplexUMI(record, BARCODE_TAG, DUPLEX_UMI).hashCode();
     }
 
     private int getReadOneBarcodeValue(final SAMRecord record) {
@@ -413,7 +409,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
                     }
                 }
             if (DUPLEX_UMI) {
-                rec.setAttribute(MOLECULAR_IDENTIFIER_TAG, rec.getContig() + ":" + rec.getAlignmentStart() + UmiUtil.getTopStrandNormalizedDuplexUMI(rec, BARCODE_TAG));
+                rec.setAttribute(MOLECULAR_IDENTIFIER_TAG, rec.getContig() + ":" + rec.getAlignmentStart() + UmiUtil.getTopStrandNormalizedDuplexUMI(rec, BARCODE_TAG, DUPLEX_UMI));
             }
 
             // Tag any read pair that was in a duplicate set with the duplicate set size and a representative read name
@@ -581,8 +577,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
                 if (rec.getReadPairedFlag() && !rec.getMateUnmappedFlag()) {
                     final String key;
                     if (DUPLEX_UMI) {
-                        key = rec.getAttribute(ReservedTagConstants.READ_GROUP_ID) + ":" + rec.getReadName() + UmiUtil.getTopStrandNormalizedDuplexUMI(rec, BARCODE_TAG);
-
+                        key = rec.getAttribute(ReservedTagConstants.READ_GROUP_ID) + ":" + rec.getReadName() + UmiUtil.getTopStrandNormalizedDuplexUMI(rec, BARCODE_TAG, DUPLEX_UMI);
                     } else {
                         key = rec.getAttribute(ReservedTagConstants.READ_GROUP_ID) + ":" + rec.getReadName();
                     }
@@ -707,12 +702,8 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
 
         if (useBarcodes) {
             final ReadEndsForMarkDuplicatesWithBarcodes endsWithBarcode = (ReadEndsForMarkDuplicatesWithBarcodes) ends;
-            if (DUPLEX_UMI) {
-                String normalizedBarcode = UmiUtil.getTopStrandNormalizedDuplexUMI(rec, BARCODE_TAG);
-                endsWithBarcode.barcode = normalizedBarcode.hashCode();
-            } else {
-                endsWithBarcode.barcode = getBarcodeValue(rec);
-            }
+            endsWithBarcode.barcode = UmiUtil.getTopStrandNormalizedDuplexUMI(rec, BARCODE_TAG, DUPLEX_UMI).hashCode();
+
             if (!rec.getReadPairedFlag() || rec.getFirstOfPairFlag()) {
                 endsWithBarcode.readOneBarcode = getReadOneBarcodeValue(rec);
             } else {

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -213,11 +213,6 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
             "With this option is it required that the BARCODE_TAG hold non-normalized UMIs. Default false.")
     public boolean DUPLEX_UMI = false;
 
-    @Argument(doc = "By default, UMIs are only allowed to contain characters that correspond to common DNA bases (e.g. upper " +
-            "and lower-case 'A','T', 'C', 'G', 'N') and '-'.  When set to true, this option allows for the use of UMIs with " +
-            "characters outside this set.  Default false.")
-    public boolean ALLOW_NON_DNA_UMI = false;
-
     private SortingCollection<ReadEndsForMarkDuplicates> pairSort;
     private SortingCollection<ReadEndsForMarkDuplicates> fragSort;
     private SortingLongCollection duplicateIndexes;
@@ -417,7 +412,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
                     }
                 }
             if (DUPLEX_UMI) {
-                rec.setAttribute(MOLECULAR_IDENTIFIER_TAG, UmiUtil.molecularIdentifierString(rec, MOLECULAR_IDENTIFIER_TAG, ALLOW_NON_DNA_UMI));
+                rec.setAttribute(MOLECULAR_IDENTIFIER_TAG, UmiUtil.molecularIdentifierString(rec, MOLECULAR_IDENTIFIER_TAG));
             }
 
             // Tag any read pair that was in a duplicate set with the duplicate set size and a representative read name
@@ -587,7 +582,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
                     key.append(ReservedTagConstants.READ_GROUP_ID);
                     key.append(rec.getReadName());
                     if (DUPLEX_UMI) {
-                        key.append(UmiUtil.getTopStrandNormalizedUmi(rec, BARCODE_TAG, DUPLEX_UMI, ALLOW_NON_DNA_UMI));
+                        key.append(UmiUtil.getTopStrandNormalizedUmi(rec, BARCODE_TAG, DUPLEX_UMI));
                     }
                     ReadEndsForMarkDuplicates pairedEnds = tmp.remove(rec.getReferenceIndex(), key.toString());
 
@@ -710,7 +705,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
 
         if (useBarcodes) {
             final ReadEndsForMarkDuplicatesWithBarcodes endsWithBarcode = (ReadEndsForMarkDuplicatesWithBarcodes) ends;
-            final String topStrandNormalizedUmi = UmiUtil.getTopStrandNormalizedUmi(rec, BARCODE_TAG, DUPLEX_UMI, ALLOW_NON_DNA_UMI);
+            final String topStrandNormalizedUmi = UmiUtil.getTopStrandNormalizedUmi(rec, BARCODE_TAG, DUPLEX_UMI);
             endsWithBarcode.barcode = Objects.hash(topStrandNormalizedUmi);
 
             if (!rec.getReadPairedFlag() || rec.getFirstOfPairFlag()) {

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -702,7 +702,8 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
 
         if (useBarcodes) {
             final ReadEndsForMarkDuplicatesWithBarcodes endsWithBarcode = (ReadEndsForMarkDuplicatesWithBarcodes) ends;
-            endsWithBarcode.barcode = UmiUtil.getTopStrandNormalizedDuplexUMI(rec, BARCODE_TAG, DUPLEX_UMI).hashCode();
+            final String topStrandNormalizedUmi = UmiUtil.getTopStrandNormalizedDuplexUMI(rec, BARCODE_TAG, DUPLEX_UMI);
+            endsWithBarcode.barcode = topStrandNormalizedUmi == null ? 0 : topStrandNormalizedUmi.hashCode();
 
             if (!rec.getReadPairedFlag() || rec.getFirstOfPairFlag()) {
                 endsWithBarcode.readOneBarcode = getReadOneBarcodeValue(rec);

--- a/src/main/java/picard/sam/markduplicates/UmiAwareDuplicateSetIterator.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareDuplicateSetIterator.java
@@ -59,7 +59,6 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
     private final boolean allowMissingUmis;
     private boolean isOpen = false;
     private final boolean duplexUmi;
-    private final boolean allowNonDnaUmis;
     private final Map<String, UmiMetrics> umiMetricsMap;
     private boolean haveWeSeenFirstRead = false;
 
@@ -77,13 +76,12 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
     UmiAwareDuplicateSetIterator(final DuplicateSetIterator wrappedIterator, final int maxEditDistanceToJoin,
                                  final String umiTag, final String molecularIdentifierTag,
                                  final boolean allowMissingUmis, final boolean duplexUmi,
-                                 final boolean allowNonDnaUmis, final Map<String, UmiMetrics> umiMetricsMap) {
+                                 final Map<String, UmiMetrics> umiMetricsMap) {
         this.wrappedIterator = wrappedIterator;
         this.maxEditDistanceToJoin = maxEditDistanceToJoin;
         this.umiTag = umiTag;
         this.molecularIdentifierTag = molecularIdentifierTag;
         this.allowMissingUmis = allowMissingUmis;
-        this.allowNonDnaUmis = allowNonDnaUmis;
         this.umiMetricsMap = umiMetricsMap;
         this.duplexUmi = duplexUmi;
         isOpen = true;
@@ -150,7 +148,7 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
             final List<SAMRecord> records = ds.getRecords();
 
             for (final SAMRecord rec : records) {
-                final String currentUmi = UmiUtil.getTopStrandNormalizedUmi(rec, umiTag, duplexUmi, allowNonDnaUmis);
+                final String currentUmi = UmiUtil.getTopStrandNormalizedUmi(rec, umiTag, duplexUmi);
 
                 if (currentUmi != null) {
                     // All UMIs should be the same length, the code presently does not support variable length UMIs.

--- a/src/main/java/picard/sam/markduplicates/UmiAwareDuplicateSetIterator.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareDuplicateSetIterator.java
@@ -147,8 +147,6 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
         // and total numbers of observed and inferred UMIs
         for (final DuplicateSet ds : duplicateSets) {
             final List<SAMRecord> records = ds.getRecords();
-            final SAMRecord representativeRead = ds.getRepresentative();
-            //final String inferredUmi = (String) representativeRead.getTransientAttribute("aI");
 
             for (final SAMRecord rec : records) {
                 final String currentUmi;
@@ -176,7 +174,7 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
 
                         // Update UMI metrics associated with each record
                         // The hammingDistance between N and a base is a distance of 1. Comparing N to N is 0 distance.
-                        final String inferredUmi = UmiUtil.getAssignedUmi(rec.getStringAttribute(molecularIdentifierTag));
+                        final String inferredUmi = (String) rec.getTransientAttribute("inferredUmi");
                         metrics.OBSERVED_BASE_ERRORS += hammingDistance(currentUmi, inferredUmi);
                         observedUmiBases += currentUmi.length() - StringUtils.countMatches(currentUmi, "-");
                         metrics.addUmiObservation(currentUmi, inferredUmi);

--- a/src/main/java/picard/sam/markduplicates/UmiAwareDuplicateSetIterator.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareDuplicateSetIterator.java
@@ -59,6 +59,7 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
     private final boolean allowMissingUmis;
     private boolean isOpen = false;
     private final boolean duplexUmi;
+    private final boolean allowNonDnaUmis;
     private final Map<String, UmiMetrics> umiMetricsMap;
     private boolean haveWeSeenFirstRead = false;
 
@@ -76,12 +77,13 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
     UmiAwareDuplicateSetIterator(final DuplicateSetIterator wrappedIterator, final int maxEditDistanceToJoin,
                                  final String umiTag, final String molecularIdentifierTag,
                                  final boolean allowMissingUmis, final boolean duplexUmi,
-                                 final Map<String, UmiMetrics> umiMetricsMap) {
+                                 final boolean allowNonDnaUmis, final Map<String, UmiMetrics> umiMetricsMap) {
         this.wrappedIterator = wrappedIterator;
         this.maxEditDistanceToJoin = maxEditDistanceToJoin;
         this.umiTag = umiTag;
         this.molecularIdentifierTag = molecularIdentifierTag;
         this.allowMissingUmis = allowMissingUmis;
+        this.allowNonDnaUmis = allowNonDnaUmis;
         this.umiMetricsMap = umiMetricsMap;
         this.duplexUmi = duplexUmi;
         isOpen = true;
@@ -148,7 +150,7 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
             final List<SAMRecord> records = ds.getRecords();
 
             for (final SAMRecord rec : records) {
-                final String currentUmi = UmiUtil.getTopStrandNormalizedUmi(rec, umiTag, duplexUmi);
+                final String currentUmi = UmiUtil.getTopStrandNormalizedUmi(rec, umiTag, duplexUmi, allowNonDnaUmis);
 
                 if (currentUmi != null) {
                     // All UMIs should be the same length, the code presently does not support variable length UMIs.

--- a/src/main/java/picard/sam/markduplicates/UmiAwareDuplicateSetIterator.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareDuplicateSetIterator.java
@@ -149,12 +149,7 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
             final List<SAMRecord> records = ds.getRecords();
 
             for (final SAMRecord rec : records) {
-                final String currentUmi;
-                if (duplexUmi) {
-                    currentUmi = UmiUtil.getTopStrandNormalizedDuplexUMI(rec, umiTag);
-                } else {
-                    currentUmi = rec.getStringAttribute(umiTag);
-                }
+                final String currentUmi = UmiUtil.getTopStrandNormalizedDuplexUMI(rec, umiTag, duplexUmi);
 
                 if (currentUmi != null) {
                     // All UMIs should be the same length, the code presently does not support variable length UMIs.

--- a/src/main/java/picard/sam/markduplicates/UmiAwareDuplicateSetIterator.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareDuplicateSetIterator.java
@@ -38,12 +38,11 @@ import htsjdk.samtools.DuplicateSet;
 import htsjdk.samtools.DuplicateSetIterator;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.util.CloseableIterator;
+import htsjdk.samtools.util.StringUtil;
 import picard.PicardException;
 
 import java.util.*;
 
-import static htsjdk.samtools.util.StringUtil.hammingDistance;
-import static picard.sam.markduplicates.UmiUtil.getUmiLength;
 
 /**
  * UmiAwareDuplicateSetIterator is an iterator that wraps a duplicate set iterator
@@ -158,7 +157,7 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
                     if (currentUmi.contains("N")) {
                         metrics.addUmiObservationN();
                     } else {
-                        final int umiLength = getUmiLength(currentUmi);
+                        final int umiLength = UmiUtil.getUmiLength(currentUmi);
                         if (!haveWeSeenFirstRead) {
                             metrics.MEAN_UMI_LENGTH = umiLength;
                             haveWeSeenFirstRead = true;
@@ -170,8 +169,8 @@ class UmiAwareDuplicateSetIterator implements CloseableIterator<DuplicateSet> {
 
                         // Update UMI metrics associated with each record
                         // The hammingDistance between N and a base is a distance of 1. Comparing N to N is 0 distance.
-                        final String inferredUmi = (String) rec.getTransientAttribute(UmiUtil.INFERRED_UMI_TAG);
-                        metrics.OBSERVED_BASE_ERRORS += hammingDistance(currentUmi, inferredUmi);
+                        final String inferredUmi = (String) rec.getTransientAttribute(UmiUtil.INFERRED_UMI_TRANSIENT_TAG);
+                        metrics.OBSERVED_BASE_ERRORS += StringUtil.hammingDistance(currentUmi, inferredUmi);
                         observedUmiBases += umiLength;
                         metrics.addUmiObservation(currentUmi, inferredUmi);
                     }

--- a/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
@@ -120,9 +120,6 @@ public class UmiAwareMarkDuplicatesWithMateCigar extends SimpleMarkDuplicatesWit
     @Argument(shortName = "UMI_TAG_NAME", doc = "Tag name to use for UMI", optional = true)
     public String UMI_TAG_NAME = "RX";
 
-    @Argument(shortName = "MOLECULAR_IDENTIFIER_TAG", doc = "Tag name to use for molecular identifier", optional = true)
-    public String MOLECULAR_IDENTIFIER_TAG = "MI";
-
     // Since we inherit from SimpleMarkDuplicatesWithMateCigar, it is useful for us to also inherit the tests
     // which do not contain UMIs.  By default, we don't allow for missing UMIs, but for the inherited tests
     // we allow for missing UMIs.

--- a/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
@@ -156,6 +156,6 @@ public class UmiAwareMarkDuplicatesWithMateCigar extends SimpleMarkDuplicatesWit
                     new DuplicateSetIterator(headerAndIterator.iterator,
                     headerAndIterator.header,
                     false,
-                    comparator), MAX_EDIT_DISTANCE_TO_JOIN, UMI_TAG_NAME, MOLECULAR_IDENTIFIER_TAG, ALLOW_MISSING_UMIS, DUPLEX_UMI, ALLOW_NON_DNA_UMI, metrics);
+                    comparator), MAX_EDIT_DISTANCE_TO_JOIN, UMI_TAG_NAME, MOLECULAR_IDENTIFIER_TAG, ALLOW_MISSING_UMIS, DUPLEX_UMI, metrics);
     }
 }

--- a/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
@@ -156,6 +156,6 @@ public class UmiAwareMarkDuplicatesWithMateCigar extends SimpleMarkDuplicatesWit
                     new DuplicateSetIterator(headerAndIterator.iterator,
                     headerAndIterator.header,
                     false,
-                    comparator), MAX_EDIT_DISTANCE_TO_JOIN, UMI_TAG_NAME, MOLECULAR_IDENTIFIER_TAG, ALLOW_MISSING_UMIS, DUPLEX_UMI, metrics);
+                    comparator), MAX_EDIT_DISTANCE_TO_JOIN, UMI_TAG_NAME, MOLECULAR_IDENTIFIER_TAG, ALLOW_MISSING_UMIS, DUPLEX_UMI, ALLOW_NON_DNA_UMI, metrics);
     }
 }

--- a/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigar.java
@@ -120,8 +120,8 @@ public class UmiAwareMarkDuplicatesWithMateCigar extends SimpleMarkDuplicatesWit
     @Argument(shortName = "UMI_TAG_NAME", doc = "Tag name to use for UMI", optional = true)
     public String UMI_TAG_NAME = "RX";
 
-    @Argument(shortName = "ASSIGNED_UMI_TAG", doc = "Tag name to use for assigned UMI", optional = true)
-    public String ASSIGNED_UMI_TAG = "MI";
+    @Argument(shortName = "MOLECULAR_IDENTIFIER_TAG", doc = "Tag name to use for molecular identifier", optional = true)
+    public String MOLECULAR_IDENTIFIER_TAG = "MI";
 
     // Since we inherit from SimpleMarkDuplicatesWithMateCigar, it is useful for us to also inherit the tests
     // which do not contain UMIs.  By default, we don't allow for missing UMIs, but for the inherited tests
@@ -156,6 +156,6 @@ public class UmiAwareMarkDuplicatesWithMateCigar extends SimpleMarkDuplicatesWit
                     new DuplicateSetIterator(headerAndIterator.iterator,
                     headerAndIterator.header,
                     false,
-                    comparator), MAX_EDIT_DISTANCE_TO_JOIN, UMI_TAG_NAME, ASSIGNED_UMI_TAG, ALLOW_MISSING_UMIS, metrics);
+                    comparator), MAX_EDIT_DISTANCE_TO_JOIN, UMI_TAG_NAME, MOLECULAR_IDENTIFIER_TAG, ALLOW_MISSING_UMIS, DUPLEX_UMI, metrics);
     }
 }

--- a/src/main/java/picard/sam/markduplicates/UmiGraph.java
+++ b/src/main/java/picard/sam/markduplicates/UmiGraph.java
@@ -194,7 +194,7 @@ public class UmiGraph {
                 } else {
                     UmiUtil.setMolecularIndex(rec, assignedUmi, molecularIdentifierTag, duplexUmis);
                 }
-                rec.setTransientAttribute(UmiUtil.INFERRED_UMI_TAG, assignedUmi);
+                rec.setTransientAttribute(UmiUtil.INFERRED_UMI_TRANSIENT_TAG, assignedUmi);
             }
 
             duplicateSetList.add(ds);
@@ -205,8 +205,7 @@ public class UmiGraph {
 
 
     /**
-     * Create a map that maps a umi to the duplicateSetID
-     * @return
+     * @return a map that maps a umi to the duplicateSetID
      */
     private Map<String, Integer> getDuplicateSetsFromUmis() {
         final Map<String, Integer> duplicateSetsFromUmis = new HashMap<>();

--- a/src/main/java/picard/sam/markduplicates/UmiGraph.java
+++ b/src/main/java/picard/sam/markduplicates/UmiGraph.java
@@ -89,7 +89,7 @@ public class UmiGraph {
         }
 
         // Count the number of times each UMI occurs
-        umiCounts = records.stream().collect(Collectors.groupingBy(p -> duplexUmis ? UmiUtil.getTopStrandNormalizedUmi(p, umiTag, duplexUmis, allowMissingUmis) : p.getStringAttribute(umiTag), counting()));
+        umiCounts = records.stream().collect(Collectors.groupingBy(p -> duplexUmis ? UmiUtil.getTopStrandNormalizedUmi(p, umiTag, duplexUmis) : p.getStringAttribute(umiTag), counting()));
 
         // At first we consider every UMI as if it were its own duplicate set
         numUmis = umiCounts.size();
@@ -131,7 +131,7 @@ public class UmiGraph {
         // Assign UMIs to duplicateSets
         final Map<String, Integer> duplicateSetsFromUmis = getDuplicateSetsFromUmis();
         for (final SAMRecord rec : records) {
-            final String umi = UmiUtil.getTopStrandNormalizedUmi(rec, umiTag, duplexUmis, allowMissingUmis);
+            final String umi = UmiUtil.getTopStrandNormalizedUmi(rec, umiTag, duplexUmis);
 
             final Integer duplicateSetIndex = duplicateSetsFromUmis.get(umi);
 
@@ -160,7 +160,7 @@ public class UmiGraph {
             long nCount = 0;
 
             for (final SAMRecord rec : recordList) {
-                final String umi = UmiUtil.getTopStrandNormalizedUmi(rec, umiTag, duplexUmis, allowMissingUmis);
+                final String umi = UmiUtil.getTopStrandNormalizedUmi(rec, umiTag, duplexUmis);
 
                 // If there is another choice, we don't want to choose the UMI with a N
                 // as the assignedUmi

--- a/src/main/java/picard/sam/markduplicates/UmiGraph.java
+++ b/src/main/java/picard/sam/markduplicates/UmiGraph.java
@@ -89,7 +89,6 @@ public class UmiGraph {
         }
 
         // Count the number of times each UMI occurs
-//        umiCounts = records.stream().collect(Collectors.groupingBy(p -> duplexUmis ? UmiUtil.getTopStrandNormalizedUmi(p, umiTag, duplexUmis) : p.getStringAttribute(umiTag), counting()));
         umiCounts = records.stream().collect(Collectors.groupingBy(p -> UmiUtil.getTopStrandNormalizedUmi(p, umiTag, duplexUmis), counting()));
 
         // At first we consider every UMI as if it were its own duplicate set

--- a/src/main/java/picard/sam/markduplicates/UmiGraph.java
+++ b/src/main/java/picard/sam/markduplicates/UmiGraph.java
@@ -89,7 +89,8 @@ public class UmiGraph {
         }
 
         // Count the number of times each UMI occurs
-        umiCounts = records.stream().collect(Collectors.groupingBy(p -> duplexUmis ? UmiUtil.getTopStrandNormalizedUmi(p, umiTag, duplexUmis) : p.getStringAttribute(umiTag), counting()));
+//        umiCounts = records.stream().collect(Collectors.groupingBy(p -> duplexUmis ? UmiUtil.getTopStrandNormalizedUmi(p, umiTag, duplexUmis) : p.getStringAttribute(umiTag), counting()));
+        umiCounts = records.stream().collect(Collectors.groupingBy(p -> UmiUtil.getTopStrandNormalizedUmi(p, umiTag, duplexUmis), counting()));
 
         // At first we consider every UMI as if it were its own duplicate set
         numUmis = umiCounts.size();
@@ -190,9 +191,8 @@ public class UmiGraph {
                 if (allowMissingUmis && rec.getStringAttribute(umiTag).isEmpty()) {
                     // The SAM spec doesn't support empty tags, so we set it to null if it is empty.
                     rec.setAttribute(umiTag, null);
-
                 } else {
-                    UmiUtil.setMolecularIndex(rec, assignedUmi, molecularIdentifierTag, duplexUmis);
+                    UmiUtil.setMolecularIdentifier(rec, assignedUmi, molecularIdentifierTag, duplexUmis);
                 }
                 rec.setTransientAttribute(UmiUtil.INFERRED_UMI_TRANSIENT_TAG, assignedUmi);
             }

--- a/src/main/java/picard/sam/markduplicates/UmiGraph.java
+++ b/src/main/java/picard/sam/markduplicates/UmiGraph.java
@@ -89,7 +89,7 @@ public class UmiGraph {
         }
 
         // Count the number of times each UMI occurs
-        umiCounts = records.stream().collect(Collectors.groupingBy(p -> duplexUmis ? UmiUtil.getTopStrandNormalizedUmi(p, umiTag, duplexUmis) : p.getStringAttribute(umiTag), counting()));
+        umiCounts = records.stream().collect(Collectors.groupingBy(p -> duplexUmis ? UmiUtil.getTopStrandNormalizedUmi(p, umiTag, duplexUmis, allowMissingUmis) : p.getStringAttribute(umiTag), counting()));
 
         // At first we consider every UMI as if it were its own duplicate set
         numUmis = umiCounts.size();
@@ -131,7 +131,7 @@ public class UmiGraph {
         // Assign UMIs to duplicateSets
         final Map<String, Integer> duplicateSetsFromUmis = getDuplicateSetsFromUmis();
         for (final SAMRecord rec : records) {
-            final String umi = UmiUtil.getTopStrandNormalizedUmi(rec, umiTag, duplexUmis);
+            final String umi = UmiUtil.getTopStrandNormalizedUmi(rec, umiTag, duplexUmis, allowMissingUmis);
 
             final Integer duplicateSetIndex = duplicateSetsFromUmis.get(umi);
 
@@ -160,7 +160,7 @@ public class UmiGraph {
             long nCount = 0;
 
             for (final SAMRecord rec : recordList) {
-                final String umi = UmiUtil.getTopStrandNormalizedUmi(rec, umiTag, duplexUmis);
+                final String umi = UmiUtil.getTopStrandNormalizedUmi(rec, umiTag, duplexUmis, allowMissingUmis);
 
                 // If there is another choice, we don't want to choose the UMI with a N
                 // as the assignedUmi

--- a/src/main/java/picard/sam/markduplicates/UmiGraph.java
+++ b/src/main/java/picard/sam/markduplicates/UmiGraph.java
@@ -59,7 +59,7 @@ public class UmiGraph {
     private final String[] umi;                 // Sequence of actual UMI, the index is the UMI ID
     private final int numUmis;                  // Number of observed UMIs
     private final String umiTag;                // UMI tag used in the SAM/BAM/CRAM file ie. RX
-    private final String molecularIdentifierTag; // Assigned UMI tag used in the SAM/BAM/CRAM file ie. MI
+    private final String molecularIdentifierTag; // Molecular identifier tag used in the SAM/BAM/CRAM file ie. MI
     private final boolean allowMissingUmis;     // Allow for missing UMIs
     private final boolean duplexUmis;
 
@@ -218,6 +218,7 @@ public class UmiGraph {
                     } else {
                         rec.setAttribute(molecularIdentifierTag, fragmentStartPosition + "/" + assignedUmi);
                     }
+                    rec.setTransientAttribute("inferredUmi", assignedUmi);
                 }
             }
 

--- a/src/main/java/picard/sam/markduplicates/UmiUtil.java
+++ b/src/main/java/picard/sam/markduplicates/UmiUtil.java
@@ -56,7 +56,7 @@ class UmiUtil {
      * @param umiTag The tag used in the bam file that designates the UMI, null returns null
      * @return Normalized Duplex UMI.  If the UMI isn't duplex, it returns the UMI unaltered.
      */
-    static String getTopStrandNormalizedUmi(final SAMRecord record, final String umiTag, final boolean duplexUmi) {
+    static String getTopStrandNormalizedUmi(final SAMRecord record, final String umiTag, final boolean duplexUmi, final boolean allowNonDnaUmi) {
         if (umiTag == null) {
             return null;
         }
@@ -66,8 +66,11 @@ class UmiUtil {
         if (umi == null) {
             return null;
         }
-        if (!umi.matches("^[ATCGNatcgn-]*$")) {
-            throw new PicardException("UMI found with illegal characters.  UMIs must match the regular expression ^[ATCGNatcgn-]*$.");
+
+        if (!allowNonDnaUmi) {
+            if (!umi.matches("^[ATCGNatcgn-]*$")) {
+                throw new PicardException("UMI found with illegal characters.  UMIs must match the regular expression ^[ATCGNatcgn-]*$.");
+            }
         }
 
         if (duplexUmi) {
@@ -106,8 +109,8 @@ class UmiUtil {
      * @param umiTag Tag that contains the UMI record
      * @return String that uniquely identifies a fragment
      */
-    static String molecularIdentifierString(final SAMRecord rec, final String umiTag) {
-        return rec.getContig() + CONTIG_SEPARATOR + rec.getAlignmentStart() + getTopStrandNormalizedUmi(rec, umiTag, true);
+    static String molecularIdentifierString(final SAMRecord rec, final String umiTag, final boolean allowNonDnaUmi) {
+        return rec.getContig() + CONTIG_SEPARATOR + rec.getAlignmentStart() + getTopStrandNormalizedUmi(rec, umiTag, true, allowNonDnaUmi);
     }
 
     /**

--- a/src/main/java/picard/sam/markduplicates/UmiUtil.java
+++ b/src/main/java/picard/sam/markduplicates/UmiUtil.java
@@ -87,13 +87,4 @@ public class UmiUtil {
 
         return read1FivePrimeCoordinate < read2FivePrimeCoordinate;
     }
-
-    static String getAssignedUmi(final String molecularIndex) {
-        if (molecularIndex == null) {
-            return null;
-        }
-        return molecularIndex.replaceAll(".*/", "");
-    }
-
-
 }

--- a/src/main/java/picard/sam/markduplicates/UmiUtil.java
+++ b/src/main/java/picard/sam/markduplicates/UmiUtil.java
@@ -51,6 +51,8 @@ class UmiUtil {
      * @return Normalized Duplex UMI.  If the UMI isn't duplex, it returns the UMI unaltered.
      */
     static String getTopStrandNormalizedDuplexUMI(final SAMRecord record, final String umiTag, final boolean duplexUmi) {
+        if(umiTag == null) return null;
+
         final String umi = record.getStringAttribute(umiTag);
 
         if (umi == null) return null;

--- a/src/main/java/picard/sam/markduplicates/UmiUtil.java
+++ b/src/main/java/picard/sam/markduplicates/UmiUtil.java
@@ -101,15 +101,15 @@ class UmiUtil {
      * @return String that uniquely identifies a fragment
      */
     static String molecularIdentifierString(final SAMRecord rec, final String umiTag) {
-        return rec.getContig() + ":" + rec.getAlignmentStart() + getTopStrandNormalizedUmi(rec, umiTag, true);
+        return rec.getContig() + CONTIG_SEPARATOR + rec.getAlignmentStart() + getTopStrandNormalizedUmi(rec, umiTag, true);
     }
 
     /**
      * Set molecular index tag of record using UMI and alignment start position along with top and bottom strand information
-     * @param rec
-     * @param assignedUmi
-     * @param molecularIdentifierTag
-     * @param duplexUmis
+     * @param rec SAMRecord to set molecular index of
+     * @param assignedUmi Assigned or inferred UMI to use in the molecular index tag
+     * @param molecularIdentifierTag SAM tag to use as molecular identifier
+     * @param duplexUmis Treat UMI as duplex, if true /A and /B will be added to denote top and bottom strands respectively
      */
     static void setMolecularIndex(final SAMRecord rec, final String assignedUmi, final String molecularIdentifierTag, final boolean duplexUmis) {
 

--- a/src/main/java/picard/sam/markduplicates/UmiUtil.java
+++ b/src/main/java/picard/sam/markduplicates/UmiUtil.java
@@ -34,7 +34,9 @@ import picard.PicardException;
  * @author mduran
  */
 
-public class UmiUtil {
+class UmiUtil {
+
+    static final String DUPLEX_UMI_DELIMITER = "-";
 
     /**
      * Creates a top-strand normalized duplex UMI.
@@ -48,20 +50,25 @@ public class UmiUtil {
      * @param umiTag The tag used in the bam file that designates the UMI.
      * @return Normalized Duplex UMI.  If the UMI isn't duplex, it returns the UMI unaltered.
      */
-    static String getTopStrandNormalizedDuplexUMI(final SAMRecord record, final String umiTag) {
+    static String getTopStrandNormalizedDuplexUMI(final SAMRecord record, final String umiTag, final boolean duplexUmi) {
         final String umi = record.getStringAttribute(umiTag);
 
         if (umi == null) return null;
 
-        final String[] split = umi.split("-");
-        if (split.length != 2) {
-            throw new PicardException("Duplex UMIs must be of the form X-Y where X and Y are equal length UMIs, for example AT-GA.  Found UMI, " + umi);
-        }
+        if (duplexUmi) {
+            final String[] split = umi.split(DUPLEX_UMI_DELIMITER);
+            if (split.length != 2) {
+                throw new PicardException("Duplex UMIs must be of the form X-Y where X and Y are equal length UMIs, for example AT-GA.  Found UMI, " + umi);
+            }
 
-        if (isTopStrand(record)) {
-            return split[0] + "-" + split[1];
-        } else {
-            return split[1] + "-" + split[0];
+            if (isTopStrand(record)) {
+                return split[0] + DUPLEX_UMI_DELIMITER + split[1];
+            } else {
+                return split[1] + DUPLEX_UMI_DELIMITER + split[0];
+            }
+        }
+        else {
+            return umi;
         }
     }
 
@@ -74,17 +81,9 @@ public class UmiUtil {
      * @return Top or bottom strand, true (top), false (bottom).
      */
     static boolean isTopStrand(final SAMRecord rec) {
-        final int read1FivePrimeCoordinate;
-        final int read2FivePrimeCoordinate;
 
-        if (rec.getFirstOfPairFlag()) {
-            read1FivePrimeCoordinate = (rec.getReadNegativeStrandFlag()) ? rec.getAlignmentEnd() : rec.getAlignmentStart();
-            read2FivePrimeCoordinate = (rec.getMateNegativeStrandFlag()) ? SAMUtils.getMateUnclippedEnd(rec) : SAMUtils.getMateUnclippedStart(rec);
-        } else {
-            read1FivePrimeCoordinate = (rec.getMateNegativeStrandFlag()) ? SAMUtils.getMateUnclippedEnd(rec) : SAMUtils.getMateUnclippedStart(rec);
-            read2FivePrimeCoordinate = (rec.getReadNegativeStrandFlag()) ? rec.getAlignmentEnd() : rec.getAlignmentStart();
-        }
-
-        return read1FivePrimeCoordinate < read2FivePrimeCoordinate;
+        final int read5PrimeStart = (rec.getReadNegativeStrandFlag()) ? rec.getUnclippedEnd() : rec.getUnclippedStart();
+        final int mate5PrimeStart = (rec.getMateNegativeStrandFlag()) ? SAMUtils.getMateUnclippedEnd(rec) : SAMUtils.getMateUnclippedStart(rec);
+        return rec.getFirstOfPairFlag() == (read5PrimeStart < mate5PrimeStart);
     }
 }

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesTest.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesTest.java
@@ -214,10 +214,9 @@ public class MarkDuplicatesTest extends AbstractMarkDuplicatesCommandLineProgram
         tester.addMappedFragment(2, 41212324, true, "50M", DEFAULT_BASE_QUALITY);
         final String barcodeTag = "BC";
         for (final SAMRecord record : new IterableAdapter<SAMRecord>(tester.getRecordIterator())) {
-            record.setAttribute(barcodeTag, "Barcode1");
+            record.setAttribute(barcodeTag, "GACT");
         }
         tester.addArg("BARCODE_TAG=" + barcodeTag);
-        tester.addArg("ALLOW_NON_DNA_UMI=" + true);
         tester.runTest();
     }
 
@@ -243,10 +242,9 @@ public class MarkDuplicatesTest extends AbstractMarkDuplicatesCommandLineProgram
         tester.addMatePair("RUNID:2:2:15993:13362", 2, 41212324, 41212310, false, false, true, true, "33S35M", "19S49M", true, true, false, false, false, DEFAULT_BASE_QUALITY);
         final String barcodeTag = "BC";
         for (final SAMRecord record : new IterableAdapter<SAMRecord>(tester.getRecordIterator())) {
-            record.setAttribute(barcodeTag, "Barcode1");
+            record.setAttribute(barcodeTag, "ATGC");
         }
         tester.addArg("BARCODE_TAG=" + barcodeTag);
-        tester.addArg("ALLOW_NON_DNA_UMI=" + true);
         tester.runTest();
     }
 
@@ -266,14 +264,13 @@ public class MarkDuplicatesTest extends AbstractMarkDuplicatesCommandLineProgram
         final String barcodeTag = "BC";
         for (final SAMRecord record : new IterableAdapter<SAMRecord>(tester.getRecordIterator())) {
             if (record.getReadName().equals(readNameOne) || record.getReadName().equals(readNameTwo)) {
-                record.setAttribute(barcodeTag, "Barcode1");
+                record.setAttribute(barcodeTag, "AAAA");
             }
             else if (record.getReadName().equals(readNameThree)) {
-                record.setAttribute(barcodeTag, "Barcode2");
+                record.setAttribute(barcodeTag, "CCCC");
             }
         }
         tester.addArg("BARCODE_TAG=" + barcodeTag);
-        tester.addArg("ALLOW_NON_DNA_UMI=" + true);
         tester.runTest();
     }
 
@@ -294,22 +291,21 @@ public class MarkDuplicatesTest extends AbstractMarkDuplicatesCommandLineProgram
         final String readOneBarcodeTag = "BX"; // want the same tag as the second end, since this is allowed
         final String readTwoBarcodeTag = "BX";
         for (final SAMRecord record : new IterableAdapter<SAMRecord>(tester.getRecordIterator())) {
-            record.setAttribute(barcodeTag, "Barcode1"); // same barcode
+            record.setAttribute(barcodeTag, "ATC"); // same barcode
             if (record.getFirstOfPairFlag()) { // always the same value for the first end
-                record.setAttribute(readOneBarcodeTag, "readOne1");
+                record.setAttribute(readOneBarcodeTag, "ACA");
             }
             else { // second end
                 if (record.getReadName().equals(readNameOne) || record.getReadName().equals(readNameTwo)) {
-                    record.setAttribute(readTwoBarcodeTag, "readTwo1");
+                    record.setAttribute(readTwoBarcodeTag, "GTC");
                 } else if (record.getReadName().equals(readNameThree)) {
-                    record.setAttribute(readTwoBarcodeTag, "readTwo2");
+                    record.setAttribute(readTwoBarcodeTag, "CGA");
                 }
             }
         }
         tester.addArg("BARCODE_TAG=" + barcodeTag);
         tester.addArg("READ_ONE_BARCODE_TAG=" + readOneBarcodeTag);
         tester.addArg("READ_TWO_BARCODE_TAG=" + readTwoBarcodeTag);
-        tester.addArg("ALLOW_NON_DNA_UMI=" + true);
 
         tester.runTest();
     }

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesTest.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesTest.java
@@ -217,6 +217,7 @@ public class MarkDuplicatesTest extends AbstractMarkDuplicatesCommandLineProgram
             record.setAttribute(barcodeTag, "Barcode1");
         }
         tester.addArg("BARCODE_TAG=" + barcodeTag);
+        tester.addArg("ALLOW_NON_DNA_UMI=" + true);
         tester.runTest();
     }
 
@@ -230,6 +231,7 @@ public class MarkDuplicatesTest extends AbstractMarkDuplicatesCommandLineProgram
             record.setAttribute(barcodeTag, "Barcode1");
         }
         tester.addArg("BARCODE_TAG=" + barcodeTag);
+        tester.addArg("ALLOW_NON_DNA_UMI=" + true);
         tester.runTest();
     }
 
@@ -244,6 +246,7 @@ public class MarkDuplicatesTest extends AbstractMarkDuplicatesCommandLineProgram
             record.setAttribute(barcodeTag, "Barcode1");
         }
         tester.addArg("BARCODE_TAG=" + barcodeTag);
+        tester.addArg("ALLOW_NON_DNA_UMI=" + true);
         tester.runTest();
     }
 
@@ -270,6 +273,7 @@ public class MarkDuplicatesTest extends AbstractMarkDuplicatesCommandLineProgram
             }
         }
         tester.addArg("BARCODE_TAG=" + barcodeTag);
+        tester.addArg("ALLOW_NON_DNA_UMI=" + true);
         tester.runTest();
     }
 
@@ -305,6 +309,7 @@ public class MarkDuplicatesTest extends AbstractMarkDuplicatesCommandLineProgram
         tester.addArg("BARCODE_TAG=" + barcodeTag);
         tester.addArg("READ_ONE_BARCODE_TAG=" + readOneBarcodeTag);
         tester.addArg("READ_TWO_BARCODE_TAG=" + readTwoBarcodeTag);
+        tester.addArg("ALLOW_NON_DNA_UMI=" + true);
 
         tester.runTest();
     }

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
@@ -155,6 +155,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
     public void testUmi(List<String> umis, List<String> assignedUmi, final List<Boolean> isDuplicate, final int editDistanceToJoin) {
         UmiAwareMarkDuplicatesWithMateCigarTester tester = getTester(false);
         tester.addArg("MAX_EDIT_DISTANCE_TO_JOIN=" + editDistanceToJoin);
+        tester.addArg("MOLECULAR_IDENTIFIER_TAG=MI");
         final String dummyLibraryName = "A";
 
         for (int i = 0; i < umis.size(); i++) {
@@ -282,6 +283,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
                                final int editDistanceToJoin, final UmiMetrics expectedMetrics) {
         UmiAwareMarkDuplicatesWithMateCigarTester tester = getTester(false);
         tester.addArg("MAX_EDIT_DISTANCE_TO_JOIN=" + editDistanceToJoin);
+        tester.addArg("MOLECULAR_IDENTIFIER_TAG=MI");
 
         for (int i = 0; i < umis.size(); i++) {
             tester.addMatePairWithUmi("A", umis.get(i), assignedUmi.get(i), isDuplicate.get(i), isDuplicate.get(i));
@@ -396,6 +398,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
         for (final UmiMetrics expectedMetrics : expectedMetricsList) {
             final UmiAwareMarkDuplicatesWithMateCigarTester tester = getTester(false);
             tester.addArg("MAX_EDIT_DISTANCE_TO_JOIN=" + editDistanceToJoin);
+            tester.addArg("MOLECULAR_IDENTIFIER_TAG=MI");
             for (int i = 0; i < umis.size(); i++) {
                 if (expectedMetrics.LIBRARY.equals(libraries.get(i))) {
                     tester.addMatePairWithUmi(libraries.get(i), umis.get(i), assignedUmi.get(i), isDuplicate.get(i), isDuplicate.get(i));

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
@@ -24,9 +24,6 @@
 
 package picard.sam.markduplicates;
 
-import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.SAMRecord;
-import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import htsjdk.samtools.util.QualityUtil;
@@ -60,20 +57,8 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
                 Arrays.asList(false, true, false, true, true), // Should it be marked as duplicate?
                 1 // Edit Distance to Join
         }, {
-                // Test basic error correction using edit distance of 1 including dashes
-                Arrays.asList("AA-AA", "--AAAA", "A-T-TA", "-AAAA----", "A-AA-T"), // Observed UMI
-                Arrays.asList("AAAA", "AAAA", "ATTA", "AAAA", "AAAA"), // Expected inferred UMI
-                Arrays.asList(false, true, false, true, true), // Should it be marked as duplicate?
-                1 // Edit Distance to Join
-        }, {
                 // Test basic error correction using edit distance of 2
                 Arrays.asList("AAAA", "AAAA", "ATTA", "AAAA", "AAAT"),
-                Arrays.asList("AAAA", "AAAA", "AAAA", "AAAA", "AAAA"),
-                Arrays.asList(false, true, true, true, true),
-                2
-        }, {
-                // Test basic error correction using edit distance of 2 including dashes
-                Arrays.asList("AAA-A", "A--AAA", "A---TT-A", "----AAAA", "A-AAT"),
                 Arrays.asList("AAAA", "AAAA", "AAAA", "AAAA", "AAAA"),
                 Arrays.asList(false, true, true, true, true),
                 2
@@ -232,7 +217,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
                         3,                           // OBSERVED_UNIQUE_UMIS
                         2,                           // INFERRED_UNIQUE_UMIS
                         2,                           // OBSERVED_BASE_ERRORS (Note: This is 2 rather than 1 because we are using paired end reads)
-                        2,                           // DUPLICATE_SETS_WITHOUT_UMI
+                        2,                           // DUPLICATE_SETS_IGNORING_UMI
                         4,                           // DUPLICATE_SETS_WITH_UMI
                         effectiveLength4_1,          // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
                         effectiveLength3_1_1,        // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
@@ -249,29 +234,12 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
                         3,                           // OBSERVED_UNIQUE_UMIS
                         1,                           // INFERRED_UNIQUE_UMIS
                         6,                           // OBSERVED_BASE_ERRORS
-                        2,                           // DUPLICATE_SETS_WITHOUT_UMI
+                        2,                           // DUPLICATE_SETS_IGNORING_UMI
                         2,                           // DUPLICATE_SETS_WITH_UMI
                         0.0,                         // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
                         effectiveLength3_1_1,        // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
                         estimatedBaseQuality3_20,    // ESTIMATED_BASE_QUALITY_OF_UMIS
                         0)                           // UMI_WITH_N
-        }, {
-                // Test basic error correction using edit distance of 2 including dashes
-                Arrays.asList("AAAA", "AAA-A", "A-TTA", "--AAA-A", "AAA-T"),
-                Arrays.asList("AAAA", "AAAA", "AAAA", "AAAA", "AAAA"),
-                Arrays.asList(false, true, true, true, true),
-                2,
-                new UmiMetrics("A",               // LIBRARY
-                        4.0,                      // MEAN_UMI_LENGTH
-                        3,                        // OBSERVED_UNIQUE_UMIS
-                        1,                        // INFERRED_UNIQUE_UMIS
-                        6,                        // OBSERVED_BASE_ERRORS
-                        2,                        // DUPLICATE_SETS_WITHOUT_UMI
-                        2,                        // DUPLICATE_SETS_WITH_UMI
-                        0.0,                      // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
-                        effectiveLength3_1_1,     // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
-                        estimatedBaseQuality3_20, // ESTIMATED_BASE_QUALITY_OF_UMIS
-                        0)                        // UMI_WITH_N
         }, {
                 // Test basic error correction using edit distance of 2 - Ns metrics should not include the umis with Ns
                 Arrays.asList("AAAA", "AAAA", "AANA", "ANNA", "ATTA", "AAAA", "ANAT"),
@@ -283,24 +251,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
                         2,                          // OBSERVED_UNIQUE_UMIS
                         1,                          // INFERRED_UNIQUE_UMIS
                         4,                          // OBSERVED_BASE_ERRORS
-                        2,                          // DUPLICATE_SETS_WITHOUT_UMI
-                        2,                          // DUPLICATE_SETS_WITH_UMI
-                        0.0,                        // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
-                        effectiveLength_N,          // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
-                        estimatedBaseQuality_N,     // ESTIMATED_BASE_QUALITY_OF_UMIS
-                        estimatedPercentWithN3_7)   // UMI_WITH_N
-        }, {
-                // Test basic error correction using edit distance of 2 including Ns and dashes
-                Arrays.asList("AAAA-", "AA-AA", "AAN-A", "ANNA", "AT-TA", "AAA-A-", "A--NAT-"),
-                Arrays.asList("AAAA", "AAAA", "AAAA", "AAAA", "AAAA", "AAAA", "AAAA"),
-                Arrays.asList(false, true, true, true, true, true, true),
-                2,
-                new UmiMetrics("A",                 // LIBRARY
-                        4.0,                        // MEAN_UMI_LENGTH
-                        2,                          // OBSERVED_UNIQUE_UMIS
-                        1,                          // INFERRED_UNIQUE_UMIS
-                        4,                          // OBSERVED_BASE_ERRORS
-                        2,                          // DUPLICATE_SETS_WITHOUT_UMI
+                        2,                          // DUPLICATE_SETS_IGNORING_UMI
                         2,                          // DUPLICATE_SETS_WITH_UMI
                         0.0,                        // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
                         effectiveLength_N,          // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
@@ -317,7 +268,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
                         16,            // OBSERVED_UNIQUE_UMIS
                         16,            // INFERRED_UNIQUE_UMIS
                         0,             // OBSERVED_BASE_ERRORS
-                        2,             // DUPLICATE_SETS_WITHOUT_UMI
+                        2,             // DUPLICATE_SETS_IGNORING_UMI
                         32,            // DUPLICATE_SETS_WITH_UMI
                         2.0,           // EFFECTIVE_LENGTH_OF_INFERRED_UMIS
                         2,             // EFFECTIVE_LENGTH_OF_OBSERVED_UMIS
@@ -347,7 +298,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
         // and a group of 1 for a total of 3.   1_1_1 means there are 3 groups of 1 UMI each.
         final double effectiveLength2_1 = -(2. / 3.) * Math.log(2. / 3.) / Math.log(4.) - (1. / 3.) * Math.log(1. / 3.) / Math.log(4.);
         final double effectiveLength1_1_1 = -3 * (1. / 3.) * Math.log(1. / 3.) / Math.log(4.);
-        
+
         final double estimatedBaseQuality1_12 = QualityUtil.getPhredScoreFromErrorProbability(1. / 12.);
         final double estimatedBaseQuality1_9 = QualityUtil.getPhredScoreFromErrorProbability(1. / 9.);
 
@@ -364,7 +315,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
                     3,                         // OBSERVED_UNIQUE_UMIS
                     2,                         // INFERRED_UNIQUE_UMIS
                     2,                         // OBSERVED_BASE_ERRORS (Note: This is 2 rather than 1 because we are using paired end reads)
-                    2,                         // DUPLICATE_SETS_WITHOUT_UMI
+                    2,                         // DUPLICATE_SETS_IGNORING_UMI
                     4,                         // DUPLICATE_SETS_WITH_UMI
                     effectiveLength2_1,        // INFERRED_UMI_ENTROPY
                     effectiveLength1_1_1,      // OBSERVED_UMI_ENTROPY
@@ -376,7 +327,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
                     1,                         // OBSERVED_UNIQUE_UMIS
                     1,                         // INFERRED_UNIQUE_UMIS
                     0,                         // OBSERVED_BASE_ERRORS
-                    2,                         // DUPLICATE_SETS_WITHOUT_UMI
+                    2,                         // DUPLICATE_SETS_IGNORING_UMI
                     2,                         // DUPLICATE_SETS_WITH_UMI
                     0.0,                       // INFERRED_UMI_ENTROPY
                     0.0,                       // OBSERVED_UMI_ENTROPY
@@ -395,8 +346,8 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
                     3.0,                       // MEAN_UMI_LENGTH
                     1,                         // OBSERVED_UNIQUE_UMIS
                     1,                         // INFERRED_UNIQUE_UMIS
-                    0,                         // OBSERVED_BASE_ERRORS (Note: This is 2 rather than 1 because we are using paired end reads)
-                    2,                         // DUPLICATE_SETS_WITHOUT_UMI
+                    0,                         // OBSERVED_BASE_ERRORS
+                    2,                         // DUPLICATE_SETS_IGNORING_UMI
                     2,                         // DUPLICATE_SETS_WITH_UMI
                     0.0,                       // INFERRED_UMI_ENTROPY
                     0.0,                       // OBSERVED_UMI_ENTROPY
@@ -408,7 +359,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
                     1,                         // OBSERVED_UNIQUE_UMIS
                     1,                         // INFERRED_UNIQUE_UMIS
                     0,                         // OBSERVED_BASE_ERRORS
-                    2,                         // DUPLICATE_SETS_WITHOUT_UMI
+                    2,                         // DUPLICATE_SETS_IGNORING_UMI
                     2,                         // DUPLICATE_SETS_WITH_UMI
                     0.0,                       // INFERRED_UMI_ENTROPY
                     0.0,                       // OBSERVED_UMI_ENTROPY
@@ -419,8 +370,8 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
                     3.0,                       // MEAN_UMI_LENGTH
                     3,                         // OBSERVED_UNIQUE_UMIS
                     2,                         // INFERRED_UNIQUE_UMIS
-                    2,                         // OBSERVED_BASE_ERRORS
-                    2,                         // DUPLICATE_SETS_WITHOUT_UMI
+                    2,                         // OBSERVED_BASE_ERRORS  (Note: This is 2 rather than 1 because we are using paired end reads)
+                    2,                         // DUPLICATE_SETS_IGNORING_UMI
                     4,                         // DUPLICATE_SETS_WITH_UMI
                     effectiveLength2_1,        // INFERRED_UMI_ENTROPY
                     effectiveLength1_1_1,      // OBSERVED_UMI_ENTROPY
@@ -457,20 +408,96 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
         }
     }
 
-    @DataProvider(name = "testUmiUtilDataProvider")
-    private Object[][] testUmiUtilDataProvider() {
+    @DataProvider(name = "testDuplexUmiDataProvider")
+    private Object[][] testDuplexUmiDataProvider() {
         return new Object[][]{{
-            Arrays.asList("AAAA", "AA-AA", "-A-T-A", "AAAAA--", "---A", "---", ""), // Observed UMI
-            Arrays.asList("AAAA", "AAAA", "ATA", "AAAAA", "A", "", "")              // Sanitized UMI
+                // Test simple case where there are two fragments that include a top and bottom strand.
+                true,                                // Use duplex UMI (true), or single stranded UMI (false)
+                0,                                   // MAX_EDIT_DISTANCE_TO_JOIN
+                Arrays.asList("AAA-GGG", "GGG-AAA"), // UMIs
+                Arrays.asList("AAA-GGG", "GGG-AAA"), // Inferred UMIs
+                Arrays.asList(false, true),          // Is duplicate
+                Arrays.asList(1, 4),                 // Start Position
+                Arrays.asList(4, 1),                 // Mate Start Position
+                Arrays.asList(false, true),          // Negative Strand Flag of first in pair
+                Arrays.asList(true, false),          // Negative Strand Flag of second in pair
+                new UmiMetrics("A",                  // LIBRARY
+                        6.0,                         // MEAN_UMI_LENGTH
+                        1,                           // OBSERVED_UNIQUE_UMIS
+                        1,                           // INFERRED_UNIQUE_UMIS
+                        0,                           // OBSERVED_BASE_ERRORS
+                        2,                           // DUPLICATE_SETS_IGNORING_UMI
+                        2,                           // DUPLICATE_SETS_WITH_UMI
+                        0.0,                         // INFERRED_UMI_ENTROPY
+                        0.0,                         // OBSERVED_UMI_ENTROPY
+                        -1,                          // ESTIMATED_BASE_QUALITY_OF_UMIS
+                        0)                           // UMI_WITH_N
+        },{
+                // Test simple case where there are two fragments with different UMIs.
+                // These UMIs will match as duplicates if they are duplex, but in this test they will be
+                // seen as non-duplicates because they are single stranded UMIs.
+                false,                               // Use duplex UMI (true), or single stranded UMI (false)
+                0,                                   // MAX_EDIT_DISTANCE_TO_JOIN
+                Arrays.asList("AAA-GGG", "GGG-AAA"), // UMIs
+                Arrays.asList("AAA-GGG", "GGG-AAA"), // Inferred UMIs
+                Arrays.asList(false, false),         // Is duplicate
+                Arrays.asList(1, 4),                 // Start Position
+                Arrays.asList(4, 1),                 // Mate Start Position
+                Arrays.asList(false, true),          // Negative Strand Flag of first in pair
+                Arrays.asList(true, false),          // Negative Strand Flag of second in pair
+                new UmiMetrics("A",                  // LIBRARY
+                        6.0,                         // MEAN_UMI_LENGTH
+                        2,                           // OBSERVED_UNIQUE_UMIS
+                        2,                           // INFERRED_UNIQUE_UMIS
+                        0,                           // OBSERVED_BASE_ERRORS
+                        2,                           // DUPLICATE_SETS_IGNORING_UMI
+                        4,                           // DUPLICATE_SETS_WITH_UMI
+                        0.5,                         // INFERRED_UMI_ENTROPY
+                        0.5,                         // OBSERVED_UMI_ENTROPY
+                        -1,                          // ESTIMATED_BASE_QUALITY_OF_UMIS
+                        0)                           // UMI_WITH_N
+        }, {
+                // Test case where a duplex UMI has a single base error.
+                true,                                // Use duplex UMI (true), or single stranded UMI (false)
+                1,                                   // MAX_EDIT_DISTANCE_TO_JOIN
+                Arrays.asList("AAA-GGG", "GGG-ATA"), // UMIs
+                Arrays.asList("AAA-GGG", "GGG-AAA"), // Inferred UMIs
+                Arrays.asList(false, true),          // Is duplicate
+                Arrays.asList(1, 4),                 // Start Position
+                Arrays.asList(4, 1),                 // Mate Start Position
+                Arrays.asList(false, true),          // Negative Strand Flag of first in pair
+                Arrays.asList(true, false),          // Negative Strand Flag of second in pair
+                new UmiMetrics("A",                  // LIBRARY
+                        6.0,                         // MEAN_UMI_LENGTH
+                        2,                           // OBSERVED_UNIQUE_UMIS
+                        1,                           // INFERRED_UNIQUE_UMIS
+                        2,                           // OBSERVED_BASE_ERRORS
+                        2,                           // DUPLICATE_SETS_IGNORING_UMI
+                        2,                           // DUPLICATE_SETS_WITH_UMI
+                        0.0,                         // INFERRED_UMI_ENTROPY
+                        0.5,                         // OBSERVED_UMI_ENTROPY
+                        11,                          // ESTIMATED_BASE_QUALITY_OF_UMIS
+                        0)                           // UMI_WITH_N
         }};
     }
 
-    @Test(dataProvider = "testUmiUtilDataProvider")
-    public void testUmiUtil(List<String> observed, List<String> expected) {
-        for (int i = 0; i < observed.size(); i++) {
-            SAMRecord rec = new SAMRecord(new SAMFileHeader());
-            rec.setAttribute("RX", observed.get(i));
-            Assert.assertEquals(UmiUtil.getSanitizedUMI(rec, "RX"), expected.get(i));
+    @Test(dataProvider = "testDuplexUmiDataProvider")
+    public void testDuplexUmi(final boolean duplexUmi, final int editDistanceToJoin, final List<String> umis, final List<String> assignedUmis,
+                              final List<Boolean> isDuplicate, final List<Integer> startPos, final List<Integer> mateStartPos,
+                              final List<Boolean> negativeStrand1, final List<Boolean> negativeStrand2, final UmiMetrics expectedMetrics) {
+
+        final String libraryName = "A"; // For the purpose of this test, all reads come from library "A".
+        final UmiAwareMarkDuplicatesWithMateCigarTester tester = getTester(false);
+        tester.addArg("MAX_EDIT_DISTANCE_TO_JOIN=" + editDistanceToJoin);
+        tester.addArg("DUPLEX_UMI=" + duplexUmi);
+
+        for (int i = 0; i < umis.size(); i++) {
+            tester.addMatePairWithUmi(libraryName, umis.get(i), assignedUmis.get(i), isDuplicate.get(i), isDuplicate.get(i),
+                    startPos.get(i), mateStartPos.get(i), negativeStrand1.get(i), negativeStrand2.get(i));
         }
+
+        tester.setExpectedMetrics(expectedMetrics);
+        tester.runTest();
     }
 }
+

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
@@ -28,6 +28,7 @@ import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.metrics.MetricsFile;
+import org.apache.commons.lang3.StringUtils;
 import org.testng.Assert;
 import picard.cmdline.CommandLineProgram;
 
@@ -196,7 +197,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
         for (final SAMRecord record : reader) {
             // If there are expected assigned UMIs, check to make sure they match
             if (expectedAssignedUmis != null) {
-                Assert.assertEquals(UmiUtil.getAssignedUmi(record.getStringAttribute("MI")), record.getAttribute(expectedUmiTag));
+                Assert.assertEquals(getAssignedUmi(record.getStringAttribute("MI")), record.getAttribute(expectedUmiTag));
             }
         }
 
@@ -235,4 +236,23 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
         UmiAwareMarkDuplicatesWithMateCigar uamdwmc = new UmiAwareMarkDuplicatesWithMateCigar();
         return uamdwmc;
     }
+
+
+    /**
+     *
+     * @param molecularIndex
+     * @return
+     */
+    private String getAssignedUmi(final String molecularIndex) {
+        if (molecularIndex == null) {
+            return null;
+        }
+
+        if (StringUtils.countMatches(molecularIndex, "/") == 2) {
+            return StringUtils.substringBetween(molecularIndex, "/", "/");
+        } else {
+            return StringUtils.substringAfter(molecularIndex, "/");
+        }
+    }
+
 }

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
@@ -248,10 +248,10 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
             return null;
         }
 
-        if (StringUtils.countMatches(molecularIndex, "/") == 2) {
-            return StringUtils.substringBetween(molecularIndex, "/", "/");
+        if (StringUtils.countMatches(molecularIndex, UmiUtil.UMI_NAME_SEPARATOR) == 2) {
+            return StringUtils.substringBetween(molecularIndex, UmiUtil.UMI_NAME_SEPARATOR, UmiUtil.UMI_NAME_SEPARATOR);
         } else {
-            return StringUtils.substringAfter(molecularIndex, "/");
+            return StringUtils.substringAfter(molecularIndex, UmiUtil.UMI_NAME_SEPARATOR);
         }
     }
 

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
@@ -99,6 +99,30 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
 
     }
 
+    public void addMatePairWithUmi(final String library, final String umi, final String assignedUMI, final boolean isDuplicate1, final boolean isDuplicate2,
+                                   final int alignmentStart1, final int alignmentStart2, final boolean strand1, final boolean strand2) {
+
+        final String readName = "READ" + readNameCounter++;
+        final String cigar1 = null;
+        final String cigar2 = null;
+
+        final int referenceSequenceIndex1 = 0;
+        final int referenceSequenceIndex2 = 0;
+
+        final boolean record1Unmapped = false;
+        final boolean record2Unmapped = false;
+
+        final boolean firstOnly = false;
+        final boolean record1NonPrimary = false;
+        final boolean record2NonPrimary = false;
+
+        final int defaultQuality = 10;
+
+        addMatePairWithUmi(library, readName, referenceSequenceIndex1, referenceSequenceIndex2, alignmentStart1, alignmentStart2, record1Unmapped,
+                record2Unmapped, isDuplicate1, isDuplicate2, cigar1, cigar2, strand1, strand2, firstOnly, record1NonPrimary, record2NonPrimary,
+                defaultQuality, umi, assignedUMI);
+    }
+
     public void addMatePairWithUmi(final String library,
                                    final String readName,
                                    final int referenceSequenceIndex1,
@@ -172,7 +196,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
         for (final SAMRecord record : reader) {
             // If there are expected assigned UMIs, check to make sure they match
             if (expectedAssignedUmis != null) {
-                Assert.assertEquals(record.getAttribute("MI"), record.getAttribute(expectedUmiTag));
+                Assert.assertEquals(UmiUtil.getAssignedUmi(record.getStringAttribute("MI")), record.getAttribute(expectedUmiTag));
             }
         }
 
@@ -185,7 +209,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
             catch (final FileNotFoundException ex) {
                 System.err.println("Metrics file not found: " + ex);
             }
-            double tolerance = 1e-6;
+            final double tolerance = 1e-6;
             Assert.assertEquals(metricsOutput.getMetrics().size(), 1);
             final UmiMetrics observedMetrics = metricsOutput.getMetrics().get(0);
 

--- a/src/test/java/picard/sam/markduplicates/UmiUtilTest.java
+++ b/src/test/java/picard/sam/markduplicates/UmiUtilTest.java
@@ -37,28 +37,39 @@ public class UmiUtilTest {
 
     @DataProvider(name = "topStrandDataProvider")
     private Object[][] testIsTopStrandDataProvider() {
+        final boolean read1 = true;
+        final boolean read2 = false;
         return new Object[][]{
-                {0, 100, 0, 200, true, false, true, true},    // Read 1 in F1R2 pair
-                {0, 100, 0, 200, false, false, true, false},  // Read 2 in F1R2 pair
-                {0, 100, 0, 200, true, true, false, true},    // Read 1 in F2R1 pair
-                {0, 200, 0, 100, false, false, true, true},   // Read 2 in F2R1 pair
-                {0, 100, 0, 200, true, false, false, true},   // Read 1 in F1F2 pair
-                {0, 200, 0, 100, false, false, false, true},  // Read 2 in F1F2 pair
-                {0, 100, 0, 200, true, true, true, true},     // Read 1 in R1R2 pair
-                {0, 200, 0, 100, false, true, true, true},    // Read 2 in R1R2 pair
-                {0, 100, 1, 200, false, false, true, true},  // Read 2 in F1R2 chimera
+                {0, 100, 0, 200, read1, false, true, true},    // Read 1 in F1R2 pair, reads point inwards, top strand
+                {0, 200, 0, 100, read2, true, false, true},    // Read 2 in F1R2 pair, reads point inwards, top strand
+                {0, 200, 0, 100, read1, false, true, false},   // Read 1 in F1R2 pair, reads point outwards
+                {0, 100, 0, 200, read2, true, false, false},   // Read 2 in F1R2 pair, reads point outwards
+                {0, 100, 0, 200, read1, true, false, true},    // Read 1 in F2R1 pair
+                {0, 200, 0, 100, read2, false, false, true},   // Read 2 in F2R1 pair
+                {0, 100, 0, 200, read1, false, false, true},   // Read 1 in F1F2 pair
+                {0, 200, 0, 100, read2, false, false, true},   // Read 2 in F1F2 pair
+                {0, 100, 0, 200, read1, true, true, true},     // Read 1 in R1R2 pair
+                {0, 200, 0, 100, read2, true, true, true},     // Read 2 in R1R2 pair
+                {0, 100, 1, 200, read1, false, true, true},    // Read 1 in F1R2 chimera
+                {0, 100, 1, 200, read2, true, false, false},   // Read 2 in F1R2 chimera
+                {0, 100, 1, 200, read1, true, false, true},    // Read 1 in F2R1 chimera
+                {0, 100, 1, 200, read2, false, false, false},  // Read 2 in F2R1 chimera
+                {0, 100, 1, 200, read2, false, true, false},   // Read 2 in F2R1 chimera
         };
     }
 
     @Test(dataProvider = "topStrandDataProvider")
-    public void testIsTopStrand(final int referenceIndex, final int alignmentStart, final int mateReferenceIndex, final int mateAlignmentStart, final boolean firstOfPairFlag,
-                              final boolean negativeStrandFlag, final boolean mateNegativeStrandFlag, final boolean topStrand) {
+    public void testIsTopStrand(final int referenceIndex, final int alignmentStart, final int mateReferenceIndex, final int mateAlignmentStart,
+                                final boolean firstOfPairFlag, final boolean negativeStrandFlag, final boolean mateNegativeStrandFlag,
+                                final boolean topStrand) {
 
+        final int readLength = 15;
+        final int contigLength = 500;
         SAMFileHeader header = new SAMFileHeader();
         SAMSequenceDictionary sequenceDictionary = new SAMSequenceDictionary();
 
-        sequenceDictionary.addSequence(new SAMSequenceRecord("chr1", 500));
-        sequenceDictionary.addSequence(new SAMSequenceRecord("chr2", 500));
+        sequenceDictionary.addSequence(new SAMSequenceRecord("chr1", contigLength));
+        sequenceDictionary.addSequence(new SAMSequenceRecord("chr2", contigLength));
 
         System.out.println(sequenceDictionary.getSequences());
 
@@ -68,9 +79,8 @@ public class UmiUtilTest {
 
         rec.setReadPairedFlag(true);
 
-        rec.setCigarString("10M");
-        rec.setAttribute("MC", "10M");
-        System.out.println("reference name = " + rec.getReferenceName());
+        rec.setCigarString(readLength + "M");
+        rec.setAttribute("MC", readLength + "M");
 
         rec.setReferenceIndex(referenceIndex);
         rec.setAlignmentStart(alignmentStart);
@@ -105,6 +115,6 @@ public class UmiUtilTest {
         rec.setAttribute("RX", brokenUmi);
 
         // This should throw an exception due to a broken UMI in rec
-        UmiUtil.getTopStrandNormalizedUmi(rec, "RX", true, false);
+        UmiUtil.getTopStrandNormalizedUmi(rec, "RX", true);
     }
 }

--- a/src/test/java/picard/sam/markduplicates/UmiUtilTest.java
+++ b/src/test/java/picard/sam/markduplicates/UmiUtilTest.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam.markduplicates;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class UmiUtilTest {
+
+    @DataProvider(name = "topStrandDataProvider")
+    private Object[][] testIsTopStrandDataProvider() {
+        return new Object[][]{
+                {100, 200, true, false, true, true},    // Read 1 in F1R2 pair
+                {100, 200, false, false, true, false},  // Read 2 in F1R2 pair
+                {100, 200, true, true, false, true},    // Read 1 in F2R1 pair
+                {200, 100, false, false, true, true},   // Read 2 in F2R1 pair
+                {100, 200, true, false, false, true},   // Read 1 in F1F2 pair
+                {200, 100, false, false, false, true},  // Read 2 in F1F2 pair
+                {100, 200, true, true, true, true},     // Read 1 in R1R2 pair
+                {200, 100, false, true, true, true},    // Read 2 in R1R2 pair
+        };
+    }
+
+    @Test(dataProvider = "topStrandDataProvider")
+    public void testIsTopStrand(final int alignmentStart, final int mateAlignmentStart, final boolean firstOfPairFlag,
+                              final boolean negativeStrandFlag, final boolean mateNegativeStrandFlag, final boolean topStrand) {
+
+        SAMFileHeader header = new SAMFileHeader();
+        SAMRecord rec = new SAMRecord(header);
+
+        rec.setReadPairedFlag(true);
+
+        rec.setCigarString("10M");
+        rec.setAttribute("MC", "10M");
+        rec.setAlignmentStart(alignmentStart);
+        rec.setMateAlignmentStart(mateAlignmentStart);
+
+        rec.setFirstOfPairFlag(firstOfPairFlag);
+        rec.setReadNegativeStrandFlag(negativeStrandFlag);
+        rec.setMateNegativeStrandFlag(mateNegativeStrandFlag);
+
+        Assert.assertEquals(UmiUtil.isTopStrand(rec), topStrand);
+    }
+}

--- a/src/test/java/picard/sam/markduplicates/UmiUtilTest.java
+++ b/src/test/java/picard/sam/markduplicates/UmiUtilTest.java
@@ -105,6 +105,6 @@ public class UmiUtilTest {
         rec.setAttribute("RX", brokenUmi);
 
         // This should throw an exception due to a broken UMI in rec
-        UmiUtil.getTopStrandNormalizedUmi(rec, "RX", true);
+        UmiUtil.getTopStrandNormalizedUmi(rec, "RX", true, false);
     }
 }

--- a/src/test/java/picard/sam/testers/SamFileTester.java
+++ b/src/test/java/picard/sam/testers/SamFileTester.java
@@ -271,7 +271,8 @@ public abstract class SamFileTester extends CommandLineProgramTest {
                             final boolean firstOnly,
                             final boolean record1NonPrimary,
                             final boolean record2NonPrimary,
-                            final int defaultQuality) {
+                            final int defaultQuality,
+                            final String umi) {
         final List<SAMRecord> samRecordList = samRecordSetBuilder.addPair(readName, referenceSequenceIndex1, referenceSequenceIndex2, alignmentStart1, alignmentStart2,
                 record1Unmapped, record2Unmapped, cigar1, cigar2, strand1, strand2, record1NonPrimary, record2NonPrimary, defaultQuality);
 
@@ -281,6 +282,11 @@ public abstract class SamFileTester extends CommandLineProgramTest {
         if (this.noMateCigars) {
             record1.setAttribute("MC", null);
             record2.setAttribute("MC", null);
+        }
+
+        if (umi != null) {
+            record1.setAttribute("RX", umi);
+            record2.setAttribute("RX", umi);
         }
 
         if (firstOnly) {
@@ -296,6 +302,27 @@ public abstract class SamFileTester extends CommandLineProgramTest {
         this.duplicateFlags.put(key2, isDuplicate2);
     }
 
+    public void addMatePair(final String readName,
+                            final int referenceSequenceIndex1,
+                            final int referenceSequenceIndex2,
+                            final int alignmentStart1,
+                            final int alignmentStart2,
+                            final boolean record1Unmapped,
+                            final boolean record2Unmapped,
+                            final boolean isDuplicate1,
+                            final boolean isDuplicate2,
+                            final String cigar1,
+                            final String cigar2,
+                            final boolean strand1,
+                            final boolean strand2,
+                            final boolean firstOnly,
+                            final boolean record1NonPrimary,
+                            final boolean record2NonPrimary,
+                            final int defaultQuality) {
+        addMatePair(readName, referenceSequenceIndex1, referenceSequenceIndex2, alignmentStart1, alignmentStart2,
+                record1Unmapped, record2Unmapped, isDuplicate1, isDuplicate2, cigar1, cigar2, strand1, strand2,
+                firstOnly, record1NonPrimary, record2NonPrimary, defaultQuality, null);
+    }
     public void addMatePair(final String readName,
                             final int referenceSequenceIndex,
                             final int alignmentStart1,


### PR DESCRIPTION
### Description

Adds DUPLEX_UMI as an argument to MarkDuplicates and UmiAwareMarkDuplicatesWithMateCigar.  This allows MarkDuplicates and UAMDWMC to properly mark duplicates using duplex strand UMIs.

When using the DUPLEX_UMI argument, the bam will contain an additional tag specified by MOLECULAR_IDENTIFIER_TAG which is "MI" by default.  The contents of this tag uniquely identify the fragment the read comes from, and labels them as having come from the top "/A" or bottom "/B" strand.

This resolves the issue in #1192.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

