### PR TITLE
Modified CollectAlignmentSummaryMetric to collect more metrics

### DIFF
--- a/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
+++ b/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
@@ -119,9 +119,13 @@ public class CollectAlignmentSummaryMetrics extends SinglePassSamProgram {
     @Argument(shortName="BS", doc="Whether the SAM or BAM file consists of bisulfite sequenced reads.")
     public boolean IS_BISULFITE_SEQUENCED = false;
 
+    @Argument(doc = "Avoid collecting actual alignment information. Only count READS, PF_READS, and NOISE_READS. (For backwards compatibility).")
+    public boolean DO_NOT_COLLECT_ALIGNMENT_INFORMATION = false;
+
     private AlignmentSummaryMetricsCollector collector;
 
-    @Override protected void setup(final SAMFileHeader header, final File samFile) {
+    @Override
+    protected void setup(final SAMFileHeader header, final File samFile) {
         IOUtil.assertFileIsWritable(OUTPUT);
 
         if (header.getSequenceDictionary().isEmpty()) {
@@ -129,8 +133,11 @@ public class CollectAlignmentSummaryMetrics extends SinglePassSamProgram {
                     "in the file are aligned, then alignment summary metrics collection will fail.");
         }
 
-        final boolean doRefMetrics = REFERENCE_SEQUENCE != null;
-        collector = new AlignmentSummaryMetricsCollector(METRIC_ACCUMULATION_LEVEL, header.getReadGroups(), doRefMetrics,
+        if(REFERENCE_SEQUENCE == null && !DO_NOT_COLLECT_ALIGNMENT_INFORMATION) {
+            log.warn("Without a REFERENCE_SEQUENCE, metrics pertaining to mismatch rates will not be collected!");
+        }
+
+        collector = new AlignmentSummaryMetricsCollector(METRIC_ACCUMULATION_LEVEL, header.getReadGroups(), !DO_NOT_COLLECT_ALIGNMENT_INFORMATION,
                 ADAPTER_SEQUENCE, MAX_INSERT_SIZE, EXPECTED_PAIR_ORIENTATIONS, IS_BISULFITE_SEQUENCED);
     }
 
@@ -147,7 +154,7 @@ public class CollectAlignmentSummaryMetrics extends SinglePassSamProgram {
         file.write(OUTPUT);
     }
 
-    //overridden to make it visible on the commandline and to change the doc.
+    // overridden to make it visible on the commandline and to change the doc.
     @Override
     protected ReferenceArgumentCollection makeReferenceArgumentCollection() {
         return new CollectAlignmentRefArgCollection();
@@ -155,7 +162,8 @@ public class CollectAlignmentSummaryMetrics extends SinglePassSamProgram {
 
     public static class CollectAlignmentRefArgCollection implements ReferenceArgumentCollection {
         @Argument(shortName = StandardOptionDefinitions.REFERENCE_SHORT_NAME,
-                doc = "Reference sequence file. Note that while this argument isn't required, without it only a small subset of the metrics will be calculated. Note also that if a reference sequence is provided, it must be accompanied by a sequence dictionary.",
+                doc = "Reference sequence file. Note that while this argument isn't required, without it a small subset (MISMATCH-related) of the metrics cannot be calculated. " +
+                        "Note also that if a reference sequence is provided, it must be accompanied by a sequence dictionary.",
                 optional = true)
         public File REFERENCE_SEQUENCE = Defaults.REFERENCE_FASTA;
 
@@ -164,5 +172,4 @@ public class CollectAlignmentSummaryMetrics extends SinglePassSamProgram {
             return REFERENCE_SEQUENCE;
         };
     }
-
 }

--- a/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
+++ b/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
@@ -119,8 +119,9 @@ public class CollectAlignmentSummaryMetrics extends SinglePassSamProgram {
     @Argument(shortName="BS", doc="Whether the SAM or BAM file consists of bisulfite sequenced reads.")
     public boolean IS_BISULFITE_SEQUENCED = false;
 
-    @Argument(doc = "Avoid collecting actual alignment information. Only count READS, PF_READS, and NOISE_READS. (For backwards compatibility).")
-    public boolean DO_NOT_COLLECT_ALIGNMENT_INFORMATION = false;
+    @Argument(doc = "A flag to disable the collection of actual alignment information. " +
+            "If false, tool will only count READS, PF_READS, and NOISE_READS. (For backwards compatibility).")
+    public boolean COLLECT_ALIGNMENT_INFORMATION = true;
 
     private AlignmentSummaryMetricsCollector collector;
 
@@ -133,11 +134,11 @@ public class CollectAlignmentSummaryMetrics extends SinglePassSamProgram {
                     "in the file are aligned, then alignment summary metrics collection will fail.");
         }
 
-        if(REFERENCE_SEQUENCE == null && !DO_NOT_COLLECT_ALIGNMENT_INFORMATION) {
+        if(REFERENCE_SEQUENCE == null && COLLECT_ALIGNMENT_INFORMATION) {
             log.warn("Without a REFERENCE_SEQUENCE, metrics pertaining to mismatch rates will not be collected!");
         }
 
-        collector = new AlignmentSummaryMetricsCollector(METRIC_ACCUMULATION_LEVEL, header.getReadGroups(), !DO_NOT_COLLECT_ALIGNMENT_INFORMATION,
+        collector = new AlignmentSummaryMetricsCollector(METRIC_ACCUMULATION_LEVEL, header.getReadGroups(), COLLECT_ALIGNMENT_INFORMATION,
                 ADAPTER_SEQUENCE, MAX_INSERT_SIZE, EXPECTED_PAIR_ORIENTATIONS, IS_BISULFITE_SEQUENCED);
     }
 

--- a/src/test/java/picard/analysis/CollectAlignmentSummaryMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectAlignmentSummaryMetricsTest.java
@@ -255,6 +255,7 @@ public class CollectAlignmentSummaryMetricsTest extends CommandLineProgramTest {
         final String[] args = new String[]{
                 "INPUT=" + input.getAbsolutePath(),
                 "OUTPUT=" + outfile.getAbsolutePath(),
+                "DO_NOT_COLLECT_ALIGNMENT_INFORMATION=true"
         };
         Assert.assertEquals(runPicardCommandLine(args), 0);
 
@@ -314,6 +315,7 @@ public class CollectAlignmentSummaryMetricsTest extends CommandLineProgramTest {
         final String[] args = new String[]{
                 "INPUT=" + input.getAbsolutePath(),
                 "OUTPUT=" + outfile.getAbsolutePath(),
+                "DO_NOT_COLLECT_ALIGNMENT_INFORMATION=true"
         };
         Assert.assertEquals(runPicardCommandLine(args), 0);
 
@@ -338,6 +340,7 @@ public class CollectAlignmentSummaryMetricsTest extends CommandLineProgramTest {
                 "METRIC_ACCUMULATION_LEVEL=SAMPLE",
                 "METRIC_ACCUMULATION_LEVEL=LIBRARY",
                 "METRIC_ACCUMULATION_LEVEL=READ_GROUP",
+                "DO_NOT_COLLECT_ALIGNMENT_INFORMATION=true"
         };
         Assert.assertEquals(runPicardCommandLine(args), 0);
 

--- a/src/test/java/picard/analysis/CollectAlignmentSummaryMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectAlignmentSummaryMetricsTest.java
@@ -255,7 +255,7 @@ public class CollectAlignmentSummaryMetricsTest extends CommandLineProgramTest {
         final String[] args = new String[]{
                 "INPUT=" + input.getAbsolutePath(),
                 "OUTPUT=" + outfile.getAbsolutePath(),
-                "DO_NOT_COLLECT_ALIGNMENT_INFORMATION=true"
+                "COLLECT_ALIGNMENT_INFORMATION=false"
         };
         Assert.assertEquals(runPicardCommandLine(args), 0);
 
@@ -315,7 +315,7 @@ public class CollectAlignmentSummaryMetricsTest extends CommandLineProgramTest {
         final String[] args = new String[]{
                 "INPUT=" + input.getAbsolutePath(),
                 "OUTPUT=" + outfile.getAbsolutePath(),
-                "DO_NOT_COLLECT_ALIGNMENT_INFORMATION=true"
+                "COLLECT_ALIGNMENT_INFORMATION=false"
         };
         Assert.assertEquals(runPicardCommandLine(args), 0);
 
@@ -340,7 +340,7 @@ public class CollectAlignmentSummaryMetricsTest extends CommandLineProgramTest {
                 "METRIC_ACCUMULATION_LEVEL=SAMPLE",
                 "METRIC_ACCUMULATION_LEVEL=LIBRARY",
                 "METRIC_ACCUMULATION_LEVEL=READ_GROUP",
-                "DO_NOT_COLLECT_ALIGNMENT_INFORMATION=true"
+                "COLLECT_ALIGNMENT_INFORMATION=false"
         };
         Assert.assertEquals(runPicardCommandLine(args), 0);
 


### PR DESCRIPTION
...in the absence of a REFERENCE_SEQUENCE

- A pathway remains for those who wish to retain the old way of collecting only TOTAL_READS, PF_READS, and NOISE_READS
- fixed #1373

### Description

_Give your PR a **concise** yet **descriptive** title_
_Please explain the changes you made here._
_Explain the **motivation** for making this change. What existing problem does the pull request solve?_
_Mention any issues fixed, addressed or otherwise related to this pull request, including issue numbers or hard links for issues in other repos._
_You can delete these instructions once you have written your PR description._

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

