### PR TITLE
Fix a typo in IntervalListTools logging

### DIFF
--- a/src/main/java/picard/util/IntervalListTools.java
+++ b/src/main/java/picard/util/IntervalListTools.java
@@ -472,7 +472,7 @@ public class IntervalListTools extends CommandLineProgram {
             resultIntervals.baseCount = output.getBaseCount();
         }
 
-        LOG.info("Produced " + resultIntervals.intervalCount + " intervals totalling " + resultIntervals.baseCount + " bases.");
+        LOG.info("Produced " + resultIntervals.intervalCount + " intervals totaling " + resultIntervals.baseCount + " bases.");
         if (COUNT_OUTPUT != null) {
             try (final PrintStream countStream = new PrintStream(COUNT_OUTPUT)) {
                 OUTPUT_VALUE.output(resultIntervals.baseCount, resultIntervals.intervalCount, countStream);


### PR DESCRIPTION
### Description

IntervalListTools logs the list stats with "totalling", which IntelliJ doesn't mind, but isn't actually a word.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

