### PR TITLE
Fixed a NullPointerException in the OpticalDuplicateFinder

### DIFF
--- a/src/main/java/picard/sam/markduplicates/util/OpticalDuplicateFinder.java
+++ b/src/main/java/picard/sam/markduplicates/util/OpticalDuplicateFinder.java
@@ -126,7 +126,7 @@ public class OpticalDuplicateFinder extends ReadNameParser implements Serializab
         // If there is only one or zero reads passed in (so there are obviously no optical duplicates),
         // or if there are too many reads (so we don't want to try to run this expensive n^2 algorithm),
         // then just return an array of all false
-        if (length < 2 || length > maxDuplicateSetSize) {
+        if (this.readNameRegex == null || length < 2 || length > maxDuplicateSetSize) {
             return opticalDuplicateFlags;
         }
 

--- a/src/main/java/picard/sam/util/ReadNameParser.java
+++ b/src/main/java/picard/sam/util/ReadNameParser.java
@@ -31,7 +31,7 @@ public class ReadNameParser implements Serializable {
 
     private final boolean useOptimizedDefaultParsing; // was the regex default?
 
-    private final String readNameRegex;
+    protected final String readNameRegex;
 
     private Pattern readNamePattern;
 
@@ -63,7 +63,7 @@ public class ReadNameParser implements Serializable {
      * @param log the log to which to write messages.
      */
     public ReadNameParser(final String readNameRegex, final Log log) {
-        this.useOptimizedDefaultParsing = readNameRegex.equals(DEFAULT_READ_NAME_REGEX);
+        this.useOptimizedDefaultParsing = DEFAULT_READ_NAME_REGEX.equals(readNameRegex);
         this.readNameRegex = readNameRegex;
         this.log = log;
     }

--- a/src/test/java/picard/sam/markduplicates/AbstractMarkDuplicatesCommandLineProgramTest.java
+++ b/src/test/java/picard/sam/markduplicates/AbstractMarkDuplicatesCommandLineProgramTest.java
@@ -652,6 +652,17 @@ public abstract class AbstractMarkDuplicatesCommandLineProgramTest {
         tester.runTest();
     }
 
+    @Test
+    public void testOpticalDuplicateBehaviorNullRegex() {
+        final AbstractMarkDuplicatesCommandLineProgramTester tester = getTester();
+        tester.getSamRecordSetBuilder().setReadLength(68);
+        tester.setExpectedOpticalDuplicate(0);
+        tester.addMatePair("RUNID:1:1:15993:13361", 2, 41212324, 41212310, false, false, false, false, "33S35M", "19S49M", true, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.addMatePair("RUNID:1:1:16020:13352", 2, 41212324, 41212319, false, false, true, true, "33S35M", "28S40M", true, true, false, false, false, DEFAULT_BASE_QUALITY);
+        tester.addArg("READ_NAME_REGEX=null");
+        tester.runTest();
+    }
+
     @DataProvider(name = "secondarySupplementaryData")
     public Object[][] secondarySupplementaryData() {
         return new Object[][] {


### PR DESCRIPTION
Fixed an exception I introduced when supplying a null regex for optical duplicate finding, also made the OpticalDuplicateFinder quit out of duplicate finding faster when the readname regex is disabled.
