### PR TITLE
Added a MIN_HISTOGRAM_WIDTH to CollectInsertSizeMetrics.

### DIFF
--- a/src/main/java/picard/analysis/CollectInsertSizeMetrics.java
+++ b/src/main/java/picard/analysis/CollectInsertSizeMetrics.java
@@ -58,7 +58,7 @@ import java.util.Set;
         programGroup = DiagnosticsAndQCProgramGroup.class
 )
 @DocumentedFeature
-public class    CollectInsertSizeMetrics extends SinglePassSamProgram {
+public class CollectInsertSizeMetrics extends SinglePassSamProgram {
     static final String USAGE_BRIEF = "Collect metrics about the insert size distribution of a paired-end library.";
     static final String USAGE_SUMMARY = "<p>This tool provides useful metrics for validating library construction including " +
             "the insert size distribution and read orientation of paired-end libraries.</p>" +

--- a/src/main/java/picard/analysis/CollectInsertSizeMetrics.java
+++ b/src/main/java/picard/analysis/CollectInsertSizeMetrics.java
@@ -29,6 +29,7 @@ import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.util.CollectionUtil;
+import htsjdk.samtools.util.Histogram;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
 import org.broadinstitute.barclay.argparser.Argument;
@@ -40,6 +41,9 @@ import picard.cmdline.programgroups.DiagnosticsAndQCProgramGroup;
 import picard.util.RExecutor;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -54,7 +58,7 @@ import java.util.Set;
         programGroup = DiagnosticsAndQCProgramGroup.class
 )
 @DocumentedFeature
-public class CollectInsertSizeMetrics extends SinglePassSamProgram {
+public class    CollectInsertSizeMetrics extends SinglePassSamProgram {
     static final String USAGE_BRIEF = "Collect metrics about the insert size distribution of a paired-end library.";
     static final String USAGE_SUMMARY = "<p>This tool provides useful metrics for validating library construction including " +
             "the insert size distribution and read orientation of paired-end libraries.</p>" +
@@ -97,6 +101,10 @@ public class CollectInsertSizeMetrics extends SinglePassSamProgram {
             "Also, when calculating mean and standard deviation, only bins <= Histogram_WIDTH will be included.", optional=true)
     public Integer HISTOGRAM_WIDTH = null;
 
+    @Argument(shortName="MW", doc="Minimum width of histogram plots. In the case when the histogram would otherwise be" +
+            "truncated to a shorter range of sizes, the MIN_HISTOGRAM_WIDTH will enforce a minimum range.", optional=true)
+    public Integer MIN_HISTOGRAM_WIDTH = null;
+
     @Argument(shortName="M", doc="When generating the Histogram, discard any data categories (out of FR, TANDEM, RF) that have fewer than this " +
             "percentage of overall reads. (Range: 0 to 1).")
     public float MINIMUM_PCT = 0.05f;
@@ -134,8 +142,8 @@ public class CollectInsertSizeMetrics extends SinglePassSamProgram {
         IOUtil.assertFileIsWritable(Histogram_FILE);
 
         //Delegate actual collection to InsertSizeMetricCollector
-        multiCollector = new InsertSizeMetricsCollector(METRIC_ACCUMULATION_LEVEL, header.getReadGroups(),
-                                                        MINIMUM_PCT, HISTOGRAM_WIDTH, DEVIATIONS, INCLUDE_DUPLICATES);
+        multiCollector = new InsertSizeMetricsCollector(METRIC_ACCUMULATION_LEVEL, header.getReadGroups(), MINIMUM_PCT,
+                HISTOGRAM_WIDTH, MIN_HISTOGRAM_WIDTH, DEVIATIONS, INCLUDE_DUPLICATES);
     }
 
     @Override protected void acceptRead(final SAMRecord record, final ReferenceSequence ref) {
@@ -158,23 +166,18 @@ public class CollectInsertSizeMetrics extends SinglePassSamProgram {
         else  {
             file.write(OUTPUT);
 
-            final int rResult;
-            if(HISTOGRAM_WIDTH == null) {
-                rResult = RExecutor.executeFromClasspath(
-                    Histogram_R_SCRIPT,
-                    OUTPUT.getAbsolutePath(),
-                    Histogram_FILE.getAbsolutePath(),
-                    INPUT.getName());
-            } else {
-                rResult = RExecutor.executeFromClasspath(
-                    Histogram_R_SCRIPT,
-                    OUTPUT.getAbsolutePath(),
-                    Histogram_FILE.getAbsolutePath(),
-                    INPUT.getName(),
-                    String.valueOf(HISTOGRAM_WIDTH) ); //Histogram_WIDTH is passed because R automatically sets Histogram width to the last
-                                                         //bin that has data, which may be less than Histogram_WIDTH and confuse the user.
+            final List<String> plotArgs = new ArrayList<>();
+            Collections.addAll(plotArgs, OUTPUT.getAbsolutePath(), Histogram_FILE.getAbsolutePath(), INPUT.getName());
+
+            if (HISTOGRAM_WIDTH != null) {
+                plotArgs.add(String.valueOf(HISTOGRAM_WIDTH));
+            }
+            else if (MIN_HISTOGRAM_WIDTH != null) {
+                final int max = (int) file.getAllHistograms().stream().mapToDouble(Histogram::getMax).max().getAsDouble();
+                plotArgs.add(String.valueOf(Math.max(max, MIN_HISTOGRAM_WIDTH)));
             }
 
+            final int rResult = RExecutor.executeFromClasspath(Histogram_R_SCRIPT, plotArgs.toArray(new String[0]));
             if (rResult != 0) {
                 throw new PicardException("R script " + Histogram_R_SCRIPT + " failed with return code " + rResult);
             }


### PR DESCRIPTION
### Description

Adds a new option to CollectInsertSizeMetrics to specify a _minimum_ width for the histogram.  This differs from `HISTOGRAM_WIDTH` which _always_ sets the width to the given value.

The motivation for this is that I have a process and pipeline that yields libraries with a very predictable insert size distribution most of the time, and for those libraries I've been using `HISTOGRAM_WIDTH` so that all the plots come out with the same X-axis scaling, making visual comparisons much easier and less error-prone.  However, occasionally odd-ball libraries come through which have significantly larger insert sizes, and the plots are then un-usable.

My intention with this option is to allow usage that uses the `DEVIATIONS` argument in combination with `MIN_HISTOGRAM_WIDTH` in such a way that _most_ libraries get plotted using `MIN_HISTOGRAM_WIDTH` but that libraries that have sufficiently higher insert sizes will end up using the calculated value and expanding the plot width.

### Checklist (never delete this)

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

