### PR TITLE
Yf collect duplicate metrics

### DIFF
--- a/src/main/java/picard/analysis/CollectMultipleMetrics.java
+++ b/src/main/java/picard/analysis/CollectMultipleMetrics.java
@@ -38,6 +38,7 @@ import picard.analysis.artifacts.CollectSequencingArtifactMetrics;
 import picard.analysis.directed.RnaSeqMetricsCollector;
 import picard.cmdline.CommandLineProgram;
 import picard.cmdline.StandardOptionDefinitions;
+import picard.cmdline.argumentcollections.RequiredOutputArgumentCollection;
 import picard.cmdline.programgroups.DiagnosticsAndQCProgramGroup;
 
 import java.io.File;
@@ -174,7 +175,7 @@ public class CollectMultipleMetrics extends CommandLineProgram {
                                                      final File refflat,
                                                      final Set<String> ignoreSequence) {
                 final CollectAlignmentSummaryMetrics program = new CollectAlignmentSummaryMetrics();
-                program.OUTPUT = new File(outbase + ".alignment_summary_metrics" + outext);
+                program.output = new RequiredOutputArgumentCollection(new File(outbase + ".alignment_summary_metrics" + outext));
 
                 // Generally programs should not be accessing these directly but it might make things smoother
                 // to just set them anyway. These are set here to make sure that in case of a the derived class
@@ -204,7 +205,7 @@ public class CollectMultipleMetrics extends CommandLineProgram {
                                                      final File refflat,
                                                      final Set<String> ignoreSequence) {
                 final CollectInsertSizeMetrics program = new CollectInsertSizeMetrics();
-                program.OUTPUT = new File(outbase + ".insert_size_metrics" + outext);
+                program.output = new RequiredOutputArgumentCollection( new File(outbase + ".insert_size_metrics" + outext));
                 program.Histogram_FILE = new File(outbase + ".insert_size_histogram.pdf");
                 // Generally programs should not be accessing these directly but it might make things smoother
                 // to just set them anyway. These are set here to make sure that in case of a the derived class
@@ -227,7 +228,7 @@ public class CollectMultipleMetrics extends CommandLineProgram {
                                                      final File refflat,
                                                      final Set<String> ignoreSequence) {
                 final QualityScoreDistribution program = new QualityScoreDistribution();
-                program.OUTPUT = new File(outbase + ".quality_distribution_metrics" + outext);
+                program.output = new RequiredOutputArgumentCollection(new File(outbase + ".quality_distribution_metrics" + outext));
                 program.CHART_OUTPUT = new File(outbase + ".quality_distribution.pdf");
                 // Generally programs should not be accessing these directly but it might make things smoother
                 // to just set them anyway. These are set here to make sure that in case of a the derived class
@@ -251,7 +252,7 @@ public class CollectMultipleMetrics extends CommandLineProgram {
                                                      final File refflat,
                                                      final Set<String> ignoreSequence) {
                 final MeanQualityByCycle program = new MeanQualityByCycle();
-                program.OUTPUT = new File(outbase + ".quality_by_cycle_metrics" + outext);
+                program.output = new RequiredOutputArgumentCollection(new File(outbase + ".quality_by_cycle_metrics" + outext));
                 program.CHART_OUTPUT = new File(outbase + ".quality_by_cycle.pdf");
                 // Generally programs should not be accessing these directly but it might make things smoother
                 // to just set them anyway. These are set here to make sure that in case of a the derived class
@@ -275,7 +276,7 @@ public class CollectMultipleMetrics extends CommandLineProgram {
                                                      final File refflat,
                                                      final Set<String> ignoreSequence) {
                 final CollectBaseDistributionByCycle program = new CollectBaseDistributionByCycle();
-                program.OUTPUT = new File(outbase + ".base_distribution_by_cycle_metrics" + outext);
+                program.output = new RequiredOutputArgumentCollection(new File(outbase + ".base_distribution_by_cycle_metrics" + outext));
                 program.CHART_OUTPUT = new File(outbase + ".base_distribution_by_cycle.pdf");
                 // Generally programs should not be accessing these directly but it might make things smoother
                 // to just set them anyway. These are set here to make sure that in case of a the derived class
@@ -309,7 +310,7 @@ public class CollectMultipleMetrics extends CommandLineProgram {
                                                      final File refflat,
                                                      final Set<String> ignoreSequence) {
                 final CollectGcBiasMetrics program = new CollectGcBiasMetrics();
-                program.OUTPUT = new File(outbase + ".gc_bias.detail_metrics" + outext);
+                program.output = new RequiredOutputArgumentCollection(new File(outbase + ".gc_bias.detail_metrics" + outext));
                 program.SUMMARY_OUTPUT = new File(outbase + ".gc_bias.summary_metrics" + outext);
                 program.CHART_OUTPUT = new File(outbase + ".gc_bias.pdf");
                 program.INPUT = input;
@@ -349,7 +350,7 @@ public class CollectMultipleMetrics extends CommandLineProgram {
                                                      final File refflat,
                                                      final Set<String> ignoreSequence) {
                 final CollectRnaSeqMetrics program = new CollectRnaSeqMetrics();
-                program.OUTPUT = new File(outbase + ".rna_metrics" + outext);
+                program.output = new RequiredOutputArgumentCollection(new File(outbase + ".rna_metrics" + outext));
                 program.CHART_OUTPUT = new File(outbase + ".rna_coverage.pdf");
                 // Generally programs should not be accessing these directly but it might make things smoother
                 // to just set them anyway. These are set here to make sure that in case of a the derived class
@@ -404,7 +405,7 @@ public class CollectMultipleMetrics extends CommandLineProgram {
                                                      final Set<String> ignoreSequence,
                                                      final boolean includeUnpaired) {
                 final CollectSequencingArtifactMetrics program = new CollectSequencingArtifactMetrics();
-                program.OUTPUT = new File(outbase);
+                program.output = new RequiredOutputArgumentCollection(new File(outbase));
                 program.FILE_EXTENSION = outext;
                 program.DB_SNP = dbSnp;
                 program.INTERVALS = intervals;
@@ -431,7 +432,7 @@ public class CollectMultipleMetrics extends CommandLineProgram {
                                                      final File refflat,
                                                      final Set<String> ignoreSequence) {
                 final CollectQualityYieldMetrics program = new CollectQualityYieldMetrics();
-                program.OUTPUT = new File(outbase + ".quality_yield_metrics" + outext);
+                program.output = new RequiredOutputArgumentCollection(new File(outbase + ".quality_yield_metrics" + outext));
                 // Generally programs should not be accessing these directly but it might make things smoother
                 // to just set them anyway. These are set here to make sure that in case of a the derived class
                 // overrides
@@ -457,7 +458,7 @@ public class CollectMultipleMetrics extends CommandLineProgram {
             doc = "Base name of output files.")
     public String OUTPUT;
 
-    //create the default accumulation level as a variable.
+    // create the default accumulation level as a variable.
     // We'll use this to init the command-line arg and for validation later.
     private final Set<MetricAccumulationLevel> accumLevelDefault = CollectionUtil.makeSet(MetricAccumulationLevel.ALL_READS);
 

--- a/src/main/java/picard/analysis/SinglePassSamProgram.java
+++ b/src/main/java/picard/analysis/SinglePassSamProgram.java
@@ -37,9 +37,12 @@ import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.ProgressLogger;
 import htsjdk.samtools.util.SequenceUtil;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import picard.PicardException;
 import picard.cmdline.CommandLineProgram;
 import picard.cmdline.StandardOptionDefinitions;
+import picard.cmdline.argumentcollections.OutputArgumentCollection;
+import picard.cmdline.argumentcollections.RequiredOutputArgumentCollection;
 
 import java.io.File;
 import java.util.Arrays;
@@ -56,8 +59,14 @@ public abstract class SinglePassSamProgram extends CommandLineProgram {
     @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "Input SAM or BAM file.")
     public File INPUT;
 
-    @Argument(shortName = "O", doc = "File to write the output to.")
-    public File OUTPUT;
+    @ArgumentCollection
+    public OutputArgumentCollection output = getOutputArgumentCollection();
+
+    protected OutputArgumentCollection getOutputArgumentCollection(){
+        return new RequiredOutputArgumentCollection();
+    }
+
+    protected File OUTPUT;
 
     @Argument(doc = "If true (default), then the sort order in the header file will be ignored.",
             shortName = StandardOptionDefinitions.ASSUME_SORTED_SHORT_NAME)
@@ -81,6 +90,8 @@ public abstract class SinglePassSamProgram extends CommandLineProgram {
      */
     @Override
     protected final int doWork() {
+
+        OUTPUT = output.getOutputFile();
         makeItSo(INPUT, REFERENCE_SEQUENCE, ASSUME_SORTED, STOP_AFTER, Arrays.asList(this));
         return 0;
     }

--- a/src/main/java/picard/analysis/SinglePassSamProgram.java
+++ b/src/main/java/picard/analysis/SinglePassSamProgram.java
@@ -91,7 +91,6 @@ public abstract class SinglePassSamProgram extends CommandLineProgram {
     @Override
     protected final int doWork() {
 
-        OUTPUT = output.getOutputFile();
         makeItSo(INPUT, REFERENCE_SEQUENCE, ASSUME_SORTED, STOP_AFTER, Arrays.asList(this));
         return 0;
     }
@@ -137,6 +136,9 @@ public abstract class SinglePassSamProgram extends CommandLineProgram {
         // Call the abstract setup method!
         boolean anyUseNoRefReads = false;
         for (final SinglePassSamProgram program : programs) {
+            if (program.OUTPUT == null) {
+                program.OUTPUT = program.output.getOutputFile();
+            }
             program.setup(in.getFileHeader(), input);
             anyUseNoRefReads = anyUseNoRefReads || program.usesNoRefReads();
         }

--- a/src/main/java/picard/cmdline/argumentcollections/EmptyOutputArgumentCollection.java
+++ b/src/main/java/picard/cmdline/argumentcollections/EmptyOutputArgumentCollection.java
@@ -21,17 +21,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package picard.cmdline.argumentcollections;
 
 import java.io.File;
 
-/**
- * Base interface for an interval argument collection.
- */
-public interface IntervalArgumentCollection {
-    /**
-     * @return The interval file provided by the user, if any, or the default, if any.
-     */
-    File getIntervalFile();
+public class EmptyOutputArgumentCollection implements OutputArgumentCollection {
+    @Override
+    public File getOutputFile() {
+        return null;
+    }
 }
+

--- a/src/main/java/picard/cmdline/argumentcollections/OptionalReferenceArgumentCollection.java
+++ b/src/main/java/picard/cmdline/argumentcollections/OptionalReferenceArgumentCollection.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package picard.cmdline.argumentcollections;
 
 import htsjdk.samtools.Defaults;

--- a/src/main/java/picard/cmdline/argumentcollections/OutputArgumentCollection.java
+++ b/src/main/java/picard/cmdline/argumentcollections/OutputArgumentCollection.java
@@ -27,11 +27,11 @@ package picard.cmdline.argumentcollections;
 import java.io.File;
 
 /**
- * Base interface for an interval argument collection.
+ * Base interface for an output argument collection.
  */
-public interface IntervalArgumentCollection {
+public interface OutputArgumentCollection {
     /**
-     * @return The interval file provided by the user, if any, or the default, if any.
+     * @return The reference provided by the user, if any, or the default, if any.
      */
-    File getIntervalFile();
+    File getOutputFile();
 }

--- a/src/main/java/picard/cmdline/argumentcollections/ReferenceArgumentCollection.java
+++ b/src/main/java/picard/cmdline/argumentcollections/ReferenceArgumentCollection.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package picard.cmdline.argumentcollections;
 
 import java.io.File;

--- a/src/main/java/picard/cmdline/argumentcollections/RequiredOutputArgumentCollection.java
+++ b/src/main/java/picard/cmdline/argumentcollections/RequiredOutputArgumentCollection.java
@@ -38,4 +38,10 @@ public class RequiredOutputArgumentCollection implements OutputArgumentCollectio
     public File getOutputFile() {
         return OUTPUT;
     }
+
+    public RequiredOutputArgumentCollection(final File output) {
+        this.OUTPUT = output;
+    }
+
+    public RequiredOutputArgumentCollection() {}
 }

--- a/src/main/java/picard/cmdline/argumentcollections/RequiredOutputArgumentCollection.java
+++ b/src/main/java/picard/cmdline/argumentcollections/RequiredOutputArgumentCollection.java
@@ -24,14 +24,18 @@
 
 package picard.cmdline.argumentcollections;
 
+import org.broadinstitute.barclay.argparser.Argument;
+import picard.cmdline.StandardOptionDefinitions;
+
 import java.io.File;
 
-/**
- * Base interface for an interval argument collection.
- */
-public interface IntervalArgumentCollection {
-    /**
-     * @return The interval file provided by the user, if any, or the default, if any.
-     */
-    File getIntervalFile();
+public class RequiredOutputArgumentCollection implements OutputArgumentCollection {
+    @Argument(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME,
+            doc = "The file to write the output to.")
+    public File OUTPUT;
+
+    @Override
+    public File getOutputFile() {
+        return OUTPUT;
+    }
 }

--- a/src/main/java/picard/cmdline/argumentcollections/RequiredReferenceArgumentCollection.java
+++ b/src/main/java/picard/cmdline/argumentcollections/RequiredReferenceArgumentCollection.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package picard.cmdline.argumentcollections;
 
 import org.broadinstitute.barclay.argparser.Argument;

--- a/src/main/java/picard/sam/markduplicates/CollectDuplicateMetrics.java
+++ b/src/main/java/picard/sam/markduplicates/CollectDuplicateMetrics.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2009 The Broad Institute
+ * Copyright (c) 2019 The Broad Institute
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -42,7 +42,7 @@ import java.io.File;
 
 /**
  *
- * Collect DuplicateMark'ing metrics from a input file that was already DuplicateMarked.
+ * Collect DuplicateMark'ing metrics from an input file that was already Duplicate-Marked.
  *
  */
 @CommandLineProgramProperties(
@@ -53,7 +53,8 @@ import java.io.File;
 
 public class CollectDuplicateMetrics extends SinglePassSamProgram {
     static final String USAGE_SUMMARY = "Collect Duplicate metrics from marked file.";
-    static final String USAGE_DETAILS = "This tool only collects the duplicate metrics from a file that has already been dupicate-marked.";
+    static final String USAGE_DETAILS = "This tool only collects the duplicate metrics from a file that has already been duplicate-marked. " +
+            "The resulting metrics file will always have a READ_PAIR_OPTICAL_DUPLICATES=0 and as a result the ESTIMATED_LIBRARY_SIZE will be slightly incorrect. ";
 
     @Argument(shortName = "M",
             doc = "File to write duplication metrics to.")
@@ -79,6 +80,7 @@ public class CollectDuplicateMetrics extends SinglePassSamProgram {
 
     @Override
     protected void setup(final SAMFileHeader header, final File samFile) {
+
         libraryIdGenerator = new LibraryIdGenerator(header);
         this.header = header;
     }
@@ -87,7 +89,6 @@ public class CollectDuplicateMetrics extends SinglePassSamProgram {
     protected void acceptRead(final SAMRecord rec, final ReferenceSequence ref) {
 
         final DuplicationMetrics metrics = AbstractMarkDuplicatesCommandLineProgram.addReadToLibraryMetrics(rec, header, libraryIdGenerator);
-
         final boolean isDuplicate = rec.getDuplicateReadFlag();
 
         if (isDuplicate) {

--- a/src/main/java/picard/sam/markduplicates/CollectDuplicateMetrics.java
+++ b/src/main/java/picard/sam/markduplicates/CollectDuplicateMetrics.java
@@ -1,0 +1,103 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam.markduplicates;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.reference.ReferenceSequence;
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
+import picard.analysis.SinglePassSamProgram;
+import picard.cmdline.argumentcollections.EmptyOutputArgumentCollection;
+import picard.cmdline.argumentcollections.OutputArgumentCollection;
+import picard.cmdline.programgroups.ReadDataManipulationProgramGroup;
+import picard.sam.DuplicationMetrics;
+import picard.sam.markduplicates.util.AbstractMarkDuplicatesCommandLineProgram;
+import picard.sam.markduplicates.util.LibraryIdGenerator;
+
+import java.io.File;
+
+/**
+ *
+ * Collect DuplicateMark'ing metrics from a input file that was already DuplicateMarked.
+ *
+ */
+@CommandLineProgramProperties(
+        summary = CollectDuplicateMetrics.USAGE_SUMMARY + CollectDuplicateMetrics.USAGE_DETAILS,
+        oneLineSummary = CollectDuplicateMetrics.USAGE_SUMMARY,
+        programGroup = ReadDataManipulationProgramGroup.class)
+@DocumentedFeature
+
+public class CollectDuplicateMetrics extends SinglePassSamProgram {
+    static final String USAGE_SUMMARY = "Collect Duplicate metrics from marked file.";
+    static final String USAGE_DETAILS = "This tool only collects the duplicate metrics from a file that has already been dupicate-marked.";
+
+    @Argument(shortName = "M",
+            doc = "File to write duplication metrics to.")
+    public File METRICS_FILE;
+
+    @Override
+    protected OutputArgumentCollection getOutputArgumentCollection() {
+        return new EmptyOutputArgumentCollection();
+    }
+
+    private LibraryIdGenerator libraryIdGenerator;
+    private SAMFileHeader header;
+
+    @Override
+    protected boolean requiresReference() {
+        return false;
+    }
+
+    @Override
+    protected boolean usesNoRefReads() {
+        return true;
+    }
+
+    @Override
+    protected void setup(final SAMFileHeader header, final File samFile) {
+        libraryIdGenerator = new LibraryIdGenerator(header);
+        this.header = header;
+    }
+
+    @Override
+    protected void acceptRead(final SAMRecord rec, final ReferenceSequence ref) {
+
+        final DuplicationMetrics metrics = AbstractMarkDuplicatesCommandLineProgram.addReadToLibraryMetrics(rec, header, libraryIdGenerator);
+
+        final boolean isDuplicate = rec.getDuplicateReadFlag();
+
+        if (isDuplicate) {
+            AbstractMarkDuplicatesCommandLineProgram.addDuplicateReadToMetrics(rec, metrics);
+        }
+    }
+
+    @Override
+    protected void finish() {
+        // Write out the metrics
+        AbstractMarkDuplicatesCommandLineProgram.finalizeAndWriteMetrics(libraryIdGenerator, getMetricsFile(), METRICS_FILE);
+    }
+}

--- a/src/main/java/picard/sam/markduplicates/CollectDuplicateMetrics.java
+++ b/src/main/java/picard/sam/markduplicates/CollectDuplicateMetrics.java
@@ -53,7 +53,8 @@ import java.io.File;
 
 public class CollectDuplicateMetrics extends SinglePassSamProgram {
     static final String USAGE_SUMMARY = "Collect Duplicate metrics from marked file.";
-    static final String USAGE_DETAILS = "This tool only collects the duplicate metrics from a file that has already been duplicate-marked. " +
+    static final String USAGE_DETAILS = "\n" +
+            "This tool only collects the duplicate metrics from a file that has already been duplicate-marked. " +
             "The resulting metrics file will always have a READ_PAIR_OPTICAL_DUPLICATES=0 and as a result the ESTIMATED_LIBRARY_SIZE will be slightly incorrect. ";
 
     @Argument(shortName = "M",

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicatesWithMateCigar.java
@@ -187,7 +187,7 @@ public class MarkDuplicatesWithMateCigar extends AbstractMarkDuplicatesCommandLi
         log.info("Found " + ((long) opticalDupesByLibraryId.getSumOfValues()) + " optical duplicate clusters."); // cast as long due to returning a double
 
         // Write out the metrics
-        finalizeAndWriteMetrics(iterator.getLibraryIdGenerator());
+        finalizeAndWriteMetrics(iterator.getLibraryIdGenerator(), getMetricsFile(), METRICS_FILE);
 
         return 0;
     }

--- a/src/main/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigar.java
@@ -220,7 +220,7 @@ public class SimpleMarkDuplicatesWithMateCigar extends MarkDuplicates {
         log.info("Marking " + numDuplicates + " records as duplicates.");
 
         // Write out the metrics
-        finalizeAndWriteMetrics(libraryIdGenerator);
+        finalizeAndWriteMetrics(libraryIdGenerator, getMetricsFile(), METRICS_FILE);
 
         return 0;
     }

--- a/src/test/java/picard/sam/markduplicates/AbstractMarkDuplicatesCommandLineProgramTester.java
+++ b/src/test/java/picard/sam/markduplicates/AbstractMarkDuplicatesCommandLineProgramTester.java
@@ -155,7 +155,7 @@ abstract public class AbstractMarkDuplicatesCommandLineProgramTester extends Sam
             // Read the output and check the duplicate flag
             int outputRecords = 0;
             final Set<String> sequencingDTErrorsSeen = new HashSet<>();
-            try(final SamReader reader = SamReaderFactory.makeDefault().open(getOutput())) {
+            try(final SamReader reader = SamReaderFactory.makeDefault().referenceSequence(fastaFiles.get(samRecordSetBuilder.getHeader())).open(getOutput())) {
                 for (final SAMRecord record : reader) {
                     outputRecords++;
                     final String key = samRecordToDuplicatesFlagsKey(record);

--- a/src/test/java/picard/sam/markduplicates/AsIsCollectDuplicateMetricsTest.java
+++ b/src/test/java/picard/sam/markduplicates/AsIsCollectDuplicateMetricsTest.java
@@ -1,0 +1,10 @@
+package picard.sam.markduplicates;
+
+import htsjdk.samtools.SAMFileHeader;
+
+public class AsIsCollectDuplicateMetricsTest extends AsIsMarkDuplicatesTest{
+    @Override
+    AbstractMarkDuplicatesCommandLineProgramTester getTester(SAMFileHeader.SortOrder so) {
+        return new CollectDuplicateMetricsTester(so);
+    }
+}

--- a/src/test/java/picard/sam/markduplicates/AsIsMarkDuplicatesTester.java
+++ b/src/test/java/picard/sam/markduplicates/AsIsMarkDuplicatesTester.java
@@ -79,7 +79,7 @@ public class AsIsMarkDuplicatesTester {
 
         final AbstractMarkDuplicatesCommandLineProgramTester tester = new BySumOfBaseQAndInOriginalOrderMDTester();
 
-        try(final SamReader reader = SamReaderFactory.makeDefault().open(input)) {
+        try (final SamReader reader = SamReaderFactory.makeDefault().open(input)) {
             tester.setHeader(reader.getFileHeader());
             reader.iterator().stream().forEach(tester::addRecord);
         }

--- a/src/test/java/picard/sam/markduplicates/CollectDuplicateMetricsTest.java
+++ b/src/test/java/picard/sam/markduplicates/CollectDuplicateMetricsTest.java
@@ -22,16 +22,16 @@
  * THE SOFTWARE.
  */
 
-package picard.cmdline.argumentcollections;
+package picard.sam.markduplicates;
 
-import java.io.File;
+public class CollectDuplicateMetricsTest extends AbstractMarkDuplicatesCommandLineProgramTest {
+    @Override
+    protected AbstractMarkDuplicatesCommandLineProgramTester getTester() {
+        final CollectDuplicateMetricsTester collectDuplicateMetricsTester = new CollectDuplicateMetricsTester();
 
-/**
- * Base interface for an interval argument collection.
- */
-public interface IntervalArgumentCollection {
-    /**
-     * @return The interval file provided by the user, if any, or the default, if any.
-     */
-    File getIntervalFile();
+        collectDuplicateMetricsTester.getArgs().removeIf(s->s.startsWith("DUPLICATE_SCORING_STRATEGY="));
+        collectDuplicateMetricsTester.getArgs().removeIf(s->s.startsWith("TAGGING_POLICY="));
+
+        return collectDuplicateMetricsTester;
+    }
 }

--- a/src/test/java/picard/sam/markduplicates/CollectDuplicateMetricsTest.java
+++ b/src/test/java/picard/sam/markduplicates/CollectDuplicateMetricsTest.java
@@ -24,13 +24,12 @@
 
 package picard.sam.markduplicates;
 
+import htsjdk.samtools.SAMFileHeader;
+
 public class CollectDuplicateMetricsTest extends AbstractMarkDuplicatesCommandLineProgramTest {
     @Override
     protected AbstractMarkDuplicatesCommandLineProgramTester getTester() {
-        final CollectDuplicateMetricsTester collectDuplicateMetricsTester = new CollectDuplicateMetricsTester();
-
-        collectDuplicateMetricsTester.getArgs().removeIf(s->s.startsWith("DUPLICATE_SCORING_STRATEGY="));
-        collectDuplicateMetricsTester.getArgs().removeIf(s->s.startsWith("TAGGING_POLICY="));
+        final CollectDuplicateMetricsTester collectDuplicateMetricsTester = new CollectDuplicateMetricsTester(SAMFileHeader.SortOrder.coordinate);
 
         return collectDuplicateMetricsTester;
     }

--- a/src/test/java/picard/sam/markduplicates/CollectDuplicateMetricsTester.java
+++ b/src/test/java/picard/sam/markduplicates/CollectDuplicateMetricsTester.java
@@ -1,0 +1,83 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package picard.sam.markduplicates;
+
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMRecord;
+import picard.PicardException;
+import picard.cmdline.CommandLineProgram;
+
+import java.io.File;
+import java.io.IOException;
+
+public class CollectDuplicateMetricsTester extends AbstractMarkDuplicatesCommandLineProgramTester {
+
+    @Override
+    public File getOutput() {
+        final File output;
+        try {
+            output = File.createTempFile("CollectDuplicateMetrics", ".sam");
+        } catch (IOException e) {
+            throw new PicardException("problems creating output file", e);
+        }
+        output.deleteOnExit();
+
+        try(SAMFileWriter writer = new SAMFileWriterFactory().makeWriter(samRecordSetBuilder.getHeader(), true, output.toPath(), this.fastaFiles.get(samRecordSetBuilder.getHeader()))) {
+            samRecordSetBuilder.getRecords().forEach(a -> {
+                final SAMRecord b = a.deepCopy();
+                b.setDuplicateReadFlag(duplicateFlags.get(samRecordToDuplicatesFlagsKey(a)));
+                writer.addAlignment(b);
+            });
+        }
+
+        return output;
+    }
+
+    @Override
+    protected void customPretestCallback() {
+        super.customPretestCallback();
+
+        getArgs().removeIf(s->s.startsWith("INPUT="));
+        getArgs().removeIf(s->s.startsWith("OUTPUT="));
+        getArgs().removeIf(s->s.startsWith("READ_NAME_REGEX="));
+
+        getArgs().add("INPUT=" + getOutput().getAbsoluteFile());
+    }
+
+    @Override
+    protected CommandLineProgram getProgram() {
+        return new CollectDuplicateMetrics();
+    }
+
+    @Override
+    public void recordOpticalDuplicatesMarked() {}
+
+    @Override
+    public void test() throws IOException {
+        // CollectDuplicateMetrics cannot identify Optical duplicates....
+        setExpectedOpticalDuplicate(0);
+        super.test();
+    }
+}

--- a/src/test/java/picard/sam/markduplicates/CollectDuplicateMetricsTester.java
+++ b/src/test/java/picard/sam/markduplicates/CollectDuplicateMetricsTester.java
@@ -23,6 +23,8 @@
  */
 package picard.sam.markduplicates;
 
+import htsjdk.samtools.DuplicateScoringStrategy;
+import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMFileWriter;
 import htsjdk.samtools.SAMFileWriterFactory;
 import htsjdk.samtools.SAMRecord;
@@ -59,16 +61,23 @@ public class CollectDuplicateMetricsTester extends AbstractMarkDuplicatesCommand
     protected void customPretestCallback() {
         super.customPretestCallback();
 
-        getArgs().removeIf(s->s.startsWith("INPUT="));
         getArgs().removeIf(s->s.startsWith("OUTPUT="));
         getArgs().removeIf(s->s.startsWith("READ_NAME_REGEX="));
+        getArgs().removeIf(s->s.startsWith("DUPLICATE_SCORING_STRATEGY="));
+        getArgs().removeIf(s->s.startsWith("TAGGING_POLICY="));
+        getArgs().removeIf(s->s.startsWith("ASSUME_SORT_ORDER="));
 
+        getArgs().removeIf(s->s.startsWith("INPUT="));
         getArgs().add("INPUT=" + getOutput().getAbsoluteFile());
     }
 
     @Override
     protected CommandLineProgram getProgram() {
         return new CollectDuplicateMetrics();
+    }
+
+    public CollectDuplicateMetricsTester( final SAMFileHeader.SortOrder sortOrder) {
+        super(DuplicateScoringStrategy.ScoringStrategy.SUM_OF_BASE_QUALITIES, sortOrder, false);
     }
 
     @Override

--- a/src/test/java/picard/sam/testers/SamFileTester.java
+++ b/src/test/java/picard/sam/testers/SamFileTester.java
@@ -27,10 +27,10 @@ public abstract class SamFileTester extends CommandLineProgramTest {
     private File output;
     private int readNameCounter = 0;
     protected boolean noMateCigars = false;
-    private boolean deleteOnExit = true;
+    final private boolean deleteOnExit;
     private final ArrayList<String> args = new ArrayList<>();
 
-    private Map<SAMFileHeader, Path> fastaFiles = new HashMap<>();
+    protected Map<SAMFileHeader, Path> fastaFiles = new HashMap<>();
 
     public SamFileTester(final int readLength, final boolean deleteOnExit, final int defaultChromosomeLength, final ScoringStrategy duplicateScoringStrategy, final SAMFileHeader.SortOrder sortOrder, boolean recordsNeedSorting) {
         this.deleteOnExit = deleteOnExit;
@@ -81,7 +81,6 @@ public abstract class SamFileTester extends CommandLineProgramTest {
     public void setOutput(final File output) {
         this.output = output;
     }
-
 
     public void addArg(final String arg) {
         args.add(arg);
@@ -366,6 +365,8 @@ public abstract class SamFileTester extends CommandLineProgramTest {
             if (inputExtension.equals(".cram")) {
                 args.add("REFERENCE_SEQUENCE=" + fastaFiles.get(samRecordSetBuilder.getHeader()));
             }
+
+            customPretestCallback();
             Assert.assertEquals(runPicardCommandLine(args), 0);
             test();
         } catch (IOException ex) {
@@ -373,6 +374,8 @@ public abstract class SamFileTester extends CommandLineProgramTest {
             throw new RuntimeException(ex);
         }
     }
+
+    protected void customPretestCallback(){};
 
     private File createInputFile(final String extension) throws IOException {
         // Create the input file

--- a/src/test/java/picard/sam/testers/SamFileTester.java
+++ b/src/test/java/picard/sam/testers/SamFileTester.java
@@ -402,7 +402,7 @@ public abstract class SamFileTester extends CommandLineProgramTest {
                     Assert.assertFalse(sum >= 10_000_000,
                             "Sequence dictionary is very large (total size " + sum + "). In a Cram test this could be a problem leading to writing lots" +
                                     "of bases to disk. please modify the tester using 'ModifyTesterForCramTests'. " +
-                                    "For exmaple look at testBulkFragmentsNoDuplicates in AbstractMarkDuplicatesCommandLineProgramTest");
+                                    "For example look at testBulkFragmentsNoDuplicates in AbstractMarkDuplicatesCommandLineProgramTest");
 
                     samRecordSetBuilder.writeRandomReference(newFasta);
                 } catch (IOException e) {
@@ -417,8 +417,11 @@ public abstract class SamFileTester extends CommandLineProgramTest {
             writer = samFileWriterFactory.makeWriter(samRecordSetBuilder.getHeader(), true, input, null);
         }
 
-        samRecordSetBuilder.getRecords().forEach(writer::addAlignment);
+        for(final SAMRecord a : samRecordSetBuilder.getRecords()) {
+            writer.addAlignment(a);
+        }
         writer.close();
+
         return input;
     }
 


### PR DESCRIPTION
A CLP to collect MarkDuplicate Metrics on a file that already has had its duplicate marked. Useful when you want to have the duplicate metrics of a file but do not want to re-preprocess it. Does NOT calculate OPTICAL_DUPLICATES.


### Description

_Give your PR a **concise** yet **descriptive** title_
_Please explain the changes you made here._
_Explain the **motivation** for making this change. What existing problem does the pull request solve?_
_Mention any issues fixed, addressed or otherwise related to this pull request, including issue numbers or hard links for issues in other repos._
_You can delete these instructions once you have written your PR description._

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

