### PR TITLE
fix google cloud import and update to new version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ def ensureBuildPrerequisites(requiredJavaVersion, buildPrerequisitesMessage) {
 ensureBuildPrerequisites(requiredJavaVersion, buildPrerequisitesMessage)
 
 final htsjdkVersion = System.getProperty('htsjdk.version', '2.20.3')
-final googleNio = 'com.google.cloud:google-cloud-nio:0.81.0-alpha:shaded'
+final googleNio = 'com.google.cloud:google-cloud-nio:0.107.0-alpha:shaded'
 
 // Get the jdk files we need to run javaDoc. We need to use these during compile, testCompile,
 // test execution, and gatkDoc generation, but we don't want them as part of the runtime
@@ -77,7 +77,9 @@ dependencies {
     compile 'commons-lang:commons-lang:2.6'
     compile 'com.github.samtools:htsjdk:' + htsjdkVersion
     compile 'org.broadinstitute:barclay:2.0.0'
-    compileOnly googleNio
+    compileOnly(googleNio) {
+        transitive = false
+    }
 
     // javadoc utilities; compile/test only to prevent redistribution of sdk jars
     compileOnly(javadocJDKFiles)


### PR DESCRIPTION
* Updating NIO dependency from 81 -> 106
   * Updating the configuration code to include new code backported from gatk.
   * This adds a hook where requester pay's support can be plugged in in a future pr.
* Fixing a bug where we were accidentally importing the non-shaded google dependencies as well as the shaded ones

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

