### PR TITLE
Fixed bug in MarkDuplicates where it was mismarking which reads were optical duplicates when TAGGING_POLICY is set. 

### DIFF
--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -314,10 +314,9 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
                 }
             }
 
-            final ProgressLogger progress = new ProgressLogger(log, (int) 1e7, "Written");
-            final CloseableIterator<SAMRecord> iterator = headerAndIterator.iterator;
-            String duplicateQueryName = null;
-            String opticalDuplicateQueryName = null;
+        final ProgressLogger progress = new ProgressLogger(log, (int) 1e7, "Written");
+        final CloseableIterator<SAMRecord> iterator = headerAndIterator.iterator;
+        String duplicateQueryName = null;
 
             while (iterator.hasNext()) {
                 final SAMRecord rec = iterator.next();
@@ -343,19 +342,13 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
 
                 // Now try and figure out the next duplicate index (if going by coordinate. if going by query name, only do this
                 // if the query name has changed.
-                final boolean needNextDuplicateIndex = recordInFileIndex > nextDuplicateIndex &&
-                        (sortOrder == SAMFileHeader.SortOrder.coordinate || !rec.getReadName().equals(duplicateQueryName));
-
-                if (needNextDuplicateIndex) {
-                    nextDuplicateIndex = (this.duplicateIndexes.hasNext() ? this.duplicateIndexes.next() : NO_SUCH_INDEX);
-                }
+                nextDuplicateIndex = iterateIndexesIfNecessary(sortOrder, recordInFileIndex, nextDuplicateIndex, duplicateQueryName, rec, this.duplicateIndexes);
 
                 final boolean isDuplicate = recordInFileIndex == nextDuplicateIndex ||
                         (sortOrder == SAMFileHeader.SortOrder.queryname &&
                                 recordInFileIndex > nextDuplicateIndex && rec.getReadName().equals(duplicateQueryName));
 
                 if (isDuplicate) {
-                    duplicateQueryName = rec.getReadName();
                     rec.setDuplicateReadFlag(true);
 
                     // only update duplicate counts for "decider" reads, not tag-a-long reads
@@ -370,20 +363,11 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
                 } else {
                     rec.setDuplicateReadFlag(false);
                 }
-
-                // Manage the flagging of optical/sequencing duplicates
-                final boolean needNextOpticalDuplicateIndex = recordInFileIndex > nextOpticalDuplicateIndex &&
-                        (sortOrder == SAMFileHeader.SortOrder.coordinate || !rec.getReadName().equals(opticalDuplicateQueryName));
-
-                // Possibly figure out the next opticalDuplicate index (if going by coordinate, if going by query name, only do this
-                // if the query name has changed)
-                if (needNextOpticalDuplicateIndex) {
-                    nextOpticalDuplicateIndex = (this.opticalDuplicateIndexes.hasNext() ? this.opticalDuplicateIndexes.next() : NO_SUCH_INDEX);
-                }
+            nextOpticalDuplicateIndex = iterateIndexesIfNecessary(sortOrder, recordInFileIndex, nextOpticalDuplicateIndex, duplicateQueryName, rec, this.opticalDuplicateIndexes);
 
                 final boolean isOpticalDuplicate = sortOrder == SAMFileHeader.SortOrder.queryname &&
                         recordInFileIndex > nextOpticalDuplicateIndex &&
-                        rec.getReadName().equals(opticalDuplicateQueryName) ||
+                        rec.getReadName().equals(duplicateQueryName) ||
                         recordInFileIndex == nextOpticalDuplicateIndex;
 
                 if (CLEAR_DT) {
@@ -392,12 +376,11 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
 
                 if (this.TAGGING_POLICY != DuplicateTaggingPolicy.DontTag && rec.getDuplicateReadFlag()) {
                     if (isOpticalDuplicate) {
-                        opticalDuplicateQueryName = rec.getReadName();
                         rec.setAttribute(DUPLICATE_TYPE_TAG, DuplicateType.SEQUENCING.code());
-                    } else if (this.TAGGING_POLICY == DuplicateTaggingPolicy.All) {
-                        rec.setAttribute(DUPLICATE_TYPE_TAG, DuplicateType.LIBRARY.code());
-                    }
+                } else if (this.TAGGING_POLICY == DuplicateTaggingPolicy.All) {
+                    rec.setAttribute(DUPLICATE_TYPE_TAG, DuplicateType.LIBRARY.code());
                 }
+            }
 
                 // Tag any read pair that was in a duplicate set with the duplicate set size and a representative read name
                 if (TAG_DUPLICATE_SET_MEMBERS) {
@@ -421,20 +404,24 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
                     }
                 }
 
