### PR TITLE
Added handling for indels within CollectHsMetrics and CollectTargetedPcrMetrics.

### DIFF
--- a/src/main/java/picard/analysis/directed/CollectHsMetrics.java
+++ b/src/main/java/picard/analysis/directed/CollectHsMetrics.java
@@ -176,6 +176,6 @@ static final String USAGE_DETAILS = "<p>This tool takes a SAM/BAM file input and
                                               final String probeSetName,
                                               final int nearProbeDistance) {
         return new HsMetricCollector(accumulationLevels, samRgRecords, refFile, perTargetCoverage, perBaseCoverage, targetIntervals, probeIntervals, probeSetName, nearProbeDistance,
-                MINIMUM_MAPPING_QUALITY, MINIMUM_BASE_QUALITY, CLIP_OVERLAPPING_READS, true, COVERAGE_CAP, SAMPLE_SIZE);
+                MINIMUM_MAPPING_QUALITY, MINIMUM_BASE_QUALITY, CLIP_OVERLAPPING_READS, true, INCLUDE_INDELS, COVERAGE_CAP, SAMPLE_SIZE);
     }
 }

--- a/src/main/java/picard/analysis/directed/CollectTargetedMetrics.java
+++ b/src/main/java/picard/analysis/directed/CollectTargetedMetrics.java
@@ -93,6 +93,9 @@ public abstract class CollectTargetedMetrics<METRIC extends MultilevelMetrics, C
     @Argument(doc = "True if we are to clip overlapping reads, false otherwise.", optional=true)
     public boolean CLIP_OVERLAPPING_READS = false;
 
+    @Argument(doc= "If true count inserted bases as on target and deleted bases as covered by a read.")
+    public boolean INCLUDE_INDELS = false;
+
     @Argument(shortName = "covMax", doc = "Parameter to set a max coverage limit for Theoretical Sensitivity calculations. Default is 200.", optional = true)
     public int COVERAGE_CAP = 200;
 

--- a/src/main/java/picard/analysis/directed/CollectTargetedPcrMetrics.java
+++ b/src/main/java/picard/analysis/directed/CollectTargetedPcrMetrics.java
@@ -115,6 +115,6 @@ public class CollectTargetedPcrMetrics extends CollectTargetedMetrics<TargetedPc
                                                         final String probeSetName,
                                                         final int nearProbeDistance) {
         return new TargetedPcrMetricsCollector(accumulationLevels, samRgRecords, refFile, perTargetCoverage, perBaseCoverage, targetIntervals, probeIntervals, probeSetName, nearProbeDistance,
-                MINIMUM_MAPPING_QUALITY, MINIMUM_BASE_QUALITY, CLIP_OVERLAPPING_READS, true, COVERAGE_CAP, SAMPLE_SIZE);
+                MINIMUM_MAPPING_QUALITY, MINIMUM_BASE_QUALITY, CLIP_OVERLAPPING_READS, true, INCLUDE_INDELS, COVERAGE_CAP, SAMPLE_SIZE);
     }
 }

--- a/src/main/java/picard/analysis/directed/HsMetricCollector.java
+++ b/src/main/java/picard/analysis/directed/HsMetricCollector.java
@@ -73,9 +73,10 @@ public class HsMetricCollector extends TargetMetricsCollector<HsMetrics> {
                              final int minimumBaseQuality,
                              final boolean clipOverlappingReads,
                              final boolean noSideEffects,
+                             final boolean includeIndels,
                              final int coverageCap,
                              final int sampleSize) {
-        super(accumulationLevels, samRgRecords, refFile, perTargetCoverage, perBaseCoverage, targetIntervals, probeIntervals, probeSetName, nearProbeDistance, minimumMappingQuality, minimumBaseQuality, clipOverlappingReads, noSideEffects, coverageCap, sampleSize);
+        super(accumulationLevels, samRgRecords, refFile, perTargetCoverage, perBaseCoverage, targetIntervals, probeIntervals, probeSetName, nearProbeDistance, minimumMappingQuality, minimumBaseQuality, clipOverlappingReads, noSideEffects, includeIndels, coverageCap, sampleSize);
     }
 
     @Override

