### PR TITLE
Yf add more sample mapping options to crosscheck + make dictionary checking more lenient

### DIFF
--- a/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
+++ b/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
@@ -356,8 +356,8 @@ public class CrosscheckFingerprints extends CommandLineProgram {
     public int EXIT_CODE_WHEN_NO_VALID_CHECKS = 1;
 
     @Hidden
-    @Argument(doc = "When true code will forgo readability checks on input files (useful for cloud access)", optional = true)
-    public boolean SKIP_INPUT_READABLITY_TEST = false;
+    @Argument(doc = "When true code will check for readability on input files (this can be slow on cloud access)")
+    public boolean TEST_INPUT_READABILITY = true;
 
     private final Log log = Log.getInstance(CrosscheckFingerprints.class);
 
@@ -445,7 +445,7 @@ public class CrosscheckFingerprints extends CommandLineProgram {
         final List<Path> inputPaths = IOUtil.getPaths(INPUT);
 
         final List<Path> unrolledFiles = IOUtil.unrollPaths(inputPaths, extensions.toArray(new String[0]));
-        if (!SKIP_INPUT_READABLITY_TEST) {
+        if (TEST_INPUT_READABILITY) {
             IOUtil.assertPathsAreReadable(unrolledFiles);
         }
 
@@ -454,7 +454,7 @@ public class CrosscheckFingerprints extends CommandLineProgram {
         // unroll and check readable here, as it can be annoying to fingerprint INPUT files and only then discover a problem
         // in a file in SECOND_INPUT
         final List<Path> unrolledFiles2 = IOUtil.unrollPaths(secondInputsPaths, extensions.toArray(new String[0]));
-        if (!SKIP_INPUT_READABLITY_TEST) {
+        if (TEST_INPUT_READABILITY) {
             IOUtil.assertPathsAreReadable(unrolledFiles2);
         }
 
@@ -664,7 +664,7 @@ public class CrosscheckFingerprints extends CommandLineProgram {
         for (final String[] strings : parser) {
             if (strings.length != 2) {
                 throw new IllegalArgumentException("Each line of the " + inputFieldName + " must have exactly two strings separated by a tab. " +
-                        "Found: " + Arrays.toString(strings) +
+                        "Found: [" + Arrays.toString(strings) +
                         "] right before [" + parser.getCurrentLine() + "], in " + sampleMapFile.getAbsolutePath());
             }
             if (sampleMap.containsKey(strings[0])) {

--- a/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
+++ b/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
@@ -150,12 +150,9 @@ import static picard.fingerprint.Fingerprint.CrosscheckMode.CHECK_SAME_SAMPLE;
  * When provided a VCF, the identity check looks at the PL, GL and GT fields (in that order) and uses the first one that
  * it finds.
  *
- *
- *
  * @author Tim Fennell
  * @author Yossi Farjoun
  */
-
 
 @CommandLineProgramProperties(
         summary =
@@ -273,13 +270,13 @@ public class CrosscheckFingerprints extends CommandLineProgram {
             "Should only be used in the presence of SECOND_INPUT. ", optional = true, mutex = {"INPUT_SAMPLE_MAP"})
     public File INPUT_SAMPLE_FILE_MAP;
 
-    @Argument(shortName = "SI", optional = true, mutex={"MATRIX_OUTPUT"},
+    @Argument(shortName = "SI", optional = true, mutex = {"MATRIX_OUTPUT"},
             doc = "A second set of input files (or lists of files) with which to compare fingerprints. If this option is provided " +
                     "the tool compares each sample in INPUT with the sample from SECOND_INPUT that has the same sample ID. " +
                     "In addition, data will be grouped by SAMPLE regardless of the value of CROSSCHECK_BY. " +
                     "When operating in this mode, each sample in INPUT must also have a corresponding sample in SECOND_INPUT. " +
                     "If this is violated, the tool will proceed to check the matching samples, but report the missing samples " +
-                    "and return a non-zero error-code." )
+                    "and return a non-zero error-code.")
     public List<String> SECOND_INPUT;
 
     @Argument(doc = "A tsv with two columns representing the sample as it appears in the SECOND_INPUT data (in column 1) and " +
@@ -337,7 +334,7 @@ public class CrosscheckFingerprints extends CommandLineProgram {
     public boolean ALLOW_DUPLICATE_READS = false;
 
     @Argument(doc = "Assumed genotyping error rate that provides a floor on the probability that a genotype comes from " +
-            "the expected sample. Must be greater than zero. " )
+            "the expected sample. Must be greater than zero. ")
     public double GENOTYPING_ERROR_RATE = 0.01;
 
     @Argument(doc = "If true then only groups that do not relate to each other as expected will have their LODs reported.")
@@ -359,8 +356,8 @@ public class CrosscheckFingerprints extends CommandLineProgram {
     public int EXIT_CODE_WHEN_NO_VALID_CHECKS = 1;
 
     @Hidden
-    @Argument(doc = "When true code will forgo readability checks on input files (useful for cloud access)",optional=true)
-    public boolean SKIP_INPUT_READABLITY_TEST=false;
+    @Argument(doc = "When true code will forgo readability checks on input files (useful for cloud access)", optional = true)
+    public boolean SKIP_INPUT_READABLITY_TEST = false;
 
     private final Log log = Log.getInstance(CrosscheckFingerprints.class);
 
@@ -379,7 +376,7 @@ public class CrosscheckFingerprints extends CommandLineProgram {
         if (SECOND_INPUT == null && SECOND_INPUT_SAMPLE_MAP != null) {
             return new String[]{"SECOND_INPUT_SAMPLE_MAP can only be used when also using SECOND_INPUT"};
         }
-        if (GENOTYPING_ERROR_RATE <= 0 ) {
+        if (GENOTYPING_ERROR_RATE <= 0) {
             return new String[]{"GENOTYPING_ERROR_RATE must be greater than zero. Found " + GENOTYPING_ERROR_RATE};
         }
 
@@ -402,7 +399,9 @@ public class CrosscheckFingerprints extends CommandLineProgram {
         // Check inputs
 
         IOUtil.assertFileIsReadable(HAPLOTYPE_MAP);
-        if (OUTPUT != null) IOUtil.assertFileIsWritable(OUTPUT);
+        if (OUTPUT != null) {
+            IOUtil.assertFileIsWritable(OUTPUT);
+        }
 
         if (!SECOND_INPUT.isEmpty() && CROSSCHECK_MODE == CHECK_SAME_SAMPLE) {
             log.info("SECOND_INPUT is not empty, and CROSSCHECK_MODE==CHECK_SAME_SAMPLE. NOT doing cross-check. Will only compare each SAMPLE in INPUT against that sample in SECOND_INPUT.");
@@ -416,10 +415,18 @@ public class CrosscheckFingerprints extends CommandLineProgram {
             log.info("SECOND_INPUT is not empty, and CROSSCHECK_MODE==CHECK_ALL_OTHERS. Will compare fingerprints from INPUT against all the fingerprints in SECOND_INPUT.");
         }
 
-        if (MATRIX_OUTPUT != null) IOUtil.assertFileIsWritable(MATRIX_OUTPUT);
-        if (INPUT_SAMPLE_MAP != null) IOUtil.assertFileIsReadable(INPUT_SAMPLE_MAP);
-        if (INPUT_SAMPLE_FILE_MAP != null) IOUtil.assertFileIsReadable(INPUT_SAMPLE_FILE_MAP);
-        if (SECOND_INPUT_SAMPLE_MAP != null) IOUtil.assertFileIsReadable(SECOND_INPUT_SAMPLE_MAP);
+        if (MATRIX_OUTPUT != null) {
+            IOUtil.assertFileIsWritable(MATRIX_OUTPUT);
+        }
+        if (INPUT_SAMPLE_MAP != null) {
+            IOUtil.assertFileIsReadable(INPUT_SAMPLE_MAP);
+        }
+        if (INPUT_SAMPLE_FILE_MAP != null) {
+            IOUtil.assertFileIsReadable(INPUT_SAMPLE_FILE_MAP);
+        }
+        if (SECOND_INPUT_SAMPLE_MAP != null) {
+            IOUtil.assertFileIsReadable(SECOND_INPUT_SAMPLE_MAP);
+        }
 
         final HaplotypeMap map = new HaplotypeMap(HAPLOTYPE_MAP);
         final FingerprintChecker checker = new FingerprintChecker(map);
@@ -438,14 +445,18 @@ public class CrosscheckFingerprints extends CommandLineProgram {
         final List<Path> inputPaths = IOUtil.getPaths(INPUT);
 
         final List<Path> unrolledFiles = IOUtil.unrollPaths(inputPaths, extensions.toArray(new String[0]));
-        if (!SKIP_INPUT_READABLITY_TEST) IOUtil.assertPathsAreReadable(unrolledFiles);
+        if (!SKIP_INPUT_READABLITY_TEST) {
+            IOUtil.assertPathsAreReadable(unrolledFiles);
+        }
 
         final List<Path> secondInputsPaths = IOUtil.getPaths(SECOND_INPUT);
 
         // unroll and check readable here, as it can be annoying to fingerprint INPUT files and only then discover a problem
         // in a file in SECOND_INPUT
         final List<Path> unrolledFiles2 = IOUtil.unrollPaths(secondInputsPaths, extensions.toArray(new String[0]));
-        if (!SKIP_INPUT_READABLITY_TEST) IOUtil.assertPathsAreReadable(unrolledFiles2);
+        if (!SKIP_INPUT_READABLITY_TEST) {
+            IOUtil.assertPathsAreReadable(unrolledFiles2);
+        }
 
         log.info("Fingerprinting " + unrolledFiles.size() + " INPUT files.");
         final Map<FingerprintIdDetails, Fingerprint> fpMap = checker.fingerprintFiles(unrolledFiles, NUM_THREADS, 1, TimeUnit.DAYS);
@@ -511,29 +522,30 @@ public class CrosscheckFingerprints extends CommandLineProgram {
         }
     }
 
-    /** Inspects the contents of sampleMapFile building a map of Sample->Sample.
+    /**
+     * Inspects the contents of sampleMapFile building a map of Sample->Sample.
      * Checks for sanity, and then replaces in the fpMap,
-     * @param fpMap A fingerprint map from a FingerprintIdDetails to a fingerprint
-     * @param sampleMapFile a file contining two columns, sample name to be mapped, and mapped sample name.
      *
+     * @param fpMap         A fingerprint map from a FingerprintIdDetails to a fingerprint
+     * @param sampleMapFile a file contining two columns, sample name to be mapped, and mapped sample name.
      */
     private void remapFingerprints(final Map<FingerprintIdDetails, Fingerprint> fpMap, final File sampleMapFile, final String inputFieldName) {
         final Map<String, String> sampleMap = getStringStringMap(sampleMapFile, inputFieldName);
 
         // check that every key in the sample map is a sample in the fpMap, and warn otherwise
-        final Set<String> samplesInFpMap = fpMap.keySet().stream().map(id->id.sample).collect(Collectors.toSet());
+        final Set<String> samplesInFpMap = fpMap.keySet().stream().map(id -> id.sample).collect(Collectors.toSet());
         final Set<String> samplesNotInSampleMap = sampleMap.keySet().stream()
-                .filter(((Predicate<String>)samplesInFpMap::contains).negate())
+                .filter(((Predicate<String>) samplesInFpMap::contains).negate())
                 .collect(Collectors.toSet());
         if (!samplesNotInSampleMap.isEmpty()) {
             log.warn("Some samples in first column in the " + inputFieldName + " were not present as samples in fingerprinted file: [" +
-                      String.join(", ", samplesNotInSampleMap)+ "].");
+                    String.join(", ", samplesNotInSampleMap) + "].");
         }
 
         // verify that resulting sample-set is unique
         final List<String> resultingSamples = new ArrayList<>(samplesInFpMap);
-        sampleMap.keySet().forEach(s->{
-            if(resultingSamples.remove(s)){
+        sampleMap.keySet().forEach(s -> {
+            if (resultingSamples.remove(s)) {
                 resultingSamples.add(sampleMap.get(s));
             }
         });
@@ -542,19 +554,22 @@ public class CrosscheckFingerprints extends CommandLineProgram {
             final Set<String> duplicates = new HashSet<>();
             final Set<String> unique = new HashSet<>();
             resultingSamples.forEach(s -> {
-                if (unique.add(s))
+                if (unique.add(s)) {
                     duplicates.add(s);
+                }
             });
             throw new IllegalArgumentException("After applying the mapping found in the " + inputFieldName + " the resulting " +
                     "sample names must be unique when taken together with the remaining unmapped samples. " +
-                    "Duplicates are: " + Arrays.toString(duplicates.toArray()) );
+                    "Duplicates are: " + Arrays.toString(duplicates.toArray()));
         }
 
         // replace samples with their mapped values:
         final Set<FingerprintIdDetails> ids = new HashSet<>(fpMap.keySet());
         ids.forEach(id -> {
             // if sample isn't in sampleMap, leave it alone
-            if (!sampleMap.containsKey(id.sample)) return;
+            if (!sampleMap.containsKey(id.sample)) {
+                return;
+            }
             // one needs to replace the item, not simply modify it so that it is placed correctly in the map (since the key is changing)
             final Fingerprint fingerprint = fpMap.remove(id);
             //update the key
@@ -564,12 +579,9 @@ public class CrosscheckFingerprints extends CommandLineProgram {
         });
     }
 
-
-
-    /** Inspects the contents of sampleMapFile building a map of Sample->Sample.
+    /**
+     * Inspects the contents of sampleMapFile building a map of Sample->Sample.
      * Checks for sanity, and then replaces in the fpMap,
-     * @param fpMap
-     * @param sampleMapFile
      */
     private void remapFingerprintsFromFiles(final Map<FingerprintIdDetails, Fingerprint> fpMap, final File sampleMapFile) {
         final Map<String, String> sampleMap = getStringStringMap(sampleMapFile, "INPUT_SAMPLE_FILE_MAP").entrySet().stream()
@@ -745,7 +757,7 @@ public class CrosscheckFingerprints extends CommandLineProgram {
         final List<FingerprintIdDetails> rhsFingerprintIdDetails = new ArrayList<>(rhsFingerprints.keySet());
 
         // use 1L to promote size() to a long and avoid possible overflow
-        final long totalChecks = lhsFingerprintIdDetails.size() * ((long) rhsFingerprintIdDetails.size() ) ;
+        final long totalChecks = lhsFingerprintIdDetails.size() * ((long) rhsFingerprintIdDetails.size());
 
         for (int row = 0; row < lhsFingerprintIdDetails.size(); row++) {
             final FingerprintIdDetails lhsId = lhsFingerprintIdDetails.get(row);
@@ -761,7 +773,9 @@ public class CrosscheckFingerprints extends CommandLineProgram {
                 if (!OUTPUT_ERRORS_ONLY || result == FingerprintResult.INCONCLUSIVE || !result.isExpected()) {
                     metrics.add(getMatchDetails(result, results, lhsId, rhsId, type));
                 }
-                if (result != FingerprintResult.INCONCLUSIVE && !result.isExpected()) unexpectedResults++;
+                if (result != FingerprintResult.INCONCLUSIVE && !result.isExpected()) {
+                    unexpectedResults++;
+                }
                 if (crosscheckMatrix != null) {
                     crosscheckMatrix[row][col] = results.getLOD();
                 }
@@ -817,7 +831,9 @@ public class CrosscheckFingerprints extends CommandLineProgram {
             if (!OUTPUT_ERRORS_ONLY || !result.isExpected()) {
                 metrics.add(getMatchDetails(result, results, lhsID, rhsID, CrosscheckMetric.DataType.SAMPLE));
             }
-            if (result != FingerprintResult.INCONCLUSIVE && !result.isExpected()) unexpectedResults++;
+            if (result != FingerprintResult.INCONCLUSIVE && !result.isExpected()) {
+                unexpectedResults++;
+            }
             if (results.getLOD() == 0) {
                 log.error("LOD score of zero found when checking sample fingerprints.  Probably there are no reads/variants at fingerprinting sites for one of the samples");
                 unexpectedResults++;

--- a/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
+++ b/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
@@ -26,12 +26,14 @@
 package picard.fingerprint;
 
 import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReader;
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.util.CollectionUtil;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.Hidden;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import picard.cmdline.CommandLineProgram;
 import picard.cmdline.StandardOptionDefinitions;
@@ -39,10 +41,21 @@ import picard.cmdline.programgroups.DiagnosticsAndQCProgramGroup;
 import picard.fingerprint.CrosscheckMetric.FingerprintResult;
 import picard.util.TabbedInputParser;
 
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.nio.file.Path;
 import java.text.NumberFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -247,8 +260,19 @@ public class CrosscheckFingerprints extends CommandLineProgram {
             "Need only include the samples that change. " +
             "Values in column 1 should be unique. " +
             "Values in column 2 should be unique even in union with the remaining unmapped samples. " +
-            "Should only be used with SECOND_INPUT. ", optional = true)
+            "Should only be used with SECOND_INPUT. ", optional = true, mutex = {"INPUT_SAMPLE_FILE_MAP"})
     public File INPUT_SAMPLE_MAP;
+
+    @Hidden
+    @Argument(doc = "A tsv with two columns representing " +
+            "the sample as it should be used for comparisons to SECOND_INPUT (in the first column) and  " +
+            "the source file (in INPUT) for the fingerprint (in the second column). " +
+            "Need only to include the samples that change. " +
+            "Values in column 1 should be unique even in union with the remaining unmapped samples. " +
+            "Values in column 2 should be unique in the file. " +
+            "Will error if more than one sample is found in a file (multi-sample vcf) pointed to in column 2. " +
+            "Should only be used in the presence of SECOND_INPUT. ", optional = true, mutex = {"INPUT_SAMPLE_MAP"})
+    public File INPUT_SAMPLE_FILE_MAP;
 
     @Argument(shortName = "SI", optional = true, mutex={"MATRIX_OUTPUT"},
             doc = "A second set of input files (or lists of files) with which to compare fingerprints. If this option is provided " +
@@ -261,7 +285,8 @@ public class CrosscheckFingerprints extends CommandLineProgram {
 
     @Argument(doc = "A tsv with two columns representing the sample as it appears in the SECOND_INPUT data (in column 1) and " +
             "the sample as it should be used for comparisons to INPUT (in the second column). " +
-            "Need only include the samples that change. " +
+            "Note that in case of unrolling files (file-of-filenames) one would need to reference the final file, i.e. the file that " +
+            "contains the genomic data. Need only include the samples that change. " +
             "Values in column 1 should be unique. " +
             "Values in column 2 should be unique even in union with the remaining unmapped samples. " +
             "Should only be used with SECOND_INPUT. ", optional = true)
@@ -334,6 +359,10 @@ public class CrosscheckFingerprints extends CommandLineProgram {
     @Argument(doc = "When all LOD score are zero, exit with this value.")
     public int EXIT_CODE_WHEN_NO_VALID_CHECKS = 1;
 
+    @Hidden
+    @Argument(doc = "When true code will forgo readability checks on input files (useful for cloud access)",optional=true)
+    public boolean SKIP_INPUT_READABLITY_TEST=false;
+
     private final Log log = Log.getInstance(CrosscheckFingerprints.class);
 
     private double[][] crosscheckMatrix = null;
@@ -345,10 +374,10 @@ public class CrosscheckFingerprints extends CommandLineProgram {
         if (GENOTYPING_ERROR_RATE <= 0 || GENOTYPING_ERROR_RATE >= 1) {
             return new String[]{"Genotyping error must be strictly greater than 0 and less than 1, found " + GENOTYPING_ERROR_RATE};
         }
-        if (SECOND_INPUT == null && INPUT_SAMPLE_MAP !=null ){
+        if (SECOND_INPUT == null && INPUT_SAMPLE_MAP != null) {
             return new String[]{"INPUT_SAMPLE_MAP can only be used when also using SECOND_INPUT"};
         }
-        if (SECOND_INPUT == null && SECOND_INPUT_SAMPLE_MAP !=null ){
+        if (SECOND_INPUT == null && SECOND_INPUT_SAMPLE_MAP != null) {
             return new String[]{"SECOND_INPUT_SAMPLE_MAP can only be used when also using SECOND_INPUT"};
         }
         if (GENOTYPING_ERROR_RATE <= 0 ) {
@@ -390,6 +419,7 @@ public class CrosscheckFingerprints extends CommandLineProgram {
 
         if (MATRIX_OUTPUT != null) IOUtil.assertFileIsWritable(MATRIX_OUTPUT);
         if (INPUT_SAMPLE_MAP != null) IOUtil.assertFileIsReadable(INPUT_SAMPLE_MAP);
+        if (INPUT_SAMPLE_FILE_MAP != null) IOUtil.assertFileIsReadable(INPUT_SAMPLE_FILE_MAP);
         if (SECOND_INPUT_SAMPLE_MAP != null) IOUtil.assertFileIsReadable(SECOND_INPUT_SAMPLE_MAP);
 
         final HaplotypeMap map = new HaplotypeMap(HAPLOTYPE_MAP);
@@ -408,23 +438,25 @@ public class CrosscheckFingerprints extends CommandLineProgram {
 
         final List<Path> inputPaths = IOUtil.getPaths(INPUT);
 
-        IOUtil.assertPathsAreReadable(inputPaths);
-        final List<Path> unrolledFiles = IOUtil.unrollPaths(inputPaths, extensions.toArray(new String[extensions.size()]));
-        IOUtil.assertPathsAreReadable(unrolledFiles);
+        final List<Path> unrolledFiles = IOUtil.unrollPaths(inputPaths, extensions.toArray(new String[0]));
+        if (!SKIP_INPUT_READABLITY_TEST) IOUtil.assertPathsAreReadable(unrolledFiles);
 
         final List<Path> secondInputsPaths = IOUtil.getPaths(SECOND_INPUT);
 
         // unroll and check readable here, as it can be annoying to fingerprint INPUT files and only then discover a problem
         // in a file in SECOND_INPUT
-        IOUtil.assertPathsAreReadable(secondInputsPaths);
-        final List<Path> unrolledFiles2 = IOUtil.unrollPaths(secondInputsPaths, extensions.toArray(new String[extensions.size()]));
-        IOUtil.assertPathsAreReadable(unrolledFiles2);
+        final List<Path> unrolledFiles2 = IOUtil.unrollPaths(secondInputsPaths, extensions.toArray(new String[0]));
+        if (!SKIP_INPUT_READABLITY_TEST) IOUtil.assertPathsAreReadable(unrolledFiles2);
 
         log.info("Fingerprinting " + unrolledFiles.size() + " INPUT files.");
         final Map<FingerprintIdDetails, Fingerprint> fpMap = checker.fingerprintFiles(unrolledFiles, NUM_THREADS, 1, TimeUnit.DAYS);
 
         if (INPUT_SAMPLE_MAP != null) {
             remapFingerprints(fpMap, INPUT_SAMPLE_MAP, "INPUT_SAMPLE_MAP");
+        }
+
+        if (INPUT_SAMPLE_FILE_MAP != null) {
+            remapFingerprintsFromFiles(fpMap, INPUT_SAMPLE_FILE_MAP);
         }
 
         final List<CrosscheckMetric> metrics = new ArrayList<>();
@@ -435,7 +467,6 @@ public class CrosscheckFingerprints extends CommandLineProgram {
             numUnexpected = crossCheckGrouped(fpMap, fpMap, metrics, Fingerprint.getFingerprintIdDetailsStringFunction(CROSSCHECK_BY), CROSSCHECK_BY);
         } else {
             log.info("Fingerprinting " + unrolledFiles2.size() + " SECOND_INPUT files.");
-
             final Map<FingerprintIdDetails, Fingerprint> fpMap2 = checker.fingerprintFiles(unrolledFiles2, NUM_THREADS, 1, TimeUnit.DAYS);
 
             if (SECOND_INPUT_SAMPLE_MAP != null) {
@@ -488,23 +519,8 @@ public class CrosscheckFingerprints extends CommandLineProgram {
      *
      */
     private void remapFingerprints(final Map<FingerprintIdDetails, Fingerprint> fpMap, final File sampleMapFile, final String inputFieldName) {
-        final Map<String, String> sampleMap = new HashMap<>();
+        final Map<String, String> sampleMap = getStringStringMap(sampleMapFile, inputFieldName);
 
-        final TabbedInputParser parser = new TabbedInputParser(false, sampleMapFile);
-
-        // build the map
-        for (final String[] strings : parser) {
-            if (strings.length != 2) {
-                throw new IllegalArgumentException("Each line of the " + inputFieldName + " must have exactly two strings separated by a tab. " +
-                        "Found: [" + String.join(",", Arrays.asList(strings)) +
-                        "] right before [" + parser.getCurrentLine() + "], in " + sampleMapFile.getAbsolutePath());
-            }
-            if (sampleMap.containsKey(strings[0])) {
-                throw new IllegalArgumentException("Strings in first column of the " + inputFieldName + " must be unique. found [" + strings[0] +
-                        "] twice. Right before [" + parser.getCurrentLine() + "] in " + sampleMapFile.getAbsolutePath());
-            }
-            sampleMap.put(strings[0],strings[1]);
-        }
         // check that every key in the sample map is a sample in the fpMap, and warn otherwise
         final Set<String> samplesInFpMap = fpMap.keySet().stream().map(id->id.sample).collect(Collectors.toSet());
         final Set<String> samplesNotInSampleMap = sampleMap.keySet().stream()
@@ -536,7 +552,7 @@ public class CrosscheckFingerprints extends CommandLineProgram {
         }
 
         // replace samples with their mapped values:
-        final Set<FingerprintIdDetails> ids = fpMap.keySet();
+        final Set<FingerprintIdDetails> ids = new HashSet<>(fpMap.keySet());
         ids.forEach(id -> {
             // if sample isn't in sampleMap, leave it alone
             if (!sampleMap.containsKey(id.sample)) return;
@@ -547,6 +563,105 @@ public class CrosscheckFingerprints extends CommandLineProgram {
             //put the fingerprint back in with the updates key
             fpMap.put(id, fingerprint);
         });
+    }
+
+
+
+    /** Inspects the contents of sampleMapFile building a map of Sample->Sample.
+     * Checks for sanity, and then replaces in the fpMap,
+     * @param fpMap
+     * @param sampleMapFile
+     */
+    private void remapFingerprintsFromFiles(final Map<FingerprintIdDetails, Fingerprint> fpMap, final File sampleMapFile) {
+        final Map<String, String> sampleMap = getStringStringMap(sampleMapFile, "INPUT_SAMPLE_FILE_MAP").entrySet().stream()
+                .collect(Collectors.toMap(e -> {
+                    try {
+                        return IOUtil.getPath(e.getValue()).toUri().toString();
+                    } catch (IOException e1) {
+                        e1.printStackTrace();
+                    }
+                    return null;
+                }, Map.Entry::getKey));
+
+        // check that every key in the sample map is a sample in the fpMap, and warn otherwise
+        final Set<String> filesInFpMap = fpMap.keySet().stream().map(id->id.file).collect(Collectors.toSet());
+        final Set<String> sampleNotInFpMap = sampleMap.keySet().stream()
+                .filter(((Predicate<String>)filesInFpMap::contains).negate())
+                .collect(Collectors.toSet());
+        if (!sampleNotInFpMap.isEmpty()) {
+            log.warn("Some samples from the first column in " + "INPUT_SAMPLE_FILE_MAP" + " were not found: [" +
+                    String.join(", ", sampleNotInFpMap)+ "].");
+        }
+
+
+        final Map<String, List<FingerprintIdDetails>> fileFpDetailSetMap = fpMap.keySet().stream().collect(Collectors.groupingBy(s->s.file));
+
+        final Map<String, String> fileSampleMap = new HashMap<>();
+        // check that each file in the map points only to one sample
+        fileFpDetailSetMap.forEach((key, fingerprintIdDetails) -> {
+            final List<String> samples = fingerprintIdDetails.stream().map(id -> id.sample).distinct().collect(Collectors.toList());
+            if (samples.size() > 1) {
+                throw new IllegalArgumentException("fingerprinting file (" + key +
+                        "in INPUT_SAMPLE_FILE_MAP contains multiple samples: " +
+                        String.join("", samples));
+            }
+            fileSampleMap.put(key,fingerprintIdDetails.get(0).sample);
+        });
+
+        // verify that resulting file-set is associated with a unique sample:
+
+        final List<String> resultingSamples = new ArrayList<>(filesInFpMap);
+        fileSampleMap.forEach((f,id)->{
+            if (resultingSamples.remove(id)){
+                resultingSamples.add(sampleMap.get(f));
+            }
+        });
+
+        if (CollectionUtil.makeSet(resultingSamples.toArray(new String[0])).size() != resultingSamples.size()) {
+            final Set<String> duplicates = new HashSet<>();
+            final Set<String> unique = new HashSet<>();
+            resultingSamples.forEach(s -> {
+                if (unique.add(s))
+                    duplicates.add(s);
+            });
+            throw new IllegalArgumentException("After applying the mapping found in the " + "INPUT_SAMPLE_FILE_MAP" + " the resulting " +
+                    "sample names must be unique when taken together with the remaining unmapped samples. " +
+                    "Duplicates are: [" + String.join(",", duplicates) + "], " + "INPUT_SAMPLE_FILE_MAP");
+        }
+
+        // replace samples with their mapped values:
+        final Set<FingerprintIdDetails> ids = new HashSet<>(fpMap.keySet());
+        ids.forEach(id -> {
+            // if sample isn't in sampleMap, leave it alone
+            if (!sampleMap.containsKey(id.file)) return;
+            // one needs to replace the item, not simply modify it so that it is placed correctly in the map (since the key is changing)
+            final Fingerprint fingerprint = fpMap.remove(id);
+            //update the key
+            id.sample = sampleMap.get(id.file);
+            //put the fingerprint back in with the updates key
+            fpMap.put(id, fingerprint);
+        });
+    }
+
+    private Map<String, String> getStringStringMap(final File sampleMapFile, final String inputFieldName) {
+        final Map<String, String> sampleMap = new HashMap<>();
+
+        final TabbedInputParser parser = new TabbedInputParser(false, sampleMapFile);
+
+        // build the map
+        for (final String[] strings : parser) {
+            if (strings.length != 2) {
+                throw new IllegalArgumentException("Each line of the " + inputFieldName + " must have exactly two strings separated by a tab. " +
+                        "Found: [" + String.join(",", Arrays.asList(strings)) +
+                        "] right before [" + parser.getCurrentLine() + "], in " + sampleMapFile.getAbsolutePath());
+            }
+            if (sampleMap.containsKey(strings[0])) {
+                throw new IllegalArgumentException("Strings in first column of the " + inputFieldName + " must be unique. found [" + strings[0] +
+                        "] twice. Right before [" + parser.getCurrentLine() + "] in " + sampleMapFile.getAbsolutePath());
+            }
+            sampleMap.put(strings[0], strings[1]);
+        }
+        return sampleMap;
     }
 
     private void writeMatrix() {
@@ -561,8 +676,8 @@ public class CrosscheckFingerprints extends CommandLineProgram {
             writer.write(CROSSCHECK_BY.name());
 
             // write the names of the keys as the first row
-            for (int col = 0; col < rhsMatrixKeys.size(); col++) {
-                writer.write('\t' + rhsMatrixKeys.get(col));
+            for (String rhsMatrixKey : rhsMatrixKeys) {
+                writer.write('\t' + rhsMatrixKey);
             }
             writer.newLine();
 
@@ -570,8 +685,8 @@ public class CrosscheckFingerprints extends CommandLineProgram {
                 // write the key in the first column
                 writer.write(lhsMatrixKeys.get(row));
                 // and then write all the values
-                for (int col = 0; col < rhsMatrixKeys.size(); col++) {
-                    writer.write('\t' + format.format(crosscheckMatrix[col][row]));
+                for (final double lod : crosscheckMatrix[row]) {
+                    writer.write('\t' + format.format(lod));
                 }
                 writer.newLine();
             }

--- a/src/main/java/picard/fingerprint/FingerprintChecker.java
+++ b/src/main/java/picard/fingerprint/FingerprintChecker.java
@@ -28,6 +28,7 @@ import com.google.cloud.storage.contrib.nio.SeekableByteChannelPrefetcher;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.ValidationStringency;
@@ -62,6 +63,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.OptionalInt;
 import java.util.Random;
 import java.util.Set;
 import java.util.SortedSet;
@@ -93,6 +95,7 @@ public class FingerprintChecker {
     private int minimumMappingQuality = DEFAULT_MINIMUM_MAPPING_QUALITY;
     private double genotypingErrorRate = DEFAULT_GENOTYPING_ERROR_RATE;
     private int maximalPLDifference = DEFAULT_MAXIMAL_PL_DIFFERENCE;
+    private File referenceFasta;
 
     public ValidationStringency getValidationStringency() {
         return validationStringency;
@@ -104,12 +107,7 @@ public class FingerprintChecker {
 
     public File getReferenceFasta() { return referenceFasta;}
 
-    public void setReferenceFasta(final File referenceFasta) {
-        this.referenceFasta = referenceFasta;
-    }
-
     private ValidationStringency validationStringency = ValidationStringency.DEFAULT_STRINGENCY;
-    private File referenceFasta;
 
     private boolean allowDuplicateReads = false;
     private double pLossofHet = 0;
@@ -189,10 +187,8 @@ public class FingerprintChecker {
      * @return a Map of Sample name to Fingerprint
      */
     public Map<String, Fingerprint> loadFingerprints(final Path fingerprintFile, final String specificSample) {
-        SequenceUtil.assertSequenceDictionariesEqual(this.haplotypes.getHeader().getSequenceDictionary(),
-                VCFFileReader.getSequenceDictionary(fingerprintFile));
-
         final VCFFileReader reader = new VCFFileReader(fingerprintFile, false);
+        checkDictionaryGoodForFingerprinting(reader.getFileHeader().getSequenceDictionary());
 
         final Map<String, Fingerprint> fingerprints;
         if (reader.isQueryable()) {
@@ -202,11 +198,33 @@ public class FingerprintChecker {
             fingerprints = loadFingerprintsFromVariantContexts(reader, specificSample, fingerprintFile);
         }
         //add an entry for each sample which was not fingerprinted
-        for (final String sample : reader.getFileHeader().getGenotypeSamples()) {
+        reader.getFileHeader().getGenotypeSamples().forEach(sample -> {
             fingerprints.computeIfAbsent(sample, s -> new Fingerprint(s, fingerprintFile, null));
-        }
+        });
 
         return fingerprints;
+    }
+
+    private void checkDictionaryGoodForFingerprinting(final SAMSequenceDictionary sequenceDictionaryToCheck ) {
+        final SAMSequenceDictionary activeDictionary = getActiveDictionary(haplotypes);
+
+        if (sequenceDictionaryToCheck.getSequences().size() < activeDictionary.size()) {
+            throw new IllegalArgumentException("Dictionary on fingerprinted file smaller than that on Haplotype Database!");
+        }
+        SequenceUtil.assertSequenceDictionariesEqual(activeDictionary, sequenceDictionaryToCheck,true);
+    }
+
+    private SAMSequenceDictionary getActiveDictionary(final HaplotypeMap haplotypes){
+        final SAMSequenceDictionary origSequenceDictionary = haplotypes.getHeader().getSequenceDictionary();
+
+        final OptionalInt maxSequenceIndex = haplotypes.getAllSnps().stream()
+                .mapToInt(s -> origSequenceDictionary.getSequenceIndex(s.getChrom()))
+                .max();
+        if (!maxSequenceIndex.isPresent()) {
+            return origSequenceDictionary;
+        }
+        //plus one since sublist is exclusive of the end.
+        return new SAMSequenceDictionary(origSequenceDictionary.getSequences().subList(0, maxSequenceIndex.getAsInt() + 1));
     }
 
     /**
@@ -221,7 +239,7 @@ public class FingerprintChecker {
      */
     public Map<String, Fingerprint> loadFingerprintsFromNonIndexedVcf(final Path fingerprintFile, final String specificSample) {
         final VCFFileReader reader = new VCFFileReader(fingerprintFile, false);
-        SequenceUtil.assertSequenceDictionariesEqual(this.haplotypes.getHeader().getSequenceDictionary(), SAMSequenceDictionaryExtractor.extractDictionary(fingerprintFile));
+        checkDictionaryGoodForFingerprinting(reader.getFileHeader().getSequenceDictionary());
 
         return loadFingerprintsFromVariantContexts(reader, specificSample, fingerprintFile);
     }
@@ -295,8 +313,7 @@ public class FingerprintChecker {
      */
     public Map<String, Fingerprint> loadFingerprintsFromQueriableReader(final VCFFileReader reader, final String specificSample, final Path source) {
 
-        SequenceUtil.assertSequenceDictionariesEqual(this.haplotypes.getHeader().getSequenceDictionary(),
-                reader.getFileHeader().getSequenceDictionary());
+        checkDictionaryGoodForFingerprinting(reader.getFileHeader().getSequenceDictionary());
 
         final SortedSet<Snp> snps = new TreeSet<>(haplotypes.getAllSnps());
 
@@ -451,8 +468,7 @@ public class FingerprintChecker {
                 .referenceSequence(referenceFasta)
                 .open(samFile, null, seekableChannelFunction);
 
-        SequenceUtil.assertSequenceDictionariesEqual(this.haplotypes.getHeader().getSequenceDictionary(),
-                in.getFileHeader().getSequenceDictionary());
+        checkDictionaryGoodForFingerprinting(in.getFileHeader().getSequenceDictionary());
 
         final SamLocusIterator iterator = new SamLocusIterator(in, loci, in.hasIndex());
         iterator.setEmitUncoveredLoci(true);
@@ -496,6 +512,7 @@ public class FingerprintChecker {
         for (final SamLocusIterator.LocusInfo info : iterator) {
 
             // if statement to avoid string building.
+            // TODO: replace with lambda version once htsjdk is rev'ed
             if (Log.isEnabled(Log.LogLevel.DEBUG)) {
                 log.debug("At locus " + info.toString());
             }
@@ -574,8 +591,7 @@ public class FingerprintChecker {
         final Map<String, Fingerprint> fingerprintsBySample = new HashMap<>();
 
         try (final SamReader in = SamReaderFactory.makeDefault().enable(CACHE_FILE_BASED_INDEXES).open(samFile)) {
-            SequenceUtil.assertSequenceDictionariesEqual(this.haplotypes.getHeader().getSequenceDictionary(),
-                    in.getFileHeader().getSequenceDictionary());
+            checkDictionaryGoodForFingerprinting(in.getFileHeader().getSequenceDictionary());
 
             final SamLocusIterator iterator = new SamLocusIterator(in, haplotypes.getIntervalList(), in.hasIndex());
             iterator.setEmitUncoveredLoci(true);
@@ -685,15 +701,23 @@ public class FingerprintChecker {
         final ExecutorService executor = new ThreadPoolExecutorWithExceptions(threads);
         final ExecutorCompletionService<Path> executorCompletionService = new ExecutorCompletionService<>(executor);
         final IntervalList intervals = this.haplotypes.getIntervalList();
-        final Map<FingerprintIdDetails, Fingerprint> retval = new ConcurrentHashMap<>();
+        final Map<FingerprintIdDetails, Fingerprint> retval = new ConcurrentHashMap<>(files.size());
 
         for (final Path p : files) {
             executorCompletionService.submit(() -> {
 
+                final Map<FingerprintIdDetails, Fingerprint> oneFileFingerprints;
                 if (CheckFingerprint.fileContainsReads(p)) {
-                    retval.putAll(fingerprintSamFile(p, intervals));
+
+                    oneFileFingerprints = fingerprintSamFile(p, intervals);
                 } else {
-                    retval.putAll(fingerprintVcf(p));
+                    oneFileFingerprints = fingerprintVcf(p);
+                }
+
+                if (oneFileFingerprints.isEmpty()) {
+                        log.warn("No fingerprint data was found in file:" + p);
+                } else {
+                    retval.putAll(oneFileFingerprints);
                 }
 
                 log.debug("Processed file: " + p.toUri().toString() + " (" + filesRead.get() + ")");
@@ -705,7 +729,6 @@ public class FingerprintChecker {
 
         executor.shutdown();
         try {
-
             executor.awaitTermination(waitTime, waitTimeUnit);
         } catch (final InterruptedException ie) {
             throw new PicardException("Interrupted while waiting for executor to terminate.", ie);
@@ -718,6 +741,8 @@ public class FingerprintChecker {
                 throw new PicardException("Failed to fingerprint", e);
             }
         }
+
+        log.info("Processed files. " + retval.size() + " fingerprints found in map.");
 
         return retval;
     }
@@ -922,5 +947,9 @@ public class FingerprintChecker {
      */
     public static MatchResults calculateMatchResults(final Fingerprint observedFp, final Fingerprint expectedFp) {
         return calculateMatchResults(observedFp, expectedFp, 0, 0);
+    }
+
+    public void setReferenceFasta(final File referenceFasta) {
+        this.referenceFasta = referenceFasta;
     }
 }

--- a/src/main/java/picard/fingerprint/FingerprintChecker.java
+++ b/src/main/java/picard/fingerprint/FingerprintChecker.java
@@ -40,7 +40,6 @@ import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.SamLocusIterator;
 import htsjdk.samtools.util.SequenceUtil;
 import htsjdk.samtools.util.StringUtil;
-import htsjdk.variant.utils.SAMSequenceDictionaryExtractor;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.Genotype;
 import htsjdk.variant.variantcontext.GenotypeLikelihoods;
@@ -205,7 +204,7 @@ public class FingerprintChecker {
         return fingerprints;
     }
 
-    private void checkDictionaryGoodForFingerprinting(final SAMSequenceDictionary sequenceDictionaryToCheck ) {
+    private void checkDictionaryGoodForFingerprinting(final SAMSequenceDictionary sequenceDictionaryToCheck) {
         final SAMSequenceDictionary activeDictionary = getActiveDictionary(haplotypes);
 
         if (sequenceDictionaryToCheck.getSequences().size() < activeDictionary.size()) {
@@ -214,7 +213,7 @@ public class FingerprintChecker {
         SequenceUtil.assertSequenceDictionariesEqual(activeDictionary, sequenceDictionaryToCheck, true);
     }
 
-    private SAMSequenceDictionary getActiveDictionary(final HaplotypeMap haplotypes){
+    private static SAMSequenceDictionary getActiveDictionary(final HaplotypeMap haplotypes) {
         final SAMSequenceDictionary origSequenceDictionary = haplotypes.getHeader().getSequenceDictionary();
 
         final OptionalInt maxSequenceIndex = haplotypes.getAllSnps().stream()
@@ -717,9 +716,9 @@ public class FingerprintChecker {
 
                 if (oneFileFingerprints.isEmpty()) {
                         log.warn("No fingerprint data was found in file:" + p);
-                } else {
-                    retval.putAll(oneFileFingerprints);
                 }
+                retval.putAll(oneFileFingerprints);
+
 
                 log.debug("Processed file: " + p.toUri().toString() + " (" + filesRead.get() + ")");
                 if (filesRead.incrementAndGet() % 100 == 0) {

--- a/src/main/java/picard/fingerprint/FingerprintChecker.java
+++ b/src/main/java/picard/fingerprint/FingerprintChecker.java
@@ -211,14 +211,15 @@ public class FingerprintChecker {
         if (sequenceDictionaryToCheck.getSequences().size() < activeDictionary.size()) {
             throw new IllegalArgumentException("Dictionary on fingerprinted file smaller than that on Haplotype Database!");
         }
-        SequenceUtil.assertSequenceDictionariesEqual(activeDictionary, sequenceDictionaryToCheck,true);
+        SequenceUtil.assertSequenceDictionariesEqual(activeDictionary, sequenceDictionaryToCheck, true);
     }
 
     private SAMSequenceDictionary getActiveDictionary(final HaplotypeMap haplotypes){
         final SAMSequenceDictionary origSequenceDictionary = haplotypes.getHeader().getSequenceDictionary();
 
         final OptionalInt maxSequenceIndex = haplotypes.getAllSnps().stream()
-                .mapToInt(s -> origSequenceDictionary.getSequenceIndex(s.getChrom()))
+                .map(Snp::getChrom)
+                .mapToInt(origSequenceDictionary::getSequenceIndex)
                 .max();
         if (!maxSequenceIndex.isPresent()) {
             return origSequenceDictionary;

--- a/src/test/java/picard/fingerprint/CrosscheckFingerprintsTest.java
+++ b/src/test/java/picard/fingerprint/CrosscheckFingerprintsTest.java
@@ -22,6 +22,8 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -653,8 +655,9 @@ public class CrosscheckFingerprintsTest extends CommandLineProgramTest {
         args.add("INPUT=" + NA12891_named_NA12892_r1.getAbsolutePath());
         args.add("SECOND_INPUT=" + NA12891_r2.getAbsolutePath());
 
-        final File map = File.createTempFile("map", ".txt");
-        map.deleteOnExit();
+        final Path map = File.createTempFile("map", ".txt").toPath();
+        IOUtil.deleteOnExit(map);
+
         tabbedWrite(map, Arrays.asList(Collections.singletonList("NA12891"), Collections.singletonList(NA12891_named_NA12892_r1.getAbsolutePath())));
 
         args.add("OUTPUT=" + metrics.getAbsolutePath());
@@ -673,14 +676,17 @@ public class CrosscheckFingerprintsTest extends CommandLineProgramTest {
         doTest(args.toArray(new String[0]), metrics, expectedRetVal, numberOfSamples1 * numberOfSamples2, CrosscheckMetric.DataType.SAMPLE, ExpectAllMatch);
     }
 
-    private void tabbedWrite(final File output, final List<List<String>> outputs) throws IOException {
+    private void tabbedWrite(final Path output, final List<List<String>> outputs) throws IOException {
         final int[] ints = outputs.stream().mapToInt(List::size).distinct().toArray();
-        if (ints.length > 1){
-            throw new IllegalArgumentException("got lists with different lengths: "+ Arrays.toString(ints));
-        } else if (ints.length == 0) return;
+        if (ints.length > 1) {
+            throw new IllegalArgumentException("got lists with different lengths: " + Arrays.toString(ints));
+        }
+        if (ints.length == 0) {
+            return;
+        }
 
         final int length = ints[0];
-        try(PrintWriter writer = new PrintWriter(new BufferedWriter(new FileWriter(output)))){
+        try (PrintWriter writer = new PrintWriter(Files.newBufferedWriter(output))) {
 
             for (int i = 0; i < length; i++) {
                 // j is not redundant, due to "effective final" requirement in lambda...

--- a/src/test/java/picard/fingerprint/CrosscheckFingerprintsTest.java
+++ b/src/test/java/picard/fingerprint/CrosscheckFingerprintsTest.java
@@ -12,9 +12,23 @@ import picard.util.TabbedTextFileWithHeaderParser;
 import picard.vcf.SamTestUtils;
 import picard.vcf.VcfTestUtils;
 
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.lang.reflect.Field;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -70,7 +84,7 @@ public class CrosscheckFingerprintsTest extends CommandLineProgramTest {
     private static File NA12891_no_fp_sites_and_NA12892_vcf;
 
     private static final Map<CrosscheckMetric.DataType, List<String>> lookupMap = new HashMap<>(4);
-    
+
     @BeforeClass
     public void setup() throws IOException {
         NA12891_r1 = SamTestUtils.createIndexedBamOrCram(NA12891_r1_sam, NA12891_r1_sam, SamReader.Type.BAM_TYPE);
@@ -620,11 +634,62 @@ public class CrosscheckFingerprintsTest extends CommandLineProgramTest {
         args.add("CROSSCHECK_BY=SAMPLE");
         args.add("CROSSCHECK_MODE=CHECK_ALL_OTHERS");
 
-        if(inputSampleMap!=null)  args.add("INPUT_SAMPLE_MAP="+inputSampleMap.getAbsolutePath());
-        if(secondInputSampleMap!=null)  args.add("SECOND_INPUT_SAMPLE_MAP="+secondInputSampleMap.getAbsolutePath());
+        if (inputSampleMap != null) {
+            args.add("INPUT_SAMPLE_MAP=" + inputSampleMap.getAbsolutePath());
+        }
+        if (secondInputSampleMap != null) {
+            args.add("SECOND_INPUT_SAMPLE_MAP=" + secondInputSampleMap.getAbsolutePath());
+        }
 
-        doTest(args.toArray(new String[args.size()]), metrics, 0, 0 , CrosscheckMetric.DataType.SAMPLE, false);
+        doTest(args.toArray(new String[0]), metrics, 0, 0, CrosscheckMetric.DataType.SAMPLE, false);
     }
+
+    @Test()
+    public void testSecondInputCheckAllWithFileMapping() throws IOException {
+        File metrics = File.createTempFile("Fingerprinting", "test.crosscheck_metrics");
+        metrics.deleteOnExit();
+
+        final List<String> args = new ArrayList<>();
+        args.add("INPUT=" + NA12891_named_NA12892_r1.getAbsolutePath());
+        args.add("SECOND_INPUT=" + NA12891_r2.getAbsolutePath());
+
+        final File map = File.createTempFile("map", ".txt");
+        map.deleteOnExit();
+        tabbedWrite(map, Arrays.asList(Collections.singletonList("NA12891"), Collections.singletonList(NA12891_named_NA12892_r1.getAbsolutePath())));
+
+        args.add("OUTPUT=" + metrics.getAbsolutePath());
+        args.add("HAPLOTYPE_MAP=" + HAPLOTYPE_MAP);
+        args.add("LOD_THRESHOLD=" + -1.0);
+        args.add("CROSSCHECK_BY=SAMPLE");
+        args.add("CROSSCHECK_MODE=CHECK_ALL_OTHERS");
+
+        args.add("INPUT_SAMPLE_FILE_MAP=" + map);
+
+        final int expectedRetVal = 0;
+        final int numberOfSamples1 = 1;
+        final int numberOfSamples2 = 1;
+        boolean ExpectAllMatch = false;
+
+        doTest(args.toArray(new String[0]), metrics, expectedRetVal, numberOfSamples1 * numberOfSamples2, CrosscheckMetric.DataType.SAMPLE, ExpectAllMatch);
+    }
+
+    private void tabbedWrite(final File output, final List<List<String>> outputs) throws IOException {
+        final int[] ints = outputs.stream().mapToInt(List::size).distinct().toArray();
+        if (ints.length > 1){
+            throw new IllegalArgumentException("got lists with different lengths: "+ Arrays.toString(ints));
+        } else if (ints.length == 0) return;
+
+        final int length = ints[0];
+        try(PrintWriter writer = new PrintWriter(new BufferedWriter(new FileWriter(output)))){
+
+            for (int i = 0; i < length; i++) {
+                // j is not redundant, due to "effective final" requirement in lambda...
+                final int j = i;
+                writer.println(outputs.stream().map(l -> l.get(j)).collect(Collectors.joining("\t")));
+            }
+        }
+    }
+
 
     @Test(dataProvider = "checkSamplesCrosscheckAllData")
     public void testSecondInputCheckAll(final List<File> files1, final List<File> files2, final int expectedRetVal, final int numberOfSamples1, final int numberOfSamples2, boolean ExpectAllMatch) throws IOException {
@@ -684,7 +749,7 @@ public class CrosscheckFingerprintsTest extends CommandLineProgramTest {
         args.add("LOD_THRESHOLD=" + -1.0);
         args.add("CROSSCHECK_BY=FILE");
 
-        doTest(args.toArray(new String[args.size()]), metrics, expectedRetVal, numberOfSamples , CrosscheckMetric.DataType.FILE, ExpectAllMatch);
+        doTest(args.toArray(new String[0]), metrics, expectedRetVal, numberOfSamples , CrosscheckMetric.DataType.FILE, ExpectAllMatch);
     }
 
     @DataProvider(name = "checkPathsData")
@@ -723,7 +788,7 @@ public class CrosscheckFingerprintsTest extends CommandLineProgramTest {
         args.add("LOD_THRESHOLD=" + -1.0);
         args.add("CROSSCHECK_BY=FILE");
 
-        doTest(args.toArray(new String[args.size()]), metrics, expectedRetVal, numberOfSamples , CrosscheckMetric.DataType.FILE, ExpectAllMatch);
+        doTest(args.toArray(new String[0]), metrics, expectedRetVal, numberOfSamples , CrosscheckMetric.DataType.FILE, ExpectAllMatch);
     }
 
     @DataProvider(name = "missingOrNoFingerprintingSitesData")
@@ -824,7 +889,7 @@ public class CrosscheckFingerprintsTest extends CommandLineProgramTest {
     }
 
     private void doTest(final String[] args, final File metrics, final int expectedRetVal, final int expectedNMetrics, final CrosscheckMetric.DataType expectedType, final boolean expectAllMatch) throws IOException {
-       
+
         final CrosscheckFingerprints crossChecker = new CrosscheckFingerprints();
         Assert.assertEquals(crossChecker.instanceMain(args), expectedRetVal);
 

--- a/src/test/java/picard/fingerprint/FingerprintCheckerTest.java
+++ b/src/test/java/picard/fingerprint/FingerprintCheckerTest.java
@@ -95,7 +95,8 @@ public class FingerprintCheckerTest {
                 {new File(TEST_DATA_DIR, "NA12891.vcf"), new File(TEST_DATA_DIR, "NA12892.fp.vcf"), "NA12891", "NA12892", -5.941691, -1.026742, -4.914948},
                 {new File(TEST_DATA_DIR, "NA12891.vcf"), new File(TEST_DATA_DIR, "NA12892.g.vcf"),  "NA12891", "NA12892", -6.638797, -1.026742, -5.612055},
                 {new File(TEST_DATA_DIR, "NA12892.vcf"), new File(TEST_DATA_DIR, "NA12891.fp.vcf"), "NA12892", "NA12891", -5.998029, -1.083080, -4.914948},
-                {new File(TEST_DATA_DIR, "NA12892.vcf"), new File(TEST_DATA_DIR, "NA12891.g.vcf"),  "NA12892", "NA12891", -6.656826, -1.083080, -5.573746}
+                {new File(TEST_DATA_DIR, "NA12892.vcf"), new File(TEST_DATA_DIR, "NA12891.g.vcf"),  "NA12892", "NA12891", -6.656826, -1.083080, -5.573746},
+                {new File(TEST_DATA_DIR, "emptyNA12892.vcf"), new File(TEST_DATA_DIR, "NA12891.g.vcf"),  "NA12892", "NA12891", 0, 0, 0},
         };
     }
 

--- a/testdata/picard/fingerprint/emptyNA12892.vcf
+++ b/testdata/picard/fingerprint/emptyNA12892.vcf
@@ -1,0 +1,98 @@
+##fileformat=VCFv4.1
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=IGC,Number=1,Type=Float,Description="Illumina GenCall Confidence Score">
+##GATKCommandLine.SelectVariants=<ID=SelectVariants,Version=nightly-2015-07-31-g3c929b0,Date="Wed Sep 14 12:18:26 EDT 2016",Epoch=1473869906846,CommandLineOptions="analysis_type=SelectVariants input_file=[] showFullBamList=false read_buffer_size=null phone_home=AWS gatk_key=null tag=NA read_filter=[] disable_read_filter=[] intervals=[Fingerprint.test.intervals] excludeIntervals=null interval_set_rule=UNION interval_merging=ALL interval_padding=0 reference_sequence=/seq/references/Homo_sapiens_assembly19/v1/Homo_sapiens_assembly19.fasta nonDeterministicRandomSeed=false disableDithering=false maxRuntime=-1 maxRuntimeUnits=MINUTES downsampling_type=BY_SAMPLE downsample_to_fraction=null downsample_to_coverage=1000 baq=OFF baqGapOpenPenalty=40.0 refactor_NDN_cigar_string=false fix_misencoded_quality_scores=false allow_potentially_misencoded_quality_scores=false useOriginalQualities=false defaultBaseQualities=-1 performanceLog=null BQSR=null quantize_quals=0 disable_indel_quals=false emit_original_quals=false preserve_qscores_less_than=6 globalQScorePrior=-1.0 validation_strictness=SILENT remove_program_records=false keep_program_records=false sample_rename_mapping_file=null unsafe=null disable_auto_index_creation_and_locking_when_reading_rods=false no_cmdline_in_header=false sites_only=false never_trim_vcf_format_field=false bcf=false bam_compression=null simplifyBAM=false disable_bam_indexing=false generate_md5=false num_threads=1 num_cpu_threads_per_data_thread=1 num_io_threads=0 monitorThreadEfficiency=false num_bam_file_handles=null read_group_black_list=null pedigree=[] pedigreeString=[] pedigreeValidationType=STRICT allow_intervals_with_unindexed_bam=false generateShadowBCF=false variant_index_type=DYNAMIC_SEEK variant_index_parameter=-1 logging_level=INFO log_to_file=null help=false version=false variant=(RodBinding name=variant source=../NA12892.101342370027_R12C02.vcf.gz) discordance=(RodBinding name= source=UNBOUND) concordance=(RodBinding name= source=UNBOUND) out=/seq/tng/ggrant/checkFpTest/subselected/NA12891.101342370027_R12C02.subselected.vcf.gz sample_name=[] sample_expressions=null sample_file=null exclude_sample_name=[] exclude_sample_file=[] exclude_sample_expressions=[] selectexpressions=[] invertselect=false excludeNonVariants=false excludeFiltered=false preserveAlleles=false removeUnusedAlternates=false restrictAllelesTo=ALL keepOriginalAC=false keepOriginalDP=false mendelianViolation=false invertMendelianViolation=false mendelianViolationQualThreshold=0.0 select_random_fraction=0.0 remove_fraction_genotypes=0.0 selectTypeToInclude=[] selectTypeToExclude=[] keepIDs=null excludeIDs=null fullyDecode=false justRead=false maxIndelSize=2147483647 minIndelSize=0 maxFilteredGenotypes=2147483647 minFilteredGenotypes=0 maxFractionFilteredGenotypes=1.0 minFractionFilteredGenotypes=0.0 setFilteredGtToNocall=false ALLOW_NONOVERLAPPING_COMMAND_LINE_SAMPLES=false filter_reads_with_N_cigar=false filter_mismatching_base_and_quals=false filter_bases_not_stored=false">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth; some reads may have been filtered">
+##contig=<ID=1,length=249250621>
+##contig=<ID=2,length=243199373>
+##contig=<ID=3,length=198022430>
+##contig=<ID=4,length=191154276>
+##contig=<ID=5,length=180915260>
+##contig=<ID=6,length=171115067>
+##contig=<ID=7,length=159138663>
+##contig=<ID=8,length=146364022>
+##contig=<ID=9,length=141213431>
+##contig=<ID=10,length=135534747>
+##contig=<ID=11,length=135006516>
+##contig=<ID=12,length=133851895>
+##contig=<ID=13,length=115169878>
+##contig=<ID=14,length=107349540>
+##contig=<ID=15,length=102531392>
+##contig=<ID=16,length=90354753>
+##contig=<ID=17,length=81195210>
+##contig=<ID=18,length=78077248>
+##contig=<ID=19,length=59128983>
+##contig=<ID=20,length=63025520>
+##contig=<ID=21,length=48129895>
+##contig=<ID=22,length=51304566>
+##contig=<ID=X,length=155270560>
+##contig=<ID=Y,length=59373566>
+##contig=<ID=MT,length=16569>
+##contig=<ID=GL000207.1,length=4262>
+##contig=<ID=GL000226.1,length=15008>
+##contig=<ID=GL000229.1,length=19913>
+##contig=<ID=GL000231.1,length=27386>
+##contig=<ID=GL000210.1,length=27682>
+##contig=<ID=GL000239.1,length=33824>
+##contig=<ID=GL000235.1,length=34474>
+##contig=<ID=GL000201.1,length=36148>
+##contig=<ID=GL000247.1,length=36422>
+##contig=<ID=GL000245.1,length=36651>
+##contig=<ID=GL000197.1,length=37175>
+##contig=<ID=GL000203.1,length=37498>
+##contig=<ID=GL000246.1,length=38154>
+##contig=<ID=GL000249.1,length=38502>
+##contig=<ID=GL000196.1,length=38914>
+##contig=<ID=GL000248.1,length=39786>
+##contig=<ID=GL000244.1,length=39929>
+##contig=<ID=GL000238.1,length=39939>
+##contig=<ID=GL000202.1,length=40103>
+##contig=<ID=GL000234.1,length=40531>
+##contig=<ID=GL000232.1,length=40652>
+##contig=<ID=GL000206.1,length=41001>
+##contig=<ID=GL000240.1,length=41933>
+##contig=<ID=GL000236.1,length=41934>
+##contig=<ID=GL000241.1,length=42152>
+##contig=<ID=GL000243.1,length=43341>
+##contig=<ID=GL000242.1,length=43523>
+##contig=<ID=GL000230.1,length=43691>
+##contig=<ID=GL000237.1,length=45867>
+##contig=<ID=GL000233.1,length=45941>
+##contig=<ID=GL000204.1,length=81310>
+##contig=<ID=GL000198.1,length=90085>
+##contig=<ID=GL000208.1,length=92689>
+##contig=<ID=GL000191.1,length=106433>
+##contig=<ID=GL000227.1,length=128374>
+##contig=<ID=GL000228.1,length=129120>
+##contig=<ID=GL000214.1,length=137718>
+##contig=<ID=GL000221.1,length=155397>
+##contig=<ID=GL000209.1,length=159169>
+##contig=<ID=GL000218.1,length=161147>
+##contig=<ID=GL000220.1,length=161802>
+##contig=<ID=GL000213.1,length=164239>
+##contig=<ID=GL000211.1,length=166566>
+##contig=<ID=GL000199.1,length=169874>
+##contig=<ID=GL000217.1,length=172149>
+##contig=<ID=GL000216.1,length=172294>
+##contig=<ID=GL000215.1,length=172545>
+##contig=<ID=GL000205.1,length=174588>
+##contig=<ID=GL000219.1,length=179198>
+##contig=<ID=GL000224.1,length=179693>
+##contig=<ID=GL000223.1,length=180455>
+##contig=<ID=GL000195.1,length=182896>
+##contig=<ID=GL000212.1,length=186858>
+##contig=<ID=GL000222.1,length=186861>
+##contig=<ID=GL000200.1,length=187035>
+##contig=<ID=GL000193.1,length=189789>
+##contig=<ID=GL000194.1,length=191469>
+##contig=<ID=GL000225.1,length=211173>
+##contig=<ID=GL000192.1,length=547496>
+##contig=<ID=NC_007605,length=171823>
+##date created=Wed Sep 14 14:48:11 UTC 2016
+##reference=file:///seq/references/Homo_sapiens_assembly19/v1/Homo_sapiens_assembly19.fasta
+##source=BPM file
+##source=SelectVariants
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA12892


### PR DESCRIPTION

For Jointcalling we re-sample on-the-fly to remove duplicate sample-names that exist in the callset. A samplename->File map is provided to the tools (VariantDB) and the resulting callset has the new sample names. In order to crosscheck the fingerprints against the original gvcfs (or bams) one would need to remap the samples again. doing this on tens-of-thousands of files is expensive, so this PR enables to remap the gvcfs sample names on the fly. 

In addition, this PR makes the dictionary comparison (for fingerprinting) less stringent in the following way: The dictionary checking only happens on the subset of sequence indices from 0 to the maximum one _that appears in the haplotype database file_ 
