### PR TITLE
Add IntervalListTools COUNT action

### DIFF
--- a/src/main/java/picard/util/IntervalListTools.java
+++ b/src/main/java/picard/util/IntervalListTools.java
@@ -41,6 +41,7 @@ import picard.util.IntervalList.IntervalListScatterMode;
 import picard.util.IntervalList.IntervalListScatterer;
 
 import java.io.File;
+import java.io.PrintWriter;
 import java.text.DecimalFormat;
 import java.util.*;
 
@@ -219,6 +220,13 @@ public class IntervalListTools extends CommandLineProgram {
                     "       O=new.interval_list" +
                     " </pre>" +
                     "" +
+                    " <h4>4. Count bases and intervals in input1.interval_list:</h4>" +
+                    " <pre>" +
+                    " java -jar picard.jar IntervalListTools \\\n" +
+                    "       ACTION=COUNT \\\n" +
+                    "       I=input1.interval_list" +
+                    " </pre>" +
+                    "" +
                     "";
 
     @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME,
@@ -335,7 +343,14 @@ public class IntervalListTools extends CommandLineProgram {
             IntervalList act(final List<IntervalList> list1, final List<IntervalList> list2) {
                 return IntervalList.overlaps(list1, list2);
             }
-        };
+        },
+        COUNT("Count number of unique bases in INPUT.  This action behaves identically to CONCAT and is provided as an intuitive convenience.",false) {
+            @Override
+            IntervalList act(final List<IntervalList> list, final List<IntervalList> unused){
+                return IntervalList.concatenate(list);
+            }
+        }
+        ;
 
         final String helpdoc;
         final boolean takesSecondInput;

--- a/src/main/java/picard/util/IntervalListTools.java
+++ b/src/main/java/picard/util/IntervalListTools.java
@@ -219,7 +219,7 @@ public class IntervalListTools extends CommandLineProgram {
                     "       O=new.interval_list" +
                     " </pre>" +
                     "" +
-                    " <h4>4. Count bases in input1.interval_list:</h4>" +
+                    " <h4>5. Count bases in input1.interval_list:</h4>" +
                     " <pre>" +
                     " java -jar picard.jar IntervalListTools \\\n" +
                     "       ACTION=COUNT \\\n" +

--- a/src/main/java/picard/util/IntervalListTools.java
+++ b/src/main/java/picard/util/IntervalListTools.java
@@ -24,7 +24,6 @@
 
 package picard.util;
 
-import com.google.common.io.CountingOutputStream;
 import htsjdk.samtools.SAMException;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMProgramRecord;

--- a/src/main/java/picard/util/IntervalListTools.java
+++ b/src/main/java/picard/util/IntervalListTools.java
@@ -344,7 +344,7 @@ public class IntervalListTools extends CommandLineProgram {
                 return IntervalList.overlaps(list1, list2);
             }
         },
