### PR TITLE
Yf debug sam collector error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ def ensureBuildPrerequisites(requiredJavaVersion, buildPrerequisitesMessage) {
 }
 ensureBuildPrerequisites(requiredJavaVersion, buildPrerequisitesMessage)
 
-final htsjdkVersion = System.getProperty('htsjdk.version', '2.19.0-49-g1d4a316-SNAPSHOT')
+final htsjdkVersion = System.getProperty('htsjdk.version', '2.19.0')
 final googleNio = 'com.google.cloud:google-cloud-nio:0.81.0-alpha:shaded'
 
 // Get the jdk files we need to run javaDoc. We need to use these during compile, testCompile,

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ def ensureBuildPrerequisites(requiredJavaVersion, buildPrerequisitesMessage) {
 }
 ensureBuildPrerequisites(requiredJavaVersion, buildPrerequisitesMessage)
 
-final htsjdkVersion = System.getProperty('htsjdk.version', '2.19.0')
+final htsjdkVersion = System.getProperty('htsjdk.version', '2.19.0-49-g1d4a316-SNAPSHOT')
 final googleNio = 'com.google.cloud:google-cloud-nio:0.81.0-alpha:shaded'
 
 // Get the jdk files we need to run javaDoc. We need to use these during compile, testCompile,

--- a/src/main/java/picard/analysis/CollectWgsMetrics.java
+++ b/src/main/java/picard/analysis/CollectWgsMetrics.java
@@ -32,19 +32,37 @@ import htsjdk.samtools.filter.SecondaryAlignmentFilter;
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.reference.ReferenceSequenceFileWalker;
-import htsjdk.samtools.util.*;
+import htsjdk.samtools.util.AbstractLocusInfo;
+import htsjdk.samtools.util.AbstractLocusIterator;
+import htsjdk.samtools.util.AbstractRecordAndOffset;
+import htsjdk.samtools.util.EdgeReadIterator;
+import htsjdk.samtools.util.Histogram;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Interval;
+import htsjdk.samtools.util.IntervalList;
+import htsjdk.samtools.util.Log;
+import htsjdk.samtools.util.ProgressLogger;
+import htsjdk.samtools.util.SamLocusIterator;
+import htsjdk.samtools.util.SequenceUtil;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import picard.cmdline.CommandLineProgram;
-import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.argumentcollections.IntervalArgumentCollection;
 import picard.cmdline.programgroups.DiagnosticsAndQCProgramGroup;
-import picard.filter.*;
+import picard.filter.CountingAdapterFilter;
+import picard.filter.CountingDuplicateFilter;
+import picard.filter.CountingFilter;
+import picard.filter.CountingMapQFilter;
+import picard.filter.CountingPairedFilter;
 
 import java.io.File;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 
 import static picard.cmdline.StandardOptionDefinitions.MINIMUM_MAPPING_QUALITY_SHORT_NAME;
 
@@ -400,8 +418,14 @@ static final String USAGE_DETAILS = "<p>This tool collects metrics about the fra
                 }
 
                 if (recs.getBaseQuality() < collectWgsMetrics.MINIMUM_BASE_QUALITY ||
-                        SequenceUtil.isNoCall(recs.getReadBase()))                  { ++basesExcludedByBaseq;   continue; }
-                if (!readNames.add(recs.getRecord().getReadName()))                 { ++basesExcludedByOverlap; continue; }
+                        SequenceUtil.isNoCall(recs.getReadBase())) {
+                    ++basesExcludedByBaseq;
+                    continue;
+                }
+                if (!readNames.add(recs.getRecord().getReadName())) {
+                    ++basesExcludedByOverlap;
+                    continue;
+                }
                 pileupSize++;
             }
             final int highQualityDepth = Math.min(pileupSize, coverageCap);

