### PR TITLE
Fixes bug that prevented liftover of spanning deletions.

### DIFF
--- a/src/main/java/picard/util/LiftoverUtils.java
+++ b/src/main/java/picard/util/LiftoverUtils.java
@@ -363,7 +363,8 @@ public class LiftoverUtils {
 
         final Map<Allele, byte[]> alleleBasesMap = new HashMap<>();
 
-        // Put each allele into the alleleBasesMap unless it is a spanning deletion
+        // Put each allele into the alleleBasesMap unless it is a spanning deletion.
+        // Spanning deletions are dealt with as a special case later in fixedAlleleMap.
         alleles.stream().filter(a->!a.equals(Allele.SPAN_DEL)).forEach(a -> alleleBasesMap.put(a, a.getBases()));
 
         int theStart = start;
@@ -429,7 +430,9 @@ public class LiftoverUtils {
         final Map<Allele, Allele> fixedAlleleMap = alleleBasesMap.entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, me -> Allele.create(me.getValue(), me.getKey().isReference())));
 
-        // A fixed spanning deletion it itself a spanning deletion
+        // A left aligned spanning deletion is itself a spanning deletion
+        // Since this is not handled by the code above, it must be handled as
+        // a special case here.
         fixedAlleleMap.put(Allele.SPAN_DEL, Allele.SPAN_DEL);
 
         //retain original order:

--- a/src/main/java/picard/util/LiftoverUtils.java
+++ b/src/main/java/picard/util/LiftoverUtils.java
@@ -195,7 +195,7 @@ public class LiftoverUtils {
 
     private static Allele reverseComplement(final Allele oldAllele, final Interval target, final ReferenceSequence referenceSequence, final boolean isIndel, final boolean addToStart) {
 
-        if (oldAllele.isSymbolic() || oldAllele.isNoCall()) {
+        if (oldAllele.isSymbolic() || oldAllele.isNoCall() || oldAllele.equals(Allele.SPAN_DEL)) {
             return oldAllele;
         } else if (isIndel) {
             // target.getStart is 1-based, reference bases are 0-based
@@ -362,7 +362,9 @@ public class LiftoverUtils {
         boolean changesInAlleles = true;
 
         final Map<Allele, byte[]> alleleBasesMap = new HashMap<>();
-        alleles.forEach(a -> alleleBasesMap.put(a, a.getBases()));
+
+        // Put each allele into the alleleBasesMap unless it is a spanning deletion
+        alleles.stream().filter(a->!a.equals(Allele.SPAN_DEL)).forEach(a -> alleleBasesMap.put(a, a.getBases()));
 
         int theStart = start;
         int theEnd = end;
@@ -426,6 +428,9 @@ public class LiftoverUtils {
 
         final Map<Allele, Allele> fixedAlleleMap = alleleBasesMap.entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, me -> Allele.create(me.getValue(), me.getKey().isReference())));
+
+        // A fixed spanning deletion it itself a spanning deletion
+        fixedAlleleMap.put(Allele.SPAN_DEL, Allele.SPAN_DEL);
 
         //retain original order:
         List<Allele> fixedAlleles = alleles.stream()


### PR DESCRIPTION
### Description

This is a fix to a bug that causes the liftover of spanning deletions to fail.

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

