### PR TITLE
Throw exception in MergeBamAlignments if UNMAPPED_BAM has mapped reads

### DIFF
--- a/src/main/java/picard/sam/AbstractAlignmentMerger.java
+++ b/src/main/java/picard/sam/AbstractAlignmentMerger.java
@@ -403,7 +403,9 @@ public abstract class AbstractAlignmentMerger {
         while (unmappedIterator.hasNext()) {
             // Load next unaligned read or read pair.
             final SAMRecord rec = unmappedIterator.next();
-
+            if (!rec.getReadUnmappedFlag()) {
+                throw new PicardException("Unmapped bam contains mapped reads");
+            }
             rec.setHeader(this.header);
             maybeSetPgTag(rec);
 

--- a/src/main/java/picard/sam/AbstractAlignmentMerger.java
+++ b/src/main/java/picard/sam/AbstractAlignmentMerger.java
@@ -403,6 +403,7 @@ public abstract class AbstractAlignmentMerger {
         while (unmappedIterator.hasNext()) {
             // Load next unaligned read or read pair.
             final SAMRecord rec = unmappedIterator.next();
+            
             rec.setHeader(this.header);
             maybeSetPgTag(rec);
 

--- a/src/main/java/picard/sam/AbstractAlignmentMerger.java
+++ b/src/main/java/picard/sam/AbstractAlignmentMerger.java
@@ -403,7 +403,7 @@ public abstract class AbstractAlignmentMerger {
         while (unmappedIterator.hasNext()) {
             // Load next unaligned read or read pair.
             final SAMRecord rec = unmappedIterator.next();
-            
+
             rec.setHeader(this.header);
             maybeSetPgTag(rec);
 

--- a/src/main/java/picard/sam/AbstractAlignmentMerger.java
+++ b/src/main/java/picard/sam/AbstractAlignmentMerger.java
@@ -403,9 +403,6 @@ public abstract class AbstractAlignmentMerger {
         while (unmappedIterator.hasNext()) {
             // Load next unaligned read or read pair.
             final SAMRecord rec = unmappedIterator.next();
-            if (!rec.getReadUnmappedFlag()) {
-                throw new PicardException("UNMAPPED_BAM contains mapped reads.  If you would like to use this file as the UNMAPPED_BAM, first revert it using RevertSam.");
-            }
             rec.setHeader(this.header);
             maybeSetPgTag(rec);
 
@@ -814,6 +811,9 @@ public abstract class AbstractAlignmentMerger {
      * @param alignment The alignment record
      */
     protected void setValuesFromAlignment(final SAMRecord rec, final SAMRecord alignment, final boolean needsSafeReverseComplement) {
+        if (!rec.getReadUnmappedFlag()) {
+            throw new PicardException("UNMAPPED_BAM contains mapped reads.  If you would like to use this file as the UNMAPPED_BAM, first revert it using RevertSam.");
+        }
         for (final SAMRecord.SAMTagAndValue attr : alignment.getAttributes()) {
             // Copy over any non-reserved attributes.  attributesToRemove overrides attributesToRetain.
             if ((!isReservedTag(attr.tag) || this.attributesToRetain.contains(attr.tag)) && !this.attributesToRemove.contains(attr.tag)) {

--- a/src/main/java/picard/sam/AbstractAlignmentMerger.java
+++ b/src/main/java/picard/sam/AbstractAlignmentMerger.java
@@ -404,7 +404,7 @@ public abstract class AbstractAlignmentMerger {
             // Load next unaligned read or read pair.
             final SAMRecord rec = unmappedIterator.next();
             if (!rec.getReadUnmappedFlag()) {
-                throw new PicardException("Unmapped bam contains mapped reads");
+                throw new PicardException("UNMAPPED_BAM contains mapped reads.  If you would like to use this file as the UNMAPPED_BAM, first revert it using RevertSam.");
             }
             rec.setHeader(this.header);
             maybeSetPgTag(rec);

--- a/src/main/java/picard/sam/MergeBamAlignment.java
+++ b/src/main/java/picard/sam/MergeBamAlignment.java
@@ -145,7 +145,7 @@ public class MergeBamAlignment extends CommandLineProgram {
     public final PGTagArgumentCollection pgTagArgumentCollection = new PGTagArgumentCollection();
 
     @Argument(shortName = "UNMAPPED",
-            doc = "Original SAM or BAM file of unmapped reads, which must be in queryname order.")
+            doc = "Original SAM or BAM file of unmapped reads, which must be in queryname order.  Reads MUST be unmapped.")
     public File UNMAPPED_BAM;
 
     @Argument(shortName = "ALIGNED",

--- a/src/test/java/picard/sam/MergeBamAlignmentTest.java
+++ b/src/test/java/picard/sam/MergeBamAlignmentTest.java
@@ -1927,7 +1927,7 @@ public class MergeBamAlignmentTest extends CommandLineProgramTest {
     }
 
     @Test(dataProvider = "mappedReadInUnmappedBamDataProvider", expectedExceptions = PicardException.class)
-    public void testSingleEndMappedReadInUnmappedBam(final boolean paired, final boolean firstUnMapped, final boolean secondUnMapped) throws IOException {
+    public void testMappedReadInUnmappedBam(final boolean paired, final boolean firstUnMapped, final boolean secondUnMapped) throws IOException {
         final SAMRecordSetBuilder samRecordSetBuilderUnmappedBam = new SAMRecordSetBuilder(true, SAMFileHeader.SortOrder.queryname);
         samRecordSetBuilderUnmappedBam.setRandomSeed(12345);
         final SAMFileHeader header = samRecordSetBuilderUnmappedBam.getHeader();

--- a/src/test/java/picard/sam/MergeBamAlignmentTest.java
+++ b/src/test/java/picard/sam/MergeBamAlignmentTest.java
@@ -35,6 +35,7 @@ import htsjdk.samtools.SAMProgramRecord;
 import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecordIterator;
+import htsjdk.samtools.SAMRecordSetBuilder;
 import htsjdk.samtools.SAMTag;
 import htsjdk.samtools.SamPairUtil;
 import htsjdk.samtools.SamReader;

--- a/src/test/java/picard/sam/MergeBamAlignmentTest.java
+++ b/src/test/java/picard/sam/MergeBamAlignmentTest.java
@@ -23,7 +23,22 @@
  */
 package picard.sam;
 
-import htsjdk.samtools.*;
+import htsjdk.samtools.BamFileIoUtils;
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.CigarElement;
+import htsjdk.samtools.CigarOperator;
+import htsjdk.samtools.Defaults;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMProgramRecord;
+import htsjdk.samtools.SAMReadGroupRecord;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMRecordIterator;
+import htsjdk.samtools.SAMTag;
+import htsjdk.samtools.SamPairUtil;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.variant.utils.SAMSequenceDictionaryExtractor;
@@ -1919,15 +1934,15 @@ public class MergeBamAlignmentTest extends CommandLineProgramTest {
     @DataProvider(name = "mappedReadInUnmappedBamDataProvider")
     Object[][] mappedReadInUnmappedBamDataProvider() {
         return new Object[][] {
-            {false, false, false},
-            {true, true, false},
-            {true, false, true},
-            {true, false, false}
+            {false, false, false, true},
+            {true, true, false, true},
+            {true, false, true, true},
+            {true, true, true, false}
         };
     }
 
-    @Test(dataProvider = "mappedReadInUnmappedBamDataProvider", expectedExceptions = PicardException.class)
-    public void testMappedReadInUnmappedBam(final boolean paired, final boolean firstUnMapped, final boolean secondUnMapped) throws IOException {
+    @Test(dataProvider = "mappedReadInUnmappedBamDataProvider")
+    public void testMappedReadInUnmappedBam(final boolean paired, final boolean firstUnMapped, final boolean secondUnMapped, final boolean shouldThrowException) throws IOException {
         final SAMRecordSetBuilder samRecordSetBuilderUnmappedBam = new SAMRecordSetBuilder(true, SAMFileHeader.SortOrder.queryname);
         samRecordSetBuilderUnmappedBam.setRandomSeed(12345);
         final SAMFileHeader header = samRecordSetBuilderUnmappedBam.getHeader();
@@ -1977,7 +1992,11 @@ public class MergeBamAlignmentTest extends CommandLineProgramTest {
         );
 
         //should throw PicardException when run because mapped read found in UNMAPPED_BAM input
-        runPicardCommandLine(args);
+        if (shouldThrowException) {
+            Assert.assertThrows(PicardException.class, () -> runPicardCommandLine(args));
+        } else {
+            runPicardCommandLine(args);
+        }
     }
 }
 


### PR DESCRIPTION
### Description
Currently, MergeBamAlignments will run through without complaint and produce a merged bam if a bam with mapped reads is used in the UNMAPPED_BAM argument.  However, any read which was aligned to the reverse strand in both the UNMAPPED_BAM and the ALIGNED_BAM will have its bases reverse complemented, resulting in a record with alignment on the reverse stand but with bases recorded for the forward strand.  See `MergeBamAlignmentTest.testReverseStrandMappedReadInUnmappedBam()` on branch [ck_Test_MBA_ReverseStrandMappedReadInUnmappedBam](https://github.com/broadinstitute/picard/tree/ck_Test_MBA_ReverseStrandMappedReadInUnmappedBam) for example.
This PR adds a check that all records in UNMAPPED_BAM are unmapped, and throws an exception if it finds any that are mapped. 

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests