### PR TITLE
Fixing up tests in MarkDuplicates so that tests with duplex umis are handled properly

### DIFF
--- a/src/test/java/picard/sam/markduplicates/MarkDuplicateWithMissingBarcodeTest.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicateWithMissingBarcodeTest.java
@@ -30,9 +30,11 @@ abstract public class MarkDuplicateWithMissingBarcodeTest extends MarkDuplicates
                     break;
                 }
             }
-            
+
             // Tests that specify the RX tag, or the DUPLEX_UMI argument should not be used with missing barcodes.
-            if (!hasRX && !isDuplex) addArg(getArgumentName() + "=" + getTagValue());
+            if (!hasRX && !isDuplex) {
+                addArg(getArgumentName() + "=" + getTagValue());
+            }
 
             super.runTest();
         }

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicateWithMissingBarcodeTest.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicateWithMissingBarcodeTest.java
@@ -19,13 +19,20 @@ abstract public class MarkDuplicateWithMissingBarcodeTest extends MarkDuplicates
         @Override
         public void runTest() {
             boolean hasRX = false;
+            boolean isDuplex = false;
             for (final String argument : this.getArgs()) {
                 if (argument.startsWith(getArgumentName())) {
                     hasRX = true;
                     break;
                 }
+                if (argument.startsWith("DUPLEX_UMI")) {
+                    isDuplex = true;
+                    break;
+                }
             }
-            if (!hasRX) addArg(getArgumentName() + "=" + getTagValue());
+            
+            // Tests that specify the RX tag, or the DUPLEX_UMI argument should not be used with missing barcodes.
+            if (!hasRX && !isDuplex) addArg(getArgumentName() + "=" + getTagValue());
 
             super.runTest();
         }

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesTest.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesTest.java
@@ -311,7 +311,7 @@ public class MarkDuplicatesTest extends AbstractMarkDuplicatesCommandLineProgram
     }
 
     @DataProvider(name = "testDuplexUmiDataProvider")
-    private Object[][] testDuplexUmiDataProvider() {
+    public Object[][] testDuplexUmiDataProvider() {
         return new Object[][]{
                 {
                         // Test case where UMIs are not duplex, but are the same.
@@ -358,7 +358,7 @@ public class MarkDuplicatesTest extends AbstractMarkDuplicatesCommandLineProgram
         };
     }
 
-    @Test(dataProvider = "testDuplexUmiDataProvider",enabled = false)
+    @Test(dataProvider = "testDuplexUmiDataProvider")
     public void testWithUMIs(final boolean duplexUmi, final List<String> UMIs, final List<Integer> alignmentStart1,
                              final List<Integer> alignmentStart2, final List<Boolean> isDuplicate,
                              final List<Boolean> isFirstNegativeStrand, final List<Boolean> isSecondNegativeStrand) {


### PR DESCRIPTION

### Description

This resolves issue, https://github.com/broadinstitute/picard/issues/1375.

A data provider in MarkDuplicatesTest was private which resulted in the tests not being run.  When the provider was changed to public, this caused some of the tests to fail.  This fixes the data provider and resulting failing tests.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

