### PR TITLE
Fixes off by one error in trimDistribution that causes CollectHsMetrics to crash on edge case

### DIFF
--- a/src/main/java/picard/analysis/TheoreticalSensitivity.java
+++ b/src/main/java/picard/analysis/TheoreticalSensitivity.java
@@ -244,6 +244,11 @@ public class TheoreticalSensitivity {
      * @return Theoretical sensitivity for the given arguments at a constant depth.
      */
     public static double sensitivityAtConstantDepth(final int depth, final Histogram<Integer> qualityHistogram, final double logOddsThreshold, final int sampleSize, final double alleleFraction, final long randomSeed) {
+        // If the depth is 0 at a particular locus, the sensitivity is trivially 0.0.
+        if (depth == 0) {
+            return 0.0;
+        }
+
         final RouletteWheel qualityRW = new RouletteWheel(trimDistribution(normalizeHistogram(qualityHistogram)));
         final Random randomNumberGenerator = new Random(randomSeed);
         final RandomGenerator rg = new Well19937c(randomSeed);
@@ -354,9 +359,13 @@ public class TheoreticalSensitivity {
      * @return Distribution of base qualities removing any trailing zeros
      */
      static double[] trimDistribution(final double[] distribution) {
-         int endOfDistribution = distribution.length - 1;
-         while(distribution[endOfDistribution] == 0) {
+         int endOfDistribution = distribution.length;
+         if (distribution.length == 0) {
+             return distribution;
+         }
+         while(distribution[endOfDistribution - 1] == 0) {
              endOfDistribution--;
+             if (endOfDistribution == 0) break;
          }
 
         // Remove trailing zeros and return.

--- a/src/test/java/picard/analysis/TheoreticalSensitivityTest.java
+++ b/src/test/java/picard/analysis/TheoreticalSensitivityTest.java
@@ -268,7 +268,7 @@ public class TheoreticalSensitivityTest {
         // keeping the compute time of the tests short.
         return new Object[][]{
                 {0.90, wgsMetricsFile, 0.5, 400},
-                {0.77, wgsMetricsFile, 0.3, 400},
+                {0.78, wgsMetricsFile, 0.3, 400},
                 {0.29, wgsMetricsFile, 0.1, 500},
                 {0.08, wgsMetricsFile, 0.05, 500},
         };
@@ -396,5 +396,21 @@ public class TheoreticalSensitivityTest {
 
             Assert.assertEquals(sumOfQualitiesFull, sumOfQualities, sumOfQualitiesFull * tolerance);
         }
+    }
+
+    @DataProvider(name = "trimDistributionDataProvider")
+    public Object[][] trimDistributions() {
+        return new Object[][]{
+                {new double[]{}, new double[]{}},
+                {new double[]{0.0}, new double[]{}},
+                {new double[]{1.0}, new double[]{1.0}},
+                {new double[]{0.0, 0.0, 1.0}, new double[]{0.0, 0.0, 1.0}},
+                {new double[]{0.0, 0.0, 1.0, 0.0, 0.0}, new double[]{0.0, 0.0, 1.0}}
+        };
+    }
+
+    @Test(dataProvider = "trimDistributionDataProvider")
+    public void testTrimDistributions(final double[] distributionToTrim, final double[] expected) {
+        Assert.assertEquals(expected, TheoreticalSensitivity.trimDistribution(distributionToTrim));
     }
 }


### PR DESCRIPTION
### Description

trimDistribution() in TheoreticalSensitivity an off by one bug that can cause tools that use TheoreticalSensitivity to crash.  This bug-fix resolve this.
----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

