### PR TITLE
Fix travis build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Coverage Status](https://coveralls.io/repos/github/broadinstitute/picard/badge.svg?branch=master)](https://coveralls.io/github/broadinstitute/picard?branch=master)
-[![Build Status](https://travis-ci.org/broadinstitute/picard.svg?branch=master)](https://travis-ci.org/broadinstitute/picard)
+[![Build Status](https://travis-ci.com/broadinstitute/picard.svg?branch=master)](https://travis-ci.com/broadinstitute/picard)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/broadinstitute/picard/blob/master/LICENSE.txt)
 
 A set of Java command line tools for manipulating high-throughput sequencing (HTS) data and formats.  


### PR DESCRIPTION
### Description

Update the build badge to use travis.com instead of travis.org

----

- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis
- [x] Final thumbs-up from reviewer
- [x] Rebase, squash and reword as applicable

