### PR TITLE
Make CollectSamErrorMetrics show up in docs

### DIFF
--- a/src/main/java/picard/sam/SamErrorMetric/CollectSamErrorMetrics.java
+++ b/src/main/java/picard/sam/SamErrorMetric/CollectSamErrorMetrics.java
@@ -87,6 +87,7 @@ import java.util.stream.Collectors;
         oneLineSummary = "Program to collect error metrics on bases stratified in various ways.",
         programGroup = DiagnosticsAndQCProgramGroup.class
 )
+@DocumentedFeature
 public class CollectSamErrorMetrics extends CommandLineProgram {
     @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "Input SAM or BAM file.")
     public File INPUT;


### PR DESCRIPTION
### Description

Added @DocumentedFeature to the CLP declaration -- otherwise it won't show up in the web docs. 

#### Content
- [x] Added or modified tests to cover changes and any new functionality -- NA / no change
- [x] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable


