### PR TITLE
Don't not add a period to output basenames

### DIFF
--- a/src/main/java/picard/fingerprint/CheckFingerprint.java
+++ b/src/main/java/picard/fingerprint/CheckFingerprint.java
@@ -223,9 +223,7 @@ public class CheckFingerprint extends CommandLineProgram {
             outputDetailMetricsFile = DETAIL_OUTPUT;
             outputSummaryMetricsFile = SUMMARY_OUTPUT;
         } else {
-            if (!OUTPUT.endsWith(".")) {
-                OUTPUT += ".";
-            }
+            OUTPUT += ".";
             outputDetailMetricsFile = new File(OUTPUT + FINGERPRINT_DETAIL_FILE_SUFFIX);
             outputSummaryMetricsFile = new File(OUTPUT + FINGERPRINT_SUMMARY_FILE_SUFFIX);
         }


### PR DESCRIPTION
### Description

A change was introduced last year to `CheckFingerprint` which made it only add a period to the end of the `OUTPUT` argument if it did not already end with a period. This causes errors in our pipeline when sample aliases end in a period, because we derive our cromwell outputs based on the sample alias concatenated with "fingerprinting_summary_metrics" and "fingerprinting_detail_metrics". If sample_alias is `MyCoolSampleG.T.`, the output files should be `MyCoolSampleG.T..fingerprinting_summary_metrics` and `MyCoolSampleG.T..fingerprinting_detail_metrics`

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

