### PR TITLE
changing ADD_PG_TAG_TO_READ to boolean

### DIFF
--- a/src/main/java/picard/sam/util/PGTagArgumentCollection.java
+++ b/src/main/java/picard/sam/util/PGTagArgumentCollection.java
@@ -8,6 +8,6 @@ import org.broadinstitute.barclay.argparser.Argument;
 public class PGTagArgumentCollection {
 
     @Argument(doc = "Add PG tag to each read in a SAM or BAM", common = true)
-    public Boolean ADD_PG_TAG_TO_READS = true;
+    public boolean ADD_PG_TAG_TO_READS = true;
 
 }

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesTest.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesTest.java
@@ -376,15 +376,4 @@ public class MarkDuplicatesTest extends AbstractMarkDuplicatesCommandLineProgram
         tester.addArg("DUPLEX_UMI=" + duplexUmi);
         tester.runTest();
     }
-
-    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*boolean field.*")
-    public void testNullFailsFastFor_ADD_PG_TAG_TO_READS(){
-        final AbstractMarkDuplicatesCommandLineProgramTester tester = getTester();
-        tester.getSamRecordSetBuilder().setReadLength(10);
-        tester.addMatePair("READ", 2, 2, 1, 1, false, false, true, true,
-                           "10M", "10M", true, false,
-                           false, false, false, DEFAULT_BASE_QUALITY);
-        tester.addArg("ADD_PG_TAG_TO_READS=null");
-        tester.runTest();
-    }
 }

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesTest.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesTest.java
@@ -376,4 +376,15 @@ public class MarkDuplicatesTest extends AbstractMarkDuplicatesCommandLineProgram
         tester.addArg("DUPLEX_UMI=" + duplexUmi);
         tester.runTest();
     }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*boolean field.*")
+    public void testNullFailsFastFor_ADD_PG_TAG_TO_READS(){
+        final AbstractMarkDuplicatesCommandLineProgramTester tester = getTester();
+        tester.getSamRecordSetBuilder().setReadLength(10);
+        tester.addMatePair("READ", 2, 2, 1, 1, false, false, true, true,
+                           "10M", "10M", true, false,
+                           false, false, false, DEFAULT_BASE_QUALITY);
+        tester.addArg("ADD_PG_TAG_TO_READS=null");
+        tester.runTest();
+    }
 }


### PR DESCRIPTION
### Description

PGTagArgumentCollection.ADD_PG_TAG_TO_READS was a `Boolean` which allowed it to be null, changing it to a` boolean` primitive instead 

This fixes https://github.com/broadinstitute/picard/issues/1261

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

