### PR TITLE
Fix CollectInsertSizeMetrics temporary file creation.

### DIFF
--- a/src/test/java/picard/analysis/CollectInsertSizeMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectInsertSizeMetricsTest.java
@@ -266,7 +266,7 @@ public class CollectInsertSizeMetricsTest extends CommandLineProgramTest {
 
     @Test
     public void testWidthOfMetrics() throws IOException {
-        final File testSamFile = File.createTempFile("CollectInsertSizeMetrics", ".bam", TEST_DATA_DIR);
+        final File testSamFile = File.createTempFile("CollectInsertSizeMetrics", ".bam");
         testSamFile.deleteOnExit();
 
         new File(testSamFile.getAbsolutePath().replace(".bam$",".bai")).deleteOnExit();


### PR DESCRIPTION
Fixes the remaining issue from https://github.com/broadinstitute/picard/issues/660.