### PR TITLE
GL-46: Revert base image change due to issues building on dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM marketplace.gcr.io/google/debian9
+FROM openjdk:8
 MAINTAINER Broad Institute DSDE <dsde-engineering@broadinstitute.org>
 
 ARG build_command=shadowJar
@@ -9,8 +9,7 @@ RUN apt-get update && \
     apt-get --no-install-recommends install -y --force-yes \
         git \
         r-base \
-        ant \
-        openjdk-8-jdk && \
+        ant && \
     apt-get clean autoclean && \
     apt-get autoremove -y
 

--- a/build_push_docker.sh
+++ b/build_push_docker.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-# This script is used to build and deploy docker images for Picard
+# This script is used to build and deploy the GCR docker image for Picard
+# The dockerhub iamge is built using a dockerhub automated build: https://hub.docker.com/r/broadinstitute/picard/builds
 
 if [[ "$1" == "" ]]
 then
@@ -10,20 +11,15 @@ fi
 
 declare -r TAG=${1}
 
-declare -r PICARD_TAG=broadinstitute/picard:${TAG}
 declare -r PICARD_CLOUD_TAG=us.gcr.io/broad-gotc-prod/picard-cloud:${TAG}
 
 echo "Will build and push the following docker images:"
-echo ${PICARD_TAG}
 echo ${PICARD_CLOUD_TAG}
 
 read -p "Is this really what you want to do? " -n 1 -r
 echo    # (optional) move to a new line
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-    docker build -t ${PICARD_TAG} --build-arg build_command=shadowJar --build-arg jar_name=picard.jar .
     docker build -t ${PICARD_CLOUD_TAG} --build-arg build_command=cloudJar --build-arg jar_name=picardcloud.jar .
-
-    docker push ${PICARD_TAG}
     gcloud docker -- push ${PICARD_CLOUD_TAG}
 fi


### PR DESCRIPTION
### Description

Dockerhub can't seem to pull google managed images, so we need to change back to the usual dockerhub image for now.
Also remove dockerhub image push from build_push script now that it's done by an automated build

----


#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