--- a/src/main/java/picard/analysis/FastWgsMetricsCollector.java
+++ b/src/main/java/picard/analysis/FastWgsMetricsCollector.java
@@ -126,7 +126,7 @@ public class FastWgsMetricsCollector extends AbstractWgsMetricsCollector<EdgingR
         final byte[] qualities = record.getBaseQualities();
         final byte[] bases = record.getRecord().getReadBases();
         for (int i = 0; i < record.getLength(); i++) {
-            final int index = i + position;
+            final int index = i + record.getRefPos();
             if (isReferenceBaseN(index, ref)) {
                 continue;
             }

--- a/src/test/java/picard/analysis/CollectWgsMetricsTestUtils.java
+++ b/src/test/java/picard/analysis/CollectWgsMetricsTestUtils.java
@@ -57,19 +57,23 @@ public class CollectWgsMetricsTestUtils{
 
     private static final String sqHeaderLN20 = "@HD	SO:coordinate	VN:1.0\n@SQ	SN:chrM	AS:HG18	LN:20\n";
     private static final String sqHeaderLN100 = "@HD	SO:coordinate	VN:1.0\n@SQ	SN:chrM	AS:HG18	LN:100\n";
-    // ACC--TACGTTCAAT
-    // .CCTACGTTCA-ATATT
+
     // 12345678901234567
     // .ACCTACGTTCAAT
     // ..CCTACGTTCAATATT
-
-
-//    private static final String s1 = "3851612	16	chrM	1	255	3M2D10M	*	0	0	ACCTACGTTCAAT	DDDDDDDDDDDDD\n";
-//    private static final String s2 = "3851612	16	chrM	2	255	10M1D5M	*	0	0	CCTACGTTCAATATT	DDDDDDDDDDDDDDD\n";
     private static final String s1 = "3851612	83	chrM	2	255	13M	=	3	10	ACCTACGTTCAAT	DDDDDDDDDDDDD\n";
     private static final String s2 = "3851612	163	chrM	3	255	15M	=	2	-10	CCTACGTTCAATATT	DDDDDDDDDDDDDDD\n";
+
+    // ACC--TACGTTCAAT
+    // .CCTACGTTCA-ATATT
+    private static final String s3 = "3851613	16	chrM	1	255	3M2D10M	*	0	0	ACCTACGTTCAAT	DDDDDDDDDDDDD\n";
+    private static final String s4 = "3851613	16	chrM	2	255	10M1D5M	*	0	0	CCTACGTTCAATATT	DDDDDDDDDDDDDDD\n";
+
     static final String exampleSamOneRead = sqHeaderLN20+s1;
     static final String exampleSamTwoReads = sqHeaderLN100+s1+s2;
+
+    static final String exampleSamComplexCigarTwoReads = sqHeaderLN20+s3+s4;
+
 
     protected static SAMRecordSetBuilder createTestSAMBuilder(final File reference,
                                                               final String readGroupId,

--- a/src/test/java/picard/analysis/FastWgsMetricsCollectorTest.java
+++ b/src/test/java/picard/analysis/FastWgsMetricsCollectorTest.java
@@ -8,11 +8,13 @@ import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.util.AbstractLocusInfo;
 import htsjdk.samtools.util.AbstractLocusIterator;
 import htsjdk.samtools.util.EdgingRecordAndOffset;
+import htsjdk.samtools.util.SamLocusIterator;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static picard.analysis.CollectWgsMetricsTestUtils.createIntervalList;
 import static picard.analysis.CollectWgsMetricsTestUtils.createReadEndsIterator;
+import static picard.analysis.CollectWgsMetricsTestUtils.createSamLocusIterator;
 import static picard.analysis.CollectWgsMetricsTestUtils.exampleSamTwoReads;
 
 
@@ -198,7 +200,7 @@ public class FastWgsMetricsCollectorTest {
 
         collector.addInfo(firstInfo, ref, false);
         collector.addInfo(secondInfo, ref, false);
-        assertEquals(0, collector.basesExcludedByOverlap, "Excluded by overlap:");
+        assertEquals( collector.basesExcludedByOverlap, 0, "Excluded by overlap:");
     }
 
     @Test
@@ -210,6 +212,18 @@ public class FastWgsMetricsCollectorTest {
             AbstractLocusInfo<EdgingRecordAndOffset> info = sli.next();
             collector.addInfo(info, ref, false);
         }
-        assertEquals(11, collector.basesExcludedByOverlap, "Excluded by overlap:");
+        assertEquals( collector.basesExcludedByOverlap, 11, "Excluded by overlap:");
+    }
+
+    @Test
+    public void testForComplicatedCigarNonFast(){
+        CollectWgsMetrics collectWgsMetrics = new CollectWgsMetrics();
+        CollectWgsMetrics.WgsMetricsCollector collector = new CollectWgsMetrics.WgsMetricsCollector(collectWgsMetrics, 100, createIntervalList());
+        AbstractLocusIterator sli = createSamLocusIterator(exampleSamTwoReads);
+        while(sli.hasNext()) {
+            AbstractLocusInfo<SamLocusIterator.RecordAndOffset> info = sli.next();
+            collector.addInfo(info, ref, false);
+        }
+        assertEquals( collector.basesExcludedByOverlap, 11,"Excluded by overlap:");
     }
 }

--- a/src/test/java/picard/analysis/FastWgsMetricsCollectorTest.java
+++ b/src/test/java/picard/analysis/FastWgsMetricsCollectorTest.java
@@ -1,6 +1,5 @@
 package picard.analysis;
 
-
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMSequenceRecord;
@@ -11,17 +10,19 @@ import htsjdk.samtools.util.EdgingRecordAndOffset;
 import htsjdk.samtools.util.SamLocusIterator;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
+
 import static org.testng.Assert.assertEquals;
 import static picard.analysis.CollectWgsMetricsTestUtils.createIntervalList;
 import static picard.analysis.CollectWgsMetricsTestUtils.createReadEndsIterator;
 import static picard.analysis.CollectWgsMetricsTestUtils.createSamLocusIterator;
+import static picard.analysis.CollectWgsMetricsTestUtils.exampleSamComplexCigarTwoReads;
 import static picard.analysis.CollectWgsMetricsTestUtils.exampleSamTwoReads;
 
 
 public class FastWgsMetricsCollectorTest {
     private byte[] highQualities = {30, 30, 30 ,30, 30, 30, 30, 30, 30, 30, 50, 50, 50 ,50, 50, 50, 50, 50, 50, 60, 60, 60, 70 ,70, 70, 80, 80, 90, 90, 90};
     private byte[] qualities = {2, 2, 3 ,3, 3, 4, 4, 4, 4, 1};
-    private byte[] refBases = {'A', 'C', 'C', 'T', 'A', 'C', 'G', 'T', 'T', 'C', 'A', 'A', 'T', 'A', 'T', 'T', 'C', 'T', 'T', 'C', 'G', 'A', 'G', 'T', 'C', 'D' , 'G', 'T', 'C', 'D','A', 'G', 'T', 'C', 'T', 'T', 'C', 'G', 'A', 'G', 'T', 'C', 'T', 'T', 'C', 'G', 'C', 'T', 'T', 'C', 'G', 'A', 'G', 'T', 'C', 'D' , 'G', 'T', 'C', 'D','A', 'G', 'T', 'C', 'T', 'T', 'C', 'G', 'A', 'G', 'T', 'C', 'T', 'T', 'C', 'G', 'C', 'T', 'T', 'C', 'G', 'A', 'G', 'T', 'C', 'D' , 'G', 'T', 'C', 'D', 'G', 'A', 'G', 'T', 'C', 'D' , 'G', 'T', 'C', 'D'};
+    private byte[] readBases = "ACCTACGTTCAATATTCTTCGAGTCDGTCDAGTCTTCGAGTCTTCGCTTCGAGTCDGTCDAGTCTTCGAGTCTTCGCTTCGAGTCDGTCDGAGTCDGTCD".getBytes();
     private SAMRecord record;
     private SAMSequenceRecord sequence;
     private SAMRecord secondRecord;
@@ -30,13 +31,13 @@ public class FastWgsMetricsCollectorTest {
 
     @BeforeTest
     public void setUp(){
-        String referenceString = ">chrM\nACCTACGTTCAATATTCTTCACCTACGTTCAATATTCTTCACCTACGTTCAATATTCTTCACCTACGTTCAATATTCTTCACCTACGTTCAATATTCTTC";
-        ref = new ReferenceSequence("chrM", 0, referenceString.getBytes());
+        final byte[] referenceBases = ">chrM\nACCTACGTTCAATATTCTTCACCTACGTTCAATATTCTTCACCTACGTTCAATATTCTTCACCTACGTTCAATATTCTTCACCTACGTTCAATATTCTTC".getBytes();
+        ref = new ReferenceSequence("chrM", 0, referenceBases);
         sequence = new SAMSequenceRecord("chrM", 100);
         record = new SAMRecord(new SAMFileHeader());
         record.setReadName("test");
         record.setBaseQualities(qualities);
-        record.setReadBases(refBases);
+        record.setReadBases(readBases);
         secondRecord = generateRecord("test1");
         thirdRecord = generateRecord("test2");
     }
@@ -45,7 +46,7 @@ public class FastWgsMetricsCollectorTest {
         SAMRecord record = new SAMRecord(new SAMFileHeader());
         record.setReadName(name);
         record.setBaseQualities(highQualities);
-        record.setReadBases(refBases);
+        record.setReadBases(readBases);
         return record;
     }
 
@@ -55,15 +56,15 @@ public class FastWgsMetricsCollectorTest {
         FastWgsMetricsCollector collector = new FastWgsMetricsCollector(collectWgsMetrics, 100, createIntervalList());
         AbstractLocusInfo<EdgingRecordAndOffset> firstInfo = new AbstractLocusInfo<>(sequence, 1);
         AbstractLocusInfo<EdgingRecordAndOffset> secondInfo = new AbstractLocusInfo<>(sequence, 10);
-        EdgingRecordAndOffset record1 = EdgingRecordAndOffset.createBeginRecord(record, 0, 10, 0);
+        EdgingRecordAndOffset record1 = EdgingRecordAndOffset.createBeginRecord(record, 0, 10, 1);
         firstInfo.add(record1);
         secondInfo.add(EdgingRecordAndOffset.createEndRecord(record1));
-        EdgingRecordAndOffset record2 = EdgingRecordAndOffset.createBeginRecord(record, 0, 10, 0);
+        EdgingRecordAndOffset record2 = EdgingRecordAndOffset.createBeginRecord(record, 0, 10, 1);
         firstInfo.add(record2);
         secondInfo.add(EdgingRecordAndOffset.createEndRecord(record2));
         collector.addInfo(firstInfo, ref, false);
         collector.addInfo(secondInfo, ref, false);
-        assertEquals(20, collector.basesExcludedByBaseq);
+        assertEquals( collector.basesExcludedByBaseq, 20);
     }
 
     @Test
@@ -73,33 +74,33 @@ public class FastWgsMetricsCollectorTest {
         AbstractLocusInfo<EdgingRecordAndOffset> firstInfo = new AbstractLocusInfo<>(sequence, 1);
         AbstractLocusInfo<EdgingRecordAndOffset> secondInfo = new AbstractLocusInfo<>(sequence, 5);
         AbstractLocusInfo<EdgingRecordAndOffset> thirdInfo = new AbstractLocusInfo<>(sequence, 10);
-        EdgingRecordAndOffset record1 = EdgingRecordAndOffset.createBeginRecord(secondRecord, 0, 10, 0);
+        EdgingRecordAndOffset record1 = EdgingRecordAndOffset.createBeginRecord(secondRecord, 0, 10, 1);
         firstInfo.add(record1);
         thirdInfo.add(EdgingRecordAndOffset.createEndRecord(record1));
-        EdgingRecordAndOffset record2 = EdgingRecordAndOffset.createBeginRecord(secondRecord, 5, 5, 0);
+        EdgingRecordAndOffset record2 = EdgingRecordAndOffset.createBeginRecord(secondRecord, 5, 5, 1);
         secondInfo.add(record2);
         thirdInfo.add(EdgingRecordAndOffset.createEndRecord(record2));
         collector.addInfo(firstInfo, ref, false);
         collector.addInfo(secondInfo, ref, false);
         collector.addInfo(thirdInfo, ref, false);
-        assertEquals(5, collector.basesExcludedByOverlap, "Excluded by overlap:");
+        assertEquals(collector.basesExcludedByOverlap, 5, "Excluded by overlap:");
     }
 
     @Test
     public void testAddInfoForCapping(){
         CollectWgsMetrics collectWgsMetrics = new CollectWgsMetrics();
         FastWgsMetricsCollector collector = new FastWgsMetricsCollector(collectWgsMetrics, 1, createIntervalList());
-        AbstractLocusInfo<EdgingRecordAndOffset> firstInfo = new AbstractLocusInfo<>(sequence, 1);
-        AbstractLocusInfo<EdgingRecordAndOffset> secondInfo = new AbstractLocusInfo<>(sequence, 10);
-        EdgingRecordAndOffset record1 = EdgingRecordAndOffset.createBeginRecord(secondRecord, 0, 10, 0);
+        AbstractLocusInfo<EdgingRecordAndOffset> firstInfo = new AbstractLocusInfo<>(sequence, 2);
+        AbstractLocusInfo<EdgingRecordAndOffset> secondInfo = new AbstractLocusInfo<>(sequence, 11);
+        EdgingRecordAndOffset record1 = EdgingRecordAndOffset.createBeginRecord(thirdRecord, 0, 10, 1);
         firstInfo.add(record1);
         secondInfo.add(EdgingRecordAndOffset.createEndRecord(record1));
-        EdgingRecordAndOffset record2 = EdgingRecordAndOffset.createBeginRecord(secondRecord, 0, 10, 0);
+        EdgingRecordAndOffset record2 = EdgingRecordAndOffset.createBeginRecord(secondRecord, 0, 10, 1);
         firstInfo.add(record2);
         secondInfo.add(EdgingRecordAndOffset.createEndRecord(record2));
         collector.addInfo(firstInfo, ref, false);
         collector.addInfo(secondInfo, ref, false);
-        assertEquals(1, collector.basesExcludedByCapping, "Excluded by capping:");
+        assertEquals( collector.basesExcludedByCapping, 1, "Excluded by capping:");
     }
 
     @Test
@@ -109,15 +110,19 @@ public class FastWgsMetricsCollectorTest {
         FastWgsMetricsCollector collector = new FastWgsMetricsCollector(collectWgsMetrics, 100, createIntervalList());
         AbstractLocusInfo<EdgingRecordAndOffset> firstInfo = new AbstractLocusInfo<>(sequence, 1);
         AbstractLocusInfo<EdgingRecordAndOffset> secondInfo = new AbstractLocusInfo<>(sequence, 30);
-        EdgingRecordAndOffset record = EdgingRecordAndOffset.createBeginRecord(secondRecord, 0, 30, 0);
+        EdgingRecordAndOffset record = EdgingRecordAndOffset.createBeginRecord(secondRecord, 0, 30, 1);
         firstInfo.add(record);
         firstInfo.add(EdgingRecordAndOffset.createEndRecord(record));
         collector.addInfo(firstInfo, ref, false);
         collector.addInfo(secondInfo, ref, false);
         long[] expectedResult =  new long[127];
-        expectedResult[30] = 10; expectedResult[50] = 9; expectedResult[60] = 3;
-        expectedResult[70] = 3;  expectedResult[80] = 2;  expectedResult[90] = 3;
-        assertEquals(expectedResult, collector.unfilteredBaseQHistogramArray);
+        expectedResult[30] = 10;
+        expectedResult[50] = 9;
+        expectedResult[60] = 3;
+        expectedResult[70] = 3;
+        expectedResult[80] = 2;
+        expectedResult[90] = 3;
+        assertEquals(collector.unfilteredBaseQHistogramArray, expectedResult);
     }
 
     @Test
@@ -128,10 +133,10 @@ public class FastWgsMetricsCollectorTest {
         AbstractLocusInfo<EdgingRecordAndOffset> firstInfo = new AbstractLocusInfo<>(sequence, 1);
         AbstractLocusInfo<EdgingRecordAndOffset> secondInfo = new AbstractLocusInfo<>(sequence, 1);
         AbstractLocusInfo<EdgingRecordAndOffset> thirdInfo = new AbstractLocusInfo<>(sequence, 1);
-        EdgingRecordAndOffset record1 = EdgingRecordAndOffset.createBeginRecord(secondRecord, 0, 30, 0);
+        EdgingRecordAndOffset record1 = EdgingRecordAndOffset.createBeginRecord(secondRecord, 0, 30, 1);
         firstInfo.add(record1);
         thirdInfo.add(EdgingRecordAndOffset.createEndRecord(record1));
-        EdgingRecordAndOffset record2 = EdgingRecordAndOffset.createBeginRecord(record, 0, 10, 0);
+        EdgingRecordAndOffset record2 = EdgingRecordAndOffset.createBeginRecord(record, 0, 10, 1);
         firstInfo.add(record2);
         secondInfo.add(EdgingRecordAndOffset.createEndRecord(record2));
         collector.addInfo(firstInfo, ref, false);
@@ -139,9 +144,15 @@ public class FastWgsMetricsCollectorTest {
         collector.addInfo(thirdInfo, ref, false);
 
         long[] expectedResult =  new long[127];
-        expectedResult[30] = 10; expectedResult[50] = 9; expectedResult[60] = 3;
-        expectedResult[70] = 3;  expectedResult[80] = 2;  expectedResult[90] = 3;
-        expectedResult[1] = 1;  expectedResult[2] = 2;  expectedResult[3] = 3;
+        expectedResult[30] = 10;
+        expectedResult[50] = 9;
+        expectedResult[60] = 3;
+        expectedResult[70] = 3;
+        expectedResult[80] = 2;
+        expectedResult[90] = 3;
+        expectedResult[1] = 1;
+        expectedResult[2] = 2;
+        expectedResult[3] = 3;
         expectedResult[4] = 4;
     }
 
@@ -149,25 +160,25 @@ public class FastWgsMetricsCollectorTest {
     public void testForHistogramArray(){
         CollectWgsMetrics collectWgsMetrics = new CollectWgsMetrics();
         FastWgsMetricsCollector collector = new FastWgsMetricsCollector(collectWgsMetrics, 10, createIntervalList());
-        long[] templateHistogramArray = {0,1,3,0,0,0,0,0,0,0,0};
+        long[] templateHistogramArray = {0, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0};
         AbstractLocusInfo<EdgingRecordAndOffset> firstInfo = new AbstractLocusInfo<>(sequence, 1);
         AbstractLocusInfo<EdgingRecordAndOffset> secondInfo = new AbstractLocusInfo<>(sequence, 10);
         AbstractLocusInfo<EdgingRecordAndOffset> thirdInfo = new AbstractLocusInfo<>(sequence, 20);
         AbstractLocusInfo<EdgingRecordAndOffset> fourthInfo = new AbstractLocusInfo<>(sequence, 30);
-        EdgingRecordAndOffset record1 = EdgingRecordAndOffset.createBeginRecord(record, 0, 10, 0);
+        EdgingRecordAndOffset record1 = EdgingRecordAndOffset.createBeginRecord(record, 0, 10, 1);
         firstInfo.add(record1);
         secondInfo.add(EdgingRecordAndOffset.createEndRecord(record1));
-        EdgingRecordAndOffset record2 = EdgingRecordAndOffset.createBeginRecord(secondRecord, 0, 30, 0);
+        EdgingRecordAndOffset record2 = EdgingRecordAndOffset.createBeginRecord(secondRecord, 0, 30, 1);
         firstInfo.add(record2);
         fourthInfo.add(EdgingRecordAndOffset.createEndRecord(record2));
-        EdgingRecordAndOffset record3 = EdgingRecordAndOffset.createBeginRecord(thirdRecord, 0, 20, 0);
+        EdgingRecordAndOffset record3 = EdgingRecordAndOffset.createBeginRecord(thirdRecord, 0, 20, 1);
         firstInfo.add(record3);
         thirdInfo.add(EdgingRecordAndOffset.createEndRecord(record3));
         collector.addInfo(firstInfo, ref, false);
         collector.addInfo(secondInfo, ref, false);
         collector.addInfo(thirdInfo, ref, false);
         collector.addInfo(fourthInfo, ref, false);
-        assertEquals(templateHistogramArray, collector.unfilteredDepthHistogramArray);
+        assertEquals(collector.unfilteredDepthHistogramArray, templateHistogramArray);
     }
 
     @Test
@@ -178,9 +189,9 @@ public class FastWgsMetricsCollectorTest {
         FastWgsMetricsCollector collector = new FastWgsMetricsCollector(collectWgsMetrics, 10, createIntervalList());
         assertEquals(templateHistogramArray, collector.unfilteredDepthHistogramArray);
         assertEquals(templateQualHistogram, collector.unfilteredBaseQHistogramArray);
-        assertEquals(0, collector.basesExcludedByCapping);
-        assertEquals(0, collector.basesExcludedByOverlap);
-        assertEquals(0, collector.basesExcludedByBaseq);
+        assertEquals(collector.basesExcludedByCapping, 0);
+        assertEquals(collector.basesExcludedByOverlap, 0);
+        assertEquals(collector.basesExcludedByBaseq, 0);
     }
 
     @Test
@@ -191,10 +202,10 @@ public class FastWgsMetricsCollectorTest {
         AbstractLocusInfo<EdgingRecordAndOffset> secondInfo = new AbstractLocusInfo<>(sequence, 5);
         AbstractLocusInfo<EdgingRecordAndOffset> thirdInfo = new AbstractLocusInfo<>(sequence, 6);
         AbstractLocusInfo<EdgingRecordAndOffset> fourthInfo = new AbstractLocusInfo<>(sequence, 10);
-        EdgingRecordAndOffset record1 = EdgingRecordAndOffset.createBeginRecord(secondRecord, 0, 5, 0);
+        EdgingRecordAndOffset record1 = EdgingRecordAndOffset.createBeginRecord(secondRecord, 0, 5, 1);
         firstInfo.add(record1);
         secondInfo.add(EdgingRecordAndOffset.createEndRecord(record1));
-        EdgingRecordAndOffset record2 = EdgingRecordAndOffset.createBeginRecord(secondRecord, 6, 5, 6);
+        EdgingRecordAndOffset record2 = EdgingRecordAndOffset.createBeginRecord(secondRecord, 6, 5, 1);
         thirdInfo.add(record2);
         fourthInfo.add(EdgingRecordAndOffset.createEndRecord(record2));
 
@@ -204,7 +215,7 @@ public class FastWgsMetricsCollectorTest {
     }
 
     @Test
-    public void testForComplicatedCigar(){
+    public void testForSimpleCigar(){
         CollectWgsMetrics collectWgsMetrics = new CollectWgsMetrics();
         FastWgsMetricsCollector collector = new FastWgsMetricsCollector(collectWgsMetrics, 100, createIntervalList());
         AbstractLocusIterator sli = createReadEndsIterator(exampleSamTwoReads);
@@ -212,11 +223,15 @@ public class FastWgsMetricsCollectorTest {
             AbstractLocusInfo<EdgingRecordAndOffset> info = sli.next();
             collector.addInfo(info, ref, false);
         }
-        assertEquals( collector.basesExcludedByOverlap, 11, "Excluded by overlap:");
+        assertEquals( collector.basesExcludedByOverlap, 12, "Excluded by overlap:");
+
+        assertEquals(collector.highQualityDepthHistogramArray[2],0);
+        assertEquals(collector.highQualityDepthHistogramArray[0],84);
+        assertEquals(collector.highQualityDepthHistogramArray[1],16);
     }
 
     @Test
-    public void testForComplicatedCigarNonFast(){
+    public void testForSimpleCigarNonFast(){
         CollectWgsMetrics collectWgsMetrics = new CollectWgsMetrics();
         CollectWgsMetrics.WgsMetricsCollector collector = new CollectWgsMetrics.WgsMetricsCollector(collectWgsMetrics, 100, createIntervalList());
         AbstractLocusIterator sli = createSamLocusIterator(exampleSamTwoReads);
@@ -224,6 +239,40 @@ public class FastWgsMetricsCollectorTest {
             AbstractLocusInfo<SamLocusIterator.RecordAndOffset> info = sli.next();
             collector.addInfo(info, ref, false);
         }
+        assertEquals( collector.basesExcludedByOverlap, 12,"Excluded by overlap:");
+        assertEquals(collector.highQualityDepthHistogramArray[2],0);
+        assertEquals(collector.highQualityDepthHistogramArray[0],84);
+        assertEquals(collector.highQualityDepthHistogramArray[1],16);
+    }
+
+    @Test
+    public void testForComplicatedCigar(){
+        CollectWgsMetrics collectWgsMetrics = new CollectWgsMetrics();
+        FastWgsMetricsCollector collector = new FastWgsMetricsCollector(collectWgsMetrics, 100, createIntervalList());
+        AbstractLocusIterator sli = createReadEndsIterator(exampleSamComplexCigarTwoReads);
+        while(sli.hasNext()) {
+            AbstractLocusInfo<EdgingRecordAndOffset> info = sli.next();
+            collector.addInfo(info, ref, false);
+        }
+        assertEquals( collector.basesExcludedByOverlap, 11, "Excluded by overlap:");
+
+        assertEquals(collector.highQualityDepthHistogramArray[0],3);
+        assertEquals(collector.highQualityDepthHistogramArray[1],17);
+        assertEquals(collector.highQualityDepthHistogramArray[2],0);
+    }
+
+    @Test
+    public void testForComplicatedCigarNonFast(){
+        CollectWgsMetrics collectWgsMetrics = new CollectWgsMetrics();
+        CollectWgsMetrics.WgsMetricsCollector collector = new CollectWgsMetrics.WgsMetricsCollector(collectWgsMetrics, 100, createIntervalList());
+        AbstractLocusIterator sli = createSamLocusIterator(exampleSamComplexCigarTwoReads);
+        while(sli.hasNext()) {
+            AbstractLocusInfo<SamLocusIterator.RecordAndOffset> info = sli.next();
+            collector.addInfo(info, ref, false);
+        }
         assertEquals( collector.basesExcludedByOverlap, 11,"Excluded by overlap:");
+        assertEquals(collector.highQualityDepthHistogramArray[0],3);
+        assertEquals(collector.highQualityDepthHistogramArray[1],17);
+        assertEquals(collector.highQualityDepthHistogramArray[2],0);
     }
 }


### PR DESCRIPTION
There was a small bug in the "Fast" WGS collector that assumed that "position" is equal to "refPosition". This assumption is broken in the newest htsjdk which allows a EdgeRead object to appear at the base prior to the read start, meaning that position is refPos-1. This lead to all sorts of interesting small inaccuracies. 

- fixed the above
- modified tests to use the proper place for "expected" and "actual"
- modified tests to be more expansive.

### Description

_Give your PR a **concise** yet **descriptive** title_
_Please explain the changes you made here._
_Explain the **motivation** for making this change. What existing problem does the pull request solve?_
_Mention any issues fixed, addressed or otherwise related to this pull request, including issue numbers or hard links for issues in other repos._
_You can delete these instructions once you have written your PR description._

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