--- a/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
+++ b/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
@@ -555,10 +555,10 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
             //   2. The number of reads contributing to per-base coverage per target
             //   3. Unfiltered coverage information for het sensitivity
             //   4. The count of bases rejected for being low baseq or off-target
-            //   5. The count of on-target bases and on-target bases from paired reads
+            //   5. The count of overall on-target bases, and on-target bases from paired reads
             final Set<Interval> coveredTargets = new HashSet<>(); // Each target is added to this the first time the read covers it
             int readOffset = 0;
-            int refOffset  = rec.getAlignmentStart() -1;
+            int refOffset  = rec.getAlignmentStart() - 1;
 
             for (final CigarElement cig : rec.getCigar()) {
                 final CigarOperator op = cig.getOperator();

--- a/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
+++ b/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
@@ -24,11 +24,7 @@
 
 package picard.analysis.directed;
 
-import htsjdk.samtools.AlignmentBlock;
-import htsjdk.samtools.SAMReadGroupRecord;
-import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.SAMSequenceRecord;
-import htsjdk.samtools.SAMUtils;
+import htsjdk.samtools.*;
 import htsjdk.samtools.metrics.MetricBase;
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.reference.ReferenceSequence;
@@ -130,6 +126,7 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
     private final int minimumBaseQuality;
     private final boolean clipOverlappingReads;
     private boolean noSideEffects;
+    private final boolean includeIndels;
 
     //A map of coverage by target in which coverage is reset every read, this is done
     //so that we can calculate overlap for a read once and the resulting coverage is
@@ -254,7 +251,7 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
                                   final boolean clipOverlappingReads,
                                   final int coverageCap,
                                   final int sampleSize) {
-        this(accumulationLevels, samRgRecords, refFile, perTargetCoverage, perBaseCoverage, targetIntervals, probeIntervals, probeSetName, nearProbeDistance, minimumMappingQuality, minimumBaseQuality, clipOverlappingReads, false, coverageCap, sampleSize);
+        this(accumulationLevels, samRgRecords, refFile, perTargetCoverage, perBaseCoverage, targetIntervals, probeIntervals, probeSetName, nearProbeDistance, minimumMappingQuality, minimumBaseQuality, clipOverlappingReads, false, false, coverageCap, sampleSize);
     }
 
     public TargetMetricsCollector(final Set<MetricAccumulationLevel> accumulationLevels,
@@ -270,6 +267,7 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
                                   final int minimumBaseQuality,
                                   final boolean clipOverlappingReads,
                                   final boolean noSideEffects,
+                                  final boolean includeIndels,
                                   final int coverageCap,
                                   final int sampleSize) {
         this.perTargetCoverage = perTargetCoverage;
@@ -321,6 +319,7 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
         this.minimumBaseQuality = minimumBaseQuality;
         this.clipOverlappingReads = clipOverlappingReads;
         this.noSideEffects = noSideEffects;
+        this.includeIndels = includeIndels;
 
         setup(accumulationLevels, samRgRecords);
     }
@@ -329,7 +328,7 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
     protected PerUnitMetricCollector<METRIC_TYPE, Integer, SAMRecord> makeChildCollector(final String sample, final String library, final String readGroup) {
         final PerUnitTargetMetricCollector collector =  new PerUnitTargetMetricCollector(probeSetName, coverageByTargetForRead.keySet(),
                 sample, library, readGroup, probeTerritory, targetTerritory, genomeSize,
-                intervalToGc, minimumMappingQuality, minimumBaseQuality, clipOverlappingReads);
+                intervalToGc, minimumMappingQuality, minimumBaseQuality, clipOverlappingReads, includeIndels);
         if (this.probeSetName != null) {
             collector.setBaitSetName(probeSetName);
         }
@@ -366,6 +365,7 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
         private final int minimumBaseQuality;
         private final CountingMapQFilter mapQFilter;
         private final boolean clipOverlappingReads;
