### PR TITLE
Removed boilerplate "main" function from picard CLPs.

### DIFF
--- a/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
+++ b/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
@@ -121,14 +121,6 @@ public class CollectAlignmentSummaryMetrics extends SinglePassSamProgram {
 
     private AlignmentSummaryMetricsCollector collector;
 
-    /** Required main method implementation. */
-    public static void main(final String[] argv) {
-        new CollectAlignmentSummaryMetrics().instanceMainWithExit(argv);
-    }
-
-    /** Silly method that is necessary to give unit test access to call doWork() */
-    protected final int testDoWork() { return doWork(); }
-
     @Override protected void setup(final SAMFileHeader header, final File samFile) {
         IOUtil.assertFileIsWritable(OUTPUT);
 

--- a/src/main/java/picard/analysis/CollectBaseDistributionByCycle.java
+++ b/src/main/java/picard/analysis/CollectBaseDistributionByCycle.java
@@ -98,10 +98,6 @@ public class CollectBaseDistributionByCycle extends SinglePassSamProgram {
     private String plotSubtitle = "";
     private final Log log = Log.getInstance(CollectBaseDistributionByCycle.class);
 
-    public static void main(String[] args) {
-        System.exit(new CollectBaseDistributionByCycle().instanceMain(args));
-    }
-
     @Override
     protected void setup(final SAMFileHeader header, final File samFile) {
         IOUtil.assertFileIsWritable(CHART_OUTPUT);

--- a/src/main/java/picard/analysis/CollectGcBiasMetrics.java
+++ b/src/main/java/picard/analysis/CollectGcBiasMetrics.java
@@ -146,13 +146,6 @@ public class CollectGcBiasMetrics extends SinglePassSamProgram {
     // at bins of each GC %. Need 101 to get from 0-100.
     private static final int BINS = 101;
 
-    ////////////////////////////////////////////////////////////////////////////
-    // Stock main method
-    ////////////////////////////////////////////////////////////////////////////
-    public static void main(final String[] args) {
-        System.exit(new CollectGcBiasMetrics().instanceMain(args));
-    }
-
     /////////////////////////////////////////////////////////////////////////////
     // Setup calculates windowsByGc for the entire reference. Must be done at
     // startup to avoid missing reference contigs in the case of small files

--- a/src/main/java/picard/analysis/CollectInsertSizeMetrics.java
+++ b/src/main/java/picard/analysis/CollectInsertSizeMetrics.java
@@ -110,11 +110,6 @@ public class CollectInsertSizeMetrics extends SinglePassSamProgram {
     // Calculates InsertSizeMetrics for all METRIC_ACCUMULATION_LEVELs provided
     private InsertSizeMetricsCollector multiCollector;
 
-    /** Required main method implementation. */
-    public static void main(final String[] argv) {
-        new CollectInsertSizeMetrics().instanceMainWithExit(argv);
-    }
-
     /**
      * Put any custom command-line validation in an override of this method.
      * clp is initialized at this point and can be used to print usage and access argv.

--- a/src/main/java/picard/analysis/CollectJumpingLibraryMetrics.java
+++ b/src/main/java/picard/analysis/CollectJumpingLibraryMetrics.java
@@ -103,11 +103,6 @@ public class CollectJumpingLibraryMetrics extends CommandLineProgram {
 
     private static final int SAMPLE_FOR_MODE = 50000; // How many outward-facing pairs to sample to determine the mode
 
-    /** Stock main method. */
-    public static void main(String[] args) {
-        System.exit(new CollectJumpingLibraryMetrics().instanceMain(args));
-    }
-
     /**
      * Calculates the detailed statistics about the jumping library and then generates the results.
      */

--- a/src/main/java/picard/analysis/CollectMultipleMetrics.java
+++ b/src/main/java/picard/analysis/CollectMultipleMetrics.java
@@ -503,11 +503,6 @@ public class CollectMultipleMetrics extends CommandLineProgram {
 
     private static final Log log = Log.getInstance(CollectMultipleMetrics.class);
 
-    // Stock main method
-    public static void main(final String[] args) {
-        new CollectMultipleMetrics().instanceMainWithExit(args);
-    }
-
     @Override
     protected String[] customCommandLineValidation() {
         if (PROGRAM.isEmpty()) {

--- a/src/main/java/picard/analysis/CollectRnaSeqMetrics.java
+++ b/src/main/java/picard/analysis/CollectRnaSeqMetrics.java
@@ -139,11 +139,6 @@ static final String USAGE_DETAILS = "<p>This tool takes a SAM/BAM file containin
      */
     private String plotSubtitle = "";
 
-    /** Required main method implementation. */
-    public static void main(final String[] argv) {
-        new CollectRnaSeqMetrics().instanceMainWithExit(argv);
-    }
-
     @Override
     protected String[] customCommandLineValidation() {
         // No ribosomal intervals file and rRNA fragment percentage = 0

--- a/src/main/java/picard/analysis/CollectRrbsMetrics.java
+++ b/src/main/java/picard/analysis/CollectRrbsMetrics.java
@@ -142,10 +142,6 @@ private static final String R_SCRIPT = "picard/analysis/rrbsQc.R";
         };
     }
 
-    public static void main(final String[] args) {
-        new CollectRrbsMetrics().instanceMainWithExit(args);
-    }
-
     @Override
     protected int doWork() {
         if (!METRICS_FILE_PREFIX.endsWith(".")) {

--- a/src/main/java/picard/analysis/CompareMetrics.java
+++ b/src/main/java/picard/analysis/CompareMetrics.java
@@ -81,8 +81,4 @@ public class CompareMetrics extends CommandLineProgram {
         }
         return 0;
     }
-
-    public static void main(String[] argv) {
-        new CompareMetrics().instanceMainWithExit(argv);
-    }
 }

--- a/src/main/java/picard/analysis/MeanQualityByCycle.java
+++ b/src/main/java/picard/analysis/MeanQualityByCycle.java
@@ -95,11 +95,6 @@ public class MeanQualityByCycle extends SinglePassSamProgram {
 
     private final Log log = Log.getInstance(MeanQualityByCycle.class);
 
-    /** Required main method. */
-    public static void main(String[] args) {
-        System.exit(new MeanQualityByCycle().instanceMain(args));
-    }
-
     private static final class HistogramGenerator {
         final boolean useOriginalQualities;
         int maxLengthSoFar = 0;

--- a/src/main/java/picard/analysis/QualityScoreDistribution.java
+++ b/src/main/java/picard/analysis/QualityScoreDistribution.java
@@ -98,11 +98,6 @@ public class QualityScoreDistribution extends SinglePassSamProgram {
 
     private final Log log = Log.getInstance(QualityScoreDistribution.class);
 
-    /** Required main method. */
-    public static void main(final String[] args) {
-        System.exit(new QualityScoreDistribution().instanceMain(args));
-    }
-
     @Override
     protected void setup(final SAMFileHeader header, final File samFile) {
         IOUtil.assertFileIsWritable(OUTPUT);

--- a/src/main/java/picard/fastq/BamToBfq.java
+++ b/src/main/java/picard/fastq/BamToBfq.java
@@ -62,39 +62,64 @@ import java.io.File;
 @DocumentedFeature
 public class BamToBfq extends CommandLineProgram {
     static final String USAGE_SUMMARY =
-    		"Converts a BAM file into a BFQ (binary fastq formatted) file";
+            "Converts a BAM file into a BFQ (binary fastq formatted) file";
     static final String USAGE_DETAILS =
-    		 "<p>The BFQ format is the input format to some tools like Maq aligner.</p>" +
-    		 "<h3>Input</h3>" +
-    		 "<p>A single BAM file to convert</p>" +
-    		 "<h3>Output</h3>" +
-    		 "<p>One or two FASTQ files depending on whether the BAM file contains single- or " +
-    		 "paired-end sequencing data. You must indicate the output directory that will contain these files (<code>ANALYSIS_DIR</code>) " +
-    		 "and the output file name prefix (<code>OUTPUT_FILE_PREFIX</code>).</p>" +
-    		 "<h3>Usage example:</h3>" +
-    		 "<pre>" +
-    		 "java -jar picard.jar BamToBfq \\\n" +
-    		 "     I=input.bam \\\n" +
-    		 "     ANALYSIS_DIR=output_dir \\\n" +
-    		 "     OUTPUT_FILE_PREFIX=output_name \\\n" +
-    		 "     PAIRED_RUN=false" +
-    		 "</pre><hr />";
+            "<p>The BFQ format is the input format to some tools like Maq aligner.</p>" +
+            "<h3>Input</h3>" +
+            "<p>A single BAM file to convert</p>" +
+            "<h3>Output</h3>" +
+            "<p>One or two FASTQ files depending on whether the BAM file contains single- or " +
+            "paired-end sequencing data. You must indicate the output directory that will contain these files (<code>ANALYSIS_DIR</code>) " +
+            "and the output file name prefix (<code>OUTPUT_FILE_PREFIX</code>).</p>" +
+            "<h3>Usage example:</h3>" +
+            "<pre>" +
+            "java -jar picard.jar BamToBfq \\\n" +
+            "     I=input.bam \\\n" +
+            "     ANALYSIS_DIR=output_dir \\\n" +
+            "     OUTPUT_FILE_PREFIX=output_name \\\n" +
+            "     PAIRED_RUN=false" +
+            "</pre><hr />";
     // The following attributes define the command-line arguments
 
-    @Argument(doc="The BAM file to parse.", shortName=StandardOptionDefinitions.INPUT_SHORT_NAME) public File INPUT;
-    @Argument(doc="The analysis directory for the binary output file. ") public File ANALYSIS_DIR;
-    @Argument(doc="Flowcell barcode (e.g. 30PYMAAXX).  ", shortName="F", mutex="OUTPUT_FILE_PREFIX") public String FLOWCELL_BARCODE;
-    @Argument(doc="Lane number. ", shortName= StandardOptionDefinitions.LANE_SHORT_NAME, optional=true,mutex="OUTPUT_FILE_PREFIX") public Integer LANE;
-    @Argument(doc="Prefix for all output files", mutex={"FLOWCELL_BARCODE","LANE"}) public String OUTPUT_FILE_PREFIX;
-    @Argument(doc="Number of reads to align (null = all).", shortName="NUM", optional=true) public Integer READS_TO_ALIGN;
-    @Argument(doc="Number of reads to break into individual groups for alignment", shortName="CHUNK") public Integer READ_CHUNK_SIZE = 2000000;
-    @Argument(doc="Whether this is a paired-end run. ", shortName="PE") public Boolean PAIRED_RUN;
-    @Argument(doc="Deprecated option; use READ_NAME_PREFIX instead", mutex="READ_NAME_PREFIX", shortName="RB", optional=true) public String RUN_BARCODE;
-    @Argument(doc="Prefix to be stripped off the beginning of all read names  (to make them short enough to run in Maq)", optional=true) public String READ_NAME_PREFIX;
-    @Argument(doc="Whether to include non-PF reads", shortName="NONPF", optional=true) public Boolean INCLUDE_NON_PF_READS = false;
-    @Argument(doc="Whether to clip adapters from the reads") public boolean CLIP_ADAPTERS = true;
+    @Argument(doc="The BAM file to parse.", shortName=StandardOptionDefinitions.INPUT_SHORT_NAME)
+    public File INPUT;
+
+    @Argument(doc="The analysis directory for the binary output file. ")
+    public File ANALYSIS_DIR;
+
+    @Argument(doc="Flowcell barcode (e.g. 30PYMAAXX).  ", shortName="F", mutex="OUTPUT_FILE_PREFIX")
+    public String FLOWCELL_BARCODE;
+
+    @Argument(doc="Lane number. ", shortName= StandardOptionDefinitions.LANE_SHORT_NAME, optional=true,mutex="OUTPUT_FILE_PREFIX")
+    public Integer LANE;
+
+    @Argument(doc="Prefix for all output files", mutex={"FLOWCELL_BARCODE","LANE"})
+    public String OUTPUT_FILE_PREFIX;
+
+    @Argument(doc="Number of reads to align (null = all).", shortName="NUM", optional=true)
+    public Integer READS_TO_ALIGN;
+
+    @Argument(doc="Number of reads to break into individual groups for alignment", shortName="CHUNK")
+    public Integer READ_CHUNK_SIZE = 2000000;
+
+    @Argument(doc="Whether this is a paired-end run. ", shortName="PE")
+    public Boolean PAIRED_RUN;
+
+    @Argument(doc="Deprecated option; use READ_NAME_PREFIX instead", mutex="READ_NAME_PREFIX", shortName="RB", optional=true)
+    public String RUN_BARCODE;
+
+    @Argument(doc="Prefix to be stripped off the beginning of all read names  (to make them short enough to run in Maq)", optional=true)
+    public String READ_NAME_PREFIX;
+
+    @Argument(doc="Whether to include non-PF reads", shortName="NONPF", optional=true)
+    public Boolean INCLUDE_NON_PF_READS = false;
+
+    @Argument(doc="Whether to clip adapters from the reads")
+    public boolean CLIP_ADAPTERS = true;
+
     @Argument(doc="The number of bases from each read to write to the bfq file.  If this is non-null, then " +
-            "only the first BASES_TO_WRITE bases from each read will be written.", optional=true) public Integer BASES_TO_WRITE = null;
+            "only the first BASES_TO_WRITE bases from each read will be written.", optional=true)
+    public Integer BASES_TO_WRITE = null;
 
     protected int doWork() {
 
@@ -111,10 +136,6 @@ public class BamToBfq extends CommandLineProgram {
         return 0;
     }
 
-    public static void main(String[] argv) {
-        System.exit(new BamToBfq().instanceMain(argv));
-    }
-
     protected String[] customCommandLineValidation() {
 
         if (OUTPUT_FILE_PREFIX == null) {
@@ -125,5 +146,4 @@ public class BamToBfq extends CommandLineProgram {
         }
         return null;
     }
-
 }

--- a/src/main/java/picard/illumina/CheckIlluminaDirectory.java
+++ b/src/main/java/picard/illumina/CheckIlluminaDirectory.java
@@ -112,13 +112,6 @@ public class CheckIlluminaDirectory extends CommandLineProgram {
             optional = true)
     public Boolean LINK_LOCS = false;
 
-    /**
-     * Required main method implementation.
-     */
-    public static void main(final String[] argv) {
-        new CheckIlluminaDirectory().instanceMainWithExit(argv);
-    }
-
     @Override
     protected int doWork() {
         final ReadStructure readStructure = new ReadStructure(READ_STRUCTURE);

--- a/src/main/java/picard/illumina/CollectIlluminaBasecallingMetrics.java
+++ b/src/main/java/picard/illumina/CollectIlluminaBasecallingMetrics.java
@@ -309,10 +309,6 @@ public class CollectIlluminaBasecallingMetrics extends CommandLineProgram {
         }
     }
 
-    public static void main(final String[] argv) {
-        new CollectIlluminaBasecallingMetrics().instanceMainWithExit(argv);
-    }
-
     /***
      * This class manages counts of Illumina Basecalling data on a Per Barcode Per Lane basis.  Cluster and PFCluster
      * counts are stored per tile number.

--- a/src/main/java/picard/illumina/CollectIlluminaLaneMetrics.java
+++ b/src/main/java/picard/illumina/CollectIlluminaLaneMetrics.java
@@ -136,10 +136,6 @@ public class CollectIlluminaLaneMetrics extends CommandLineProgram {
         return 0;
     }
 
-    public static void main(final String[] args) {
-        new CollectIlluminaLaneMetrics().instanceMainWithExit(args);
-    }
-
     /**
      * Utility for collating Tile records from the Illumina TileMetrics file into lane-level and phasing-level metrics.
      */

--- a/src/main/java/picard/illumina/ExtractIlluminaBarcodes.java
+++ b/src/main/java/picard/illumina/ExtractIlluminaBarcodes.java
@@ -479,10 +479,6 @@ public class ExtractIlluminaBarcodes extends CommandLineProgram {
         return messages.toArray(new String[messages.size()]);
     }
 
-    public static void main(final String[] argv) {
-        new ExtractIlluminaBarcodes().instanceMainWithExit(argv);
-    }
-
     private void parseBarcodeFile(final ArrayList<String> messages) {
         try (final TabbedTextFileWithHeaderParser barcodesParser = new TabbedTextFileWithHeaderParser(BARCODE_FILE)) {
             final String sequenceColumn = barcodesParser.hasColumn(BARCODE_SEQUENCE_COLUMN)

--- a/src/main/java/picard/illumina/IlluminaBasecallsToFastq.java
+++ b/src/main/java/picard/illumina/IlluminaBasecallsToFastq.java
@@ -388,10 +388,6 @@ public class IlluminaBasecallsToFastq extends CommandLineProgram {
         return new FastqRecordsWriter(templateWriters, sampleBarcodeWriters, molecularBarcodeWriters);
     }
 
-    public static void main(final String[] args) {
-        new IlluminaBasecallsToFastq().instanceMainWithExit(args);
-    }
-
     /**
      * Container for various FastqWriters, one for each template read, one for each sample barcode read,
      * and one for each molecular barcode read.

--- a/src/main/java/picard/illumina/IlluminaBasecallsToSam.java
+++ b/src/main/java/picard/illumina/IlluminaBasecallsToSam.java
@@ -510,10 +510,6 @@ public class IlluminaBasecallsToSam extends CommandLineProgram {
         return new SAMFileWriterWrapper(new SAMFileWriterFactory().makeSAMOrBAMWriter(header, presorted, output));
     }
 
-    public static void main(final String[] args) {
-        System.exit(new IlluminaBasecallsToSam().instanceMain(args));
-    }
-
     /**
      * Put any custom command-line validation in an override of this method.
      * clp is initialized at this point and can be used to print usage and access args.

--- a/src/main/java/picard/illumina/MarkIlluminaAdapters.java
+++ b/src/main/java/picard/illumina/MarkIlluminaAdapters.java
@@ -138,11 +138,6 @@ public class MarkIlluminaAdapters extends CommandLineProgram {
 
     private static final Log log = Log.getInstance(MarkIlluminaAdapters.class);
 
-    // Stock main method
-    public static void main(final String[] args) {
-        System.exit(new MarkIlluminaAdapters().instanceMain(args));
-    }
-
     @Override
     protected String[] customCommandLineValidation() {
         if ((FIVE_PRIME_ADAPTER != null && THREE_PRIME_ADAPTER == null) || (THREE_PRIME_ADAPTER != null && FIVE_PRIME_ADAPTER == null)) {

--- a/src/main/java/picard/illumina/quality/CollectHiSeqXPfFailMetrics.java
+++ b/src/main/java/picard/illumina/quality/CollectHiSeqXPfFailMetrics.java
@@ -179,11 +179,6 @@ public class CollectHiSeqXPfFailMetrics extends CommandLineProgram {
         }
     }
 
-    /** Stock main method. */
-    public static void main(final String[] args) {
-        new CollectHiSeqXPfFailMetrics().instanceMainWithExit(args);
-    }
-
     @Override
     protected int doWork() {
 

--- a/src/main/java/picard/reference/ExtractSequences.java
+++ b/src/main/java/picard/reference/ExtractSequences.java
@@ -80,10 +80,6 @@ public class ExtractSequences extends CommandLineProgram {
     @Argument(doc="Maximum line length for sequence data.")
     public int LINE_LENGTH = 80;
 
-    public static void main(final String[] args) {
-        new ExtractSequences().instanceMainWithExit(args);
-    }
-
     @Override
     protected boolean requiresReference() {
         return true;

--- a/src/main/java/picard/reference/NonNFastaSize.java
+++ b/src/main/java/picard/reference/NonNFastaSize.java
@@ -78,10 +78,6 @@ public class NonNFastaSize extends CommandLineProgram {
     @Argument(shortName = "INTERVALS", doc = "An interval list file that contains the locations of the positions to assess.  If not provided, the entire reference will be used", optional = true)
     public File INTERVALS = null;
 
-    public static void main(final String[] args) {
-        new NonNFastaSize().instanceMainWithExit(args);
-    }
-
     @Override
     protected int doWork() {
         IOUtil.assertFileIsReadable(INPUT);

--- a/src/main/java/picard/reference/NormalizeFasta.java
+++ b/src/main/java/picard/reference/NormalizeFasta.java
@@ -56,10 +56,6 @@ public class NormalizeFasta extends CommandLineProgram {
 
     private final Log log = Log.getInstance(NormalizeFasta.class);
 
-    public static void main(final String[] args) {
-        new NormalizeFasta().instanceMainWithExit(args);
-    }
-
     @Override
     protected int doWork() {
         IOUtil.assertFileIsReadable(INPUT);

--- a/src/main/java/picard/sam/AddCommentsToBam.java
+++ b/src/main/java/picard/sam/AddCommentsToBam.java
@@ -50,8 +50,6 @@ public class AddCommentsToBam extends CommandLineProgram {
     @Argument(shortName = "C", doc = "Comments to add to the BAM file")
     public List<String> COMMENT;
 
-    public static void main(final String[] args) { new AddCommentsToBam().instanceMainWithExit(args); }
-
     protected int doWork() {
         IOUtil.assertFileIsReadable(INPUT);
         IOUtil.assertFileIsWritable(OUTPUT);

--- a/src/main/java/picard/sam/BamIndexStats.java
+++ b/src/main/java/picard/sam/BamIndexStats.java
@@ -62,7 +62,7 @@ public class BamIndexStats extends CommandLineProgram {
             "      I=input.bam \\<br />" +
             "      O=output" +
             "</pre>" +
-            "<hr />"       ;
+            "<hr />";
     private static final Log log = Log.getInstance(BamIndexStats.class);
 
     @Argument(shortName= StandardOptionDefinitions.INPUT_SHORT_NAME,

--- a/src/main/java/picard/sam/BamIndexStats.java
+++ b/src/main/java/picard/sam/BamIndexStats.java
@@ -61,7 +61,7 @@ public class BamIndexStats extends CommandLineProgram {
             "java -jar picard.jar BamIndexStats \\<br />" +
             "      I=input.bam \\<br />" +
             "      O=output" +
-            "</pre>"   +
+            "</pre>" +
             "<hr />"       ;
     private static final Log log = Log.getInstance(BamIndexStats.class);
 

--- a/src/main/java/picard/sam/BamIndexStats.java
+++ b/src/main/java/picard/sam/BamIndexStats.java
@@ -69,11 +69,6 @@ public class BamIndexStats extends CommandLineProgram {
             doc="A BAM file to process.")
     public File INPUT;
 
-    /** Stock main method for a command line program. */
-    public static void main(final String[] argv) {
-        System.exit(new BamIndexStats().instanceMain(argv));
-    }
-
     /**
      * Main method for the program.  Checks that input file is present and
      * readable, then iterates through the index printing meta data to stdout.

--- a/src/main/java/picard/sam/BuildBamIndex.java
+++ b/src/main/java/picard/sam/BuildBamIndex.java
@@ -80,11 +80,6 @@ public class BuildBamIndex extends CommandLineProgram {
                     "If INPUT is a URL and OUTPUT is unspecified, defaults to a file in the current directory.", optional = true)
     public File OUTPUT;
 
-    /** Stock main method for a command line program. */
-    public static void main(final String[] argv) {
-        System.exit(new BuildBamIndex().instanceMain(argv));
-    }
-
     /**
      * Main method for the program.  Checks that all input files are present and
      * readable and that the output file can be written to.  Then iterates through

--- a/src/main/java/picard/sam/CalculateReadGroupChecksum.java
+++ b/src/main/java/picard/sam/CalculateReadGroupChecksum.java
@@ -40,10 +40,6 @@ public class CalculateReadGroupChecksum extends CommandLineProgram {
     @Argument(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "The file to which the hash code should be written.", optional = true)
     public File OUTPUT;
 
-    public static void main(final String[] args) {
-        new CalculateReadGroupChecksum().instanceMainWithExit(args);
-    }
-
     /**
      * Creates a file name (not including the path) for an RG MD5 file based on the name of the input file.
      */

--- a/src/main/java/picard/sam/CheckTerminatorBlock.java
+++ b/src/main/java/picard/sam/CheckTerminatorBlock.java
@@ -28,10 +28,6 @@ public class CheckTerminatorBlock extends CommandLineProgram {
     @Argument(shortName= StandardOptionDefinitions.INPUT_SHORT_NAME, doc="The block compressed file to check.")
     public File INPUT;
 
-    public static void main(final String[] args) {
-        new CheckTerminatorBlock().instanceMainWithExit(args);
-    }
-
     @Override protected int doWork() {
         IOUtil.assertFileIsReadable(INPUT);
         try {

--- a/src/main/java/picard/sam/CleanSam.java
+++ b/src/main/java/picard/sam/CleanSam.java
@@ -61,10 +61,6 @@ public class CleanSam extends CommandLineProgram {
     @Argument(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "Where to write cleaned SAM.")
     public File OUTPUT;
 
-    public static void main(final String[] argv) {
-        new CleanSam().instanceMainWithExit(argv);
-    }
-
     /**
      * Do the work after command line has been parsed.
      * RuntimeException may be thrown by this method, and are reported appropriately.

--- a/src/main/java/picard/sam/CompareSAMs.java
+++ b/src/main/java/picard/sam/CompareSAMs.java
@@ -65,10 +65,6 @@ public class CompareSAMs extends CommandLineProgram {
     @PositionalArguments(minElements = 2, maxElements = 2)
     public List<File> samFiles;
 
-    public static void main(String[] argv) {
-        new CompareSAMs().instanceMainWithExit(argv);
-    }
-
     /**
      * Do the work after command line has been parsed. RuntimeException may be
      * thrown by this method, and are reported appropriately.

--- a/src/main/java/picard/sam/CreateSequenceDictionary.java
+++ b/src/main/java/picard/sam/CreateSequenceDictionary.java
@@ -136,10 +136,6 @@ public class CreateSequenceDictionary extends CommandLineProgram {
         }
     }
 
-    public static void main(final String[] argv) {
-        System.exit(new CreateSequenceDictionary().instanceMain(argv));
-    }
-
     /**
      * Read all the sequences from the given reference file, and convert into SAMSequenceRecords
      * @param referenceFile fasta or fasta.gz

--- a/src/main/java/picard/sam/FastqToSam.java
+++ b/src/main/java/picard/sam/FastqToSam.java
@@ -250,10 +250,6 @@ public class FastqToSam extends CommandLineProgram {
         return qualityFormat;
     }
 
-    /** Stock main method. */
-    public static void main(final String[] argv) {
-        System.exit(new FastqToSam().instanceMain(argv));
-    }
 
     /**
      * Get a list of FASTQs that are sequentially numbered based on the first (base) fastq.

--- a/src/main/java/picard/sam/FixMateInformation.java
+++ b/src/main/java/picard/sam/FixMateInformation.java
@@ -129,10 +129,6 @@ public class FixMateInformation extends CommandLineProgram {
 
     protected SAMFileWriter out;
 
-    public static void main(final String[] args) {
-        new FixMateInformation().instanceMainWithExit(args);
-    }
-
     protected int doWork() {
         // Open up the input
         boolean allQueryNameSorted = true;

--- a/src/main/java/picard/sam/GatherBamFiles.java
+++ b/src/main/java/picard/sam/GatherBamFiles.java
@@ -11,9 +11,9 @@ import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import picard.cmdline.CommandLineProgram;
-import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.programgroups.ReadDataManipulationProgramGroup;
 
@@ -60,26 +60,26 @@ import java.util.List;
         programGroup = ReadDataManipulationProgramGroup.class)
 @DocumentedFeature
 public class GatherBamFiles extends CommandLineProgram {
-    static final String USAGE_SUMMARY = 
-    		"Concatenate efficiently BAM files that resulted from a scattered parallel analysis";
-    static final String USAGE_DETAILS = 
-    		"<p>This tool performs a rapid \"gather\" or concatenation on BAM files. " + 
-    		"This is often needed in operations that have been run in parallel across genomics regions by scattering " + 
-    		"their execution across computing nodes and cores thus resulting in smaller BAM files.</p><p>This tool does not support SAM files</p>" + 
-    		"<h3>Inputs</h3>" +
-    		"<p>A list of BAM files to combine using the INPUT argument. " +
-    		"These files must be provided in the order that they should be concatenated.</p>" +
-    		"<h3>Output</h3>" +
-    		"<p>A single BAM file. The header is copied from the first input file.</p>" +
-    		"<h3>Usage example:</h3>" +
-    		"<pre>java -jar picard.jar GatherBamFiles \\\n" +
-    		"      I=input1.bam \\\n" +
-    		"      I=input2.bam \\\n" +
-    		"      O=gathered_files.bam</pre>" +
-    		"<h3>Notes</h3>" +
-    		"<p>Operates via copying of the gzip blocks directly for speed but also supports generation of an MD5 " +
-    		"on the output and indexing of the output BAM file.</p>" +
-    		"<hr/>";
+    static final String USAGE_SUMMARY =
+            "Concatenate efficiently BAM files that resulted from a scattered parallel analysis";
+    static final String USAGE_DETAILS =
+            "<p>This tool performs a rapid \"gather\" or concatenation on BAM files. " +
+            "This is often needed in operations that have been run in parallel across genomics regions by scattering " +
+            "their execution across computing nodes and cores thus resulting in smaller BAM files.</p><p>This tool does not support SAM files</p>" +
+            "<h3>Inputs</h3>" +
+            "<p>A list of BAM files to combine using the INPUT argument. " +
+            "These files must be provided in the order that they should be concatenated.</p>" +
+            "<h3>Output</h3>" +
+            "<p>A single BAM file. The header is copied from the first input file.</p>" +
+            "<h3>Usage example:</h3>" +
+            "<pre>java -jar picard.jar GatherBamFiles \\\n" +
+            "      I=input1.bam \\\n" +
+            "      I=input2.bam \\\n" +
+            "      O=gathered_files.bam</pre>" +
+            "<h3>Notes</h3>" +
+            "<p>Operates via copying of the gzip blocks directly for speed but also supports generation of an MD5 " +
+            "on the output and indexing of the output BAM file.</p>" +
+            "<hr/>";
     
     @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME,
             doc = "Two or more BAM files or text files containing lists of BAM files (one per line).")
@@ -89,13 +89,6 @@ public class GatherBamFiles extends CommandLineProgram {
     public File OUTPUT;
 
     private static final Log log = Log.getInstance(GatherBamFiles.class);
-
-    // Stock main method.
-    public static void main(final String[] args) {
-        final GatherBamFiles gatherer = new GatherBamFiles();
-        gatherer.CREATE_INDEX = true;
-        gatherer.instanceMainWithExit(args);
-    }
 
     @Override
     protected int doWork() {

--- a/src/main/java/picard/sam/MergeSamFiles.java
+++ b/src/main/java/picard/sam/MergeSamFiles.java
@@ -131,11 +131,6 @@ public class MergeSamFiles extends CommandLineProgram {
 
     private static final int PROGRESS_INTERVAL = 1000000;
 
-    /** Required main method implementation. */
-    public static void main(final String[] argv) {
-        System.exit(new MergeSamFiles().instanceMain(argv));
-    }
-
     /** Combines multiple SAM/BAM files into one. */
     @Override
     protected int doWork() {

--- a/src/main/java/picard/sam/ReplaceSamHeader.java
+++ b/src/main/java/picard/sam/ReplaceSamHeader.java
@@ -79,10 +79,6 @@ public class ReplaceSamHeader extends CommandLineProgram {
             shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME)
     public File OUTPUT;
 
-    public static void main(final String[] argv) {
-        new ReplaceSamHeader().instanceMainWithExit(argv);
-    }
-
     /**
      * Do the work after command line has been parsed.
      * RuntimeException may be thrown by this method, and are reported appropriately.

--- a/src/main/java/picard/sam/RevertOriginalBaseQualitiesAndAddMateCigar.java
+++ b/src/main/java/picard/sam/RevertOriginalBaseQualitiesAndAddMateCigar.java
@@ -65,11 +65,6 @@ public class RevertOriginalBaseQualitiesAndAddMateCigar extends CommandLineProgr
         this.CREATE_MD5_FILE = true;
     }
 
-    /** Default main method impl. */
-    public static void main(final String[] args) {
-        new RevertOriginalBaseQualitiesAndAddMateCigar().instanceMainWithExit(args);
-    }
-
     public int doWork() {
         IOUtil.assertFileIsReadable(INPUT);
         IOUtil.assertFileIsWritable(OUTPUT);

--- a/src/main/java/picard/sam/SamFormatConverter.java
+++ b/src/main/java/picard/sam/SamFormatConverter.java
@@ -63,10 +63,6 @@ public class SamFormatConverter extends CommandLineProgram {
     @Argument(doc = "The BAM or SAM output file. ", shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME)
     public File OUTPUT;
 
-    public static void main(final String[] argv) {
-        new SamFormatConverter().instanceMainWithExit(argv);
-    }
-
     protected int doWork() {
         convert(INPUT, OUTPUT, REFERENCE_SEQUENCE, CREATE_INDEX);
         return 0;

--- a/src/main/java/picard/sam/SamToFastq.java
+++ b/src/main/java/picard/sam/SamToFastq.java
@@ -165,10 +165,6 @@ public class SamToFastq extends CommandLineProgram {
 
     private final Log log = Log.getInstance(SamToFastq.class);
 
-    public static void main(final String[] argv) {
-        System.exit(new SamToFastq().instanceMain(argv));
-    }
-
     protected int doWork() {
         IOUtil.assertFileIsReadable(INPUT);
         final SamReader reader = SamReaderFactory.makeDefault().referenceSequence(REFERENCE_SEQUENCE).open(INPUT);

--- a/src/main/java/picard/sam/SetNmMdAndUqTags.java
+++ b/src/main/java/picard/sam/SetNmMdAndUqTags.java
@@ -117,10 +117,6 @@ public class SetNmMdAndUqTags extends CommandLineProgram {
 
     private final Log log = Log.getInstance(SetNmMdAndUqTags.class);
 
-    public static void main(final String[] argv) {
-        new SetNmMdAndUqTags().instanceMainWithExit(argv);
-    }
-
     protected int doWork() {
         IOUtil.assertFileIsReadable(INPUT);
         IOUtil.assertFileIsWritable(OUTPUT);

--- a/src/main/java/picard/sam/SplitSamByLibrary.java
+++ b/src/main/java/picard/sam/SplitSamByLibrary.java
@@ -112,10 +112,6 @@ public class SplitSamByLibrary extends CommandLineProgram {
 
     public static final int NO_LIBRARIES_SPECIFIED_IN_HEADER = 2;
 
-    public static void main(String[] args) {
-        System.exit(new SplitSamByLibrary().instanceMain(args));
-    }
-
     @Override
     protected int doWork() {
         IOUtil.assertFileIsReadable(INPUT);

--- a/src/main/java/picard/sam/ValidateSamFile.java
+++ b/src/main/java/picard/sam/ValidateSamFile.java
@@ -164,10 +164,6 @@ public class ValidateSamFile extends CommandLineProgram {
             "large amounts of memory to run, so this flag allows you to forego that check.")
     public boolean SKIP_MATE_VALIDATION = false;
 
-    public static void main(final String[] args) {
-        System.exit(new ValidateSamFile().instanceMain(args));
-    }
-
     /**
      * Return types for doWork()
      */

--- a/src/main/java/picard/sam/ViewSam.java
+++ b/src/main/java/picard/sam/ViewSam.java
@@ -126,10 +126,6 @@ public class ViewSam extends CommandLineProgram {
     @Argument(doc = "An intervals file used to restrict what records are output.", optional = true)
     public File INTERVAL_LIST;
 
-    public static void main(final String[] args) {
-        new ViewSam().instanceMain(args);
-    }
-
     @Override
     protected int doWork() {
         return writeSamText(System.out);

--- a/src/main/java/picard/sam/markduplicates/EstimateLibraryComplexity.java
+++ b/src/main/java/picard/sam/markduplicates/EstimateLibraryComplexity.java
@@ -417,11 +417,6 @@ public class EstimateLibraryComplexity extends AbstractOpticalDuplicateFinderCom
         return getReadBarcodeValue(record, READ_TWO_BARCODE_TAG);
     }
 
-    /** Stock main method. */
-    public static void main(final String[] args) {
-        new EstimateLibraryComplexity().instanceMainWithExit(args);
-    }
-
     public EstimateLibraryComplexity() {
         final int sizeInBytes;
         if (null != BARCODE_TAG || null != READ_ONE_BARCODE_TAG || null != READ_TWO_BARCODE_TAG) {

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -240,13 +240,6 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
     }
 
     /**
-     * Stock main method.
-     */
-    public static void main(final String[] args) {
-        new MarkDuplicates().instanceMainWithExit(args);
-    }
-
-    /**
      * Main work method.  Reads the BAM file once and collects sorted information about
      * the 5' ends of both ends of each read (or just one end in the case of pairs).
      * Then makes a pass through those determining duplicates before re-reading the

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicatesWithMateCigar.java
@@ -112,11 +112,6 @@ public class MarkDuplicatesWithMateCigar extends AbstractMarkDuplicatesCommandLi
     private boolean warnedNullProgramRecords = false;
     private boolean warnedMissingProgramRecords = false;
 
-    /** Stock main method. */
-    public static void main(final String[] args) {
-        new MarkDuplicatesWithMateCigar().instanceMainWithExit(args);
-    }
-
     /**
      * Main work method.
      */

--- a/src/main/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigar.java
@@ -74,19 +74,12 @@ import java.util.Set;
 public class SimpleMarkDuplicatesWithMateCigar extends MarkDuplicates {
     private final Log log = Log.getInstance(MarkDuplicatesWithMateCigar.class);
 
-    /** Stock main method. */
-    public static void main(final String[] args) {
-        new MarkDuplicatesWithMateCigar().instanceMainWithExit(args);
-    }
-
-    private class ReadEndsForSimpleMarkDuplicatesWithMateCigar extends ReadEnds {
-    }
+    private class ReadEndsForSimpleMarkDuplicatesWithMateCigar extends ReadEnds {}
     
     private static boolean isPairedAndBothMapped(final SAMRecord record) {
         return record.getReadPairedFlag() &&
                 !record.getReadUnmappedFlag() &&
                 !record.getMateUnmappedFlag();
-        
     }
 
     /**

--- a/src/main/java/picard/util/BaitDesigner.java
+++ b/src/main/java/picard/util/BaitDesigner.java
@@ -363,11 +363,6 @@ static final String USAGE_DETAILS = "<p>This tool is used to design custom bait 
         return count;
     }
 
-    /** Stock main method. */
-    public static void main(final String[] args) {
-        new BaitDesigner().instanceMainWithExit(args);
-    }
-
     @Override
     protected String[] customCommandLineValidation() {
         final List<String> errors = new ArrayList<String>();

--- a/src/main/java/picard/util/BedToIntervalList.java
+++ b/src/main/java/picard/util/BedToIntervalList.java
@@ -104,11 +104,6 @@ public class BedToIntervalList extends CommandLineProgram {
 
     final Log LOG = Log.getInstance(getClass());
 
-    // Stock main method
-    public static void main(final String[] args) {
-        new BedToIntervalList().instanceMainWithExit(args);
-    }
-
     @Override
     protected int doWork() {
         IOUtil.assertFileIsReadable(INPUT);

--- a/src/main/java/picard/util/FifoBuffer.java
+++ b/src/main/java/picard/util/FifoBuffer.java
@@ -102,11 +102,6 @@ public class FifoBuffer extends CommandLineProgram {
         this(System.in, System.out);
     }
 
-    // Stock main method
-    public static void main(final String[] args) {
-        new FifoBuffer().instanceMainWithExit(args);
-    }
-
     @Override
     protected int doWork() {
         final CircularByteBuffer fifo = new CircularByteBuffer(BUFFER_SIZE);

--- a/src/main/java/picard/util/ScatterIntervalsByNs.java
+++ b/src/main/java/picard/util/ScatterIntervalsByNs.java
@@ -124,10 +124,6 @@ public class ScatterIntervalsByNs extends CommandLineProgram {
     private static final ProgressLogger locusProgress = new ProgressLogger(log, (int) 1e7, "examined", "loci");
     private static final ProgressLogger intervalProgress = new ProgressLogger(log, (int) 10, "found", "intervals");
 
-    public static void main(final String[] args) {
-        new ScatterIntervalsByNs().instanceMainWithExit(args);
-    }
-
     // return a custom argument collection since this tool uses a (required) argument name
     // of "REFERENCE", not "REFERENCE_SEQUENCE"
     @Override

--- a/src/main/java/picard/vcf/CollectVariantCallingMetrics.java
+++ b/src/main/java/picard/vcf/CollectVariantCallingMetrics.java
@@ -80,10 +80,6 @@ public class CollectVariantCallingMetrics extends CommandLineProgram {
 
     private final Log log = Log.getInstance(CollectVariantCallingMetrics.class);
 
-    public static void main(final String[] args) {
-        new CollectVariantCallingMetrics().instanceMainWithExit(args);
-    }
-
     @Override
     protected int doWork() {
         IOUtil.assertFileIsReadable(INPUT);

--- a/src/main/java/picard/vcf/FixVcfHeader.java
+++ b/src/main/java/picard/vcf/FixVcfHeader.java
@@ -99,11 +99,6 @@ public class FixVcfHeader extends CommandLineProgram {
 
     private final Log log = Log.getInstance(FixVcfHeader.class);
 
-    // Stock main method
-    public static void main(final String[] args) {
-        new FixVcfHeader().instanceMainWithExit(args);
-    }
-
     @Override
     protected String[] customCommandLineValidation() {
         if (HEADER != null && 0 <= CHECK_FIRST_N_RECORDS) return new String[]{"CHECK_FIRST_N_RECORDS should no be specified when HEADER is specified"};

--- a/src/main/java/picard/vcf/GatherVcfs.java
+++ b/src/main/java/picard/vcf/GatherVcfs.java
@@ -48,10 +48,6 @@ public class GatherVcfs extends CommandLineProgram {
 
     private static final Log log = Log.getInstance(GatherVcfs.class);
 
-    public static void main(final String[] args) {
-        new GatherVcfs().instanceMainWithExit(args);
-    }
-
     public GatherVcfs() {
         CREATE_INDEX = true;
     }

--- a/src/main/java/picard/vcf/GenotypeConcordance.java
+++ b/src/main/java/picard/vcf/GenotypeConcordance.java
@@ -239,10 +239,6 @@ public class GenotypeConcordance extends CommandLineProgram {
     public static final String OUTPUT_VCF_TRUTH_SAMPLE_NAME = "truth";
     public static final String OUTPUT_VCF_CALL_SAMPLE_NAME = "call";
 
-    public static void main(final String[] args) {
-        new GenotypeConcordance().instanceMainWithExit(args);
-    }
-
     @Override
     protected String[] customCommandLineValidation() {
         // Note - If the user specifies to use INTERVALS, the code will fail if the vcfs are not indexed, so we set USE_VCF_INDEX to true and check that the vcfs are indexed.

--- a/src/main/java/picard/vcf/MakeSitesOnlyVcf.java
+++ b/src/main/java/picard/vcf/MakeSitesOnlyVcf.java
@@ -15,10 +15,10 @@ import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 import htsjdk.variant.vcf.VCFFileReader;
 import htsjdk.variant.vcf.VCFHeader;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import picard.PicardException;
 import picard.cmdline.CommandLineProgram;
-import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.programgroups.VariantManipulationProgramGroup;
 
@@ -76,27 +76,22 @@ public class MakeSitesOnlyVcf extends CommandLineProgram {
     @Argument(shortName="S", doc="Names of one or more samples to include in the output VCF.", optional=true)
     public Set<String> SAMPLE = new TreeSet<String>();
 
-    // Stock main method
-    public static void main(final String[] args) {
-        new MakeSitesOnlyVcf().instanceMainWithExit(args);
+    public MakeSitesOnlyVcf() {
+        CREATE_INDEX = true;
     }
-
-	public MakeSitesOnlyVcf() {
-		CREATE_INDEX = true;
-	}
 
     @Override
     protected int doWork() {
         IOUtil.assertFileIsReadable(INPUT);
         IOUtil.assertFileIsWritable(OUTPUT);
 
-	    final VCFFileReader reader = new VCFFileReader(INPUT, false);
-	    final VCFHeader inputVcfHeader = new VCFHeader(reader.getFileHeader().getMetaDataInInputOrder());
-	    final SAMSequenceDictionary sequenceDictionary = inputVcfHeader.getSequenceDictionary();
+        final VCFFileReader reader = new VCFFileReader(INPUT, false);
+        final VCFHeader inputVcfHeader = new VCFHeader(reader.getFileHeader().getMetaDataInInputOrder());
+        final SAMSequenceDictionary sequenceDictionary = inputVcfHeader.getSequenceDictionary();
 
-	    if (CREATE_INDEX && sequenceDictionary == null) {
-		    throw new PicardException("A sequence dictionary must be available (either through the input file or by setting it explicitly) when creating indexed output.");
-	    }
+        if (CREATE_INDEX && sequenceDictionary == null) {
+            throw new PicardException("A sequence dictionary must be available (either through the input file or by setting it explicitly) when creating indexed output.");
+        }
 
         final ProgressLogger progress = new ProgressLogger(Log.getInstance(MakeSitesOnlyVcf.class), 10000);
 
@@ -115,16 +110,16 @@ public class MakeSitesOnlyVcf extends CommandLineProgram {
 
         // Go through the input, strip the records and write them to the output
         final CloseableIterator<VariantContext> iterator = reader.iterator();
-	    while (iterator.hasNext()) {
-		    final VariantContext full = iterator.next();
+        while (iterator.hasNext()) {
+            final VariantContext full = iterator.next();
             final VariantContext site = subsetToSamplesWithOriginalAnnotations(full, SAMPLE);
             writer.add(site);
             progress.record(site.getContig(), site.getStart());
         }
 
-	    CloserUtil.close(iterator);
-	    CloserUtil.close(reader);
-	    writer.close();
+        CloserUtil.close(iterator);
+        CloserUtil.close(reader);
+        writer.close();
 
         return 0;
     }

--- a/src/main/java/picard/vcf/MergeVcfs.java
+++ b/src/main/java/picard/vcf/MergeVcfs.java
@@ -151,10 +151,6 @@ public class MergeVcfs extends CommandLineProgram {
 
     private final Log log = Log.getInstance(MergeVcfs.class);
 
-    public static void main(final String[] argv) {
-        new MergeVcfs().instanceMainWithExit(argv);
-    }
-
     public MergeVcfs() {
         this.CREATE_INDEX = true;
     }

--- a/src/main/java/picard/vcf/RenameSampleInVcf.java
+++ b/src/main/java/picard/vcf/RenameSampleInVcf.java
@@ -105,11 +105,6 @@ public class RenameSampleInVcf extends CommandLineProgram {
     @Argument(doc="New name to give sample in output VCF.")
     public String NEW_SAMPLE_NAME;
 
-
-    public static void main(final String[] args) {
-        new RenameSampleInVcf().instanceMainWithExit(args);
-    }
-
     @Override
     protected int doWork() {
         IOUtil.assertFileIsReadable(INPUT);

--- a/src/main/java/picard/vcf/SortVcf.java
+++ b/src/main/java/picard/vcf/SortVcf.java
@@ -69,10 +69,6 @@ public class SortVcf extends CommandLineProgram {
     private final List<VCFFileReader> inputReaders = new ArrayList<VCFFileReader>();
     private final List<VCFHeader> inputHeaders = new ArrayList<VCFHeader>();
 
-    public static void main(final String[] args) {
-        new SortVcf().instanceMainWithExit(args);
-    }
-
     // Overrides the option default, including in the help message. Option remains settable on commandline.
     public SortVcf() {
         this.CREATE_INDEX = true;

--- a/src/main/java/picard/vcf/SplitVcfs.java
+++ b/src/main/java/picard/vcf/SplitVcfs.java
@@ -67,10 +67,6 @@ public class SplitVcfs extends CommandLineProgram {
 
     private final Log log = Log.getInstance(SplitVcfs.class);
 
-    public static void main(final String[] argv) {
-        new SplitVcfs().instanceMainWithExit(argv);
-    }
-
     public SplitVcfs() {
         this.CREATE_INDEX = true;
     }

--- a/src/main/java/picard/vcf/UpdateVcfSequenceDictionary.java
+++ b/src/main/java/picard/vcf/UpdateVcfSequenceDictionary.java
@@ -72,10 +72,6 @@ public class UpdateVcfSequenceDictionary extends CommandLineProgram {
 
     private final Log log = Log.getInstance(UpdateVcfSequenceDictionary.class);
 
-    public static void main(final String[] args) {
-        new UpdateVcfSequenceDictionary().instanceMainWithExit(args);
-    }
-
     @Override
     protected int doWork() {
         IOUtil.assertFileIsReadable(INPUT);

--- a/src/main/java/picard/vcf/VcfFormatConverter.java
+++ b/src/main/java/picard/vcf/VcfFormatConverter.java
@@ -80,16 +80,12 @@ public class VcfFormatConverter extends CommandLineProgram {
     @Argument(doc="The BCF or VCF output file name.", shortName=StandardOptionDefinitions.OUTPUT_SHORT_NAME)
     public File OUTPUT;
 
-	@Argument(doc="Fail if an index is not available for the input VCF/BCF")
-	public Boolean REQUIRE_INDEX = true;
+    @Argument(doc = "Fail if an index is not available for the input VCF/BCF")
+    public Boolean REQUIRE_INDEX = true;
 
-    public static void main(final String[] argv) {
-        new VcfFormatConverter().instanceMainWithExit(argv);
+    public VcfFormatConverter() {
+        this.CREATE_INDEX = true;
     }
-
-	public VcfFormatConverter() {
-		this.CREATE_INDEX = true;
-	}
 
     @Override
     protected int doWork() {
@@ -98,12 +94,12 @@ public class VcfFormatConverter extends CommandLineProgram {
         IOUtil.assertFileIsReadable(INPUT);
         IOUtil.assertFileIsWritable(OUTPUT);
 
-	    final VCFFileReader reader = new VCFFileReader(INPUT, REQUIRE_INDEX);
-	    final VCFHeader header = new VCFHeader(reader.getFileHeader());
-	    final SAMSequenceDictionary sequenceDictionary = header.getSequenceDictionary();
-	    if (CREATE_INDEX && sequenceDictionary == null) {
-		    throw new PicardException("A sequence dictionary must be available in the input file when creating indexed output.");
-	    }
+        final VCFFileReader reader = new VCFFileReader(INPUT, REQUIRE_INDEX);
+        final VCFHeader header = new VCFHeader(reader.getFileHeader());
+        final SAMSequenceDictionary sequenceDictionary = header.getSequenceDictionary();
+        if (CREATE_INDEX && sequenceDictionary == null) {
+            throw new PicardException("A sequence dictionary must be available in the input file when creating indexed output.");
+        }
 
         final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
                 .setOutputFile(OUTPUT)
@@ -114,16 +110,16 @@ public class VcfFormatConverter extends CommandLineProgram {
             builder.unsetOption(Options.INDEX_ON_THE_FLY);
         final VariantContextWriter writer = builder.build();
         writer.writeHeader(header);
-	    final CloseableIterator<VariantContext> iterator = reader.iterator();
+        final CloseableIterator<VariantContext> iterator = reader.iterator();
 
-	    while (iterator.hasNext()) {
-		    final VariantContext context = iterator.next();
+        while (iterator.hasNext()) {
+            final VariantContext context = iterator.next();
             writer.add(context);
             progress.record(context.getContig(), context.getStart());
         }
 
-	    CloserUtil.close(iterator);
-	    CloserUtil.close(reader);
+        CloserUtil.close(iterator);
+        CloserUtil.close(reader);
         writer.close();
 
         return 0;

--- a/src/main/java/picard/vcf/VcfToIntervalList.java
+++ b/src/main/java/picard/vcf/VcfToIntervalList.java
@@ -79,10 +79,6 @@ public class VcfToIntervalList extends CommandLineProgram {
             optional = true)
     public boolean INCLUDE_FILTERED = false;
 
-    public static void main(final String[] argv) {
-        new VcfToIntervalList().instanceMainWithExit(argv);
-    }
-
     @Override
     protected int doWork() {
         IOUtil.assertFileIsReadable(INPUT);

--- a/src/main/java/picard/vcf/filter/FilterVcf.java
+++ b/src/main/java/picard/vcf/filter/FilterVcf.java
@@ -91,11 +91,6 @@ public class FilterVcf extends CommandLineProgram {
     /** Constructor to default to having index creation on. */
     public FilterVcf() { this.CREATE_INDEX = true; }
 
-    // Stock main method
-    public static void main(final String[] args) {
-        new FilterVcf().instanceMainWithExit(args);
-    }
-
     final private Log log = Log.getInstance(FilterVcf.class);
     final private ProgressLogger progress = new ProgressLogger(log, 100_000, "Processed", "Variants");
 


### PR DESCRIPTION
For several years now, picard CLPs do not need their own `main` function, but since we all copy-paste, it remains...this PR removes all un-needed mentions of the main function.

Github shows some files as if I've deleted and then added everything...not sure why...local changes are small.