### PR TITLE
PO-18867 Catch NaN Percent_Duplcation edge case

### DIFF
--- a/src/main/java/picard/sam/DuplicationMetrics.java
+++ b/src/main/java/picard/sam/DuplicationMetrics.java
@@ -103,7 +103,11 @@ public class DuplicationMetrics extends MergeableMetricBase {
         this.ESTIMATED_LIBRARY_SIZE = estimateLibrarySize(this.READ_PAIRS_EXAMINED - this.READ_PAIR_OPTICAL_DUPLICATES,
                 this.READ_PAIRS_EXAMINED - this.READ_PAIR_DUPLICATES);
 
-        PERCENT_DUPLICATION = (UNPAIRED_READ_DUPLICATES + READ_PAIR_DUPLICATES * 2) / (double) (UNPAIRED_READS_EXAMINED + READ_PAIRS_EXAMINED * 2);
+        if (UNPAIRED_READS_EXAMINED + READ_PAIRS_EXAMINED == 0) {
+            PERCENT_DUPLICATION = (double) 0;
+        } else {
+            PERCENT_DUPLICATION = (UNPAIRED_READ_DUPLICATES + READ_PAIR_DUPLICATES * 2) / (double) (UNPAIRED_READS_EXAMINED + READ_PAIRS_EXAMINED * 2);
+        }
     }
 
     /**

--- a/src/main/java/picard/sam/DuplicationMetrics.java
+++ b/src/main/java/picard/sam/DuplicationMetrics.java
@@ -103,10 +103,10 @@ public class DuplicationMetrics extends MergeableMetricBase {
         this.ESTIMATED_LIBRARY_SIZE = estimateLibrarySize(this.READ_PAIRS_EXAMINED - this.READ_PAIR_OPTICAL_DUPLICATES,
                 this.READ_PAIRS_EXAMINED - this.READ_PAIR_DUPLICATES);
 
-        if (UNPAIRED_READS_EXAMINED + READ_PAIRS_EXAMINED == 0) {
-            PERCENT_DUPLICATION = (double) 0;
-        } else {
+        if (UNPAIRED_READS_EXAMINED + READ_PAIRS_EXAMINED != 0) {
             PERCENT_DUPLICATION = (UNPAIRED_READ_DUPLICATES + READ_PAIR_DUPLICATES * 2) / (double) (UNPAIRED_READS_EXAMINED + READ_PAIRS_EXAMINED * 2);
+        } else {
+            PERCENT_DUPLICATION = (double) 0;
         }
     }
 

--- a/src/test/java/picard/sam/DuplicationMetricsTest.java
+++ b/src/test/java/picard/sam/DuplicationMetricsTest.java
@@ -61,6 +61,11 @@ public class DuplicationMetricsTest {
         return metric;
     }
 
+    @Test
+    public void testEmptyDuplicationMetricsDerivation(){
+        Assert.assertEquals(emptyMetrics().PERCENT_DUPLICATION, 0.0);
+    }
+
     @Test(dataProvider="testMergeDataProvider")
     public void testMerge(final DuplicationMetrics left, final DuplicationMetrics right, final DuplicationMetrics expected) {
         left.merge(right);


### PR DESCRIPTION
### Description

Fixes NaN error causing weird aggregation metrics. This fix prevents a divide by zero NaN error as a value for `PERCENT_DUPLICATION` by defaulting to zero if it looks like it will be a NaN (`UNPAIRED_READS_EXAMINED` and `READ_PAIRS_EXAMINED`== 0). If even one library was empty, it would cause there to be 0s for values such as `Mean Coverage`.

----

### Checklist (never delete this)

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

