### PR TITLE
Yf optimize query for independent replicate metrics

### DIFF
--- a/src/main/java/picard/analysis/replicates/CollectIndependentReplicateMetrics.java
+++ b/src/main/java/picard/analysis/replicates/CollectIndependentReplicateMetrics.java
@@ -198,7 +198,7 @@ public class CollectIndependentReplicateMetrics extends CommandLineProgram {
 
         log.info("Querying BAM for sites.");
 
-        final SAMRecordIterator samRecordIterator = in.query(intervalAlleleMap.keySet().toArray(new QueryInterval[intervalAlleleMap.size()]), false);
+        final SAMRecordIterator samRecordIterator = in.query(QueryInterval.optimizeIntervals(intervalAlleleMap.keySet().toArray(new QueryInterval[0])), false);
         final List<SamRecordFilter> samFilters = CollectionUtil.makeList(
                 new AlignedFilter(true),
                 new CountingPairedFilter(),

--- a/src/main/java/picard/analysis/replicates/CollectIndependentReplicateMetrics.java
+++ b/src/main/java/picard/analysis/replicates/CollectIndependentReplicateMetrics.java
@@ -66,6 +66,8 @@ import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.programgroups.DiagnosticsAndQCProgramGroup;
 import picard.filter.CountingPairedFilter;
+import picard.util.BarcodeEditDistanceQuery;
+import picard.util.SingleBarcodeDistanceMetric;
 
 import java.io.File;
 import java.util.HashMap;
@@ -155,6 +157,14 @@ public class CollectIndependentReplicateMetrics extends CommandLineProgram {
     @Argument(shortName = "FUR", doc = "Whether to filter unpaired reads from the input.", optional = true)
     public boolean FILTER_UNPAIRED_READS=true;
 
+    @Argument(
+            fullName = "PROGRESS_STEP_INTERVAL",
+            doc = "The interval between which progress will be displayed.",
+            optional = true
+    )
+    public int PROGRESS_STEP_INTERVAL = 100000;
+
+
     private static final Log log = Log.getInstance(CollectIndependentReplicateMetrics.class);
 
     @Override
@@ -222,12 +232,12 @@ public class CollectIndependentReplicateMetrics extends CommandLineProgram {
         log.info("Queried BAM, getting duplicate sets.");
 
         // get duplicate iterator from iterator above
-        final DuplicateSetIterator duplicateSets = new DuplicateSetIterator(filteredSamRecordIterator, in.getFileHeader());
+        final DuplicateSetIterator duplicateSets = new DuplicateSetIterator(filteredSamRecordIterator, in.getFileHeader(),false, null, log);
 
         QueryInterval queryInterval = null;
 
         log.info("Starting iteration on reads");
-        final ProgressLogger progress = new ProgressLogger(log, 10000000, "examined", "duplicate sets");
+        final ProgressLogger progress = new ProgressLogger(log, PROGRESS_STEP_INTERVAL, "examined", "duplicate sets");
 
         IndependentReplicateMetric locusData = new IndependentReplicateMetric();
         boolean useLocus = true;
@@ -353,13 +363,13 @@ public class CollectIndependentReplicateMetrics extends CommandLineProgram {
             log.debug("Classification of set is: " + classification);
             if (setSize == DOUBLETON_SIZE) {
 
-                final boolean useBarcodes = !set.getRecords().stream()
+                final boolean useBarcodes = set.getRecords().stream()
                         .map(read -> read.getStringAttribute(BARCODE_BQ))
-                        .map(string -> string == null ? "" : string).map(string ->
+                        .map(string -> string == null ? "" : string).noneMatch(string ->
                         {
                             final byte[] bytes = SAMUtils.fastqToPhred(string);
                             return IntStream.range(0, bytes.length).map(i -> bytes[i]).anyMatch(q -> q < MINIMUM_BARCODE_BQ);
-                        }).anyMatch(a -> a);
+                        });
 
                 log.debug("using barcodes?" + useBarcodes);
 
@@ -371,7 +381,7 @@ public class CollectIndependentReplicateMetrics extends CommandLineProgram {
 
                 log.debug("found UMIs:" + barcodes);
                 final boolean hasMultipleOrientations = set.getRecords().stream()
-                        .map(SAMRecord::getFirstOfPairFlag) //must be paired, due to filter on sam Iterator
+                        .map(rec->!rec.getReadPairedFlag() || rec.getFirstOfPairFlag())
                         .distinct().count() != 1;
                 log.debug("reads have multiple orientation?" + hasMultipleOrientations);
 
@@ -390,24 +400,36 @@ public class CollectIndependentReplicateMetrics extends CommandLineProgram {
                     if (useBarcodes) {
                         umiEditDistanceInDiffBiDups.increment(editDistance);
 
-                        if(editDistance == 0) locusData.nMatchingUMIsInDiffBiDups++; else locusData.nMismatchingUMIsInDiffBiDups++;
+                        if (editDistance == 0) {
+                            locusData.nMatchingUMIsInDiffBiDups++;
+                        } else {
+                            locusData.nMismatchingUMIsInDiffBiDups++;
+                        }
                     }
 
                     // we're going to toss out this locus.
                 } else if (classification == SetClassification.MISMATCHING_ALLELE) {
                     locusData.nMismatchingAllelesBiDups++;
                 } else { // the classification is either ALTERNATE_ALLELE or REFERENCE_ALLELE if we've reached here
-                    if (classification == SetClassification.ALTERNATE_ALLELE) locusData.nAlternateAllelesBiDups++;
-                    else locusData.nReferenceAllelesBiDups++;
+                    if (classification == SetClassification.ALTERNATE_ALLELE) {
+                        locusData.nAlternateAllelesBiDups++;
+                    } else {
+                        locusData.nReferenceAllelesBiDups++;
+                    }
 
                     if (useBarcodes) {
-
                         umiEditDistanceInSameBiDups.increment(editDistance);
                         final ComparableTuple<String, String> key = new ComparableTuple<>(barcodes.get(0), barcodes.get(1));
                         umiConfusionMatrix.increment(key);
-                        if (!umiConfusionMatrixEditDistance.containsKey(key)) umiConfusionMatrixEditDistance.increment(key, editDistance);
+                        if (!umiConfusionMatrixEditDistance.containsKey(key)) {
+                            umiConfusionMatrixEditDistance.increment(key, editDistance);
+                        }
 
-                        if (editDistance == 0) locusData.nMatchingUMIsInSameBiDups++; else  locusData.nMismatchingUMIsInSameBiDups++;
+                        if (editDistance == 0) {
+                            locusData.nMatchingUMIsInSameBiDups++;
+                        } else {
+                            locusData.nMismatchingUMIsInSameBiDups++;
+                        }
                     }
                 }
             }
@@ -484,16 +506,24 @@ public class CollectIndependentReplicateMetrics extends CommandLineProgram {
 
     private static SetClassification classifySet(final int nRef, final int nAlt, final int nOther) {
         // if we found any "other" alleles, this is a mismatching set
-        if (nOther != 0) return SetClassification.MISMATCHING_ALLELE;
+        if (nOther != 0) {
+            return SetClassification.MISMATCHING_ALLELE;
+        }
 
         // if we found both ref and alt alleles, this is a heterogeneous set
-        if (nAlt > 0 && nRef > 0) return SetClassification.DIFFERENT_ALLELES;
+        if (nAlt > 0 && nRef > 0) {
+            return SetClassification.DIFFERENT_ALLELES;
+        }
 
         // if we found no reference alleles, this is an "alternate" set
-        if (nRef == 0) return SetClassification.ALTERNATE_ALLELE;
+        if (nRef == 0) {
+            return SetClassification.ALTERNATE_ALLELE;
+        }
 
         // if we found no alternate alleles, this is a "reference" set.
-        if (nAlt == 0) return SetClassification.REFERENCE_ALLELE;
+        if (nAlt == 0) {
+            return SetClassification.REFERENCE_ALLELE;
+        }
 
         throw new IllegalAccessError("shouldn't be here!");
     }

--- a/src/main/java/picard/analysis/replicates/CollectIndependentReplicateMetrics.java
+++ b/src/main/java/picard/analysis/replicates/CollectIndependentReplicateMetrics.java
@@ -60,6 +60,7 @@ import htsjdk.variant.vcf.VCFHeader;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ExperimentalFeature;
 import org.broadinstitute.barclay.help.DocumentedFeature;
+import picard.PicardException;
 import picard.cmdline.CommandLineProgram;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import picard.cmdline.StandardOptionDefinitions;
@@ -159,6 +160,13 @@ public class CollectIndependentReplicateMetrics extends CommandLineProgram {
         IOUtil.assertFileIsReadable(VCF);
         IOUtil.assertFileIsReadable(INPUT);
 
+        // get an iterator to reads that overlap the heterozygous sites
+        final SamReader in = SamReaderFactory.makeDefault().open(INPUT);
+
+        if (!in.hasIndex()) {
+            throw new PicardException("INPUT file must have an index.");
+        }
+
         IOUtil.assertFileIsWritable(OUTPUT);
         if (MATRIX_OUTPUT != null) IOUtil.assertFileIsWritable(MATRIX_OUTPUT);
 
@@ -193,8 +201,6 @@ public class CollectIndependentReplicateMetrics extends CommandLineProgram {
 
         log.info("Found " + intervalAlleleMap.size() + " heterozygous sites in VCF.");
 
-        // get an iterator to reads that overlap the heterozygous sites
-        final SamReader in = SamReaderFactory.makeDefault().open(INPUT);
 
         log.info("Querying BAM for sites.");
 

--- a/src/main/java/picard/analysis/replicates/CollectIndependentReplicateMetrics.java
+++ b/src/main/java/picard/analysis/replicates/CollectIndependentReplicateMetrics.java
@@ -108,13 +108,31 @@ import static picard.cmdline.StandardOptionDefinitions.MINIMUM_MAPPING_QUALITY_S
 @DocumentedFeature
 @ExperimentalFeature
 @CommandLineProgramProperties(
-        summary = "Estimates the rate of independent replication rate of reads within a bam. \n" +
-                "That is, it estimates the fraction of the reads which would be marked as duplicates but " +
-                "are actually biological replicates, independent observations of the data. ",
-        oneLineSummary = "Estimates the rate of independent replication of reads within a bam.",
+        summary = CollectIndependentReplicateMetrics.USAGE_SUMMARY + CollectIndependentReplicateMetrics.USAGE_DETAILS,
+        oneLineSummary = CollectIndependentReplicateMetrics.USAGE_SUMMARY,
         programGroup = DiagnosticsAndQCProgramGroup.class
 )
 public class CollectIndependentReplicateMetrics extends CommandLineProgram {
+
+    static final String USAGE_SUMMARY = "Estimates the rate of independent replication rate of reads within a bam. \n";
+    static final String USAGE_DETAILS = "<p>" +
+            "This tool estimates the fraction of the input reads which would be marked as duplicates but " +
+            "are actually biological replicates, independent observations of the data. " +
+            "<p>" +
+            "The tools examines duplicate sets of size 2 and 3 that overlap known heterozygous sites of the sample. " +
+            "The tool classifies these duplicate sets into heterogeneous and homogeneous sets (those that contain the " +
+            "two alleles that are present in the variant and those that only contain one of them). From this the tool" +
+            "estimates the fraction of duplicates that arose from different original molecules, i.e. independently. " +
+            "<p>" +
+            "<h4>Usage example:</h4>" +
+            "<pre>" +
+            "java -jar picard.jar CollectIndependentReplicateMetrics \\\n" +
+            "    I=input.bam \\\n" +
+            "    V=input.vcf \\\n" +
+            "    O=output.independent_replicates_metrics \\\n" +
+            "</pre> ";
+
+
     private static final int DOUBLETON_SIZE = 2, TRIPLETON_SIZE = 3;
 
     @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "Input (indexed) BAM file.")

--- a/src/main/java/picard/analysis/replicates/CollectIndependentReplicateMetrics.java
+++ b/src/main/java/picard/analysis/replicates/CollectIndependentReplicateMetrics.java
@@ -152,6 +152,9 @@ public class CollectIndependentReplicateMetrics extends CommandLineProgram {
     @Argument(shortName = "MBQ", doc = "minimal value for the base quality of all the bases in a molecular barcode, for it to be used.", optional = true)
     public Integer MINIMUM_BARCODE_BQ = 30;
 
+    @Argument(shortName = "FUR", doc = "Whether to filter unpaired reads from the input.", optional = true)
+    public boolean FILTER_UNPAIRED_READS=true;
+
     private static final Log log = Log.getInstance(CollectIndependentReplicateMetrics.class);
 
     @Override
@@ -207,10 +210,13 @@ public class CollectIndependentReplicateMetrics extends CommandLineProgram {
         final SAMRecordIterator samRecordIterator = in.query(QueryInterval.optimizeIntervals(intervalAlleleMap.keySet().toArray(new QueryInterval[0])), false);
         final List<SamRecordFilter> samFilters = CollectionUtil.makeList(
                 new AlignedFilter(true),
-                new CountingPairedFilter(),
                 new SecondaryOrSupplementaryFilter(),
                 new MappingQualityFilter(MINIMUM_MQ)
         );
+
+        if (FILTER_UNPAIRED_READS){
+            samFilters.add(new CountingPairedFilter());
+        }
 
         final FilteringSamIterator filteredSamRecordIterator = new FilteringSamIterator(samRecordIterator, new AggregateFilter(samFilters));
         log.info("Queried BAM, getting duplicate sets.");

--- a/src/main/java/picard/analysis/replicates/IndependentReplicateMetric.java
+++ b/src/main/java/picard/analysis/replicates/IndependentReplicateMetric.java
@@ -33,112 +33,219 @@ import picard.analysis.MergeableMetricBase;
  */
 public class IndependentReplicateMetric extends MergeableMetricBase {
 
-    // the count of sites used
+    /**
+     * The count of sites used.
+     */
     @MergeByAdding
     public Integer nSites = 0;
-    // the count of sites in which a third allele was found
+
+    /**
+     * The count of sites in which a third allele was found.
+     */
     @MergeByAdding
     public Integer nThreeAllelesSites = 0;
-    // the total number of reads over the het sites
+
+    /**
+     * The total number of reads over the het sites.
+     */
     @MergeByAdding
     public Integer nTotalReads = 0;
-    // the number of duplicate sets examined
+
+    /**
+     * The number of duplicate sets examined.
+     */
     @MergeByAdding
     public Integer nDuplicateSets = 0;
-    // the number of sets of size exactly 3 found
+
+    /**
+     * The number of sets of size exactly 3 found.
+     */
     @MergeByAdding
     public Integer nExactlyTriple = 0;
-    // the number of sets of size exactly 2 found
+
+    /**
+     * The number of sets of size exactly 2 found.
+     */
     @MergeByAdding
     public Integer nExactlyDouble = 0;
-    // the number of reads in duplicate of sizes greater than 3
+
+    /**
+     * The number of reads in duplicate of sizes greater than 3.
+     */
     @MergeByAdding
     public Integer nReadsInBigSets = 0;
-    // the number of doubletons where the two reads had different bases in the locus
+
+    /**
+     * The number of doubletons where the two reads had different bases in the locus.
+     */
     @MergeByAdding
     public Integer nDifferentAllelesBiDups = 0;
-    // the number of doubletons where the two reads matched the reference
+
+    /**
+     * The number of doubletons where the two reads matched the reference.
+     */
     @MergeByAdding
     public Integer nReferenceAllelesBiDups = 0;
-    // the number of doubletons where the two reads matched the alternate
+
+    /**
+     * The number of doubletons where the two reads matched the alternate.
+     */
     @MergeByAdding
     public Integer nAlternateAllelesBiDups = 0;
-    // the number of tripletons where at least one of the reads didn't match either allele of the het site
+
+    /**
+     * The number of tripletons where at least one of the reads didn't match either allele of the het site.
+     */
     @MergeByAdding
     public Integer nDifferentAllelesTriDups = 0;
-    // the number of tripletons where the two reads had different bases in the locus
+
+    /**
+     * The number of tripletons where the two reads had different bases in the locus.
+     */
     @MergeByAdding
     public Integer nMismatchingAllelesBiDups = 0;
-    // the number of tripletons where the two reads matched the reference
+
+    /**
+     * The number of tripletons where the two reads matched the reference.
+     */
     @MergeByAdding
     public Integer nReferenceAllelesTriDups = 0;
-    // the number of tripletons where the two reads matched the alternate
+
+    /**
+     * The number of tripletons where the two reads matched the alternate.
+     */
     @MergeByAdding
     public Integer nAlternateAllelesTriDups = 0;
-    // the number of tripletons where at least one of the reads didn't match either allele of the het site
+
+    /**
+     * The number of tripletons where at least one of the reads didn't match either allele of the het site.
+     */
     @MergeByAdding
     public Integer nMismatchingAllelesTriDups = 0;
-    // the number of reference alleles in the reads;
+
+    /**
+     * The number of reference alleles in the reads.
+     */
     @MergeByAdding
     public Integer nReferenceReads = 0;
-    // the number of alternate alleles in the reads;
+
+    /**
+     * The number of alternate alleles in the reads.
+     */
     @MergeByAdding
     public Integer nAlternateReads = 0;
-    // the number of UMIs that are different within Bi-sets that come from different Alleles
+
+    /**
+     * The number of UMIs that are different within Bi-sets that come from different alleles.
+     */
     @MergeByAdding
     public Integer nMismatchingUMIsInDiffBiDups = 0;
-    // the number of UMIs that are match within Bi-sets that come from different Alleles
+
+    /**
+     * The number of UMIs that are match within Bi-sets that come from different alleles.
+     */
     @MergeByAdding
     public Integer nMatchingUMIsInDiffBiDups = 0;
-    // the number of UMIs that are different within Bi-sets that come from the same Alleles
+
+    /**
+     * The number of UMIs that are different within Bi-sets that come from the same alleles.
+     */
     @MergeByAdding
     public Integer nMismatchingUMIsInSameBiDups = 0;
-    // the number of UMIs that are match within Bi-sets that come from the same Alleles
+
+    /**
+     * The number of UMIs that are match within Bi-sets that come from the same alleles.
+     */
     @MergeByAdding
     public Integer nMatchingUMIsInSameBiDups = 0;
-    // the number of bi-sets with mismatching UMIs and same orientation
+
+    /**
+     * The number of bi-sets with mismatching UMIs and same orientation.
+     */
     @MergeByAdding
     public Integer nMismatchingUMIsInCoOrientedBiDups = 0;
-    // the number of bi-sets with mismatching UMIs and opposite orientation
+
+    /**
+     * The number of bi-sets with mismatching UMIs and opposite orientation.
+     */
     @MergeByAdding
     public Integer nMismatchingUMIsInContraOrientedBiDups = 0;
-    // the number of sets where the UMIs had poor quality bases and were not used for any comparisons.
+
+    /**
+     * The number of sets where the UMIs had poor quality bases and were not used for any comparisons.
+     */
     @MergeByAdding
     public Integer nBadBarcodes = 0;
-    // the number of sets where the UMIs had good quality bases and were used for any comparisons.
+
+    /**
+     * the number of sets where the UMIs had good quality bases and were used for any comparisons.
+     */
     @MergeByAdding
     public Integer nGoodBarcodes = 0;
-    // the rate of heterogeneity within doubleton sets
+
+    /**
+     * the rate of heterogeneity within doubleton sets.
+     */
     @NoMergingIsDerived
     public Double biSiteHeterogeneityRate = 0.0;
-    // the rate of heterogeneity within tripleton sets
+
+    /**
+     * the rate of heterogeneity within tripleton sets
+     */
     @NoMergingIsDerived
     public Double triSiteHeterogeneityRate = 0.0;
-    // the rate of homogeneity within doubleton sets
+
+    /**
+     * the rate of homogeneity within doubleton sets.
+     */
     @NoMergingIsDerived
     public Double biSiteHomogeneityRate = 0.0;
-    // the rate of homogeneity within tripleton sets
+
+    /**
+     * the rate of homogeneity within tripleton sets.
+     */
     @NoMergingIsDerived
     public Double triSiteHomogeneityRate = 0.0;
-    //The biological duplication rate calculated from doublton sets
+
+    /*
+     * The biological duplication rate (as a fraction of the duplicates sets)
+     * calculated from doublton sets.
+    */
     @NoMergingIsDerived
     public Double independentReplicationRateFromBiDups = 0.0;
-    //The biological duplication rate calculated from tripleton sets
+
+    /**
+     * The biological duplication rate (as a fraction of the duplicates sets)
+     * calculated from tripleton sets.
+     */
     @NoMergingIsDerived
     public Double independentReplicationRateFromTriDups = 0.0;
-    // when the alleles are different, we know that this is a biological duplication, thus we expect nearly all
-    // the UMIs to be different (allowing for equality due to chance). So we expect this to be near 1.
+
+    /**
+     * When the alleles are different, we know that this is a biological duplication, thus we expect nearly all
+     * the UMIs to be different (allowing for equality due to chance). So we expect this to be near 1.
+     */
     @NoMergingIsDerived
     public Double pSameUmiInIndependentBiDup = 0.0;
-    //when the UMIs mismatch, we expect about the same number of different alleles as the same (assuming
-    //that different UMI implied biological duplicate. thus, this value should be near 0.5
+
+    /**
+     * When the UMIs mismatch, we expect about the same number of different alleles as the same
+     * (assuming that different UMI implies biological duplicate) thus, this value should be near 0.5
+     */
     @NoMergingIsDerived
     public Double pSameAlleleWhenMismatchingUmi = 0.0;
-    // given the UMIs one can estimate the rate of biological duplication directly, as this would be the
-    // rate of having different UMIs in all duplicate sets. This is only a good estimate if the assumptions hold, for example if pSameUmiInIndependentBiDup is near 1.
+
+    /**
+     * Given the UMIs one can estimate the rate of biological duplication directly, as this would be the
+     * rate of having different UMIs in all duplicate sets. This is only a good estimate if the assumptions hold,
+     * for example if pSameUmiInIndependentBiDup is near 1.
+     */
     @NoMergingIsDerived
     public Double independentReplicationRateFromUmi = 0.0;
-    //an estimate of the duplication rate that is based on the duplicate sets we observed
+
+    /**
+     * An estimate of the duplication rate that is based on the duplicate sets we observed.
+     */
     @NoMergingIsDerived
     public Double replicationRateFromReplicateSets = 0.0;
 


### PR DESCRIPTION
CollectIndependentReplicateMetrics was using a non-optimized query which led to be slow runtimes...this significantly improves runtime, enables running on single-ended reads and also makes the code little nicer.
----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

