### PR TITLE
Update plugin versions for github-pages documentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '5.1.0'
     id "com.github.kt3k.coveralls" version '2.6.3'
     id "org.ajoberstar.grgit" version "4.0.0-rc.1"
-    id "org.ajoberstar.github-pages" version "1.7.2"
+    id "org.ajoberstar.git-publish" version "2.1.1"
 }
 
 mainClassName = "picard.cmdline.PicardCommandLine"
@@ -416,14 +416,15 @@ task updateGhPages(dependsOn: ['copyJavadoc', 'copyPicardDoc']){
   outputs.dir htmlDir
 }
 
-updateGhPages.finalizedBy publishGhPages
+updateGhPages.finalizedBy gitPublishPush
 
-githubPages {
-  repoUri = 'git@github.com:broadinstitute/picard.git'
-  targetBranch = 'gh-pages'
-  deleteExistingFiles = false
-  pages {
-    from htmlDir
-    into 'newdocs'
-  }
+gitPublish {
+    repoUri = 'git@github.com:broadinstitute/picard.git'
+    branch = 'gh-pages'
+    preserve { include '**/*' }
+    contents { 
+        from('build/docs/html') { 
+            into 'newdocs' 
+        } 
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ plugins {
     id 'com.palantir.git-version' version '0.5.1'
     id 'com.github.johnrengelman.shadow' version '5.1.0'
     id "com.github.kt3k.coveralls" version '2.6.3'
-    id 'org.ajoberstar.grgit' version '1.4.2'
-    id 'org.ajoberstar.github-pages' version '1.4.2'
+    id "org.ajoberstar.grgit" version "4.0.0-rc.1"
+    id "org.ajoberstar.github-pages" version "1.7.2"
 }
 
 mainClassName = "picard.cmdline.PicardCommandLine"


### PR DESCRIPTION
### Description

Updated versions of plugins used to automatically update the documentation on gh-pages.

For each release, we run the command `./gradlew updateGhPages` to update the documentation at https://broadinstitute.github.io/picard/, but this command has been broken for a while. Updating the plugin versions fixes this. 

Note that this PR allows us to update the documentation in the 'newdocs' directory which is not rendered as part of the public facing documentation. Additional work/coordination will need to be done before we can update the docs at http://broadinstitute.github.io/picard/. 

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