-                // Output the record if desired and bump the record index
-                recordInFileIndex++;
-                if (this.REMOVE_DUPLICATES && rec.getDuplicateReadFlag()) {
-                    continue;
-                }
-                if (this.REMOVE_SEQUENCING_DUPLICATES && isOpticalDuplicate) {
-                    continue;
-                }
-                if (PROGRAM_RECORD_ID != null && pgTagArgumentCollection.ADD_PG_TAG_TO_READS) {
-                    rec.setAttribute(SAMTag.PG.name(), chainedPgIds.get(rec.getStringAttribute(SAMTag.PG.name())));
-                }
-                out.addAlignment(rec);
-                progress.record(rec);
+                if (isDuplicate) {
+                duplicateQueryName = rec.getReadName();
             }
+
+            // Output the record if desired and bump the record index
+            recordInFileIndex++;
+            if (this.REMOVE_DUPLICATES && rec.getDuplicateReadFlag()) {
+                continue;
+            }
+            if (this.REMOVE_SEQUENCING_DUPLICATES && isOpticalDuplicate) {
+                continue;
+            }
+            if (PROGRAM_RECORD_ID != null && pgTagArgumentCollection.ADD_PG_TAG_TO_READS) {
+                rec.setAttribute(SAMTag.PG.name(), chainedPgIds.get(rec.getStringAttribute(SAMTag.PG.name())));
+            }
+            out.addAlignment(rec);
+            progress.record(rec);
+        }
 
             // remember to close the inputs
             iterator.close();
@@ -888,6 +875,35 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
                 }
             }
         }
