### PR TITLE
demultiplex only when we should

### DIFF
--- a/src/main/java/picard/illumina/ClusterDataToSamConverter.java
+++ b/src/main/java/picard/illumina/ClusterDataToSamConverter.java
@@ -123,7 +123,7 @@ public class ClusterDataToSamConverter implements
         this.readNameEncoder = new IlluminaReadNameEncoder(runBarcode);
 
         this.isPairedEnd = readStructure.templates.length() == 2;
-        this.hasSampleBarcode = !readStructure.sampleBarcodes.isEmpty();
+        this.hasSampleBarcode = readStructure.hasSampleBarcode();
         this.hasMolecularBarcode = !readStructure.molecularBarcode.isEmpty();
 
         if (adapters.isEmpty()) {

--- a/src/main/java/picard/illumina/IlluminaBasecallsConverter.java
+++ b/src/main/java/picard/illumina/IlluminaBasecallsConverter.java
@@ -789,7 +789,7 @@ public class IlluminaBasecallsConverter<CLUSTER_OUTPUT_RECORD> extends Basecalls
      */
     private static IlluminaDataType[] getDataTypesFromReadStructure(final ReadStructure readStructure,
                                                                     final boolean demultiplex) {
-        if (readStructure.sampleBarcodes.isEmpty() || !demultiplex) {
+        if (!readStructure.hasSampleBarcode() || !demultiplex) {
             return DATA_TYPES_NO_BARCODE;
         } else {
             return DATA_TYPES_WITH_BARCODE;

--- a/src/main/java/picard/illumina/IlluminaBasecallsToSam.java
+++ b/src/main/java/picard/illumina/IlluminaBasecallsToSam.java
@@ -305,17 +305,18 @@ public class IlluminaBasecallsToSam extends CommandLineProgram {
             adapters.add(new CustomAdapterPair(FIVE_PRIME_ADAPTER, THREE_PRIME_ADAPTER));
         }
 
+        final boolean demultiplex = !readStructure.sampleBarcodes.isEmpty();
         if (IlluminaFileUtil.hasCbcls(BASECALLS_DIR, LANE)) {
             if (BARCODES_DIR == null) BARCODES_DIR = BASECALLS_DIR;
             basecallsConverter = new NewIlluminaBasecallsConverter<>(BASECALLS_DIR, BARCODES_DIR, LANE, readStructure,
-                    barcodeSamWriterMap, true, Math.max(1, MAX_READS_IN_RAM_PER_TILE / numOutputRecords),
+                    barcodeSamWriterMap, demultiplex, Math.max(1, MAX_READS_IN_RAM_PER_TILE / numOutputRecords),
                     TMP_DIR, NUM_PROCESSORS,
                     FIRST_TILE, TILE_LIMIT, new QueryNameComparator(),
                     new Codec(numOutputRecords),
                     SAMRecordsForCluster.class, bclQualityEvaluationStrategy, IGNORE_UNEXPECTED_BARCODES);
         } else {
             basecallsConverter = new IlluminaBasecallsConverter<>(BASECALLS_DIR, BARCODES_DIR, LANE, readStructure,
-                    barcodeSamWriterMap, true, MAX_READS_IN_RAM_PER_TILE / numOutputRecords, TMP_DIR, NUM_PROCESSORS, FORCE_GC,
+                    barcodeSamWriterMap, demultiplex, MAX_READS_IN_RAM_PER_TILE / numOutputRecords, TMP_DIR, NUM_PROCESSORS, FORCE_GC,
                     FIRST_TILE, TILE_LIMIT, new QueryNameComparator(), new Codec(numOutputRecords), SAMRecordsForCluster.class,
                     bclQualityEvaluationStrategy, APPLY_EAMSS_FILTER, INCLUDE_NON_PF_READS, IGNORE_UNEXPECTED_BARCODES);
         }

--- a/src/main/java/picard/illumina/IlluminaBasecallsToSam.java
+++ b/src/main/java/picard/illumina/IlluminaBasecallsToSam.java
@@ -305,7 +305,7 @@ public class IlluminaBasecallsToSam extends CommandLineProgram {
             adapters.add(new CustomAdapterPair(FIVE_PRIME_ADAPTER, THREE_PRIME_ADAPTER));
         }
 
-        final boolean demultiplex = !readStructure.sampleBarcodes.isEmpty();
+        final boolean demultiplex = readStructure.hasSampleBarcode();
         if (IlluminaFileUtil.hasCbcls(BASECALLS_DIR, LANE)) {
             if (BARCODES_DIR == null) BARCODES_DIR = BASECALLS_DIR;
             basecallsConverter = new NewIlluminaBasecallsConverter<>(BASECALLS_DIR, BARCODES_DIR, LANE, readStructure,
@@ -531,7 +531,7 @@ public class IlluminaBasecallsToSam extends CommandLineProgram {
         final ArrayList<String> messages = new ArrayList<>();
 
         readStructure = new ReadStructure(READ_STRUCTURE);
-        if (!readStructure.sampleBarcodes.isEmpty() && LIBRARY_PARAMS == null) {
+        if (readStructure.hasSampleBarcode() && LIBRARY_PARAMS == null) {
             messages.add("BARCODE_PARAMS or LIBRARY_PARAMS is missing.  If READ_STRUCTURE contains a B (barcode)" +
                     " then either LIBRARY_PARAMS or BARCODE_PARAMS(deprecated) must be provided!");
         }

--- a/src/main/java/picard/illumina/parser/ReadStructure.java
+++ b/src/main/java/picard/illumina/parser/ReadStructure.java
@@ -248,6 +248,10 @@ public class ReadStructure {
         return res;
     }
 
+    public boolean hasSampleBarcode() {
+        return !sampleBarcodes.isEmpty();
+    }
+
     /** Represents a subset of ReadDescriptors in the containing ReadStructure, they ARE NOT necessarily contiguous
      *  in the containing ReadStructure but they ARE in the order they appear in the containing ReadStructure */
     public class Substructure implements Iterable<ReadDescriptor> {


### PR DESCRIPTION
### Description

Currently, IlluminaBasecallsToSam always demultiplexes. We should only demultiplex when the read structure indicates we should.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

