### PR TITLE
Speeds up MarkDuplicates on queryname input by using the in memory read-ends map.

### DIFF
--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -533,7 +533,8 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
         final SamHeaderAndIterator headerAndIterator = openInputs(true);
         final SAMFileHeader.SortOrder assumedSortOrder = headerAndIterator.header.getSortOrder();
         final SAMFileHeader header = headerAndIterator.header;
-        final ReadEndsForMarkDuplicatesMap tmp = new DiskBasedReadEndsForMarkDuplicatesMap(MAX_FILE_HANDLES_FOR_READ_ENDS_MAP, diskCodec);
+        final ReadEndsForMarkDuplicatesMap tmp = assumedSortOrder == SAMFileHeader.SortOrder.queryname ?
+                new MemoryBasedReadEndsForMarkDuplicatesMap() :  new DiskBasedReadEndsForMarkDuplicatesMap(MAX_FILE_HANDLES_FOR_READ_ENDS_MAP, diskCodec);
         long index = 0;
         final ProgressLogger progress = new ProgressLogger(log, (int) 1e6, "Read");
         final CloseableIterator<SAMRecord> iterator = headerAndIterator.iterator;

--- a/src/main/java/picard/sam/markduplicates/util/MemoryBasedReadEndsForMarkDuplicatesMap.java
+++ b/src/main/java/picard/sam/markduplicates/util/MemoryBasedReadEndsForMarkDuplicatesMap.java
@@ -33,7 +33,7 @@ import java.util.HashMap;
  *
  * @author alecw@broadinstitute.org
  */
-class MemoryBasedReadEndsForMarkDuplicatesMap implements ReadEndsForMarkDuplicatesMap {
+public class MemoryBasedReadEndsForMarkDuplicatesMap implements ReadEndsForMarkDuplicatesMap {
 
     /**
      * Index of this list is sequence index.  Value is map from String {read group id:read name} to ReadEnds.


### PR DESCRIPTION
### Description

MarkDuplicates is glacially slow when operating on `queryname` sorted input.  The reason for this is that it continues to use the `DiskBasedReadEndsForMarkDuplicatesMap` which does a bunch of disk-based IO every time it sees a record mapped to a different chromosome than the last record it saw - which is essentially every other record when operating in queryname order.

I was testing with 2m random reads from an exome BAM, and it was taking ~15 minutes to go through the first phase or calculating the read ends.  Subbing in the in-memory map reduced this to < 10 seconds.  This should be entirely safe because when operating on queryname sorted data the read ends map will generally only ever have 1 read in it at a time!

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

