### PR TITLE
updating htsjdk to 2.20.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ def ensureBuildPrerequisites(requiredJavaVersion, buildPrerequisitesMessage) {
 }
 ensureBuildPrerequisites(requiredJavaVersion, buildPrerequisitesMessage)
 
-final htsjdkVersion = System.getProperty('htsjdk.version', '2.19.0')
+final htsjdkVersion = System.getProperty('htsjdk.version', '2.20.0')
 final googleNio = 'com.google.cloud:google-cloud-nio:0.81.0-alpha:shaded'
 
 // Get the jdk files we need to run javaDoc. We need to use these during compile, testCompile,


### PR DESCRIPTION
### Description

Updating htsjdk 2.19.0 -> 2.20.0.  This has new features like vcf 4.3 reads support and the ability to write indexed gzipped fasta files.

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable
