### PR TITLE
Make CheckIlluminaDirectory log if faking files

### DIFF
--- a/src/main/java/picard/illumina/CheckIlluminaDirectory.java
+++ b/src/main/java/picard/illumina/CheckIlluminaDirectory.java
@@ -304,6 +304,7 @@ public class CheckIlluminaDirectory extends CommandLineProgram {
                 for (final IlluminaDataType dataType : unmatchedDataTypes) {
                     final IlluminaFileUtil.SupportedIlluminaFormat format =
                             IlluminaDataProviderFactory.findPreferredFormat(dataType, fileUtil);
+                    log.info("Faking files for " + dataType.name());
                     fileUtil.getUtil(format).fakeFiles(expectedTiles, cycles, format);
 
                 }


### PR DESCRIPTION
### Description

It is useful for `CheckIlluminaDirectory` to log faked files if the `FAKE_FILES` parameter is set to `true`. 

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

