### PR TITLE
Stop removing periods from the end of output names

### DIFF
--- a/src/main/java/picard/analysis/CollectMultipleMetrics.java
+++ b/src/main/java/picard/analysis/CollectMultipleMetrics.java
@@ -688,9 +688,6 @@ public class CollectMultipleMetrics extends CommandLineProgram {
 
     @Override
     public int doWork() {
-        if (OUTPUT.endsWith(".")) {
-            OUTPUT = OUTPUT.substring(0, OUTPUT.length() - 1);
-        }
 
         final Map<ProgramInterface, List<String>> additionalArguments = processAdditionalArguments(EXTRA_ARGUMENT);
 

--- a/src/main/java/picard/fingerprint/CheckFingerprint.java
+++ b/src/main/java/picard/fingerprint/CheckFingerprint.java
@@ -216,8 +216,8 @@ public class CheckFingerprint extends CommandLineProgram {
 
     private final Log log = Log.getInstance(CheckFingerprint.class);
 
-    public static final String FINGERPRINT_SUMMARY_FILE_SUFFIX = "fingerprinting_summary_metrics";
-    public static final String FINGERPRINT_DETAIL_FILE_SUFFIX = "fingerprinting_detail_metrics";
+    public static final String FINGERPRINT_SUMMARY_FILE_SUFFIX = ".fingerprinting_summary_metrics";
+    public static final String FINGERPRINT_DETAIL_FILE_SUFFIX = ".fingerprinting_detail_metrics";
 
     private Path inputPath;
     private Path genotypesPath;
@@ -229,7 +229,6 @@ public class CheckFingerprint extends CommandLineProgram {
             outputDetailMetricsFile = DETAIL_OUTPUT;
             outputSummaryMetricsFile = SUMMARY_OUTPUT;
         } else {
-            OUTPUT += ".";
             outputDetailMetricsFile = new File(OUTPUT + FINGERPRINT_DETAIL_FILE_SUFFIX);
             outputSummaryMetricsFile = new File(OUTPUT + FINGERPRINT_SUMMARY_FILE_SUFFIX);
         }


### PR DESCRIPTION
### Description

`CollectMultipleMetrics` currently strips a trailing period from the `OUTPUT` parameter. This behavior is unexpected and causes problems in our cloud pipelines. Metrics files, by convention, are names `${sample_alias}.${metrics_suffix}`. In removing a trailing `.` from the `OUTPUT`, `CollectMultipleMetrics` writes unexpected file names, causing problems when our cloud pipelines try to delocalize files. When supplied an `OUTPUT` of `foo.bar.`, the resulting metrics files should look like `foo.bar..pre_adapter_detail_metrics`. This is still a valid path in all filesystems.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

