### PR TITLE
Improving missing tools.jar error message.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,14 +48,15 @@ jacoco {
 }
 
 final requiredJavaVersion = "8"
-final buildPrerequisitesMessage = "See https://github.com/broadinstitute/picard/blob/master/README.md#building-picard for information on how to build picard"
+final buildPrerequisitesMessage = "See https://github.com/broadinstitute/picard/blob/master/README.md#building-picard for information on how to build picard."
 // Ensure that we have the right JDK version, a clone of the git repository
 def ensureBuildPrerequisites(requiredJavaVersion, buildPrerequisitesMessage) {
     // Make sure we can get a ToolProvider class loader. If not we may have just a JRE, or a JDK from the future.
     if (ToolProvider.getSystemToolClassLoader() == null) {
         throw new GradleException(
-                "The ClassLoader obtained from the Java ToolProvider is null. "
-                + "A Java $requiredJavaVersion JDK must be installed. $buildPrerequisitesMessage")
+                "The ClassLoader obtained from the Java ToolProvider is null. \n"
+                + "A Java $requiredJavaVersion JDK must be installed. $buildPrerequisitesMessage \n"
+		+ "The detected java version was ${JavaVersion.current()} located at: ${System.getProperty('java.home')} ")
     }
     if (!file(".git").isDirectory()) {
         throw new GradleException("The Picard Github repository must be cloned using \"git clone\" to run the build. "


### PR DESCRIPTION
### Description
Improving the error message produced when building fails because of a missing tools.jar
- Adding the detected java version and path to the error message
- This makes problems like https://github.com/broadinstitute/picard/issues/1335 easier to diagnose



### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