-        COUNT("Count number of unique bases in INPUT.  This action behaves identically to CONCAT and is provided as an intuitive convenience.",false) {
+        COUNT("Count number of unique bases or intervals in INPUT.  This action behaves identically to CONCAT and is provided as an intuitively named convenience.",false) {
             @Override
             IntervalList act(final List<IntervalList> list, final List<IntervalList> unused){
                 return IntervalList.concatenate(list);

--- a/src/main/java/picard/util/IntervalListTools.java
+++ b/src/main/java/picard/util/IntervalListTools.java
@@ -41,7 +41,6 @@ import picard.util.IntervalList.IntervalListScatterMode;
 import picard.util.IntervalList.IntervalListScatterer;
 
 import java.io.File;
-import java.io.PrintWriter;
 import java.text.DecimalFormat;
 import java.util.*;
 
@@ -220,11 +219,12 @@ public class IntervalListTools extends CommandLineProgram {
                     "       O=new.interval_list" +
                     " </pre>" +
                     "" +
-                    " <h4>4. Count bases and intervals in input1.interval_list:</h4>" +
+                    " <h4>4. Count bases in input1.interval_list:</h4>" +
                     " <pre>" +
                     " java -jar picard.jar IntervalListTools \\\n" +
                     "       ACTION=COUNT \\\n" +
-                    "       I=input1.interval_list" +
+                    "       I=input1.interval_list \\\n" +
+                    "       OUTPUT_VALUE=BASES" +
                     " </pre>" +
                     "" +
                     "";

--- a/src/main/java/picard/util/IntervalListTools.java
+++ b/src/main/java/picard/util/IntervalListTools.java
@@ -40,10 +40,7 @@ import picard.cmdline.programgroups.IntervalsManipulationProgramGroup;
 import picard.util.IntervalList.IntervalListScatterMode;
 import picard.util.IntervalList.IntervalListScatterer;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.*;
 import java.text.DecimalFormat;
 import java.util.*;
 
@@ -282,22 +279,22 @@ public class IntervalListTools extends CommandLineProgram {
 
     enum Output {
         NONE {
-            void output(final long totalBaseCount, final long intervalCount, final PrintWriter writer){
+            void output(final long totalBaseCount, final long intervalCount, final PrintStream writer){
 
             }
         },
         BASES {
-            void output(final long totalBaseCount, final long intervalCount, final PrintWriter writer) {
+            void output(final long totalBaseCount, final long intervalCount, final PrintStream writer) {
                 writer.println(totalBaseCount);
             }
         },
         INTERVALS {
-            void output(final long totalBaseCount, final long intervalCount, final PrintWriter writer) {
+            void output(final long totalBaseCount, final long intervalCount, final PrintStream writer) {
                 writer.println(intervalCount);
             }
         };
 
-        abstract void output(final long totalBaseCount, final long intervalCount, final PrintWriter writer);
+        abstract void output(final long totalBaseCount, final long intervalCount, final PrintStream writer);
     }
 
     private static final Log LOG = Log.getInstance(IntervalListTools.class);
@@ -467,14 +464,15 @@ public class IntervalListTools extends CommandLineProgram {
         LOG.info("Produced " + intervalCount + " intervals totalling " + totalBaseCount + " bases.");
         if (COUNT_OUTPUT != null) {
             IOUtil.assertFileIsWritable(COUNT_OUTPUT);
-            try {
-                final PrintWriter countWriter = new PrintWriter(new FileWriter(COUNT_OUTPUT));
+            try (final PrintStream countWriter = new PrintStream(COUNT_OUTPUT)){
                 OUTPUT_VALUE.output(totalBaseCount, intervalCount,countWriter);
-                countWriter.close();
             }
             catch (final IOException e) {
                 throw new PicardException("There was a problem writing count to "+COUNT_OUTPUT.getAbsolutePath());
             }
+        }
+        else {
+            OUTPUT_VALUE.output(totalBaseCount,intervalCount,System.out);
         }
         return 0;
     }

--- a/src/main/java/picard/util/IntervalListTools.java
+++ b/src/main/java/picard/util/IntervalListTools.java
@@ -366,6 +366,9 @@ public class IntervalListTools extends CommandLineProgram {
         // Check inputs
         IOUtil.assertFilesAreReadable(INPUT);
         IOUtil.assertFilesAreReadable(SECOND_INPUT);
+        if (COUNT_OUTPUT != null) {
+            IOUtil.assertFileIsWritable(COUNT_OUTPUT);
+        }
 
         // Read in the interval lists and apply any padding
         final List<IntervalList> lists = openIntervalLists(INPUT);
@@ -466,7 +469,6 @@ public class IntervalListTools extends CommandLineProgram {
 
         LOG.info("Produced " + intervalCount + " intervals totalling " + totalBaseCount + " bases.");
         if (COUNT_OUTPUT != null) {
-            IOUtil.assertFileIsWritable(COUNT_OUTPUT);
             try (final PrintStream countStream = new PrintStream(COUNT_OUTPUT)) {
                 OUTPUT_VALUE.output(totalBaseCount, intervalCount, countStream);
             }

--- a/src/main/java/picard/util/IntervalListTools.java
+++ b/src/main/java/picard/util/IntervalListTools.java
@@ -349,8 +349,7 @@ public class IntervalListTools extends CommandLineProgram {
             IntervalList act(final List<IntervalList> list, final List<IntervalList> unused){
                 return IntervalList.concatenate(list);
             }
-        }
-        ;
+        };
 
         final String helpdoc;
         final boolean takesSecondInput;

--- a/src/test/java/picard/util/IntervalListToolsTest.java
+++ b/src/test/java/picard/util/IntervalListToolsTest.java
@@ -69,12 +69,7 @@ public class IntervalListToolsTest extends CommandLineProgramTest {
             intervalListTools.OUTPUT_VALUE = output_value;
             intervalListTools.COUNT_OUTPUT = null;
             String[] errors = intervalListTools.customCommandLineValidation();
-            if (output_value == IntervalListTools.Output.NONE) {
-                Assert.assertNull(errors);
-            }
-            else {
-                Assert.assertTrue(errors.length == 1);
-            }
+            Assert.assertNull(errors);
 
             intervalListTools.COUNT_OUTPUT = new File("fakefile");
             errors = intervalListTools.customCommandLineValidation();
@@ -249,7 +244,7 @@ public class IntervalListToolsTest extends CommandLineProgramTest {
             args.add("OUTPUT_VALUE=" + outputValue);
         }
 
-        args.add("COUNT_OUTPUT="+countOutput);
+        args.add("COUNT_OUTPUT=" + countOutput);
 
         Assert.assertEquals(runPicardCommandLine(args), 0);
 

--- a/src/test/java/picard/util/IntervalListToolsTest.java
+++ b/src/test/java/picard/util/IntervalListToolsTest.java
@@ -61,6 +61,32 @@ public class IntervalListToolsTest extends CommandLineProgramTest {
         Assert.assertTrue(errors.length == 1);
     }
 
+    @Test
+    public void testCountOutputValidation() {
+        final IntervalListTools intervalListTools = new IntervalListTools();
+
+        for(IntervalListTools.Output output_value : IntervalListTools.Output.values()) {
+            intervalListTools.OUTPUT_VALUE = output_value;
+            intervalListTools.COUNT_OUTPUT = null;
+            String[] errors = intervalListTools.customCommandLineValidation();
+            if (output_value == IntervalListTools.Output.NONE) {
+                Assert.assertNull(errors);
+            }
+            else {
+                Assert.assertTrue(errors.length == 1);
+            }
+
+            intervalListTools.COUNT_OUTPUT = new File("fakefile");
+            errors = intervalListTools.customCommandLineValidation();
+            if (output_value == IntervalListTools.Output.NONE) {
+                Assert.assertTrue(errors.length == 1);
+            }
+            else {
+                Assert.assertNull(errors);
+            }
+        }
+    }
+
     @Override
     public String getCommandLineProgramName() {
         return IntervalListTools.class.getSimpleName();
@@ -108,7 +134,6 @@ public class IntervalListToolsTest extends CommandLineProgramTest {
         Assert.assertEquals(il.getBaseCount(), bases, "unexpected number of bases found.");
         Assert.assertEquals(il.getIntervals().size(), intervals, "unexpected number of intervals found.");
 
-        Assert.assertEquals(testerCountOutput(action,null),bases,"unexpected number of bases written to count_output file.");
         Assert.assertEquals(testerCountOutput(action,IntervalListTools.Output.BASES),bases, "unexpected number of bases written to count_output file.");
         Assert.assertEquals(testerCountOutput(action,IntervalListTools.Output.INTERVALS),intervals,"unexpected number of intervals written to count_output file.");
     }
@@ -133,7 +158,6 @@ public class IntervalListToolsTest extends CommandLineProgramTest {
         Assert.assertEquals(il.getBaseCount(), bases, "unexpected number of bases found.");
         Assert.assertEquals(il.getIntervals().size(), intervals, "unexpected number of intervals found.");
 
-        Assert.assertEquals(testerCountOutput(action, null, true, false), bases, "unexpected number of bases written to count_output file.");
         Assert.assertEquals(testerCountOutput(action, IntervalListTools.Output.BASES, true, false), bases, "unexpected number of bases written to count_output file.");
         Assert.assertEquals(testerCountOutput(action, IntervalListTools.Output.INTERVALS, true, false), intervals, "unexpected number of intervals written to count_output file.");
     }
@@ -156,7 +180,6 @@ public class IntervalListToolsTest extends CommandLineProgramTest {
         Assert.assertEquals(il.getBaseCount(), bases, "unexpected number of bases found.");
         Assert.assertEquals(il.getIntervals().size(), intervals, "unexpected number of intervals found.");
 
-        Assert.assertEquals(testerCountOutput(action, null, false, true), bases, "unexpected number of bases written to count_output file.");
         Assert.assertEquals(testerCountOutput(action, IntervalListTools.Output.BASES, false, true), bases, "unexpected number of bases written to count_output file.");
         Assert.assertEquals(testerCountOutput(action, IntervalListTools.Output.INTERVALS, false, true), intervals, "unexpected number of intervals written to count_output file.");
     }

--- a/src/test/java/picard/util/IntervalListToolsTest.java
+++ b/src/test/java/picard/util/IntervalListToolsTest.java
@@ -102,7 +102,7 @@ public class IntervalListToolsTest extends CommandLineProgramTest {
                 {IntervalListTools.Action.SUBTRACT, 60, 2},
                 {IntervalListTools.Action.SYMDIFF, 61, 3},
                 {IntervalListTools.Action.OVERLAPS, 150, 2},
-                {IntervalListTools.Action.COUNT,341,4}
+                {IntervalListTools.Action.COUNT, 341, 4}
         };
     }
 

--- a/src/test/java/picard/util/IntervalListToolsTest.java
+++ b/src/test/java/picard/util/IntervalListToolsTest.java
@@ -102,6 +102,7 @@ public class IntervalListToolsTest extends CommandLineProgramTest {
                 {IntervalListTools.Action.SUBTRACT, 60, 2},
                 {IntervalListTools.Action.SYMDIFF, 61, 3},
                 {IntervalListTools.Action.OVERLAPS, 150, 2},
+                {IntervalListTools.Action.COUNT,341,4}
         };
     }
 
@@ -123,6 +124,7 @@ public class IntervalListToolsTest extends CommandLineProgramTest {
                 {IntervalListTools.Action.SUBTRACT, totalBasesInDict - 60, 2 + totalContigsInDict},
                 {IntervalListTools.Action.SYMDIFF, totalBasesInDict - 61, 3 + totalContigsInDict},
                 {IntervalListTools.Action.OVERLAPS, totalBasesInDict - 150, 2 + totalContigsInDict},
+                {IntervalListTools.Action.COUNT, totalBasesInDict - 201, 2 + totalContigsInDict}
         };
     }
 


### PR DESCRIPTION
Adds a COUNT action to IntervalListTools.  This action behaves identically to CONCAT, but including it as a duplicate provides an intuitively named way to count the bases or intervals in an interval list.

----


#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable


