### PR TITLE
liftovervcf: remove last '##reference=...' and set the new one.

### DIFF
--- a/src/main/java/picard/vcf/LiftoverVcf.java
+++ b/src/main/java/picard/vcf/LiftoverVcf.java
@@ -323,8 +323,8 @@ public class LiftoverVcf extends CommandLineProgram {
                 .stream()
                 .filter(M->!M.getKey().equals("reference"))
                 .collect(Collectors.toCollection(LinkedHashSet::new)),
-		    inHeader.getSampleNamesInOrder()
-	        );
+            inHeader.getSampleNamesInOrder()
+            );
         outHeader.setSequenceDictionary(walker.getSequenceDictionary());
         if (WRITE_ORIGINAL_POSITION) {
             for (final VCFInfoHeaderLine line : ATTRS) outHeader.addMetaDataLine(line);

--- a/src/test/java/picard/util/LiftoverVcfTest.java
+++ b/src/test/java/picard/util/LiftoverVcfTest.java
@@ -10,6 +10,8 @@ import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Interval;
 import htsjdk.variant.variantcontext.*;
 import htsjdk.variant.vcf.VCFFileReader;
+import htsjdk.variant.vcf.VCFHeader;
+
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.DataProvider;
@@ -279,7 +281,9 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
 
         //try to open with / without index
         try (final VCFFileReader liftReader = new VCFFileReader(liftOutputFile, !disableSort)) {
-            try (final CloseableIterator<VariantContext> iter = liftReader.iterator()) {
+        	final VCFHeader header = liftReader.getFileHeader();
+        	Assert.assertNotNull(header.getOtherHeaderLine("reference"));
+        	try (final CloseableIterator<VariantContext> iter = liftReader.iterator()) {
                 Assert.assertEquals(iter.stream().count(), 5L);
                 }
             }

--- a/src/test/java/picard/util/LiftoverVcfTest.java
+++ b/src/test/java/picard/util/LiftoverVcfTest.java
@@ -278,12 +278,16 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         };
 
         Assert.assertEquals(runPicardCommandLine(args), 0);
-
+        //check input/header
+        try (final VCFFileReader inputReader = new VCFFileReader(input, false)) {
+                final VCFHeader header = inputReader.getFileHeader();
+                Assert.assertNull(header.getOtherHeaderLine("reference"));
+                }
         //try to open with / without index
         try (final VCFFileReader liftReader = new VCFFileReader(liftOutputFile, !disableSort)) {
-        	final VCFHeader header = liftReader.getFileHeader();
-        	Assert.assertNotNull(header.getOtherHeaderLine("reference"));
-        	try (final CloseableIterator<VariantContext> iter = liftReader.iterator()) {
+                final VCFHeader header = liftReader.getFileHeader();
+                Assert.assertNotNull(header.getOtherHeaderLine("reference"));
+                try (final CloseableIterator<VariantContext> iter = liftReader.iterator()) {
                 Assert.assertEquals(iter.stream().count(), 5L);
                 }
             }


### PR DESCRIPTION
### Description

after liftovervcf ,  the previous vcf header `##reference=file://.../previous-old.build.fa` persists while the new one is not set, which is misleading. This PR removes the previous `##reference` (if any) when building the new VCFheader and set a new `##reference=`.

in the test, I check that there is non-null "reference" header line. 



### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x ] Added or modified tests to cover changes and any new functionality
- [ x] Edited the README / documentation (if applicable)
- [x ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