+    }
+
+    /**
+     * Method for deciding when to pull from the SortingLongCollection for the next read based on sorting order.
+     * - If file is queryname sorted then we expect one index per pair of reads, so we only want to iterate when we
+     *   are no longer reading from that readgroup.
+     * - If file is sorted otherwise we want to base our iteration entirely on the indexes of both reads in the pair
+     *
+     * This logic is applied to both Optical and Library duplicates
+     *
+     * @param sortOrder          Sort order for the underlying bam file
+     * @param recordInFileIndex  Index of the current sam record rec
+     * @param nextDuplicateIndex Index of next expected duplicate (optical or otherwise) in the file
+     * @param lastQueryName      Name of the last read seen (for keeping queryname sorted groups together)
+     * @param rec                Current record to compare against
+     * @param duplicateIndexes   DuplicateIndexes collection to iterate over
+     * @return  the duplicate after iteration
+     */
+    private long iterateIndexesIfNecessary(final SAMFileHeader.SortOrder sortOrder, final long recordInFileIndex, final long nextDuplicateIndex, final String lastQueryName, final SAMRecord rec, final SortingLongCollection duplicateIndexes) {
+        // Manage the flagging of optical/sequencing duplicates
+        final boolean needNextDuplicateIndex = recordInFileIndex > nextDuplicateIndex &&
+                (sortOrder == SAMFileHeader.SortOrder.coordinate || !rec.getReadName().equals(lastQueryName));
+
+        // Possibly figure out the next opticalDuplicate index (if going by coordinate, if going by query name, only do this
+        // if the query name has changed)
+        if (needNextDuplicateIndex) {
+            return (duplicateIndexes.hasNext() ? duplicateIndexes.next() : NO_SUCH_INDEX);
+        }
+        return nextDuplicateIndex;
     }
 
     /**

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -882,7 +882,9 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
 
                 if (end.isOpticalDuplicate && this.opticalDuplicateIndexes != null) {
                     this.opticalDuplicateIndexes.add(end.read1IndexInFile);
-                    this.opticalDuplicateIndexes.add(end.read2IndexInFile);
+                    if(end.read2IndexInFile != end.read1IndexInFile) {
+                        this.opticalDuplicateIndexes.add(end.read2IndexInFile);
+                    }
                 }
             }
         }

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -872,6 +872,8 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
                     this.opticalDuplicateIndexes.add(end.read1IndexInFile);
                     // We expect end.read2IndexInFile==read1IndexInFile when we are in queryname sorted files, as the read-pairs
                     // will be sorted together and nextIndexIfNeeded() will only pull one index from opticalDuplicateIndexes.
+                    // This means that in queryname sorted order we will only pull from the sorting collection once,
+                    // where as we would pull twice for coordinate sorted files. 
                     if(end.read2IndexInFile != end.read1IndexInFile) {
                         this.opticalDuplicateIndexes.add(end.read2IndexInFile);
                     }

--- a/src/test/java/picard/sam/markduplicates/AbstractMarkDuplicatesCommandLineProgramTester.java
+++ b/src/test/java/picard/sam/markduplicates/AbstractMarkDuplicatesCommandLineProgramTester.java
@@ -87,11 +87,11 @@ abstract public class AbstractMarkDuplicatesCommandLineProgramTester extends Sam
     /**
      * Tells MarkDuplicates to record which reads are optical duplicates
      *
-     * NOTE: this should be overridden as a blank methods for inhereting classes where the tested tool doesn't support the 'TAGGING_POLICY' argument
+     * NOTE: this should be overridden as a blank method for inheriting classes where the tested tool doesn't support the 'TAGGING_POLICY' argument
      */
     public void recordOpticalDuplicatesMarked() {
         testOpticalDuplicateDTTag = true;
-        addArg("TAGGING_POLICY="+MarkDuplicates.DuplicateTaggingPolicy.OpticalOnly);
+        addArg("TAGGING_POLICY=" + MarkDuplicates.DuplicateTaggingPolicy.OpticalOnly);
     }
 
     /**
@@ -149,7 +149,7 @@ abstract public class AbstractMarkDuplicatesCommandLineProgramTester extends Sam
 
             // Read the output and check the duplicate flag
             int outputRecords = 0;
-            Set<String> sequencingDTErrorsSeen = new HashSet<>();
+            final Set<String> sequencingDTErrorsSeen = new HashSet<>();
             final SamReader reader = SamReaderFactory.makeDefault().open(getOutput());
             for (final SAMRecord record : reader) {
                 outputRecords++;
@@ -195,6 +195,7 @@ abstract public class AbstractMarkDuplicatesCommandLineProgramTester extends Sam
             Assert.assertEquals(observedMetrics.SECONDARY_OR_SUPPLEMENTARY_RDS, expectedMetrics.SECONDARY_OR_SUPPLEMENTARY_RDS, "SECONDARY_OR_SUPPLEMENTARY_RDS does not match expected");
             if (testOpticalDuplicateDTTag) {
                 Assert.assertEquals(sequencingDTErrorsSeen.size(), expectedMetrics.READ_PAIR_OPTICAL_DUPLICATES, "READ_PAIR_OPTICAL_DUPLICATES does not match duplicate groups observed in the file");
+                Assert.assertEquals(sequencingDTErrorsSeen.size(), observedMetrics.READ_PAIR_OPTICAL_DUPLICATES, "READ_PAIR_OPTICAL_DUPLICATES does not match duplicate groups observed in the file");
             }
         } finally {
             TestUtil.recursiveDelete(getOutputDir());

--- a/src/test/java/picard/sam/markduplicates/AbstractMarkDuplicatesCommandLineProgramTester.java
+++ b/src/test/java/picard/sam/markduplicates/AbstractMarkDuplicatesCommandLineProgramTester.java
@@ -43,6 +43,8 @@ import picard.sam.testers.SamFileTester;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * This class is an extension of SamFileTester used to test AbstractMarkDuplicatesCommandLineProgram's with SAM files generated on the fly.
@@ -52,6 +54,8 @@ abstract public class AbstractMarkDuplicatesCommandLineProgramTester extends Sam
 
     final File metricsFile;
     final DuplicationMetrics expectedMetrics;
+
+    boolean testOpticalDuplicateDTTag = false;
 
     public AbstractMarkDuplicatesCommandLineProgramTester(final ScoringStrategy duplicateScoringStrategy, SAMFileHeader.SortOrder sortOrder) {
         this(duplicateScoringStrategy, sortOrder, true);
@@ -66,6 +70,7 @@ abstract public class AbstractMarkDuplicatesCommandLineProgramTester extends Sam
         metricsFile = new File(getOutputDir(), "metrics.txt");
         addArg("METRICS_FILE=" + metricsFile);
         addArg("DUPLICATE_SCORING_STRATEGY=" + duplicateScoringStrategy.name());
+        recordOpticalDuplicatesMarked();
     }
 
     public AbstractMarkDuplicatesCommandLineProgramTester(final ScoringStrategy duplicateScoringStrategy) {
@@ -78,6 +83,16 @@ abstract public class AbstractMarkDuplicatesCommandLineProgramTester extends Sam
 
     @Override
     public String getCommandLineProgramName() { return getProgram().getClass().getSimpleName(); }
+
+    /**
+     * Tells MarkDuplicates to record which reads are optical duplicates
+     *
+     * NOTE: this should be overridden as a blank methods for inhereting classes where the tested tool doesn't support the 'TAGGING_POLICY' argument
+     */
+    public void recordOpticalDuplicatesMarked() {
+        testOpticalDuplicateDTTag = true;
+        addArg("TAGGING_POLICY="+MarkDuplicates.DuplicateTaggingPolicy.OpticalOnly);
+    }
 
     /**
      * Fill in expected duplication metrics directly from the input records given to this tester
@@ -134,6 +149,7 @@ abstract public class AbstractMarkDuplicatesCommandLineProgramTester extends Sam
 
             // Read the output and check the duplicate flag
             int outputRecords = 0;
+            Set<String> sequencingDTErrorsSeen = new HashSet<>();
             final SamReader reader = SamReaderFactory.makeDefault().open(getOutput());
             for (final SAMRecord record : reader) {
                 outputRecords++;
@@ -149,6 +165,9 @@ abstract public class AbstractMarkDuplicatesCommandLineProgramTester extends Sam
                     System.err.print(record.getSAMString());
                 }
                 Assert.assertEquals(record.getDuplicateReadFlag(), value);
+                if (testOpticalDuplicateDTTag && MarkDuplicates.DUPLICATE_TYPE_SEQUENCING.equals(record.getAttribute("DT"))) {
+                    sequencingDTErrorsSeen.add(record.getReadName());
+                }
             }
             CloserUtil.close(reader);
 
@@ -174,6 +193,9 @@ abstract public class AbstractMarkDuplicatesCommandLineProgramTester extends Sam
             Assert.assertEquals(observedMetrics.PERCENT_DUPLICATION, expectedMetrics.PERCENT_DUPLICATION, "PERCENT_DUPLICATION does not match expected");
             Assert.assertEquals(observedMetrics.ESTIMATED_LIBRARY_SIZE, expectedMetrics.ESTIMATED_LIBRARY_SIZE, "ESTIMATED_LIBRARY_SIZE does not match expected");
             Assert.assertEquals(observedMetrics.SECONDARY_OR_SUPPLEMENTARY_RDS, expectedMetrics.SECONDARY_OR_SUPPLEMENTARY_RDS, "SECONDARY_OR_SUPPLEMENTARY_RDS does not match expected");
+            if (testOpticalDuplicateDTTag) {
+                Assert.assertEquals(sequencingDTErrorsSeen.size(), expectedMetrics.READ_PAIR_OPTICAL_DUPLICATES, "READ_PAIR_OPTICAL_DUPLICATES does not match duplicate groups observed in the file");
+            }
         } finally {
             TestUtil.recursiveDelete(getOutputDir());
         }

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesTagRepresentativeReadIndexTester.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesTagRepresentativeReadIndexTester.java
@@ -58,6 +58,9 @@ public class MarkDuplicatesTagRepresentativeReadIndexTester extends AbstractMark
     }
 
     @Override
+    public void recordOpticalDuplicatesMarked() {}
+
+    @Override
     protected CommandLineProgram getProgram() { return new MarkDuplicates(); }
 
     @Override

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesTest.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesTest.java
@@ -41,11 +41,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * This class defines the individual test cases to run. The actual running of the test is done

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesTestQueryNameSorted.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesTestQueryNameSorted.java
@@ -24,12 +24,16 @@
 
 package picard.sam.markduplicates;
 
+import org.testng.annotations.Test;
+
 /**
  * The purpose of this class is to show that MarkDuplicates gives (almost) the same results when run on files that
  * are queryname sorted.
  *
  */
 public class MarkDuplicatesTestQueryNameSorted extends MarkDuplicatesTest {
+    final static String TEST_DATA_DIR = "testdata/picard/sam/MarkDuplicates";
+
     @Override
     protected boolean markUnmappedRecordsLikeTheirMates() {
         return true;
@@ -43,5 +47,24 @@ public class MarkDuplicatesTestQueryNameSorted extends MarkDuplicatesTest {
     @Override
     protected AbstractMarkDuplicatesCommandLineProgramTester getTester() {
         return new QuerySortedMarkDuplicatesTester();
+    }
+
+    @Test
+    public void testOpticalDuplicateFinding() {
+        final AbstractMarkDuplicatesCommandLineProgramTester tester = getTester();
+
+        // explicitly creating 1 expected optical duplicate pair
+        tester.setExpectedOpticalDuplicate(2);
+
+        // pass in the read names manually, in order to control duplicates vs optical duplicates
+        tester.addMatePair("READ0:1:1:1:1", 1, 1, 100, false, false, false, false, "50M", "50M", false, true, false,
+                false, false, DEFAULT_BASE_QUALITY); // non-duplicate mapped pair to start
+        tester.addMatePair("READ1:1:1:1:300", 1, 1, 100, false, false, true, true, "50M", "50M", false, true, false,
+                false, false, DEFAULT_BASE_QUALITY); // duplicate pair, NOT optical duplicate (delta-Y > 100)
+        tester.addMatePair("READ1:1:1:1:50", 1, 1, 100, false, false, true, true, "50M", "50M", false, true, false,
+                false, false, DEFAULT_BASE_QUALITY); // two marked optical duplicates in sequence, because the sort order is queryname this might fail
+        tester.addMatePair("READ2:1:1:2:50", 1, 1, 100, false, false, true, true, "50M", "50M", false, true, false,
+                false, false, DEFAULT_BASE_QUALITY); // duplicate pair, expected optical duplicate (delta-X and delta-Y < 100)
+        tester.runTest();
     }
 }

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesWithMateCigarTester.java
@@ -42,5 +42,8 @@ public class MarkDuplicatesWithMateCigarTester extends AbstractMarkDuplicatesCom
     }
 
     @Override
+    public void recordOpticalDuplicatesMarked() {}
+
+    @Override
     protected CommandLineProgram getProgram() { return new MarkDuplicatesWithMateCigar(); }
 }

--- a/src/test/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigarTester.java
@@ -40,6 +40,9 @@ public class SimpleMarkDuplicatesWithMateCigarTester extends AbstractMarkDuplica
     }
 
     @Override
+    public void recordOpticalDuplicatesMarked() {}
+
+    @Override
     protected CommandLineProgram getProgram() { return new SimpleMarkDuplicatesWithMateCigar(); }
 }
 

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
@@ -68,6 +68,9 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
         }
     }
 
+    @Override
+    public void recordOpticalDuplicatesMarked() {}
+
     public void addMatePairWithUmi(final String library, final String umi, final String assignedUMI, final boolean isDuplicate1, final boolean isDuplicate2) {
 
         final String readName = "READ" + readNameCounter++;


### PR DESCRIPTION
I enabled tests for the DT field for all MarkDuplicate family tools for which it is relevant, and added a test that triggered the issue (was miscounting specifically in the case where optical duplicate indexes for a group were next to each-other in the file for querygrouped files).