+        private final boolean includeIndels;
 
         /**
          * Constructor that parses the squashed reference to genome reference file and stores the
@@ -377,7 +377,8 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
                                             final Map<Interval, Double> intervalToGc,
                                             final int minimumMappingQuality,
                                             final int minimumBaseQuality,
-                                            final boolean clipOverlappingReads) {
+                                            final boolean clipOverlappingReads,
+                                            final boolean includeIndels) {
             this.metrics.SAMPLE      = sample;
             this.metrics.LIBRARY     = library;
             this.metrics.READ_GROUP  = readGroup;
@@ -399,6 +400,7 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
             this.minimumBaseQuality = minimumBaseQuality;
             this.intervalToGc = intervalToGc;
             this.clipOverlappingReads = clipOverlappingReads;
+            this.includeIndels = includeIndels;
         }
 
         /** Sets the (optional) File to write per-target coverage information to. If null (the default), no file is produced. */
@@ -548,59 +550,67 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
                 rec = record;
             }
 
+            // Calculate all the things that require examining individual bases in the read. This includes:
+            //   1. Per-base coverage
+            //   2. The number of reads contributing to per-base coverage per target
+            //   3. Unfiltered coverage information for het sensitivity
+            //   4. The count of bases rejected for being low baseq or off-target
+            //   5. The count of on-target bases and on-target bases from paired reads
             // Find the target overlaps
