### PR TITLE
Trim descriptions to shorten --list display width.

### DIFF
--- a/src/main/java/picard/cmdline/CommandLineProgram.java
+++ b/src/main/java/picard/cmdline/CommandLineProgram.java
@@ -89,6 +89,12 @@ public abstract class CommandLineProgram {
     private static String PROPERTY_CONVERT_LEGACY_COMMAND_LINE = "picard.convertCommandLine";
     private static Boolean useLegacyParser;
 
+    /**
+     * CommandLineProgramProperties oneLineSummary attribute must be shorted than this in order to maintain
+     * reasonable help output formatting.
+     */
+    public static int MAX_ALLOWABLE_ONE_LINE_SUMMARY_LENGTH = 120;
+
     @Argument(doc="One or more directories with space available to be used by this program for temporary storage of working files",
             common=true, optional=true)
     public List<File> TMP_DIR = new ArrayList<>();

--- a/src/main/java/picard/cmdline/PicardCommandLine.java
+++ b/src/main/java/picard/cmdline/PicardCommandLine.java
@@ -78,8 +78,8 @@ public class PicardCommandLine {
     private final static String COMMAND_LINE_NAME = PicardCommandLine.class.getSimpleName();
 
     /** Prefixes for class that annotated by @ExperimentalFeature and @BetaFeature **/
-    private final static String BETA_PREFIX = "**BETA FEATURE - WORK IN PROGRESS** ";
-    private final static String EXPERIMENTAL_PREFIX = "**EXPERIMENTAL FEATURE - USE AT YOUR OWN RISK** ";
+    private final static String BETA_PREFIX = "**BETA - WORK IN PROGRESS** ";
+    private final static String EXPERIMENTAL_PREFIX = "**EXPERIMENTAL - USE AT YOUR OWN RISK** ";
 
     /** The packages we wish to include in our command line **/
     protected static List<String> getPackageList() {
@@ -264,8 +264,8 @@ public class PicardCommandLine {
                 if (!commandListOnly) {
                     builder.append(String.format(
                             clazz.getSimpleName().length() >= 45
-                                ? "%s    %s    %s%s%s%s%s\n"
-                                : "%s    %-45s%s%s%s%s%s\n",
+                                ? "%s    %s    %s%s%s%.120s%s\n"
+                                : "%s    %-45s%s%s%s%.120s%s\n",
                             KGRN, clazz.getSimpleName(),
                             KRED, getToolSummaryPrefix(clazz),
                             KCYN, property.oneLineSummary(),

--- a/src/main/java/picard/cmdline/PicardCommandLine.java
+++ b/src/main/java/picard/cmdline/PicardCommandLine.java
@@ -264,8 +264,8 @@ public class PicardCommandLine {
                 if (!commandListOnly) {
                     builder.append(String.format(
                             clazz.getSimpleName().length() >= 45
-                                ? "%s    %s    %s%s%s%.120s%s\n"
-                                : "%s    %-45s%s%s%s%.120s%s\n",
+                                ? "%s    %s    %s%s%s%s%s\n"
+                                : "%s    %-45s%s%s%s%s%s\n",
                             KGRN, clazz.getSimpleName(),
                             KRED, getToolSummaryPrefix(clazz),
                             KCYN, property.oneLineSummary(),

--- a/src/main/java/picard/vcf/GenotypeConcordance.java
+++ b/src/main/java/picard/vcf/GenotypeConcordance.java
@@ -118,13 +118,11 @@ import static picard.vcf.GenotypeConcordanceStateCodes.*;
         programGroup = VariantEvaluationProgramGroup.class)
 @DocumentedFeature
 public class GenotypeConcordance extends CommandLineProgram {
-    static final String USAGE_SUMMARY = "Calculates the concordance between genotype data of one samples in each of two VCFs - one " +
-            " being considered the truth (or reference) the other being the call.  The concordance is broken into separate " +
-            "results sections for SNPs and indels.  Statistics are reported in three different files.";
-            ;
+    static final String USAGE_SUMMARY = "Calculates the concordance between genotype data of one sample in each of two VCFs -" +
+            " truth (or reference) vs. calls.";
     static final String USAGE_DETAILS =
             "<h3>Summary</h3>" +
-            "Calculates the concordance between genotype data of one samples in each of two VCFs - one being considered the truth (or reference) " +
+            "Calculates the concordance between genotype data of one sample in each of two VCFs - one being considered the truth (or reference) " +
             "the other being the call.  The concordance is broken into separate results sections for SNPs and indels.  Summary and detailed statistics " +
             "are reported.\n" +
             "\n" +

--- a/src/test/java/picard/cmdline/PicardCommandLineTest.java
+++ b/src/test/java/picard/cmdline/PicardCommandLineTest.java
@@ -4,10 +4,25 @@ import org.broadinstitute.barclay.argparser.CommandLineArgumentParser;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import java.util.*;
 
 public class PicardCommandLineTest {
+
+    // cache all the command line programs once so we don't have to rediscover them for each test
+    private static Map<Class<CommandLineProgram>, CommandLineProgramProperties> allCLPS = new HashMap<>();
+
+    @BeforeClass
+    public static void getAllCommandLineProgramClasses() {
+        // cache all the command line programs once so we don't have to rediscover them for each test
+        PicardCommandLine.processAllCommandLinePrograms(
+                PicardCommandLine.getPackageList(),
+                (Class<CommandLineProgram> clazz, CommandLineProgramProperties clProperties) -> {
+                    allCLPS.put(clazz, clProperties);
+                });
+        Assert.assertTrue(allCLPS.size() > 0);
+    }
 
     @Test
     public void TestPicardPublic() { // this tests fails if any CLP in picard is missing its @CommandLineProgramProperties annotation
@@ -17,15 +32,9 @@ public class PicardCommandLineTest {
 
     @Test
     public void testProcessCommandLinePrograms() {
-        final List<Class<CommandLineProgram>> allCLPs = new ArrayList<>();
-
-        PicardCommandLine.processAllCommandLinePrograms(
-                Collections.singletonList("picard"),
-                (Class<CommandLineProgram> clazz, CommandLineProgramProperties clProperties) -> {
-                    allCLPs.add(clazz);
-                });
-        Assert.assertTrue(allCLPs.size() > 0);
-        allCLPs.forEach(clazz -> Assert.assertTrue(CommandLineProgram.class.isAssignableFrom(clazz)));
+        allCLPS.forEach((clazz, properties) -> {
+           Assert.assertTrue(CommandLineProgram.class.isAssignableFrom(clazz));
+        });
     }
 
     // Find every CommandLineProgram in picard, instantiate it, and initialize a Barclay parser using the
@@ -36,24 +45,20 @@ public class PicardCommandLineTest {
     // rejected with a CommandLineParserInternalException from the Barclay parser.
     @Test
     public void testLaunchAllCommandLineProgramsWithBarclayParser() {
-        PicardCommandLine.processAllCommandLinePrograms(
-                Collections.singletonList("picard"),
-                (Class<CommandLineProgram> clazz, CommandLineProgramProperties clProperties) -> {
-                    // Check for missing annotations
-                    if (null != clProperties) {
-                        try {
-                            final Object commandLineProgram = clazz.newInstance();
-                            try {
-                                new CommandLineArgumentParser(commandLineProgram);
-                            } catch (CommandLineException.CommandLineParserInternalException e) {
-                                throw new RuntimeException("Barclay command line parser internal exception parsing class: " + clazz.getName(), e);
-                            }
-                        } catch (IllegalAccessException | InstantiationException e) {
-                            throw new RuntimeException("Failure instantiating command line program: " + clazz.getName(), e);
-                        }
-                    }
+        allCLPS.forEach((Class<CommandLineProgram> clazz, CommandLineProgramProperties clProperties) -> {
+            // Check for missing annotations
+            Assert.assertNotNull(clProperties);
+            try {
+                final Object commandLineProgram = clazz.newInstance();
+                try {
+                    new CommandLineArgumentParser(commandLineProgram);
+                } catch (CommandLineException.CommandLineParserInternalException e) {
+                    throw new RuntimeException("Barclay command line parser internal exception parsing class: " + clazz.getName(), e);
                 }
-        );
+            } catch (IllegalAccessException | InstantiationException e) {
+                throw new RuntimeException("Failure instantiating command line program: " + clazz.getName(), e);
+            }
+        });
     }
 
     @Test
@@ -65,14 +70,15 @@ public class PicardCommandLineTest {
     public void testCommandlineProgramPropertiesOneLineSummaryLength() {
         // Find and test each command line tool to ensure that one line
         // summaries don't exceed the maximum allowable length
-        PicardCommandLine.processAllCommandLinePrograms(
-                Collections.singletonList("picard"),
-                (Class<picard.cmdline.CommandLineProgram> clazz, CommandLineProgramProperties clProperties) ->
+        allCLPS.forEach(
+            (Class<picard.cmdline.CommandLineProgram> clazz, CommandLineProgramProperties clProperties) -> {
+                    Assert.assertNotNull(clProperties);
                     Assert.assertTrue(
-                            clProperties.oneLineSummary().length() <= CommandLineProgram.MAX_ALLOWABLE_ONE_LINE_SUMMARY_LENGTH,
-                            String.format("One line summary for tool '%s' exceeds allowable length of %d",
-                                    clazz.getCanonicalName(),
-                                    CommandLineProgram.MAX_ALLOWABLE_ONE_LINE_SUMMARY_LENGTH)));
+                        clProperties.oneLineSummary().length() <= CommandLineProgram.MAX_ALLOWABLE_ONE_LINE_SUMMARY_LENGTH,
+                        String.format("One line summary for tool '%s' exceeds allowable length of %d",
+                                clazz.getCanonicalName(),
+                                CommandLineProgram.MAX_ALLOWABLE_ONE_LINE_SUMMARY_LENGTH));
+            });
     }
 
 }

--- a/src/test/java/picard/cmdline/PicardCommandLineTest.java
+++ b/src/test/java/picard/cmdline/PicardCommandLineTest.java
@@ -60,4 +60,19 @@ public class PicardCommandLineTest {
     public void testPrintUsage() {
         Assert.assertEquals(new PicardCommandLine().instanceMain(new String[]{"-h"}), 1);
     }
+
+    @Test
+    public void testCommandlineProgramPropertiesOneLineSummaryLength() {
+        // Find and test each command line tool to ensure that one line
+        // summaries don't exceed the maximum allowable length
+        PicardCommandLine.processAllCommandLinePrograms(
+                Collections.singletonList("picard"),
+                (Class<picard.cmdline.CommandLineProgram> clazz, CommandLineProgramProperties clProperties) ->
+                    Assert.assertTrue(
+                            clProperties.oneLineSummary().length() <= CommandLineProgram.MAX_ALLOWABLE_ONE_LINE_SUMMARY_LENGTH,
+                            String.format("One line summary for tool '%s' exceeds allowable length of %d",
+                                    clazz.getCanonicalName(),
+                                    CommandLineProgram.MAX_ALLOWABLE_ONE_LINE_SUMMARY_LENGTH)));
+    }
+
 }


### PR DESCRIPTION
Picard part of https://github.com/broadinstitute/gatk/issues/5421.

Before:
<img width="1334" alt="screen shot 2018-12-27 at 9 04 18 am" src="https://user-images.githubusercontent.com/10062863/50482944-50286300-09b7-11e9-94a0-da5d17293e90.png">

After:
<img width="1241" alt="screen shot 2018-12-27 at 9 07 45 am" src="https://user-images.githubusercontent.com/10062863/50482941-4999eb80-09b7-11e9-8155-b46e93e58bc6.png">