### PR TITLE
GL-143 remove fields defined in base class

### DIFF
--- a/src/main/java/picard/analysis/directed/TargetedPcrMetrics.java
+++ b/src/main/java/picard/analysis/directed/TargetedPcrMetrics.java
@@ -32,9 +32,6 @@ public class TargetedPcrMetrics extends TargetMetricsBase {
     /**  The name of the amplicon set used in this metrics collection run */
     public String CUSTOM_AMPLICON_SET;
 
-    /** The number of bases in the reference genome used for alignment */
-    public long GENOME_SIZE;
-
     /** The number of unique bases covered by the intervals of all amplicons in the amplicon set */
     public long AMPLICON_TERRITORY;
 
@@ -47,12 +44,6 @@ public class TargetedPcrMetrics extends TargetMetricsBase {
 
     /** The number of PF_BASES_ALIGNED that mapped neither on or near an amplicon. */
     public long OFF_AMPLICON_BASES;
-
-    /** The number of PF_BASES_ALIGNED that mapped to a targeted region of the genome. */
-    public long ON_TARGET_BASES;
-
-    /** The number of bases from PF_SELECTED_UNIQUE_PAIRS that mapped to a targeted region of the genome. */
-    public long ON_TARGET_FROM_PAIR_BASES;
 
     /** The fraction of PF_BASES_ALIGNED that mapped to or near an amplicon, (ON_AMPLICON_BASES +
      * NEAR_AMPLICON_BASES)/PF_BASES_ALIGNED. */
@@ -70,15 +61,6 @@ public class TargetedPcrMetrics extends TargetMetricsBase {
 
     /** The mean read coverage of all amplicon regions in the experiment. */
     public double MEAN_AMPLICON_COVERAGE;
-
-    /** The mean read coverage of all target regions in an experiment. */
-    public double MEAN_TARGET_COVERAGE;
-
-    /** The median coverage of reads that mapped to target regions of an experiment. */
-    public double MEDIAN_TARGET_COVERAGE;
-
-    /** The maximum coverage of reads that mapped to target regions of an experiment. */
-    public long MAX_TARGET_COVERAGE;
 
     /** The fold by which the amplicon region has been amplified above genomic background. */
     public double FOLD_ENRICHMENT;

--- a/src/test/java/picard/metrics/MetricBaseTest.java
+++ b/src/test/java/picard/metrics/MetricBaseTest.java
@@ -1,40 +1,32 @@
 package picard.metrics;
 
+import htsjdk.samtools.metrics.MetricBase;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import picard.analysis.CollectRawWgsMetrics;
-import picard.analysis.CollectWgsMetricsWithNonZeroCoverage;
-import picard.analysis.directed.HsMetrics;
-import picard.analysis.directed.TargetMetrics;
-import picard.analysis.directed.TargetedPcrMetrics;
+import picard.cmdline.ClassFinder;
 
 import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Set;
 
-
 public class MetricBaseTest {
 
-    @DataProvider(name= "testMetricClasses")
-    public Object[][] getMetricClasses(){
-        return new Object[][]{
-                {TargetedPcrMetrics.class},
-                {HsMetrics.class},
-                {TargetMetrics.class},
-                {CollectRawWgsMetrics.RawWgsMetrics.class},
-                {CollectWgsMetricsWithNonZeroCoverage.WgsMetricsWithNonZeroCoverage.class}
-            };
-        }
+    @DataProvider(name = "testMetricClasses")
+    public java.util.Iterator<Object[]> getMetricClasses() {
+        final ClassFinder classFinder = new ClassFinder();
+
+        classFinder.find("picard", MetricBase.class);
+        return classFinder.getClasses().stream().map(c -> new Object[]{c}).iterator();
+    }
 
     @Test(dataProvider = "testMetricClasses")
-    public void testUniqueFields(Class metricClass) {
+    public void testUniqueFields(final Class metricClass) {
 
-        Set<String> metricFields = new HashSet<>();
+        final Set<String> metricFields = new HashSet<>();
 
         for (final Field f : metricClass.getFields()) {
-            Assert.assertTrue(metricFields.add(f.getName()), f.getName() + " has a naming collision");
+            Assert.assertFalse(!metricFields.add(f.getName()), metricClass + " has a naming collision in field " + f.getName());
         }
     }
 }
-

--- a/src/test/java/picard/metrics/MetricBaseTest.java
+++ b/src/test/java/picard/metrics/MetricBaseTest.java
@@ -1,0 +1,40 @@
+package picard.metrics;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import picard.analysis.CollectRawWgsMetrics;
+import picard.analysis.CollectWgsMetricsWithNonZeroCoverage;
+import picard.analysis.directed.HsMetrics;
+import picard.analysis.directed.TargetMetrics;
+import picard.analysis.directed.TargetedPcrMetrics;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Set;
+
+
+public class MetricBaseTest {
+
+    @DataProvider(name= "testMetricClasses")
+    public Object[][] getMetricClasses(){
+        return new Object[][]{
+                {TargetedPcrMetrics.class},
+                {HsMetrics.class},
+                {TargetMetrics.class},
+                {CollectRawWgsMetrics.RawWgsMetrics.class},
+                {CollectWgsMetricsWithNonZeroCoverage.WgsMetricsWithNonZeroCoverage.class}
+            };
+        }
+
+    @Test(dataProvider = "testMetricClasses")
+    public void testUniqueFields(Class metricClass) {
+
+        Set<String> metricFields = new HashSet<>();
+
+        for (final Field f : metricClass.getFields()) {
+            Assert.assertTrue(metricFields.add(f.getName()), f.getName() + " has a naming collision");
+        }
+    }
+}
+

--- a/src/test/java/picard/metrics/MetricBaseTest.java
+++ b/src/test/java/picard/metrics/MetricBaseTest.java
@@ -8,21 +8,23 @@ import picard.cmdline.ClassFinder;
 
 import java.lang.reflect.Field;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
 
 public class MetricBaseTest {
 
     @DataProvider(name = "testMetricClasses")
-    public java.util.Iterator<Object[]> getMetricClasses() {
+    public Iterator<Object[]> getMetricClasses() {
         final ClassFinder classFinder = new ClassFinder();
 
         classFinder.find("picard", MetricBase.class);
-        return classFinder.getClasses().stream().map(c -> new Object[]{c}).iterator();
+        return classFinder.getClasses().stream()
+                .map(c -> new Object[]{c})
+                .iterator();
     }
 
     @Test(dataProvider = "testMetricClasses")
     public void testUniqueFields(final Class metricClass) {
-
         final Set<String> metricFields = new HashSet<>();
 
         for (final Field f : metricClass.getFields()) {


### PR DESCRIPTION
### Description

Resolving naming collisions by removing fields that are duplicated in the TargetedPCRMetrics class and its base class (TargetMetricsBase).

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

