### PR TITLE
Remove an unused import which points to a java internal class

### DIFF
--- a/src/main/java/picard/illumina/IlluminaBasecallsToFastq.java
+++ b/src/main/java/picard/illumina/IlluminaBasecallsToFastq.java
@@ -23,7 +23,6 @@
  */
 package picard.illumina;
 
-import com.sun.xml.internal.rngom.parse.host.Base;
 import htsjdk.samtools.SAMRecordQueryNameComparator;
 import htsjdk.samtools.SAMUtils;
 import htsjdk.samtools.fastq.BasicFastqWriter;


### PR DESCRIPTION
### Description

* Removing import of com.sun.xml.internal.rngom.parse.host.Base which was unused.
I noticed this because it causes a warning when gatk builds it's doc.

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable


