### PR TITLE
GL-143 Move the probe metrics into TargetMetrics and add a test for HsMetrics

### DIFF
--- a/src/main/java/picard/analysis/directed/HsMetrics.java
+++ b/src/main/java/picard/analysis/directed/HsMetrics.java
@@ -46,7 +46,7 @@ package picard.analysis.directed;
  *
  * @author Tim Fennell
  */
-public class HsMetrics extends TargetMetricsBase {
+public class HsMetrics extends PanelMetricsBase {
     /** The name of the bait set used in the hybrid selection. */
     public String BAIT_SET;
 

--- a/src/main/java/picard/analysis/directed/PanelMetricsBase.java
+++ b/src/main/java/picard/analysis/directed/PanelMetricsBase.java
@@ -1,0 +1,153 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.analysis.directed;
+
+import picard.metrics.MultilevelMetrics;
+
+/**
+ * TargetMetrics, are metrics to measure how well we hit specific targets (or baits) when using a targeted sequencing process like hybrid selection
+ * or Targeted PCR Techniques (TSCA).  TargetMetrics at the moment are the metrics that are shared by both HybridSelection and TargetedPcrMetrics.
+ */
+public class PanelMetricsBase extends MultilevelMetrics {
+    /** The number of unique bases covered by the intervals of all targets that should be covered */
+    public long TARGET_TERRITORY;
+
+    /** The number of bases in the reference genome used for alignment. */
+    public long GENOME_SIZE;
+
+    /** The total number of reads in the SAM or BAM file examined. */
+    public long TOTAL_READS;
+
+    /** The number of passing filter reads (PF). */
+    public long PF_READS;
+
+    /** The number of bases in the PF_READS of a SAM or BAM file */
+    public long PF_BASES;
+
+    /** The number of PF_READS that are not marked as duplicates. */
+    public long PF_UNIQUE_READS;
+
+    /** The number of PF_UNIQUE_READS that are aligned with mapping score > 0 to the reference genome. */
+    public long PF_UQ_READS_ALIGNED;
+
+    /** The number of PF_BASES that are aligned with mapping score > 0 to the reference genome. */
+    public long PF_BASES_ALIGNED;
+
+    /** The number of PF unique bases that are aligned with mapping score > 0 to the reference genome. */
+    public long PF_UQ_BASES_ALIGNED;
+
+    /** The number of PF aligned bases that mapped to a targeted region of the genome. */
+    public long ON_TARGET_BASES;
+
+    //metrics below here are derived after collection
+
+    /** The fraction of reads passing filter, PF_READS/TOTAL_READS.   */
+    public double PCT_PF_READS;
+
+    /** The fraction of unique reads passing filter, PF_UNIQUE_READS/TOTAL_READS. */
+    public double PCT_PF_UQ_READS;
+
+    /** The fraction of unique reads passing filter that align to the reference,
+     * PF_UQ_READS_ALIGNED/PF_UNIQUE_READS. */
+    public double PCT_PF_UQ_READS_ALIGNED;
+
+    /** The mean coverage of targets. */
+    public double MEAN_TARGET_COVERAGE;
+
+    /** The median coverage of targets. */
+    public double MEDIAN_TARGET_COVERAGE;
+
+    /** The maximum coverage of reads that mapped to target regions of an experiment. */
+    public long MAX_TARGET_COVERAGE;
+
+    /** The fraction of targets that did not reach coverage=1 over any base. */
+    public double ZERO_CVG_TARGETS_PCT;
+
+    /** The fraction of aligned bases that were filtered out because they were in reads marked as duplicates. */
+    public double PCT_EXC_DUPE;
+
+    /** The fraction of aligned bases in reads that have MQ=0 and whose 5' end consists of adapter sequence. */
+    public double PCT_EXC_ADAPTER;
+
+    /** The fraction of aligned bases that were filtered out because they were in reads with low mapping quality. */
+    public double PCT_EXC_MAPQ;
+
+    /** The fraction of aligned bases that were filtered out because they were of low base quality. */
+    public double PCT_EXC_BASEQ;
+
+    /** The fraction of aligned bases that were filtered out because they were the second observation from
+     *  an insert with overlapping reads. */
+    public double PCT_EXC_OVERLAP;
+
+    /** The fraction of aligned bases that were filtered out because they did not align over a target base. */
+    public double PCT_EXC_OFF_TARGET;
+
+    /**
+     * The fold over-coverage necessary to raise 80% of bases in "non-zero-cvg" targets to
+     * the mean coverage level in those targets.
+     */
+    public double FOLD_80_BASE_PENALTY;
+
+    /** The fraction of all target bases achieving 1X or greater coverage. */
+    public double PCT_TARGET_BASES_1X;
+    /** The fraction of all target bases achieving 2X or greater coverage. */
+    public double PCT_TARGET_BASES_2X;
+    /** The fraction of all target bases achieving 10X or greater coverage. */
+    public double PCT_TARGET_BASES_10X;
+    /** The fraction of all target bases achieving 20X or greater coverage. */
+    public double PCT_TARGET_BASES_20X;
+    /** The fraction of all target bases achieving 30X or greater coverage. */
+    public double PCT_TARGET_BASES_30X;
+    /** The fraction of all target bases achieving 40X or greater coverage. */
+    public double PCT_TARGET_BASES_40X;
+    /** The fraction of all target bases achieving 50X or greater coverage. */
+    public double PCT_TARGET_BASES_50X;
+    /** The fraction of all target bases achieving 100X or greater coverage. */
+    public double PCT_TARGET_BASES_100X;
+
+    /**
+     * A measure of how undercovered <= 50% GC regions are relative to the mean. For each GC bin [0..50]
+     * we calculate a = % of target territory, and b = % of aligned reads aligned to these targets.
+     * AT DROPOUT is then abs(sum(a-b when a-b < 0)). E.g. if the value is 5% this implies that 5% of total
+     * reads that should have mapped to GC<=50% regions mapped elsewhere.
+     */
+    public double AT_DROPOUT;
+
+    /**
+     * A measure of how undercovered >= 50% GC regions are relative to the mean. For each GC bin [50..100]
+     * we calculate a = % of target territory, and b = % of aligned reads aligned to these targets.
+     * GC DROPOUT is then abs(sum(a-b when a-b < 0)). E.g. if the value is 5% this implies that 5% of total
+     * reads that should have mapped to GC>=50% regions mapped elsewhere.
+     */
+    public double GC_DROPOUT;
+
+    /** The theoretical HET SNP sensitivity. */
+    public double HET_SNP_SENSITIVITY;
+
+    /** The Phred Scaled Q Score of the theoretical HET SNP sensitivity. */
+    public double HET_SNP_Q;
+}
+
+

--- a/src/main/java/picard/analysis/directed/PanelMetricsBase.java
+++ b/src/main/java/picard/analysis/directed/PanelMetricsBase.java
@@ -27,8 +27,8 @@ package picard.analysis.directed;
 import picard.metrics.MultilevelMetrics;
 
 /**
- * TargetMetrics, are metrics to measure how well we hit specific targets (or baits) when using a targeted sequencing process like hybrid selection
- * or Targeted PCR Techniques (TSCA).  TargetMetrics at the moment are the metrics that are shared by both HybridSelection and TargetedPcrMetrics.
+ * A base class for Metrics for targeted panels. Metrics for library construction protocols based on
+ * PCR amplicons/probes and Hybrid Selection baits are derived from this class.
  */
 public class PanelMetricsBase extends MultilevelMetrics {
     /** The number of unique bases covered by the intervals of all targets that should be covered */

--- a/src/main/java/picard/analysis/directed/TargetMetrics.java
+++ b/src/main/java/picard/analysis/directed/TargetMetrics.java
@@ -35,6 +35,16 @@ public class TargetMetrics extends TargetMetricsBase {
     /** The number of unique bases covered by the intervals of all probes in the probe set */
     public long PROBE_TERRITORY;
 
+    /** The number of PF aligned probed bases that mapped to a baited region of the genome. */
+    public long ON_PROBE_BASES;
+
+    /** The number of PF aligned bases that mapped to within a fixed interval of a probed region, but not on a
+     *  baited region. */
+    public long NEAR_PROBE_BASES;
+
+    /** The number of PF aligned bases that mapped to neither on or near a probe. */
+    public long OFF_PROBE_BASES;
+
     /** The fraction of bases that map on or near a probe (ON_PROBE_BASES + NEAR_PROBE_BASES)/(ON_PROBE_BASES +
      * NEAR_PROBE_BASES + OFF_PROBE_BASES). */
     public double PCT_SELECTED_BASES;

--- a/src/main/java/picard/analysis/directed/TargetMetricsBase.java
+++ b/src/main/java/picard/analysis/directed/TargetMetricsBase.java
@@ -64,16 +64,6 @@ public class TargetMetricsBase extends MultilevelMetrics {
     /** The number of PF unique bases that are aligned with mapping score > 0 to the reference genome. */
     public long PF_UQ_BASES_ALIGNED;
 
-    /** The number of PF aligned probed bases that mapped to a baited region of the genome. */
-    public long ON_PROBE_BASES;
-
-    /** The number of PF aligned bases that mapped to within a fixed interval of a probed region, but not on a
-     *  baited region. */
-    public long NEAR_PROBE_BASES;
-
-    /** The number of PF aligned bases that mapped to neither on or near a probe. */
-    public long OFF_PROBE_BASES;
-
     /** The number of PF aligned bases that mapped to a targeted region of the genome. */
     public long ON_TARGET_BASES;
 

--- a/src/main/java/picard/analysis/directed/TargetMetricsBase.java
+++ b/src/main/java/picard/analysis/directed/TargetMetricsBase.java
@@ -24,30 +24,11 @@
 
 package picard.analysis.directed;
 
-import picard.metrics.MultilevelMetrics;
-
 /**
  * TargetMetrics, are metrics to measure how well we hit specific targets (or baits) when using a targeted sequencing process like hybrid selection
  * or Targeted PCR Techniques (TSCA).  TargetMetrics at the moment are the metrics that are shared by both HybridSelection and TargetedPcrMetrics.
  */
-public class TargetMetricsBase extends MultilevelMetrics {
-    /** The number of unique bases covered by the intervals of all targets that should be covered */
-    public long TARGET_TERRITORY;
-
-    /** The number of bases in the reference genome used for alignment. */
-    public long GENOME_SIZE;
-
-    /** The total number of reads in the SAM or BAM file examined. */
-    public long TOTAL_READS;
-
-    /** The number of passing filter reads (PF). */
-    public long PF_READS;
-
-    /** The number of bases in the PF_READS of a SAM or BAM file */
-    public long PF_BASES;
-
-    /** The number of PF_READS that are not marked as duplicates. */
-    public long PF_UNIQUE_READS;
+public class TargetMetricsBase extends PanelMetricsBase {
 
     /** Tracks the number of read pairs that we see that are PF (used to calculate library size) */
     public long PF_SELECTED_PAIRS;
@@ -55,108 +36,9 @@ public class TargetMetricsBase extends MultilevelMetrics {
     /** Tracks the number of unique PF_SELECTED_PAIRS we see (used to calc library size) */
     public long PF_SELECTED_UNIQUE_PAIRS;
 
-    /** The number of PF_UNIQUE_READS that are aligned with mapping score > 0 to the reference genome. */
-    public long PF_UQ_READS_ALIGNED;
-
-    /** The number of PF_BASES that are aligned with mapping score > 0 to the reference genome. */
-    public long PF_BASES_ALIGNED;
-
-    /** The number of PF unique bases that are aligned with mapping score > 0 to the reference genome. */
-    public long PF_UQ_BASES_ALIGNED;
-
-    /** The number of PF aligned bases that mapped to a targeted region of the genome. */
-    public long ON_TARGET_BASES;
-
     /** The number of PF aligned bases that are mapped in pair to a targeted region of the genome. */
     public long ON_TARGET_FROM_PAIR_BASES;
 
-    //metrics below here are derived after collection
-
-    /** The fraction of reads passing filter, PF_READS/TOTAL_READS.   */
-    public double PCT_PF_READS;
-
-    /** The fraction of unique reads passing filter, PF_UNIQUE_READS/TOTAL_READS. */
-    public double PCT_PF_UQ_READS;
-
-    /** The fraction of unique reads passing filter that align to the reference,
-     * PF_UQ_READS_ALIGNED/PF_UNIQUE_READS. */
-    public double PCT_PF_UQ_READS_ALIGNED;
-
-    /** The mean coverage of targets. */
-    public double MEAN_TARGET_COVERAGE;
-
-    /** The median coverage of targets. */
-    public double MEDIAN_TARGET_COVERAGE;
-
-    /** The maximum coverage of reads that mapped to target regions of an experiment. */
-    public long MAX_TARGET_COVERAGE;
-
-    /** The fraction of targets that did not reach coverage=1 over any base. */
-    public double ZERO_CVG_TARGETS_PCT;
-
-    /** The fraction of aligned bases that were filtered out because they were in reads marked as duplicates. */
-    public double PCT_EXC_DUPE;
-
-    /** The fraction of aligned bases in reads that have MQ=0 and whose 5' end consists of adapter sequence. */
-    public double PCT_EXC_ADAPTER;
-
-    /** The fraction of aligned bases that were filtered out because they were in reads with low mapping quality. */
-    public double PCT_EXC_MAPQ;
-
-    /** The fraction of aligned bases that were filtered out because they were of low base quality. */
-    public double PCT_EXC_BASEQ;
-
-    /** The fraction of aligned bases that were filtered out because they were the second observation from
-     *  an insert with overlapping reads. */
-    public double PCT_EXC_OVERLAP;
-
-    /** The fraction of aligned bases that were filtered out because they did not align over a target base. */
-    public double PCT_EXC_OFF_TARGET;
-
-    /**
-     * The fold over-coverage necessary to raise 80% of bases in "non-zero-cvg" targets to
-     * the mean coverage level in those targets.
-     */
-    public double FOLD_80_BASE_PENALTY;
-
-    /** The fraction of all target bases achieving 1X or greater coverage. */
-    public double PCT_TARGET_BASES_1X;
-    /** The fraction of all target bases achieving 2X or greater coverage. */
-    public double PCT_TARGET_BASES_2X;
-    /** The fraction of all target bases achieving 10X or greater coverage. */
-    public double PCT_TARGET_BASES_10X;
-    /** The fraction of all target bases achieving 20X or greater coverage. */
-    public double PCT_TARGET_BASES_20X;
-    /** The fraction of all target bases achieving 30X or greater coverage. */
-    public double PCT_TARGET_BASES_30X;
-    /** The fraction of all target bases achieving 40X or greater coverage. */
-    public double PCT_TARGET_BASES_40X;
-    /** The fraction of all target bases achieving 50X or greater coverage. */
-    public double PCT_TARGET_BASES_50X;
-    /** The fraction of all target bases achieving 100X or greater coverage. */
-    public double PCT_TARGET_BASES_100X;
-
-    /**
-     * A measure of how undercovered <= 50% GC regions are relative to the mean. For each GC bin [0..50]
-     * we calculate a = % of target territory, and b = % of aligned reads aligned to these targets.
-     * AT DROPOUT is then abs(sum(a-b when a-b < 0)). E.g. if the value is 5% this implies that 5% of total
-     * reads that should have mapped to GC<=50% regions mapped elsewhere.
-     */
-    public double AT_DROPOUT;
-
-    /**
-     * A measure of how undercovered >= 50% GC regions are relative to the mean. For each GC bin [50..100]
-     * we calculate a = % of target territory, and b = % of aligned reads aligned to these targets.
-     * GC DROPOUT is then abs(sum(a-b when a-b < 0)). E.g. if the value is 5% this implies that 5% of total
-     * reads that should have mapped to GC>=50% regions mapped elsewhere.
-     */
-    public double GC_DROPOUT;
-
-    /** The theoretical HET SNP sensitivity. */
-    public double HET_SNP_SENSITIVITY;
-
-    /** The Phred Scaled Q Score of the theoretical HET SNP sensitivity. */
-    public double HET_SNP_Q;
 }
 
 

--- a/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
+++ b/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
@@ -34,15 +34,15 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
         return new Object[][] {
                 // two reads, each has 100 bases. bases in one read are medium quality (20), in the other read poor quality (10).
                 // test that we exclude half of the bases
-                {TEST_DIR + "/lowbaseq.sam",    intervals, 1, 10, true,  2, 200, 0.5, 0.0, 0.50, 0.0,  1, 0, 1000},
+                {TEST_DIR + "/lowbaseq.sam",    intervals, 1, 10, true,  2, 200, 0.5, 0.0, 0.50, 0.0,  1, 200, 1000},
                 // test that read 2 (with mapping quality 1) is filtered out with minimum mapping quality 2
-                {TEST_DIR + "/lowmapq.sam",     intervals, 2, 0, true,  2, 202, 0,   0.0, 0.505, 0.0,   1, 0, 1000},
+                {TEST_DIR + "/lowmapq.sam",     intervals, 2, 0, true,  2, 202, 0,   0.0, 0.505, 0.0,   1, 202, 1000},
                 // test that we clip overlapping bases
-                {TEST_DIR + "/overlapping.sam", intervals, 0, 0, true,  2, 202, 0,   0.5, 0.505, 0, 1, 0, 1000},
+                {TEST_DIR + "/overlapping.sam", intervals, 0, 0, true,  2, 202, 0,   0.5, 0.505, 0, 1, 202, 1000},
                 // test that we do not clip overlapping bases
-                {TEST_DIR + "/overlapping.sam", intervals, 0, 0, false, 2, 202, 0,   0.0, 0.505, 0.505, 2, 0, 1000},
+                {TEST_DIR + "/overlapping.sam", intervals, 0, 0, false, 2, 202, 0,   0.0, 0.505, 0.505, 2, 202, 1000},
                 // A read 10 base pairs long. two intervals: one maps identically to the read, other does not overlap at all
-                {TEST_DIR + "/single-short-read.sam", twoSmallIntervals, 20, 20, true, 1, 10, 0.0, 0.0, 0.5, 0.0, 1, 0, 1000 }
+                {TEST_DIR + "/single-short-read.sam", twoSmallIntervals, 20, 20, true, 1, 10, 0.0, 0.0, 0.5, 0.0, 1, 10, 1000 }
 
         };
     }

--- a/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
+++ b/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
@@ -25,7 +25,7 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
         return CollectHsMetrics.class.getSimpleName();
     }
 
-    @DataProvider(name = "collectHsMetricsDataProvider", parallel = true)
+    @DataProvider(name = "collectHsMetricsDataProvider")
     public Object[][] targetedIntervalDataProvider() {
         final String referenceFile = TEST_DIR + "/chrM.fasta";
         final String intervals = TEST_DIR + "/chrM.interval_list";

--- a/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
+++ b/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
@@ -25,7 +25,7 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
         return CollectHsMetrics.class.getSimpleName();
     }
 
-    @DataProvider(name = "collectHsMetricsDataProvider")
+    @DataProvider(name = "collectHsMetricsDataProvider", parallel = true)
     public Object[][] targetedIntervalDataProvider() {
         final String referenceFile = TEST_DIR + "/chrM.fasta";
         final String intervals = TEST_DIR + "/chrM.interval_list";
@@ -34,15 +34,15 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
         return new Object[][] {
                 // two reads, each has 100 bases. bases in one read are medium quality (20), in the other read poor quality (10).
                 // test that we exclude half of the bases
-                {TEST_DIR + "/lowbaseq.sam",    intervals, 1, 10, true,  2, 200, 0.5, 0.0, 0.50, 0.0,  1, 1000},
+                {TEST_DIR + "/lowbaseq.sam",    intervals, 1, 10, true,  2, 200, 0.5, 0.0, 0.50, 0.0,  1, 0, 1000},
                 // test that read 2 (with mapping quality 1) is filtered out with minimum mapping quality 2
-                {TEST_DIR + "/lowmapq.sam",     intervals, 2, 0, true,  2, 202, 0,   0.0, 0.505, 0.0,   1, 1000},
+                {TEST_DIR + "/lowmapq.sam",     intervals, 2, 0, true,  2, 202, 0,   0.0, 0.505, 0.0,   1, 0, 1000},
                 // test that we clip overlapping bases
-                {TEST_DIR + "/overlapping.sam", intervals, 0, 0, true,  2, 202, 0,   0.5, 0.505, 0, 1, 1000},
+                {TEST_DIR + "/overlapping.sam", intervals, 0, 0, true,  2, 202, 0,   0.5, 0.505, 0, 1, 0, 1000},
                 // test that we do not clip overlapping bases
-                {TEST_DIR + "/overlapping.sam", intervals, 0, 0, false, 2, 202, 0,   0.0, 0.505, 0.505, 2, 1000},
+                {TEST_DIR + "/overlapping.sam", intervals, 0, 0, false, 2, 202, 0,   0.0, 0.505, 0.505, 2, 0, 1000},
                 // A read 10 base pairs long. two intervals: one maps identically to the read, other does not overlap at all
-                {TEST_DIR + "/single-short-read.sam", twoSmallIntervals, 20, 20, true, 1, 10, 0.0, 0.0, 0.5, 0.0, 1, 1000 }
+                {TEST_DIR + "/single-short-read.sam", twoSmallIntervals, 20, 20, true, 1, 10, 0.0, 0.0, 0.5, 0.0, 1, 0, 1000 }
 
         };
     }

--- a/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
+++ b/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
@@ -80,6 +80,7 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
                                               final double pctTargetBases1x,
                                               final double pctTargetBases2x,
                                               final long maxTargetCoverage,
+                                              final long pfBases,
                                               final int sampleSize) throws IOException {
 
         final File outfile = File.createTempFile("CollectHsMetrics", ".hs_metrics", TEST_DIR);
@@ -106,6 +107,7 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
         Assert.assertEquals(metrics.PCT_TARGET_BASES_1X, pctTargetBases1x);
         Assert.assertEquals(metrics.PCT_TARGET_BASES_2X, pctTargetBases2x);
         Assert.assertEquals(metrics.MAX_TARGET_COVERAGE, maxTargetCoverage);
+        Assert.assertEquals(metrics.PF_BASES, pfBases);
     }
 
     @Test


### PR DESCRIPTION
**Move the probe metrics into TargetMetrics and add a test for HsMetrics**

The probe metrics (ON_PROBE_BASES, NEAR_PROBE_BASES, and OFF_PROBE_BASES) were being inherited by TargetedPCRMetrics and HsMetrics as well as TargetMetrics. These metrics are duplicated as ON_AMPLICON_BASES (etc.) in TargetedPCRMetrics and ON_BAIT_BASES (etc.) in HsMetrics. The probe metrics were moved into TargetMetrics to address the issue. 

Additionally, prior to the refactor that created TargetMetricsBase, HsMetrics did not contain the field PF_BASES. Since we would like to capture this metric for hybrid selection, I have added a check to the CollectHsMetrics test class to check that this metric is being calculated now. 

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