-            final Set<Interval> coveredTargets = new HashSet<>();
-            for (final AlignmentBlock block : rec.getAlignmentBlocks()) {
-                final int length = block.getLength();
-                final int refStart = block.getReferenceStart();
-                final int readStart = block.getReadStart();
+            final Set<Interval> coveredTargets = new HashSet<>(); // Each target is added to this the first time the read covers it
+            int readOffset = 0;
+            int refOffset  = rec.getAlignmentStart() -1;
 
-                for (int offset = 0; offset < length; ++offset) {
-                    final int refPos = refStart + offset;
-                    final int readPos = readStart + offset;
-                    final int qual = baseQualities[readPos - 1];
+            for (final CigarElement cig : rec.getCigar()) {
+                final CigarOperator op = cig.getOperator();
 
-                    if (qual <= 2) {
-                        metrics.PCT_EXC_BASEQ++;
-                        continue;
-                    }
+                for (int i=0; i<cig.getLength(); ++i) {
+                    final int refPos       = refOffset + 1;
+                    final int qual         = baseQualities[readOffset];
+                    final boolean highQual = qual >= this.minimumBaseQuality;
+                    final boolean onTarget = targets.stream().anyMatch(t -> t.getStart() <= refPos && t.getEnd() >= refPos);
+                    final boolean incrementPerTargetCoverage = op != CigarOperator.INSERTION;  // Inserted bases don't have a target position
 
-                    boolean isOnTarget = false;
-                    for (final Interval target : targets) {
-                        if (refPos >= target.getStart() && refPos <= target.getEnd()) {
-                            final int targetOffset = refPos - target.getStart();
+                    if (op.isAlignment() || (this.includeIndels && op.isIndel())) {
+                        // Firstly handle all the summary metrics
+                        if (!highQual) {
+                            metrics.PCT_EXC_BASEQ++;
+                        } else if (!onTarget) {
+                            metrics.PCT_EXC_OFF_TARGET++;
+                        } else {
+                            metrics.ON_TARGET_BASES++;
+                            if (mappedInPair) metrics.ON_TARGET_FROM_PAIR_BASES++;
+                        }
 
-                            // if the base quality exceeds the minimum threshold, then we update various metrics
-                            if (qual >= minimumBaseQuality) {
-                                ++metrics.ON_TARGET_BASES;
-                                if (mappedInPair) ++metrics.ON_TARGET_FROM_PAIR_BASES;
-                                final Coverage highQualityCoverage = highQualityCoverageByTarget.get(target);
-                                highQualityCoverage.addBase(targetOffset);
-                                if (!coveredTargets.contains(target)) {
-                                    highQualityCoverage.incrementReadCount();
-                                    coveredTargets.add(target);
-                                    isOnTarget = true;
+                        // Then go through the per-target/per-base hq and unfiltered coverage
+                        // The cutoff of >= 2 is because even the unfilteredCoverage doesn't want Q1 or Q0 bases!
+                        if (qual > 2 && incrementPerTargetCoverage) {
+                            for (final Interval target : targets) {
+                                if (refPos >= target.getStart() && refPos <= target.getEnd()) {
+                                    final int targetOffset = refPos - target.getStart();
+
+                                    // Unfiltered first (for theoretical het sensitivity)
+                                    final Coverage ufCoverage = unfilteredCoverageByTarget.get(target);
+                                    ufCoverage.addBase(targetOffset);
+                                    if (ufCoverage.getDepths()[targetOffset] <= coverageCap) baseQHistogramArray[qual]++;
+
+                                    // Then filtered
+                                    if (highQual) {
+                                        final Coverage hqCoverage = highQualityCoverageByTarget.get(target);
+                                        hqCoverage.addBase(targetOffset);
+
+                                        if (coveredTargets.add(target)) {
+                                            hqCoverage.incrementReadCount();
+                                        }
+                                    }
                                 }
-
-                            } else {
-                                // the base quality is in the range (2, minimumBaseQuality). we exclude them from the high-quality coverage histogram
-                                this.metrics.PCT_EXC_BASEQ++;
-                            }
-
-                            // even when the base quality is below minimumBaseQuality (but higher than 2), update the base quality and unfiltered coverage histogram for theoretical het sensitivity
-                            // we don't bother with the read count for unfiltered coverage histogram because we don't use it
-                            unfilteredCoverageByTarget.get(target).addBase(targetOffset);
-
-                            // we do not want to increment the base quality histogram for bases that will eventually get thrown out by the coverage cap
-                            if (unfilteredCoverageByTarget.get(target).getDepths()[targetOffset] <= coverageCap){
-                                baseQHistogramArray[qual]++;
                             }
                         }
                     }
 
-                    // a base must not be on target and its base quality must exceed minimumBaseQuality for us to increment PCT_EXC_OFF_TARGET
-                    if (!isOnTarget) this.metrics.PCT_EXC_OFF_TARGET++;
-
+                    // Finally update the offsets!
+                    if (op.consumesReadBases()) readOffset += 1;
+                    if (op.consumesReferenceBases()) refOffset += 1;
                 }
             }
         }

--- a/src/main/java/picard/analysis/directed/TargetedPcrMetricsCollector.java
+++ b/src/main/java/picard/analysis/directed/TargetedPcrMetricsCollector.java
@@ -73,9 +73,10 @@ public class TargetedPcrMetricsCollector extends TargetMetricsCollector<Targeted
                                        final int minimumBaseQuality,
                                        final boolean clipOverlappingReads,
                                        final boolean noSideEffects,
+                                       final boolean includeIndels,
                                        final int coverageCap,
                                        final int sampleSize) {
-        super(accumulationLevels, samRgRecords, refFile, perTargetCoverage, perBaseCoverage, targetIntervals, probeIntervals, probeSetName, nearProbeDistance, minimumMappingQuality, minimumBaseQuality, clipOverlappingReads, noSideEffects, coverageCap, sampleSize);
+        super(accumulationLevels, samRgRecords, refFile, perTargetCoverage, perBaseCoverage, targetIntervals, probeIntervals, probeSetName, nearProbeDistance, minimumMappingQuality, minimumBaseQuality, clipOverlappingReads, noSideEffects, includeIndels, coverageCap, sampleSize);
     }
     @Override
     public TargetedPcrMetrics convertMetric(final TargetMetrics targetMetrics) {

--- a/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
+++ b/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
@@ -61,9 +61,9 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
 
     /** Writes the contents of a SAMRecordSetBuilder out to a file. */
     File writeBam(final SAMRecordSetBuilder builder, final File f) {
-        final SAMFileWriter out = new SAMFileWriterFactory().makeSAMOrBAMWriter(builder.getHeader(), false, f);
-        builder.forEach(out::addAlignment);
-        out.close();
+        try (final SAMFileWriter out = new SAMFileWriterFactory().makeSAMOrBAMWriter(builder.getHeader(), false, f)) {
+            builder.forEach(out::addAlignment);
+        }
         return f;
     }
 
@@ -186,6 +186,8 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
         final HsMetrics insWithoutIndelHandling = readMetrics(out);
         runPicardCommandLine(Arrays.asList("INCLUDE_INDELS=true", "SAMPLE_SIZE=0", "TI="+ts.getPath(), "BI="+bs.getPath(), "O="+out.getPath(), "I="+withInsBam.getAbsolutePath()));
         final HsMetrics insWithIndelHandling = readMetrics(out);
+
+        IOUtil.deleteDirectoryTree(dir);
 
         Assert.assertEquals(delsWithoutIndelHandling.MEAN_TARGET_COVERAGE, 90.0);  // 100X over 180/200 bases due to deletion
         Assert.assertEquals(delsWithIndelHandling.MEAN_TARGET_COVERAGE, 100.0);    // 100X with counting the deletion

--- a/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
+++ b/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
@@ -1,7 +1,11 @@
 package picard.analysis.directed;
 
+import htsjdk.samtools.SAMFileHeader.SortOrder;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMRecordSetBuilder;
 import htsjdk.samtools.metrics.MetricsFile;
-import htsjdk.samtools.util.Histogram;
+import htsjdk.samtools.util.*;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -10,6 +14,8 @@ import picard.cmdline.CommandLineProgramTest;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
 
 public class CollectHsMetricsTest extends CommandLineProgramTest {
     private final static File TEST_DIR = new File("testdata/picard/analysis/directed/CollectHsMetrics");
@@ -39,6 +45,26 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
                 {TEST_DIR + "/single-short-read.sam", twoSmallIntervals, 20, 20, true, 1, 10, 0.0, 0.0, 0.5, 0.0, 1, 1000 }
 
         };
+    }
+
+    /** Read back the first metrics record in an hs metrics file. */
+    HsMetrics readMetrics(final File f) {
+        try {
+            final MetricsFile<HsMetrics, Comparable<?>> mFile = new MetricsFile<HsMetrics, Comparable<?>>();
+            mFile.read(new FileReader(f));
+            return mFile.getMetrics().get(0);
+        }
+        catch (IOException ioe) {
+             throw new RuntimeIOException(ioe);
+        }
+    }
+
+    /** Writes the contents of a SAMRecordSetBuilder out to a file. */
+    File writeBam(final SAMRecordSetBuilder builder, final File f) {
+        final SAMFileWriter out = new SAMFileWriterFactory().makeSAMOrBAMWriter(builder.getHeader(), false, f);
+        builder.forEach(out::addAlignment);
+        out.close();
+        return f;
     }
 
     @Test(dataProvider = "collectHsMetricsDataProvider")
@@ -72,19 +98,14 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
 
         Assert.assertEquals(runPicardCommandLine(args), 0);
 
-        final MetricsFile<HsMetrics, Comparable<?>> output = new MetricsFile<HsMetrics, Comparable<?>>();
-        output.read(new FileReader(outfile));
-
-        for (final HsMetrics metrics : output.getMetrics()) {
-            // overlap
-            Assert.assertEquals(metrics.TOTAL_READS, totalReads);
-            Assert.assertEquals(metrics.PF_UQ_BASES_ALIGNED, pfUqBasesAligned);
-            Assert.assertEquals(metrics.PCT_EXC_BASEQ, pctExcBaseq);
-            Assert.assertEquals(metrics.PCT_EXC_OVERLAP, pctExcOverlap);
-            Assert.assertEquals(metrics.PCT_TARGET_BASES_1X, pctTargetBases1x);
-            Assert.assertEquals(metrics.PCT_TARGET_BASES_2X, pctTargetBases2x);
-            Assert.assertEquals(metrics.MAX_TARGET_COVERAGE, maxTargetCoverage);
-        }
+        final HsMetrics metrics = readMetrics(outfile);
+        Assert.assertEquals(metrics.TOTAL_READS, totalReads);
+        Assert.assertEquals(metrics.PF_UQ_BASES_ALIGNED, pfUqBasesAligned);
+        Assert.assertEquals(metrics.PCT_EXC_BASEQ, pctExcBaseq);
+        Assert.assertEquals(metrics.PCT_EXC_OVERLAP, pctExcOverlap);
+        Assert.assertEquals(metrics.PCT_TARGET_BASES_1X, pctTargetBases1x);
+        Assert.assertEquals(metrics.PCT_TARGET_BASES_2X, pctTargetBases2x);
+        Assert.assertEquals(metrics.MAX_TARGET_COVERAGE, maxTargetCoverage);
     }
 
     @Test
@@ -127,5 +148,49 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
         final Histogram<Integer> coverageHistogram = output.getAllHistograms().get(0);
         Assert.assertEquals(coverageHistogram.get(0).getValue(), 10.0);
         Assert.assertEquals(coverageHistogram.get(1).getValue(), 10.0);
+    }
+
+    @Test
+    public void testHsMetricsHandlesIndelsAppropriately() throws IOException {
+        final SAMRecordSetBuilder withDeletions = new SAMRecordSetBuilder(true, SortOrder.coordinate);
+        final SAMRecordSetBuilder withInsertions = new SAMRecordSetBuilder(true, SortOrder.coordinate);
+        final IntervalList targets = new IntervalList(withDeletions.getHeader());
+        final IntervalList baits   = new IntervalList(withDeletions.getHeader());
+        targets.add(new Interval("chr1", 1000, 1199, false, "t1"));
+        baits.add(new Interval("chr1", 950,  1049, false, "b1"));
+        baits.add(new Interval("chr1", 1050, 1149, false, "b2"));
+        baits.add(new Interval("chr1", 1150, 1249, false, "b3"));
+
+        // Generate 100 reads that fully cover the the target in each BAM
+        for (int i=0; i<100; ++i) {
+            withDeletions.addFrag( "d" + i, 0, 1000, false, false, "100M20D80M", null, 30);
+            withInsertions.addFrag("i" + i, 0, 1000, false, false, "100M50I100M", null, 30);
+        }
+
+        // Write things out to file
+        final File dir = IOUtil.createTempDir("hsmetrics.", ".test");
+        final File bs = new File(dir, "baits.interval_list").getAbsoluteFile();
+        final File ts = new File(dir, "targets.interval_list").getAbsoluteFile();
+        baits.write(bs);
+        targets.write(ts);
+        final File withDelBam = writeBam(withDeletions,  new File(dir, "with_del.bam"));
+        final File withInsBam = writeBam(withInsertions, new File(dir, "with_ins.bam"));
+
+        // Now run CollectHsMetrics four times
+        final File out = Files.createTempFile("hsmetrics.", ".txt").toFile();
+        runPicardCommandLine(Arrays.asList("INCLUDE_INDELS=false", "SAMPLE_SIZE=0", "TI=", ts.getPath(), "BI=", bs.getPath(), "O=", out.getPath(), "I=", withDelBam.getAbsolutePath()));
+        final HsMetrics delsWithoutIndelHandling = readMetrics(out);
+        runPicardCommandLine(Arrays.asList("INCLUDE_INDELS=true", "SAMPLE_SIZE=0", "TI=", ts.getPath(), "BI=", bs.getPath(), "O=", out.getPath(), "I=", withDelBam.getAbsolutePath()));
+        final HsMetrics delsWithIndelHandling = readMetrics(out);
+        runPicardCommandLine(Arrays.asList("INCLUDE_INDELS=false", "SAMPLE_SIZE=0", "TI=", ts.getPath(), "BI=", bs.getPath(), "O=", out.getPath(), "I=", withInsBam.getAbsolutePath()));
+        final HsMetrics insWithoutIndelHandling = readMetrics(out);
+        runPicardCommandLine(Arrays.asList("INCLUDE_INDELS=true", "SAMPLE_SIZE=0", "TI=", ts.getPath(), "BI=", bs.getPath(), "O=", out.getPath(), "I=", withInsBam.getAbsolutePath()));
+        final HsMetrics insWithIndelHandling = readMetrics(out);
+
+        Assert.assertEquals(delsWithoutIndelHandling.MEAN_TARGET_COVERAGE, 90.0);  // 100X over 180/200 bases due to deletion
+        Assert.assertEquals(delsWithIndelHandling.MEAN_TARGET_COVERAGE, 100.0);    // 100X with counting the deletion
+
+        Assert.assertEquals(insWithoutIndelHandling.PCT_USABLE_BASES_ON_TARGET, 200/250d); // 50/250 inserted bases are not counted as on target
+        Assert.assertEquals(insWithIndelHandling.PCT_USABLE_BASES_ON_TARGET,   1.0d);      // inserted bases are counted as on target
     }
 }

--- a/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
+++ b/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
@@ -178,13 +178,13 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
 
         // Now run CollectHsMetrics four times
         final File out = Files.createTempFile("hsmetrics.", ".txt").toFile();
-        runPicardCommandLine(Arrays.asList("INCLUDE_INDELS=false", "SAMPLE_SIZE=0", "TI=", ts.getPath(), "BI=", bs.getPath(), "O=", out.getPath(), "I=", withDelBam.getAbsolutePath()));
+        runPicardCommandLine(Arrays.asList("INCLUDE_INDELS=false", "SAMPLE_SIZE=0", "TI="+ts.getPath(), "BI="+bs.getPath(), "O="+out.getPath(), "I="+withDelBam.getAbsolutePath()));
         final HsMetrics delsWithoutIndelHandling = readMetrics(out);
-        runPicardCommandLine(Arrays.asList("INCLUDE_INDELS=true", "SAMPLE_SIZE=0", "TI=", ts.getPath(), "BI=", bs.getPath(), "O=", out.getPath(), "I=", withDelBam.getAbsolutePath()));
+        runPicardCommandLine(Arrays.asList("INCLUDE_INDELS=true", "SAMPLE_SIZE=0", "TI="+ts.getPath(), "BI="+bs.getPath(), "O="+out.getPath(), "I="+withDelBam.getAbsolutePath()));
         final HsMetrics delsWithIndelHandling = readMetrics(out);
-        runPicardCommandLine(Arrays.asList("INCLUDE_INDELS=false", "SAMPLE_SIZE=0", "TI=", ts.getPath(), "BI=", bs.getPath(), "O=", out.getPath(), "I=", withInsBam.getAbsolutePath()));
+        runPicardCommandLine(Arrays.asList("INCLUDE_INDELS=false", "SAMPLE_SIZE=0", "TI="+ts.getPath(), "BI="+bs.getPath(), "O="+out.getPath(), "I="+withInsBam.getAbsolutePath()));
         final HsMetrics insWithoutIndelHandling = readMetrics(out);
-        runPicardCommandLine(Arrays.asList("INCLUDE_INDELS=true", "SAMPLE_SIZE=0", "TI=", ts.getPath(), "BI=", bs.getPath(), "O=", out.getPath(), "I=", withInsBam.getAbsolutePath()));
+        runPicardCommandLine(Arrays.asList("INCLUDE_INDELS=true", "SAMPLE_SIZE=0", "TI="+ts.getPath(), "BI="+bs.getPath(), "O="+out.getPath(), "I="+withInsBam.getAbsolutePath()));
         final HsMetrics insWithIndelHandling = readMetrics(out);
 
         Assert.assertEquals(delsWithoutIndelHandling.MEAN_TARGET_COVERAGE, 90.0);  // 100X over 180/200 bases due to deletion


### PR DESCRIPTION
### Description

When the INCLUDE_INDELS parameter is set to true:
  1. Deletions within reads are treated as covering the reference bases if the preceding base is high quality
  2. Inserted bases are counted as "on-target" but don't contribute coverage to any target base(s)

There are two motivations for this change:
1. I want to be able to use CollectHsMetrics' per-base coverage output to assess how well an assay is covering target bases.  If the sample being sequenced has one or more short deletions within the targets this results in a precipitous drop in target coverage.  However, I'd argue that those bases in the reference/target are covered, and if covered sufficiently will allow for a deletion to be called in variant calling.
2. When the het sensitivity code was introduced a bug was introduced that would lead to reads being double-counted in some places if a read overlapped more than one target.  E.g. I would expect that, other than for rounding issues, `PCT_USABLE_BASES_ON_TARGET` + `PCT_EXC_*` to add up to 1.0.  However I would frequently see this adding up to substantially over 1.0.  

I've done my best to re-organize the code to make it easier to follow and maintain in future.

### Checklist


#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable
