### PR TITLE
Sort test files that are used in tests that assume they're indexable.

### DIFF
--- a/testdata/picard/fingerprint/NA12891.over.fingerprints.shifted.for.crams.r1.sam
+++ b/testdata/picard/fingerprint/NA12891.over.fingerprints.shifted.for.crams.r1.sam
@@ -1,4 +1,4 @@
-@HD	VN:1.5
+@HD	VN:1.6	SO:coordinate
 @SQ	SN:1	LN:1001	M5:af506819d4b9357827ce128b6c83a816	UR:file:reference.shifted.for.crams.fasta
 @SQ	SN:3	LN:2001	M5:bfecd72141fd7c10b33f04958736baef	UR:file:reference.shifted.for.crams.fasta
 @SQ	SN:4	LN:1001	M5:ac7d9a3274b2f1fa8eac3f01b3ff9b43	UR:file:reference.shifted.for.crams.fasta

--- a/testdata/picard/fingerprint/NA12891.over.fingerprints.shifted.for.crams.r2.sam
+++ b/testdata/picard/fingerprint/NA12891.over.fingerprints.shifted.for.crams.r2.sam
@@ -1,4 +1,4 @@
-@HD	VN:1.5
+@HD	VN:1.6	SO:coordinate
 @SQ	SN:1	LN:1001	M5:af506819d4b9357827ce128b6c83a816	UR:file:reference.shifted.for.crams.fasta
 @SQ	SN:3	LN:2001	M5:bfecd72141fd7c10b33f04958736baef	UR:file:reference.shifted.for.crams.fasta
 @SQ	SN:4	LN:1001	M5:ac7d9a3274b2f1fa8eac3f01b3ff9b43	UR:file:reference.shifted.for.crams.fasta

--- a/testdata/picard/fingerprint/NA12892.over.fingerprints.shifted.for.crams.r1.sam
+++ b/testdata/picard/fingerprint/NA12892.over.fingerprints.shifted.for.crams.r1.sam
@@ -1,4 +1,4 @@
-@HD	VN:1.5
+@HD	VN:1.6	SO:coordinate
 @SQ	SN:1	LN:1001	M5:af506819d4b9357827ce128b6c83a816	UR:file:reference.shifted.for.crams.fasta
 @SQ	SN:3	LN:2001	M5:bfecd72141fd7c10b33f04958736baef	UR:file:reference.shifted.for.crams.fasta
 @SQ	SN:4	LN:1001	M5:ac7d9a3274b2f1fa8eac3f01b3ff9b43	UR:file:reference.shifted.for.crams.fasta

--- a/testdata/picard/fingerprint/NA12892.over.fingerprints.shifted.for.crams.r2.sam
+++ b/testdata/picard/fingerprint/NA12892.over.fingerprints.shifted.for.crams.r2.sam
@@ -1,4 +1,4 @@
-@HD	VN:1.5
+@HD	VN:1.6	SO:coordinate
 @SQ	SN:1	LN:1001	M5:af506819d4b9357827ce128b6c83a816	UR:file:/Users/ckachuli/picard/testdata/picard/fingerprint/reference.shifted.for.crams.fasta
 @SQ	SN:3	LN:2001	M5:bfecd72141fd7c10b33f04958736baef	UR:file:/Users/ckachuli/picard/testdata/picard/fingerprint/reference.shifted.for.crams.fasta
 @SQ	SN:4	LN:1001	M5:ac7d9a3274b2f1fa8eac3f01b3ff9b43	UR:file:/Users/ckachuli/picard/testdata/picard/fingerprint/reference.shifted.for.crams.fasta


### PR DESCRIPTION
The next release of htsjdk will reject attempts to create an index on a CRAM that is not coordinate sorted. This updates CrossCheckFingerprint test sams that are used to create CRAMs, which were already sorted, but the sort order was  not reflected in the header (the updated files were run through SortSam).