### PR TITLE
Fixes assert statement in UmiAwareMDWMC tester

### DIFF
--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
@@ -232,7 +232,7 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
         try {
             super.test();
         } catch (IOException ex) {
-            Assert.fail("Could not open metrics file: " + ex);
+            Assert.fail("Could not open metrics file: ", ex);
         }
     }
 


### PR DESCRIPTION
### Description

This is a simple bug fix to fix an assert statement in UmiAwareMDWMC tester.

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

