### PR TITLE
Fixed order dependance bug in graphUtils.cluster() algorithm. 

### DIFF
--- a/src/main/java/picard/util/GraphUtils.java
+++ b/src/main/java/picard/util/GraphUtils.java
@@ -37,6 +37,11 @@ public class GraphUtils {
         final private List<Node> nodes;
         final private List<List<Integer>> neighbors;
 
+        // A public getter for the nodes in the list for iteration, note that this is no
+        public List<Node> getNodes() {
+            return Collections.unmodifiableList(nodes);
+        }
+
         /**
          * returns the cluster map of connected components
          *
@@ -50,7 +55,7 @@ public class GraphUtils {
                     neighbors.get(i).stream().forEach(j -> joinNodes(cluster, j, i)));
 
             // Must call findRepNode() here in case nodes are orphaned and become only transitively equal to roots in their cluster.
-            return nodes.stream().collect(Collectors.toMap(n -> n, n -> findRepNode(cluster, cluster[nodes.indexOf(n)])));
+            return nodes.stream().collect(Collectors.toMap(n -> n, n -> findRepNode(cluster, nodes.indexOf(n))));
 
         }
 

--- a/src/main/java/picard/util/GraphUtils.java
+++ b/src/main/java/picard/util/GraphUtils.java
@@ -49,7 +49,8 @@ public class GraphUtils {
             IntStream.range(0, neighbors.size()).forEach(i ->
                     neighbors.get(i).stream().forEach(j -> joinNodes(cluster, j, i)));
 
-            return nodes.stream().collect(Collectors.toMap(n -> n, n -> cluster[nodes.indexOf(n)]));
+            // Must call findRepNode() here in case nodes are orphaned and become only transitively equal to roots in their cluster.
+            return nodes.stream().collect(Collectors.toMap(n -> n, n -> findRepNode(cluster, cluster[nodes.indexOf(n)])));
 
         }
 

--- a/src/main/java/picard/util/GraphUtils.java
+++ b/src/main/java/picard/util/GraphUtils.java
@@ -37,7 +37,7 @@ public class GraphUtils {
         final private List<Node> nodes;
         final private List<List<Integer>> neighbors;
 
-        // A public getter for the nodes in the list for iteration, note that this is no
+        // A public getter for an unmodifiable list of nodes currently held in the graph for iteration.
         public List<Node> getNodes() {
             return Collections.unmodifiableList(nodes);
         }

--- a/src/test/java/picard/util/GraphUtilsTest.java
+++ b/src/test/java/picard/util/GraphUtilsTest.java
@@ -73,4 +73,39 @@ public class GraphUtilsTest {
         assertNotEquals(fivesCluster, eightsCluster);
         assertNotEquals(eightsCluster, threesCluster);
     }
+
+
+    @Test
+    public void pathologicalInputOrderingTest() {
+        final GraphUtils.Graph<Integer> graph = new GraphUtils.Graph<>();
+
+        final int a = 0, b = 1, c = 2, d = 3, e = 4, f = 5, h = 6, g = 7;
+        graph.addNode(a);
+        graph.addNode(b);
+        graph.addNode(c);
+        graph.addNode(d);
+        graph.addNode(f);
+        graph.addNode(h);
+        graph.addNode(e);
+        graph.addNode(g);
+
+        // This graph is a hand constructed case where the algorithm produces in its final form an orphaned node that only
+        // transitively points to the root for the rest of the graph (node d as it turns out)
+        graph.addEdge(a, h);
+        graph.addEdge(b, f);
+        graph.addEdge(c, h);
+        graph.addEdge(d, f);
+        graph.addEdge(e, h);
+        graph.addEdge(e, f);
+        graph.addEdge(g, a);
+
+        final Map<Integer, Integer> clusters = graph.cluster();
+
+        // 9 nodes
+        assertEquals(clusters.size(), 8);
+
+        // Asserting that this connected graph has every node pointing to the same place
+        final Integer repCluster = clusters.get(a);
+        IntStream.range(0,7).forEach(i -> assertEquals(clusters.get(i), repCluster));
+    }
 }

--- a/src/test/java/picard/util/GraphUtilsTest.java
+++ b/src/test/java/picard/util/GraphUtilsTest.java
@@ -106,6 +106,6 @@ public class GraphUtilsTest {
 
         // Asserting that this connected graph has every node pointing to the same place
         final Integer repCluster = clusters.get(a);
-        IntStream.range(0,7).forEach(i -> assertEquals(clusters.get(i), repCluster));
+        graph.getNodes().forEach(i -> assertEquals(clusters.get(i), repCluster));
     }
 }


### PR DESCRIPTION
The documentation claims that all nodes in the same cluster will have the same representative read as output. As it turns out this would not have been the case for certain graphs with many branching edges and pathological input ordering. I have added a test that demonstrates this problem on the old branch and added an extra step to resolve transitive node parenthood so that we are consistent with the stated behavior. 