### PR TITLE
Changed the OpticalDuplicateFinder to rely on a clustering algorithm to find duplicate groups

### DIFF
--- a/src/main/java/picard/sam/markduplicates/util/OpticalDuplicateFinder.java
+++ b/src/main/java/picard/sam/markduplicates/util/OpticalDuplicateFinder.java
@@ -28,9 +28,10 @@ import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.ProgressLogger;
 import picard.sam.util.PhysicalLocation;
 import picard.sam.util.ReadNameParser;
+import picard.util.GraphUtils;
 
 import java.io.Serializable;
-import java.util.List;
+import java.util.*;
 
 /**
  * Contains methods for finding optical/co-localized/sequencing duplicates.
@@ -38,7 +39,7 @@ import java.util.List;
  * @author Tim Fennell
  * @author Nils Homer
  */
-public class OpticalDuplicateFinder extends ReadNameParser implements Serializable  {
+public class OpticalDuplicateFinder extends ReadNameParser implements Serializable {
 
     public int opticalDuplicatePixelDistance;
 
@@ -83,10 +84,9 @@ public class OpticalDuplicateFinder extends ReadNameParser implements Serializab
     }
 
     /**
-     *
-     * @param readNameRegex see {@link ReadNameParser#DEFAULT_READ_NAME_REGEX}.
+     * @param readNameRegex                 see {@link ReadNameParser#DEFAULT_READ_NAME_REGEX}.
      * @param opticalDuplicatePixelDistance the optical duplicate pixel distance
-     * @param log the log to which to write messages.
+     * @param log                           the log to which to write messages.
      */
     public OpticalDuplicateFinder(final String readNameRegex, final int opticalDuplicatePixelDistance, final Log log) {
         super(readNameRegex, log);
@@ -94,11 +94,10 @@ public class OpticalDuplicateFinder extends ReadNameParser implements Serializab
     }
 
     /**
-     *
-     * @param readNameRegex see {@link ReadNameParser#DEFAULT_READ_NAME_REGEX}.
+     * @param readNameRegex                 see {@link ReadNameParser#DEFAULT_READ_NAME_REGEX}.
      * @param opticalDuplicatePixelDistance the optical duplicate pixel distance
-     * @param maxDuplicateSetSize the size of a set that is too big enough to process
-     * @param log the log to which to write messages.
+     * @param maxDuplicateSetSize           the size of a set that is too big enough to process
+     * @param log                           the log to which to write messages.
      */
     public OpticalDuplicateFinder(final String readNameRegex, final int opticalDuplicatePixelDistance, final long maxDuplicateSetSize, final Log log) {
         super(readNameRegex, log);
@@ -113,7 +112,7 @@ public class OpticalDuplicateFinder extends ReadNameParser implements Serializab
      * optical duplicates are indicated by returning "true" at the same index in the resulting boolean[] as the
      * read appeared in the input list of physical locations.
      *
-     * @param list a list of reads that are determined to be duplicates of one another
+     * @param list   a list of reads that are determined to be duplicates of one another
      * @param keeper a single PhysicalLocation that is the one being kept as non-duplicate, and thus should never be
      *               annotated as an optical duplicate. May in some cases be null, or a PhysicalLocation not
      *               contained within the list!
@@ -150,48 +149,114 @@ public class OpticalDuplicateFinder extends ReadNameParser implements Serializab
             progressLoggerForRest = null;
         }
 
-        // First go through and compare all the reads to the keeper
-        if (actualKeeper != null) {
-            for (int i = 0; i < length; ++i) {
-                final PhysicalLocation other = list.get(i);
-                opticalDuplicateFlags[i] = closeEnough(actualKeeper, other, distance);
+        // Make a graph where the edges are reads that lie within the optical duplicate pixel distance from each other,
+        // we will then use the union-find algorithm to cluster the graph and find optical duplicate groups
+        final GraphUtils.Graph<Integer> opticalDistanceRelationGraph = new GraphUtils.Graph<>();
+        if (logProgress) {
+            log.debug("Building adjacency graph for duplicate group");
+        }
 
-                // The main point of adding this log and if statement (also below) is a workaround a bug in the JVM
-                // which causes a deep exception (https://github.com/broadinstitute/picard/issues/472).
-                // It seems that this is related to https://bugs.openjdk.java.net/browse/JDK-8033717 which
-                // was closed due to non-reproducibility. We came across a bam file that evoked this error
-                // every time we tried to duplicate-mark it. The problem seemed to be a duplicate-set of size 500,000,
-                // and this loop seemed to kill the JVM for some reason. This logging statement (and the one in the
-                // loop below) solved the problem.
-                if (logProgress) progressLoggerForKeeper.record(String.format("%d", other.getReadGroup()), other.getX());
+        final Map<Integer, List<Integer>> tileRGmap = new HashMap<>();
+
+        int keeperIndex = -1;
+        for (int i = 0; i < list.size(); i++) {
+            PhysicalLocation currentLoc = list.get(i);
+            if (currentLoc == keeper) {
+                keeperIndex = i;
+            }
+            if (currentLoc.hasLocation()) {
+                final int key = ((int) currentLoc.getReadGroup() << 16) + currentLoc.getTile();
+
+                if (tileRGmap.containsKey(key)) {
+                    tileRGmap.get(key).add(i);
+                } else {
+                    final List<Integer> pLocation = new ArrayList<>();
+                    pLocation.add(i);
+                    tileRGmap.put(key, pLocation);
+                }
+            }
+            opticalDistanceRelationGraph.addNode(i);
+        }
+
+        // Since because finding adjacent optical duplicates is an O(n^2) operation, we can subdivide the input into its
+        // readgroups in order to reduce the amount of redundant checks across readgroups between reads.
+        for (List<Integer> tileGroup : tileRGmap.values()) {
+            if (tileGroup.size() > 1) {
+                fillGraphFromAGroup(list, tileGroup, logProgress, progressLoggerForKeeper, distance, opticalDistanceRelationGraph);
             }
         }
-        if (logProgress) log.debug("Done with comparing to keeper, now the rest.");
 
-        // Now go through and do each pairwise comparison not involving the actualKeeper
-        for (int i = 0; i < length; ++i) {
-            final PhysicalLocation lhs = list.get(i);
-            if (lhs == actualKeeper) continue; // no comparisons to actualKeeper since those are all handled above
+        if (logProgress) {
+            log.debug("Finished building adjacency graph for duplicate group, moving onto clustering");
+        }
 
+        // Keep a map of the reads and their cluster assignments
+        final Map<Integer, Integer> opticalDuplicateClusterMap = opticalDistanceRelationGraph.cluster();
+        final Map<Integer, Integer> clusterToRepresentativeRead = new HashMap<>();
+        Integer keeperCluster = null;
+
+        // Specially mark the keeper as specifically not a duplicate if it exists
+        if (keeperIndex >= 0) {
+            clusterToRepresentativeRead.put(opticalDuplicateClusterMap.get(keeperIndex), keeperIndex);
+            keeperCluster = opticalDuplicateClusterMap.get(keeperIndex);
+        }
+
+        for (final Map.Entry<Integer, Integer> entry : opticalDuplicateClusterMap.entrySet()) {
             // logging here for same reason as above
-            if (logProgress) progressLoggerForRest.record(String.format("%d", lhs.getReadGroup()), lhs.getX());
+            final int recordIndex = entry.getKey();
+            final int recordAssignedCluster = entry.getValue();
+            if (logProgress) {
+                progressLoggerForRest.record(String.format("%d", list.get(recordIndex).getReadGroup()), list.get(recordIndex).getX());
+            }
 
-            for (int j = i + 1; j < length; ++j) {
-                final PhysicalLocation rhs = list.get(j);
-                if (rhs == actualKeeper) continue; // no comparisons to actualKeeper since those are all handled above
-                if (opticalDuplicateFlags[i] && opticalDuplicateFlags[j]) continue; // both already marked, no need to check
+            // If its not the first read we've seen for this cluster, mark it as an optical duplicate
+            if (clusterToRepresentativeRead.containsKey(recordAssignedCluster) && recordIndex != keeperIndex) {
+                final PhysicalLocation representativeLoc = list.get(clusterToRepresentativeRead.get(recordAssignedCluster));
+                final PhysicalLocation currentRecordLoc = list.get(recordIndex);
 
-                if (closeEnough(lhs, rhs, distance)) {
-                    // At this point we want to mark either lhs or rhs as duplicate. Either could have been marked
-                    // as a duplicate of the keeper (but not both - that's checked above), so be careful about which
-                    // one to now mark as a duplicate.
-                    final int index = opticalDuplicateFlags[j] ? i : j;
-                    opticalDuplicateFlags[index] = true;
+                // If not in the keeper cluster, then keep the minX -> minY valued duplicate (note the tile must be equal for reads to cluster together)
+                if (!(keeperIndex >= 0 && recordAssignedCluster == keeperCluster) && // checking we don't accidentally set the keeper as an optical duplicate
+                        (currentRecordLoc.getX() < representativeLoc.getX() || (currentRecordLoc.getX() == representativeLoc.getX() && currentRecordLoc.getY() < representativeLoc.getY()))) {
+                    // Mark the old min as an optical duplicate, and save the new min
+                    opticalDuplicateFlags[clusterToRepresentativeRead.get(recordAssignedCluster)] = true;
+                    clusterToRepresentativeRead.put(recordAssignedCluster, recordIndex);
+                } else {
+                    // If a smaller read has already been visited, mark the test read as an optical duplicate
+                    opticalDuplicateFlags[recordIndex] = true;
+                }
+            } else {
+                clusterToRepresentativeRead.put(recordAssignedCluster, recordIndex);
+            }
+        }
+        
+        return opticalDuplicateFlags;
+    }
+
+    private void fillGraphFromAGroup(final List<? extends PhysicalLocation> wholeList, final List<Integer> groupList, final boolean logProgress, final ProgressLogger progressLoggerForKeeper, final int distance, final GraphUtils.Graph<Integer> opticalDistanceRelationGraph) {
+
+        for (int i = 0; i < groupList.size(); i++) {
+            final int iIndex = groupList.get(i);
+            final PhysicalLocation currentLoc = wholeList.get(iIndex);
+            // The main point of adding this log and if statement (also below) is a workaround a bug in the JVM
+            // which causes a deep exception (https://github.com/broadinstitute/picard/issues/472).
+            // It seems that this is related to https://bugs.openjdk.java.net/browse/JDK-8033717 which
+            // was closed due to non-reproducibility. We came across a bam file that evoked this error
+            // every time we tried to duplicate-mark it. The problem seemed to be a duplicate-set of size 500,000,
+            // and this loop seemed to kill the JVM for some reason. This logging statement (and the one in the
+            // loop below) solved the problem.
+            if (logProgress) {
+                progressLoggerForKeeper.record(String.format("%d", currentLoc.getReadGroup()), currentLoc.getX());
+            }
+
+            for (int j = i + 1; j < groupList.size(); j++) {
+                final int jIndex = groupList.get(j);
+                final PhysicalLocation other = wholeList.get(jIndex);
+
+                if (closeEnoughShort(currentLoc, other, distance)) {
+                    opticalDistanceRelationGraph.addEdge(iIndex, jIndex);
                 }
             }
         }
-
-        return opticalDuplicateFlags;
     }
 
     /** Returns the keeper if it is contained within the list and has location information, otherwise null. */
@@ -212,5 +277,11 @@ public class OpticalDuplicateFinder extends ReadNameParser implements Serializab
                lhs.getTile()      == rhs.getTile()      &&      // and the same tile
                Math.abs(lhs.getX() - rhs.getX()) <= distance &&
                Math.abs(lhs.getY() - rhs.getY()) <= distance;
+    }
+
+    private boolean closeEnoughShort(final PhysicalLocation lhs, final PhysicalLocation rhs, final int distance) {
+        return lhs != rhs &&
+                Math.abs(lhs.getX() - rhs.getX()) <= distance &&
+                Math.abs(lhs.getY() - rhs.getY()) <= distance;
     }
 }

--- a/src/main/java/picard/sam/markduplicates/util/OpticalDuplicateFinder.java
+++ b/src/main/java/picard/sam/markduplicates/util/OpticalDuplicateFinder.java
@@ -148,9 +148,9 @@ public class OpticalDuplicateFinder extends ReadNameParser implements Serializab
             progressLoggerForRest = null;
         }
         if (length >= (keeper == null ? 3 : 4)) {
-            return getOpticalDuplicatesFlagWithGraph(list, keeper, opticalDuplicateFlags, log, progressLoggerForKeeper, progressLoggerForRest, logProgress);
+            return getOpticalDuplicatesFlagWithGraph(list, actualKeeper, opticalDuplicateFlags, log, progressLoggerForKeeper, progressLoggerForRest, logProgress);
         } else {
-            return getOpticalDuplicatesFlagFast(list, keeper, opticalDuplicateFlags, log, progressLoggerForKeeper, progressLoggerForRest, logProgress);
+            return getOpticalDuplicatesFlagFast(list, actualKeeper, opticalDuplicateFlags, log, progressLoggerForKeeper, progressLoggerForRest, logProgress);
         }
     }
 


### PR DESCRIPTION
This change should fix optical duplicate mismatching with the gatk MarkDuplicatesSpark tool. Before, the algorithm for optical duplicate finding did not cluster the reads properly which resulted in the number of optical duplicates found to be input order dependent. To get around this problem I updated the algorithm to use union-find to cluster the optical duplicates and select a single representative non-optical duplicate from each cluster. 

This solves the order dependent count issue while still leaving open the issue of tie-breaking, since the read in each cluster that gets selected is still order dependent. This could be solved with some better tiebreaking but I was not sure the best metric to use at this stage. If we don't fix the problem now it shouldn't affect markDuplicatesSpark because it currently doesn't support labeling of optical duplicate reads. This may change in the future and steps could be taken to increase optical duplicate concordance in spark. 

If there are performance concerns about this branch I suspect there approaches to this clustering that would avoid some of the excessive object creation involved in this implementation.  
