### PR TITLE
Recover from side effects introduced in CollectIndependentReplicatesMetric tests.

### DIFF
--- a/src/main/java/picard/cmdline/CommandLineProgram.java
+++ b/src/main/java/picard/cmdline/CommandLineProgram.java
@@ -240,11 +240,15 @@ public abstract class CommandLineProgram {
             SAMFileWriterImpl.setDefaultMaxRecordsInRam(MAX_RECORDS_IN_RAM);
         }
 
+        final boolean defaultHTSJDKIndexCreation = SAMFileWriterFactory.getDefaultCreateIndexWhileWriting();
         if (CREATE_INDEX) {
             SAMFileWriterFactory.setDefaultCreateIndexWhileWriting(true);
         }
 
-        SAMFileWriterFactory.setDefaultCreateMd5File(CREATE_MD5_FILE);
+        final boolean defaultMD5Creation = SAMFileWriterFactory.getDefaultCreateMd5File();
+        if (CREATE_MD5_FILE) {
+            SAMFileWriterFactory.setDefaultCreateMd5File(CREATE_MD5_FILE);
+        }
 
         for (final File f : TMP_DIR) {
             // Intentionally not checking the return values, because it may be that the program does not
@@ -294,6 +298,9 @@ public abstract class CommandLineProgram {
         try {
             ret = doWork();
         } finally {
+            // restore the default to eliminate problems in downstream code caused by setting CREATE_INDEX=true above
+            SAMFileWriterFactory.setDefaultCreateIndexWhileWriting(defaultHTSJDKIndexCreation);
+            SAMFileWriterFactory.setDefaultCreateMd5File(defaultMD5Creation);
             try {
                 // Emit the time even if program throws
                 if (!QUIET) {

--- a/src/test/java/picard/analysis/replicates/CollectIndependentReplicatesMetricTest.java
+++ b/src/test/java/picard/analysis/replicates/CollectIndependentReplicatesMetricTest.java
@@ -1,7 +1,6 @@
 package picard.analysis.replicates;
 
 import com.google.common.collect.ImmutableMap;
-import htsjdk.samtools.SAMFileWriterFactory;
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.TestUtil;
@@ -209,20 +208,15 @@ public class CollectIndependentReplicatesMetricTest {
      *
      */
     private static File convertSamToBam(final String sam) throws IOException {
-        boolean defaultIndexCreation = SAMFileWriterFactory.getDefaultCreateIndexWhileWriting();
-        try {
-            final MergeSamFiles msf = new MergeSamFiles();
-            final File bam = new File(bamOutDir, sam.replaceAll("sam$", "bam"));
-            final int returnCode = msf.instanceMain(
-                    new String[]{
-                            "INPUT=" + (new File(testdir, sam).getAbsolutePath()),
-                            "CREATE_INDEX=true",
-                            "OUTPUT=" + bam.getAbsolutePath()});
-            Assert.assertEquals(returnCode, 0);
-            return bam;
-        } finally {
-            // restore the default to eliminate problems in downstream code caused by setting CREATE_INDEX=true above
-            SAMFileWriterFactory.setDefaultCreateIndexWhileWriting(defaultIndexCreation);
-        }
+        final MergeSamFiles msf = new MergeSamFiles();
+        final File bam = new File(bamOutDir, sam.replaceAll("sam$", "bam"));
+        final int returnCode = msf.instanceMain(
+                new String[]{
+                        "INPUT=" + (new File(testdir, sam).getAbsolutePath()),
+                        "CREATE_INDEX=true",
+                        "OUTPUT=" + bam.getAbsolutePath()});
+        Assert.assertEquals(returnCode, 0);
+
+        return bam;
     }
 }


### PR DESCRIPTION
This fix is needed as a prerequisite to upgrade Picard to the next version of htsjdk.

`CollectIndependentReplicatesMetricTest` has an `@BeforeTest` method that runs `MergeSamFiles` as a command line program, with CREATE_INDEX=true. `CommandLineProgram` in turn has a side effect that leaves htsjdk's global SAMFileWriterFactory state mutated with non-default values. The next version of htsjdk has code that rejects attempts to create an index for a CRAM file that isn't coordinate sorted. `RevertSamTest.testOutputByReadGroupWithOutputMap` creates CRAM files that are queryname sorted, and usually succeeds because it doesn't attempt to write an index, but fails intermittently with the new htsjdk code if it happens to be run after the `CollectIndependentReplicatesMetricTest` `@BeforeTest` method has executed, due to the leftover htsjdk state.

Longer term we should fix `CommandLineProgram` to not set the global defaults.