### PR TITLE
Add reconstruct trios clps

### DIFF
--- a/src/main/java/picard/fingerprint/FingerprintChecker.java
+++ b/src/main/java/picard/fingerprint/FingerprintChecker.java
@@ -34,7 +34,6 @@ import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.ValidationStringency;
 import htsjdk.samtools.filter.SamRecordFilter;
 import htsjdk.samtools.filter.SecondaryAlignmentFilter;
-import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.IntervalList;
 import htsjdk.samtools.util.Log;
@@ -509,11 +508,8 @@ public class FingerprintChecker {
         // Now go through the data at each locus and figure stuff out!
         for (final SamLocusIterator.LocusInfo info : iterator) {
 
-            // if statement to avoid string building.
-            // TODO: replace with lambda version once htsjdk is rev'ed
-            if (Log.isEnabled(Log.LogLevel.DEBUG)) {
-                log.debug("At locus " + info.toString());
-            }
+            log.debug(() -> "At locus " + info.toString());
+
             // TODO: Filter out the locus if the allele balance doesn't make sense for either a
             // TODO: 50/50 het or a hom with some errors; in HS data with deep coverage any base
             // TODO: with major strand bias could cause errors

--- a/src/main/java/picard/fingerprint/FingerprintChecker.java
+++ b/src/main/java/picard/fingerprint/FingerprintChecker.java
@@ -34,6 +34,7 @@ import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.ValidationStringency;
 import htsjdk.samtools.filter.SamRecordFilter;
 import htsjdk.samtools.filter.SecondaryAlignmentFilter;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.IntervalList;
 import htsjdk.samtools.util.Log;
@@ -366,10 +367,7 @@ public class FingerprintChecker {
         for (final String sample : fingerprints.keySet()) {
             final Fingerprint fp = fingerprints.get(sample);
 
-            //PLs are preferred over GTs
-            //TODO: this code is replicated in various places (ReconstructTriosFromVCF for example). Needs refactoring.
-            //TODO: add a way to force using GTs when both are available (why?)
-
+            // PLs are preferred over GTs
             // Get the genotype for the sample and check that it is useful
             final Genotype genotype = usableSnp.getGenotype(sample);
             if (genotype == null) {
@@ -390,7 +388,7 @@ public class FingerprintChecker {
 
                 if (genotype.isNoCall()) continue;
 
-                // TODO: when multiple genotypes are available for a Haplotype check that they
+                // TODO: when multiple genotypes are available for a Haplotype, check that they
                 // TODO: agree. Not urgent since DownloadGenotypes already does this.
                 // TODO: more urgent now as we convert vcfs to haplotypeProbabilities and
                 // TODO: there could be different VCs with information we'd like to use...

--- a/src/main/java/picard/fingerprint/InferSex.java
+++ b/src/main/java/picard/fingerprint/InferSex.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.fingerprint;
+
+import htsjdk.samtools.util.CollectionUtil;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Log;
+import org.broadinstitute.barclay.argparser.Argument;
+import picard.cmdline.CommandLineProgram;
+import picard.cmdline.StandardOptionDefinitions;
+import picard.pedigree.PedFile;
+import picard.pedigree.Sex;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Attempts to use a set of genome data samples to determine sex within the cohort provided.
+ *
+ * @author Tim Fennell
+ * @author Jonathan Barlev
+ * @author Yossi Farjoun
+ */
+
+// Abstract class that provides the outline of a sex inferencing CLP.
+// The implementing class will have to implement getSexInferencer()
+public abstract class InferSex extends CommandLineProgram {
+
+    @Argument(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "Output pedigree file name.")
+    public File OUTPUT;
+
+    @Argument(doc="List of possible names for male sex chromosome(s)")
+    public Set<String> MALE_CHROMS = CollectionUtil.makeSet("Y", "chrY");
+
+    @Argument(doc="List of possible names for female sex chromosome(s)")
+    public Set<String> FEMALE_CHROMS = CollectionUtil.makeSet("X", "chrX");
+
+    final Log log = Log.getInstance(InferSex.class);
+
+    abstract SexInferenceEngine getSexInference();
+
+    @Override
+    protected int doWork() {
+        IOUtil.assertFileIsWritable(OUTPUT);
+
+        // Determine gender for everyone
+        log.info("Determining sample sexes");
+        final Map<String,Sex> sampleSexes =  getSexInference().determineSexes();
+        PedFile.fromSexMap(sampleSexes).write(OUTPUT);
+
+        return 0;
+    }
+}

--- a/src/main/java/picard/fingerprint/InferSexFromBAM.java
+++ b/src/main/java/picard/fingerprint/InferSexFromBAM.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.fingerprint;
+
+import htsjdk.samtools.util.IOUtil;
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.ExperimentalFeature;
+import picard.cmdline.StandardOptionDefinitions;
+import picard.cmdline.programgroups.DiagnosticsAndQCProgramGroup;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Program to Infer Sex of a cohort of samples from bams. Needs a large cohort with both sexes to
+ * work since it uses a clustering-based algorithm
+ *
+ * See InferSex for more details.
+ *
+ * This class looks at the index information to get average coverage over the sex chromosomes.
+ * it provides that information to the base class.
+ *
+ * Created by jbarlev on 5/30/14.
+ *
+ * @author Jonathan Barlev
+ * @author Yossi Farjoun
+ */
+@CommandLineProgramProperties(
+        summary = "A program that can infer sample sex from a collection of BAM files." +
+                "It compares the coverage over the male and female chromosomes to that over the rest of the" +
+                "genome, and performs clustering to find the answer. It uses the bam index to avoid having to " +
+                "iterate over the whole BAM file.",
+        oneLineSummary = "Infer sample sex from a collection of BAM files",
+        programGroup = DiagnosticsAndQCProgramGroup.class
+)
+@ExperimentalFeature
+public class InferSexFromBAM extends InferSex {
+
+    @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "Input BAM (not SAM) file. Must be indexed.")
+    public List<File> INPUT;
+
+    @Override
+    SexInferenceEngine getSexInference() {
+        return new SexInferenceEngineFromBAM(MALE_CHROMS, FEMALE_CHROMS, INPUT);
+    }
+
+    @Override
+    protected int doWork() {
+        IOUtil.assertFilesAreReadable(INPUT);
+
+        return super.doWork();
+    }
+}

--- a/src/main/java/picard/fingerprint/InferSexFromVCF.java
+++ b/src/main/java/picard/fingerprint/InferSexFromVCF.java
@@ -1,0 +1,87 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.fingerprint;
+
+import htsjdk.samtools.util.IOUtil;
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.ExperimentalFeature;
+import picard.cmdline.StandardOptionDefinitions;
+import picard.cmdline.programgroups.DiagnosticsAndQCProgramGroup;
+
+import java.io.File;
+
+/**
+ * Program to Infer Sex of a cohort of samples from a vcf. Needs a large cohort with both sexes to
+ * work since it uses a clustering-based algorithm
+ *
+ * See InferSex for more details.
+ *
+ * This class looks at depth markers on spaced variants in the VCF and provide information from that to the base class.
+ *
+ * Created by jbarlev on 5/30/14.
+ *
+ * @author Jonathan Barlev
+ * @author Yossi Farjoun
+ */
+@CommandLineProgramProperties(
+        summary = "A program that can infer sample sex from a VCF file." +
+                "It compares the coverage over the male and female chromosomes to that over the rest of the" +
+                "genome, and performs clustering to find the answer.",
+        oneLineSummary = "Infer sample sex from a VCF file",
+        programGroup = DiagnosticsAndQCProgramGroup.class
+)
+@ExperimentalFeature
+public class InferSexFromVCF extends InferSex {
+    @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "Input VCF file.")
+    public File INPUT;
+
+    @Argument(shortName = "AUTO_V", doc = "Number determining how many variants are sampled for coverage on each non-sex chromosome. " +
+            "Program will (attempt to) sample coverage at AUTOSOMAL_VARIANTS evenly spaced variants on each non-sex chromosome.")
+    public int AUTOSOMAL_VARIANTS = 10;
+
+    @Argument(shortName = "ALLO_V", doc = "Number determining how many variants are sampled for coverage on each sex chromosome. " +
+            "Program will (attempt to) sample coverage at ALLOSOMAL_VARIANTS evenly spaced variants on each sex chromosome. ")
+    public int ALLOSOMAL_VARIANTS = 100;
+
+    @Argument(shortName = "PAR", doc = "An IntervalList containing the pseudoautosomal region. Used for masking out that region since the regions on one " +
+            "chromosome may get mapped to the other and thus can change the apparent coverage.", optional = true)
+    public File PSEUDOAUTOSOMAL_REGION = null;
+
+    @Argument(doc="Some VCFs do not have variants (called) on Male chromosomes. Consequently, when determining sex, one may wish to give less weight to their Coverage than" +
+            "the memale chromosomes. Do this by dividing the male chromosome coverage values by a factor of Y_COVERAGE_SHRINK_FACTOR.")
+    public double Y_COVERAGE_SHRINK_FACTOR = 2.0;
+
+    @Override
+    SexInferenceEngine getSexInference() {
+        return new SexInferenceEngineFromVCF(MALE_CHROMS, FEMALE_CHROMS, INPUT, AUTOSOMAL_VARIANTS, ALLOSOMAL_VARIANTS, PSEUDOAUTOSOMAL_REGION, Y_COVERAGE_SHRINK_FACTOR);
+    }
+
+    @Override
+    protected int doWork() {
+        IOUtil.assertFileIsReadable(INPUT);
+        return super.doWork();
+    }
+}

--- a/src/main/java/picard/fingerprint/ReconstructTrios.java
+++ b/src/main/java/picard/fingerprint/ReconstructTrios.java
@@ -1,0 +1,667 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.fingerprint;
+
+import htsjdk.samtools.util.CollectionUtil;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.ListMap;
+import htsjdk.samtools.util.Log;
+import org.broadinstitute.barclay.argparser.Argument;
+import picard.cmdline.CommandLineProgram;
+import picard.cmdline.StandardOptionDefinitions;
+import picard.pedigree.PedFile;
+import picard.pedigree.Sex;
+import picard.util.MathUtil;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.lang.Math.log10;
+
+/**
+ * Attempts to use a set of genome data samples to determine trio relationships within the cohort provided.
+ * Roughly speaking it:
+ * Determines genders
+ * Performs pairwise tests between samples for 1st vs. 2nd degree relatedness
+ * Tests all plausible trios from 1st degree related samples of appropriate genders
+ *
+ * @author Tim Fennell
+ * @author Jonathan Barlev
+ * @author Yossi Farjoun
+ */
+public abstract class ReconstructTrios extends CommandLineProgram {
+
+    @Argument(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "Output pedigree file name (PED format).")
+    public File OUTPUT;
+
+    @Argument(doc = "Output sex-only file name. If provided this file will be populated with the sex inference done internally.", optional = true)
+    public File OUTPUT_SEX = null;
+
+    @Argument(doc = "Input sex PED file. If provided this file will be used instead of trying to figure out the sex of the samples.", optional = true)
+    public File INPUT_SEX = null;
+
+    @Argument(doc = "Don't use sex to limit search.", optional = true)
+    public Boolean NO_SEX = null;
+
+    @Argument(shortName = "H", doc = "Haplotype map to be used for fingerprinting. FORMAT of Halotype map is, standard SAM header (with one @HD and multiple @SQs) " +
+            "followed by a tab-separated header line and lines describing SNPs and Haplotype blocks. For example :" +
+            "#CHROMOSOME    POSITION    NAME        MAJOR_ALLELE    MINOR_ALLELE    MAF         ANCHOR_SNP  PANELS" +
+            "1              29478419    rs2503005   C               T               0.483791    rs2230678   panel1" +
+            "1              29497820    rs1994859   C               T               0.483791    rs2230678   panel2" +
+            "1              29500995    rs2486204   T               C               0.484167    rs2230678         " +
+            "1              29509603    rs2428556   C               T               0.728976    rs2230679   panel1" +
+            "" +
+            "NOTE: SNPs listed with the same ANCHOR_SNP will be in the same haplotype. In case of discrepancy between the MAFs within a block, " +
+            "the MAF of the first (smallest genomic position) SNP in the block is considered the MAF of the block." +
+            "NOTE: the PANEL field is optional (as a value, not in the header)")
+    public File HAPLOTYPE_MAP;
+
+    @Argument(doc = "Minimum LOD score to achieve in the putative parent test to treat samples as possible parents for trio testing.")
+    public double PARENT_ALONE_LOD = 2;
+
+    @Argument(doc = "Minimum LOD difference between unrelated and the other models to stop the calculation short and call the relationship unrelated.")
+    public double UNRELATED_SHORTCUT_LOD = 10;
+
+    @Argument(doc = "Minimum LOD for the trio test in order to report the trio in the output ped file.")
+    public double TRIO_LOD = 8;
+
+    @Argument(shortName = "MC", doc = "List of possible names for male sex chromosome(s)")
+    public Set<String> MALE_CHROMOSOMES = CollectionUtil.makeSet("Y", "chrY");
+
+    @Argument(shortName = "FC", doc = "List of possible names for female sex chromosome(s)")
+    public Set<String> FEMALE_CHROMOSOMES = CollectionUtil.makeSet("X", "chrX");
+
+    @Argument(doc = "If given, will only try to reconstruct trios involving these samples", optional = true)
+    public List<String> SAMPLE = null;
+
+    @Argument(doc = "Same as SAMPLE but file containing samples to use", optional = true)
+    public File SAMPLE_FILE = null;
+
+    @Argument(doc = "Probability of denovo mutation. Includes the probability of an incorrect genotyping due to large structural variation and other incorrect modeling assumptions.")
+    public double P_DENOVO = 0.000_01;
+
+    @Argument(doc = "Emit all putative trios (that have putative mother and father) regardless of LOD and rank (for debugging purposes.)")
+    public boolean EMIT_ALL_TRIOS = false;
+
+    @Argument(doc = "Emit all samples into pedigree file (so that founding members get a line on their own).")
+    public boolean EMIT_ALL_SAMPLES = false;
+
+
+    protected Set<String> sexChromosomes;
+    protected final Log log = Log.getInstance(ReconstructTrios.class);
+    protected HaplotypeMap hapmap;
+
+    protected abstract SexInferenceEngine getSexInferencer();
+
+    private final int IDENTITY_CHECK_MIN_LOD = -3;
+
+    @Override
+    protected int doWork() {
+        initializeMatrices();
+
+        IOUtil.assertFileIsReadable(HAPLOTYPE_MAP);
+        IOUtil.assertFileIsWritable(OUTPUT);
+        if (SAMPLE_FILE != null) IOUtil.assertFileIsReadable(SAMPLE_FILE);
+        if (OUTPUT_SEX != null) IOUtil.assertFileIsWritable(OUTPUT_SEX);
+        if (INPUT_SEX != null) IOUtil.assertFileIsReadable(INPUT_SEX);
+
+        // Create the map of haploptypes without any on the sex chromosomes
+        sexChromosomes = new HashSet<>();
+        sexChromosomes.addAll(MALE_CHROMOSOMES);
+        sexChromosomes.addAll(FEMALE_CHROMOSOMES);
+
+        hapmap = new HaplotypeMap(HAPLOTYPE_MAP).withoutChromosomes(sexChromosomes);
+
+        // Read all the fingerprints into per-sample FPs in memory
+        log.info("Fingerprinting files");
+        final Map<String, Fingerprint> fingerprints;
+
+        if (SAMPLE_FILE != null) {
+            try {
+                SAMPLE = IOUtil.slurpLines(SAMPLE_FILE);
+            } catch (FileNotFoundException e) {
+                log.error(e);
+                return -1;
+            }
+        }
+
+        final Function<FingerprintIdDetails, String> idDetailsToSample = Fingerprint.getFingerprintIdDetailsStringFunction(CrosscheckMetric.DataType.SAMPLE);
+
+        final Map<String, Fingerprint> fingerprintsAll = Fingerprint.mergeFingerprintsBy(getFingerprints(), idDetailsToSample)
+                .entrySet().stream()
+                .collect(Collectors.toMap(e->e.getKey().getSample(), Map.Entry::getValue));
+
+        if (SAMPLE != null && !SAMPLE.isEmpty()) {
+            log.info("subsetting to " + SAMPLE.size() + " samples.");
+            fingerprints = fingerprintsAll.entrySet()
+                    .stream()
+                    .filter(fpEntry -> SAMPLE.contains(fpEntry.getKey()))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            log.info("resulting map contains " + fingerprints.size() + " samples.");
+
+        } else {
+            fingerprints = fingerprintsAll;
+        }
+
+        if (fingerprints.size() < 3) {
+            log.warn("Not enough samples to perform trio testing: " + fingerprints.size());
+            new PedFile(true).write(OUTPUT); // Write out empty ped file.
+            return 0;
+        }
+
+        // Determine gender for everyone that we can assign mother vs. father
+        final Map<String, Sex> sampleSexes;
+        if( NO_SEX ) {
+            log.info("Not using sex. Will try both roles for every sample. Resulting genders in PED file are arbitrary!");
+            sampleSexes = new CollectionUtil.DefaultingMap<>(Sex.Unknown);
+        } else if (INPUT_SEX != null) {
+            log.info("Reading sample sexes");
+            final PedFile sampleSex = PedFile.fromFile(INPUT_SEX, false);
+            sampleSexes = sampleSex.entrySet().stream()
+                    .collect(Collectors.toMap(e -> e.getValue().getIndividualId(), e -> e.getValue().getSex()));
+
+            SAMPLE.stream().filter(s -> !sampleSex.containsKey(s)).findAny().ifPresent(s -> {
+                final String error = "Couldn't find sex for individual " + s + " in provided file " + INPUT_SEX;
+                log.error(error);
+                throw new RuntimeException(error);
+            });
+
+        } else {
+            log.info("Determining sample sexes");
+            sampleSexes = getSexInferencer().determineSexes();
+        }
+
+        if (OUTPUT_SEX != null) {
+            log.info("writing sample sexes to output file.");
+            PedFile.fromSexMap(sampleSexes).write(OUTPUT_SEX);
+        }
+
+        final ListMap<String, String> sampleToPotentialMothers = new ListMap<>();
+        final ListMap<String, String> sampleToPotentialFathers = new ListMap<>();
+        final ListMap<String, String> sampleToUngenderedParents = new ListMap<>();
+
+
+        final NumberFormat fmt = new DecimalFormat("#.00");
+        log.info("Looking for putative parents.");
+        // Do a first pass and pick out samples that appear related to one another
+        for (final Fingerprint offspring : fingerprints.values()) {
+            for (final Fingerprint parent : fingerprints.values()) {
+                if (offspring == parent) continue;
+
+                final double lodParent = testParent(parent, offspring);
+                final Sex parentSex = sampleSexes.get(parent.getSample());
+
+                //otherwise debug messages get unruly
+                if (lodParent > -30.0) {
+                    log.debug(String.format("%s is %s of %s. LOD: %g.", parent.getSample(), (parentSex == Sex.Male ? "father" : "mother"), offspring.getSample(), lodParent));
+                }
+                //If putative parent seems more like a parent than a grandparent (and
+                if (lodParent >= PARENT_ALONE_LOD) {
+                    switch(parentSex ) {
+                        case Female:
+                            sampleToPotentialMothers.add(offspring.getSample(), parent.getSample());
+                            break;
+                        case Male:
+                            sampleToPotentialFathers.add(offspring.getSample(), parent.getSample());
+                            break;
+                        case Unknown:
+                            sampleToUngenderedParents.add(offspring.getSample(), parent.getSample());
+                            break;
+                        default:
+                            throw new RuntimeException("Unpossible!");
+                    }
+                }
+            }
+            // Once all the putative parents have been collected, see if they all are identical (within gender sets).
+            // if not, emit a warning since this seems a little odd. This entire loop only checks for warning, so will
+            // be bypassed if warnings are not emitted.
+
+            // TODO: fix this...
+            // TODO: 1. not a problem since parent and child will show up here.
+            // TODO: 2. need to account for ungendered parents.
+            if (Log.isEnabled(Log.LogLevel.WARNING)) {
+                for (final List<String> sampleToParent : CollectionUtil.makeList(
+                        sampleToPotentialFathers.get(offspring.getSample()),
+                        sampleToPotentialMothers.get(offspring.getSample()))) {
+
+                    if (sampleToParent == null) {
+                        continue;
+                    } // no parents here, move along (makeList returns null in this case, not an empty list...)
+
+                    for (int i = 0; i < sampleToParent.size(); i++) {
+                        final String parent1 = sampleToParent.get(i);
+                        final Fingerprint parent1FP = fingerprints.get(parent1);
+
+                        for (int j = 0; j < i; j++) {
+                            final String parent2 = sampleToParent.get(j);
+                            final Fingerprint parent2FP = fingerprints.get(parent2);
+
+                            final double lodIdentical = FingerprintChecker.calculateMatchResults(parent1FP, parent2FP).getLOD();
+                            if (lodIdentical < IDENTITY_CHECK_MIN_LOD) { //  different individuals
+                                log.warn(String.format("Found more than one distinct putative %s, for sample %s: %s, and, %s. LOD=%s", (sampleSexes.get(parent1) == Sex.Male ? "father" : "mother"), offspring.getSample(), parent1, parent2, fmt.format(lodIdentical)));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        log.info("Looking for trios within possible families.");
+
+        // Check for actual trios within families
+        final PedFile pedfile = new PedFile(true);
+        final Random rng = new Random();
+
+        for (final Fingerprint offspring : fingerprints.values()) {
+            final String offspringName = offspring.getSample();
+            final Collection<String> potentialMothers = Optional.ofNullable(sampleToPotentialMothers.get(offspringName)).orElseGet(ArrayList::new);
+            potentialMothers.addAll(Optional.ofNullable(sampleToUngenderedParents.get(offspringName)).orElseGet(ArrayList::new));
+
+            final Collection<String> potentialFathers = Optional.ofNullable(sampleToPotentialFathers.get(offspringName)).orElseGet(ArrayList::new);
+            potentialFathers.addAll(Optional.ofNullable(sampleToUngenderedParents.get(offspringName)).orElseGet(ArrayList::new));
+
+            final SortedSet<TrioTestResults> results = new TreeSet<>();
+
+            if (potentialMothers.isEmpty() || potentialFathers.isEmpty()) {
+                log.debug(String.format("sample %s doesn't have a putative %s", offspringName, potentialMothers.isEmpty() ? "mother" : "father"));
+                continue;
+            }
+
+            for (final String motherName : potentialMothers) {
+                // once a sample has been considered as a mother, do not consider it as a father
+                potentialFathers.remove(motherName);
+                for (final String fatherName : potentialFathers) {
+
+                    final Fingerprint mother = fingerprints.get(motherName);
+                    final Fingerprint father = fingerprints.get(fatherName);
+
+                    final TrioTestResults result = testTrios(mother, father, offspring);
+                    log.debug(String.format("Trio test results for  %s + %s -> %s are llTrio=%g, llFatherPlusRandom=%g, llMotherPlusRandom=%g, llRandomParents=%g, llSibsAsParents=%g, llThreeGenChain=%g, lodTrio=%g",
+                            mother.getSample(), father.getSample(), offspring.getSample(), result.llTrio, result.llFatherPlusRandom, result.llMotherPlusRandom, result.llRandomParents, result.llSibsAsParents, result.llThreeGenChain, result.lodTrio));
+
+                    if (result.lodTrio > Math.min(TRIO_LOD, 0)) results.add(result);
+                }
+            }
+
+            log.debug(results.size() + " trio matches for offspring" + offspringName);
+            if (!results.isEmpty()) {
+
+                final TrioTestResults best = results.first();
+                if (best.lodTrio >= TRIO_LOD) {
+                    log.debug(String.format("Best match for %s has LOD %s for Father=%s, and Mother=%s.", best.offspring, fmt.format(best.lodTrio), best.father, best.mother));
+
+                    results.stream()
+                            .limit(EMIT_ALL_TRIOS ? Integer.MAX_VALUE : 1)
+                            .filter(t -> EMIT_ALL_TRIOS || t.lodTrio > TRIO_LOD)
+                            .forEach(trio -> pedfile.put(trio.offspring + "_" + rng.nextInt(),pedfile.new PedTrio(trio.offspring, trio.offspring, trio.father, trio.mother,
+                                    sampleSexes.get(trio.offspring), trio.lodTrio)));
+                }
+            }
+        }
+
+        if (EMIT_ALL_SAMPLES) {
+            log.info("adding founding members");
+
+            final Set<String> offsprings = pedfile.values().stream()
+                    .map(PedFile.PedTrio::getIndividualId)
+                    .collect(Collectors.toSet());
+
+            fingerprints.keySet().stream()
+                    .filter(s -> !offsprings.contains(s))
+                    .map(sample -> pedfile.new PedTrio(sample, sample, null, null, sampleSexes.get(sample), -9))
+                    .forEach(pedfile::add);
+        }
+
+        log.info("writing pedigree to file");
+        pedfile.write(OUTPUT);
+
+        return 0;
+    }
+
+    /**
+     * Tests whether the three samples appear to constitute a mother/father/offspring trio. Calculates the
+     * likelihood of this arrangement vs. the likelihoods of the three samples being unrelated random samples
+     * and also of one of the parents being a true parent and one of the samples being a random unrelated sample.
+     *
+     * @param mother    the fingerprint of the putative mother
+     * @param father    the fingerprint of the putative father
+     * @param offspring the fingerprint of the offspring
+     * @return a TrioTestResults object that has the likelihoods of each scenarios along with the names of the samples
+     */
+    private TrioTestResults testTrios(final Fingerprint mother, final Fingerprint father, final Fingerprint offspring) {
+        double llTrio = 0, llMotherPlusRandom = 0, llFatherPlusRandom = 0, llRandomParents = 0, llSibsAsParents = 0;
+        double llThreeGenerationChain = 0;
+
+
+        for (final HaplotypeBlock hap : mother.keySet()) {
+            final HaplotypeProbabilities mom = mother.get(hap);
+            final HaplotypeProbabilities dad = father.get(hap);
+            final HaplotypeProbabilities os = offspring.get(hap);
+
+            // Skip any haplotypes where we don't have information for all three people
+            if (mom == null || dad == null || os == null) continue;
+
+            final double[] probsMom = mom.getPosteriorProbabilities();
+            final double[] probsDad = dad.getPosteriorProbabilities();
+            final double[] random = hap.getHaplotypeFrequencies();
+
+            llTrio += llChildofKnownParents(probsMom, probsDad, os);
+            llMotherPlusRandom += llChildofKnownParents(probsMom, random, os);
+            llFatherPlusRandom += llChildofKnownParents(random, probsDad, os);
+            llRandomParents += llChildofKnownParents(random, random, os);
+
+            // here we are giving the putative parents as if they are the children, since that's what we
+            // want to protect against.
+            llSibsAsParents += llParentOfKnownChildren(probsDad, probsMom, os);
+
+            // protect against a scenario where one of the parents is actually the offspring of the child
+            llThreeGenerationChain += Math.max( llMiddleOfChain(probsDad, os, probsMom), llMiddleOfChain(probsMom, os, probsDad));
+
+            final double lodTrio=llChildofKnownParents(probsMom, probsDad, os) - MathUtil.max(new double[] {
+                    llChildofKnownParents(random, probsDad, os), llChildofKnownParents(probsMom, random, os),
+                    llChildofKnownParents(random, random, os), llParentOfKnownChildren(probsDad, probsMom, os),
+                    llMiddleOfChain(probsDad, os, probsMom), llMiddleOfChain(probsMom, os, probsDad)});
+
+            log.debug(String.format("Trio test for  %s + %s -> %s  at Haplotype %s are llTrio=%g, llFatherPlusRandom=%g, llMotherPlusRandom=%g, llRandomParents=%g, llSibsAsParents=%g, llThreeGenChainDadisGramps=%g, llThreeGenChainDadisSon=%g lodTrio=%g",
+                    mother.getSample(), father.getSample(), offspring.getSample(), hap.toString(), llChildofKnownParents(probsMom, probsDad, os),
+                    llChildofKnownParents(random, probsDad, os), llChildofKnownParents(probsMom, random, os),
+                    llChildofKnownParents(random, random, os), llParentOfKnownChildren(probsDad, probsMom, os),
+                    llMiddleOfChain(probsDad, os, probsMom), llMiddleOfChain(probsMom, os, probsDad), lodTrio));
+        }
+
+        return new TrioTestResults(offspring.getSample(), father.getSample(), mother.getSample(),
+                llTrio, llMotherPlusRandom, llFatherPlusRandom, llRandomParents, llSibsAsParents, llThreeGenerationChain);
+    }
+
+    /**
+     * Little class to encapsulate the results of testing three samples that may or may not form a Trio.
+     */
+    private static class TrioTestResults implements Comparable<TrioTestResults> {
+        public TrioTestResults(final String offspring, final String father, final String mother,
+                               final double llTrio, final double llMotherPlusRandom,
+                               final double llFatherPlusRandom, final double llRandomParents, double llSibsAsParents, double llThreeGenChain) {
+            this.offspring = offspring;
+            this.father = father;
+            this.mother = mother;
+            this.llTrio = llTrio;
+            this.llMotherPlusRandom = llMotherPlusRandom;
+            this.llFatherPlusRandom = llFatherPlusRandom;
+            this.llRandomParents = llRandomParents;
+            this.llSibsAsParents = llSibsAsParents;
+            this.llThreeGenChain = llThreeGenChain;
+
+            this.lodTrio = llTrio - MathUtil.max(new double[]{llMotherPlusRandom, llFatherPlusRandom, llRandomParents, llSibsAsParents, llThreeGenChain});
+        }
+
+        public final String offspring;
+
+        public final String father;
+        public final String mother;
+        public final double llTrio;
+        public final double llMotherPlusRandom;
+        public final double llFatherPlusRandom;
+        public final double llRandomParents;
+        public final double llSibsAsParents;
+        public final double llThreeGenChain;
+
+        public final double lodTrio;
+
+        /**
+         * Comparison function that orders things with higher LODs first.
+         */
+        @Override
+        public int compareTo(final TrioTestResults that) {
+            // Multiply by 1000 so that the conversion to int only truncates after 3 significant digits
+            return (int) ((that.lodTrio * 1000) - (this.lodTrio * 1000));
+        }
+    }
+
+    /**
+     * Attempts to determine if samples have 50% sharing of genetic material (and therefore could be parent/offspring)
+     * or are more likely to be 25% related or unrelated.
+     * <p/>
+     * Works as follows:
+     * - Assume one FP comes from the parent and ask what the likelihood of the two fingerprints is
+     * given the model that one sample is a parent of the other sample.
+     * - Assume that the putative parent is actually a grandparent and synthesize the likelihoods of
+     * postulative - parent and perform the same test as above
+     * - Lastly do the same but using the population frequencies as the likelihood of a "random" parent
+     */
+    private double testParent(final Fingerprint parentFp, final Fingerprint offspringFp) {
+        double llUnrelated = 0, llIdentical = 0, ll50Related = 0, ll25Related = 0;
+
+        for (final HaplotypeBlock hap : parentFp.keySet()) {
+            final HaplotypeProbabilities parent = parentFp.get(hap);
+            final HaplotypeProbabilities offspring = offspringFp.get(hap);
+
+            if (parent == null || offspring == null) continue;
+            final double[] pParentModel = parent.getPosteriorProbabilities();
+            final double[] pPopulationModel = hap.getHaplotypeFrequencies();
+
+            // Calculate a set of probabilities for a hypothetical parent who is themselves the offspring of the putative "parent"
+            // passed in and a random other sample from the population
+            final double[] pPseudoParentModel = getModelFromParents(pParentModel, pPopulationModel);
+
+            // Now add to our likelihoods
+            llUnrelated += offspring.shiftedLogEvidenceProbability();
+            llIdentical += offspring.shiftedLogEvidenceProbabilityUsingGenotypeFrequencies(pParentModel);
+
+            ll50Related += llChildofKnownParents(pParentModel, pPopulationModel, offspring);
+            ll25Related += llChildofKnownParents(pPseudoParentModel, pPopulationModel, offspring);
+
+            // if the unrelated model has grown so much as to overshadow the other models, call the situation unrelated and stop the calculation
+            // This is the slowest part of the program, so looking for ways to speed it up.
+
+            if (llUnrelated > MathUtil.max(new double[]{llIdentical, ll25Related, ll50Related}) + UNRELATED_SHORTCUT_LOD) {
+                break;
+            }
+        }
+        //The logic here is that the likelihood of the trio is compared to the most likely other option for the offspring and the ratio
+        //of those two likelihoods is used for calculating the LOD
+        final double LodParent = ll50Related - MathUtil.max(new double[]{llIdentical, ll25Related, llUnrelated});
+        log.debug(String.format("Parent test results for  %s -> %s are ll50Related=%g, llIdentical=%g, ll25Related=%g, llUnrelated=%g. LOD=%g",
+                parentFp.getSample(),offspringFp.getSample(),ll50Related, llIdentical, ll25Related, llUnrelated, LodParent));
+
+        return LodParent;
+    }
+
+    private static double[][] getDenovoMatrix(final double delta){
+        final double tau = 1 - delta;
+        final double tau_delta = tau * delta;
+        final double tau_2 = tau * tau;
+        final double delta_2 = delta * delta;
+        return new double[][] {
+                {tau_2, tau_delta, delta_2},
+                {2 * tau_delta, delta_2 + tau_2, 2 * tau_delta},
+                {delta_2, tau_delta, tau_2}
+        };
+    }
+
+    // Mendelian matrix. M[a][b][c] is the probability that
+    // genotype a come from parents with genotype b and c
+    private double [][][] MWithDenovo = null;
+    private double [][][][] M2WithDenovo = null;
+
+
+    private static double[][][] getMWithDenovoMutations(final double delta) {
+        final double[][][] M = {
+            {
+                    {1, .5, 0}, //hom_ref child
+                    {.5, .25, 0},
+                    {0, 0, 0}
+            },
+            {
+                    {0, .5, 1},//het child
+                    {.5, .5, .5},
+                    {1, .5, 0}
+            },
+            {
+                    {0, 0, 0},//hom_var child
+                    {0, .25, .5},
+                    {0, .5, 1}
+            }
+        };
+
+        final double [][][] retval = new double[3][][];
+        final double [][] denovoMatrix = getDenovoMatrix(delta);
+
+        for (final int child : genotypes) {
+            retval[child] = new double[genotypes.length][];
+            for (final int parent1 : genotypes) {
+                retval[child][parent1] = new double[genotypes.length];
+                for (final int parent2 : genotypes) {
+                    for (final int altchild : genotypes) {
+                        retval[child][parent1][parent2] += denovoMatrix[child][altchild] * M[altchild][parent1][parent2];
+                    }
+                }
+            }
+        }
+        return retval;
+    }
+
+    private void initializeMatrices(){
+        MWithDenovo = getMWithDenovoMutations(P_DENOVO);
+        M2WithDenovo = getParentsAndTwoChildrenTensor(MWithDenovo);
+    }
+
+    static public int[] genotypes = {0, 1, 2};
+
+    /**
+     * Returns the probabilities of each of the three genotypes given a random mating between two parents with specified probabilities.
+     */
+    private double[] getModelFromParents(final double[] pModel1, final double[] pModel2) {
+        final double[] pPriorOffspring = new double[genotypes.length];
+
+        for (final int child : genotypes) {
+            for (final int parent1 : genotypes) {
+                for (final int parent2 : genotypes) {
+                    pPriorOffspring[child] += pModel1[parent1] * pModel2[parent2] * MWithDenovo[child][parent1][parent2];
+                }
+            }
+        }
+        return pPriorOffspring;
+    }
+
+    /** M^2 the tensor for two parents and two children  */
+    private static double[][][][] getParentsAndTwoChildrenTensor(double[][][] M) {
+        final int n = genotypes.length;
+        final double[][][][] parentsAndTwoChildrenTensor = new double[n][n][n][n];
+
+        for (final int child1 : genotypes) {
+            for (final int child2 : genotypes) {
+                for (final int parent1 : genotypes) {
+                    for (final int parent2 : genotypes) {
+                        parentsAndTwoChildrenTensor[parent1][parent2][child1][child2] = M[child1][parent1][parent2] * M[child2][parent1][parent2];
+                    }
+                }
+            }
+        }
+        return parentsAndTwoChildrenTensor;
+    }
+
+
+    /**
+     * Calculates the likelihood of the offspring being the product of two parents by synthesizing the genotype probabilities
+     * for an offspring given the parent's genotypes and then comparing that to the actual offspring's genotypes likelihoods.
+     */
+    private double llChildofKnownParents(final double[] parent1, final double[] parent2, final HaplotypeProbabilities offspring) {
+        final double[] predictedOffspring = getModelFromParents(parent1, parent2);
+        return offspring.shiftedLogEvidenceProbabilityUsingGenotypeFrequencies(predictedOffspring);
+    }
+
+    /**
+     * Calculates the likelihood that the data is from the parent of both given genotypes
+     */
+    private double pParentOfKnownChildren(final double[] child1, final double[] child2, final HaplotypeProbabilities parentHP) {
+
+        double probability = 0;
+        final double [] parent = parentHP.getLikelihoods();
+        final double [] prior = parentHP.getPriorProbablities();
+        for (int child1G : genotypes) {
+            for (int child2G : genotypes) {
+                for (int parent1G : genotypes) {
+                    for (int parent2G : genotypes) {
+                        probability += M2WithDenovo[parent1G][parent2G][child1G][child2G] * child1[child1G] * child2[child2G] * parent[parent1G] * prior[parent2G];
+                    }
+                }
+            }
+        }
+        return probability;
+    }
+
+    /**
+     * Calculates the likelihood that the data is from the parent of both given genotypes
+     */
+    private double llParentOfKnownChildren(final double[] child1, final double[] child2, final HaplotypeProbabilities parentHP) {
+        return log10(pParentOfKnownChildren(child1, child2, parentHP));
+    }
+
+    /**
+     * calculates the likelihood that the data of child agrees with a model where the parent and offspring are given
+     * @param parent probabilities of parent of subject
+     * @param childHP probabilities of subject
+     * @param grandchild probabilities of putative child of subject
+     * @return likelihood that data would arise from such an arrangement
+     */
+    private double pMiddleOfChain(final double[] parent, final HaplotypeProbabilities childHP, final double[] grandchild) {
+        double probability = 0;
+        final double [] child = childHP.getLikelihoods();
+        final double [] prior = childHP.getPriorProbablities();
+        for (int parent1G : genotypes) {
+            for (int unknownSpouce1G : genotypes) {
+                for (int childG : genotypes) {
+                    for (int unknownSpouce2G : genotypes) {
+                        for (int grandChildG : genotypes) {
+                            probability +=
+                                    MWithDenovo[childG][parent1G][unknownSpouce1G] * prior[unknownSpouce1G] *
+                                    MWithDenovo[grandChildG][childG][unknownSpouce2G] * prior[unknownSpouce2G] * parent[parent1G] * child[childG] * grandchild[grandChildG];
+                        }
+                    }
+                }
+            }
+        }
+        return probability;
+     }
+
+    /**
+     * calculates the log likelihood that the data of child agrees with a model where the parent and offspring are given
+     * @param parent probabilities of parent of subject
+     * @param childHP probabilities of subject
+     * @param grandchild probabilities of putative child of subject
+     * @return probability that data would arise from such an arrangement
+     */
+    private double llMiddleOfChain(final double[] parent, final HaplotypeProbabilities childHP, final double[] grandchild) {
+        return log10(pMiddleOfChain(parent, childHP, grandchild));
+    }
+
+    protected abstract Map<FingerprintIdDetails, Fingerprint> getFingerprints();
+}
+

--- a/src/main/java/picard/fingerprint/ReconstructTrios.java
+++ b/src/main/java/picard/fingerprint/ReconstructTrios.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2014 The Broad Institute
+ * Copyright (c) 2019 The Broad Institute
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/picard/fingerprint/ReconstructTriosFromBAMs.java
+++ b/src/main/java/picard/fingerprint/ReconstructTriosFromBAMs.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package picard.fingerprint;
+
+import htsjdk.samtools.util.FileExtensions;
+import htsjdk.samtools.util.IOUtil;
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.ExperimentalFeature;
+import picard.cmdline.StandardOptionDefinitions;
+import picard.cmdline.programgroups.DiagnosticsAndQCProgramGroup;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * A Program that infers trios in a cohort from a collection of BAM files",
+ */
+@CommandLineProgramProperties(
+        summary = "Attempts to use a set of genome data samples to determine trio relationships within the cohort provided.\n" +
+                " " +
+                "Roughly speaking it:\n" +
+                " - Determines genders\n" +
+                " - Performs pairwise tests between samples for 1st vs. 2nd degree relatedness\n" +
+                " - Tests all plausible trios from 1st degree related samples of appropriate genders\n" +
+                "Emits likely trios in PED file.",
+        oneLineSummary = "Infers trios in a cohort from a collection of BAM files.",
+        programGroup = DiagnosticsAndQCProgramGroup.class
+)
+@ExperimentalFeature
+public class ReconstructTriosFromBAMs extends ReconstructTrios {
+
+    @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "Input BAM files, or files listing input file locations.")
+    public List<File> INPUT;
+
+    @Argument(doc = "The number of threads to use when fingerprinting files.")
+    public int NUM_THREADS = 1;
+
+    @Argument(doc = "The maximum runtime in hours that should be used for fingerprinting files.")
+    public int MAX_RUNTIME_HOURS = 5 * 24;
+
+    @Override
+    protected SexInferenceEngine getSexInferencer() {
+        return new SexInferenceEngineFromBAM(MALE_CHROMOSOMES, FEMALE_CHROMOSOMES, INPUT);
+    }
+
+    @Override
+    protected int doWork() {
+        IOUtil.assertFilesAreReadable(INPUT);
+        return super.doWork();
+    }
+
+    @Override
+    public final Map<FingerprintIdDetails, Fingerprint> getFingerprints() {
+        final List<Path> bams = IOUtil.unrollPaths(INPUT.stream().map(File::toPath).collect(Collectors.toList()), FileExtensions.BAM);
+        final FingerprintChecker checker = new FingerprintChecker(hapmap);
+        final Map<FingerprintIdDetails, Fingerprint> fpMap = checker.fingerprintFiles(bams, NUM_THREADS, MAX_RUNTIME_HOURS, TimeUnit.HOURS);
+        return Fingerprint.mergeFingerprintsBy(fpMap, Fingerprint.getFingerprintIdDetailsStringFunction(CrosscheckMetric.DataType.SAMPLE));
+    }
+}

--- a/src/main/java/picard/fingerprint/ReconstructTriosFromBAMs.java
+++ b/src/main/java/picard/fingerprint/ReconstructTriosFromBAMs.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2014 The Broad Institute
+ * Copyright (c) 2019 The Broad Institute
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/picard/fingerprint/ReconstructTriosFromVCFs.java
+++ b/src/main/java/picard/fingerprint/ReconstructTriosFromVCFs.java
@@ -1,0 +1,95 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package picard.fingerprint;
+
+import htsjdk.samtools.util.IOUtil;
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.ExperimentalFeature;
+import picard.cmdline.StandardOptionDefinitions;
+import picard.cmdline.programgroups.DiagnosticsAndQCProgramGroup;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ *
+ * @author Tim Fennell
+ * @author Jonathan Barlev
+ * @author Yossi Farjoun
+ */
+@CommandLineProgramProperties(
+        summary = "A program that infers trios in a cohort given by a VCF of variant calls. The program infers the sex of each sample " +
+                "(by looking at AD fields in the VCF), find possible parents for each sample (by calculating the probability that " +
+                "other sample is a parent), and then from the list of possible mothers and fathers tries to come up with the most likely trio.",
+        oneLineSummary = "Infers trios in a cohort given by a VCF.",
+        programGroup = DiagnosticsAndQCProgramGroup.class
+)
+@ExperimentalFeature
+public class ReconstructTriosFromVCFs extends ReconstructTrios {
+
+    @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "Input VCF file.")
+    public File INPUT;
+
+    @Argument(shortName = "AUTO_V", doc = "The number of variants which will be sampled for coverage on each non-sex chromosome. " +
+            "(Attempt to) sample coverage at AUTOSOMAL_VARIANTS evenly spaced variants on each non-Sex chromosome.")
+    public int AUTOSOMAL_VARIANTS = 1000;
+
+    @Argument(shortName = "ALLO_V", doc = "The number of variants which will be sampled for coverage on each sex chromosome. " +
+            "(Attempt to) sample coverage at ALLOSOMAL_VARIANTS evenly spaced variants on each Sex chromosome. ")
+    public int ALLOSOMAL_VARIANTS = 10000;
+
+    @Argument(shortName = "PARIL", doc = "An Interval List contain the pseudoautosomal region. " +
+            "Used for masking out that region since the regions on one chromosome will get mapped to the other and thus can change the apparent coverage.", optional = true)
+    public File PSEUDOAUTOSOMAL_REGION_INTERVAL_LIST = null;
+
+    @Argument(doc = "Some VCFs do not have variants on Male chromosomes. Consequently, when determining sex, one may wish to give less weight to their coverage than" +
+            "the female chromosomes. We do this by dividing the male chromosome coverage values by a factor of Y_COVERAGE_SHRINK_FACTOR.")
+    public double Y_COVERAGE_SHRINK_FACTOR = 2.0;
+
+    @Argument(doc = "The number of threads to use when fingerprinting files.")
+    public int NUM_THREADS = 1;
+
+    @Argument(doc = "The maximum runtime in hours that should be used for fingerprinting files.")
+    public int MAX_RUNTIME_HOURS = 5 * 24;
+
+    @Override
+    protected SexInferenceEngine getSexInferencer() {
+        return new SexInferenceEngineFromVCF(MALE_CHROMOSOMES, FEMALE_CHROMOSOMES, INPUT, AUTOSOMAL_VARIANTS, ALLOSOMAL_VARIANTS, PSEUDOAUTOSOMAL_REGION_INTERVAL_LIST, Y_COVERAGE_SHRINK_FACTOR);
+    }
+
+    @Override
+    protected int doWork() {
+        IOUtil.assertFileIsReadable(INPUT);
+        return super.doWork();
+    }
+
+    @Override
+    public Map<FingerprintIdDetails, Fingerprint> getFingerprints() {
+        final FingerprintChecker checker = new FingerprintChecker(hapmap);
+        return checker.fingerprintFiles(Collections.singleton(INPUT.toPath()), NUM_THREADS, MAX_RUNTIME_HOURS, TimeUnit.HOURS);
+    }
+}

--- a/src/main/java/picard/fingerprint/ReconstructTriosFromVCFs.java
+++ b/src/main/java/picard/fingerprint/ReconstructTriosFromVCFs.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2014 The Broad Institute
+ * Copyright (c) 2019 The Broad Institute
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/picard/fingerprint/SexInferenceEngine.java
+++ b/src/main/java/picard/fingerprint/SexInferenceEngine.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package picard.fingerprint;
 
 import htsjdk.samtools.util.Log;

--- a/src/main/java/picard/fingerprint/SexInferenceEngine.java
+++ b/src/main/java/picard/fingerprint/SexInferenceEngine.java
@@ -1,0 +1,116 @@
+package picard.fingerprint;
+
+import htsjdk.samtools.util.Log;
+import picard.pedigree.Sex;
+import picard.util.MathUtil;
+
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Abstract class that encapsulates the logic behind determining sex from sequence data.
+ * Extending classes will have to implement two functions, one that returns a list of SampleXy instances, and another that returns
+ * the starting centroids for the k-means algorithm
+ * The algorithm cluasters the data, looking for 2 clusters, corresponding to the two sexes.
+ *
+ * @author Yossi Farjoun
+ */
+abstract public class SexInferenceEngine {
+
+    final protected Set<String> MALE_CHROMS = new TreeSet<>();
+    final protected Set<String> FEMALE_CHROMS = new TreeSet<>();
+    final protected Set<String> SEX_CHROMS = new TreeSet<>();
+
+    final Log log = Log.getInstance(SexInferenceEngine.class);
+
+    protected SexInferenceEngine(final Set<String> MALE_CHROMS, final Set<String> FEMALE_CHROMS) {
+
+        this.MALE_CHROMS.addAll(MALE_CHROMS);
+        this.FEMALE_CHROMS.addAll(FEMALE_CHROMS);
+
+        this.SEX_CHROMS.addAll(FEMALE_CHROMS);
+        this.SEX_CHROMS.addAll(MALE_CHROMS);
+
+    }
+
+    /**
+     * Determine the sex of each of the samples.
+     * performs a 2-cluster k-means clustering of those values to assign samples to either sex
+     * based on the fact that females will have density ~ 0 on chrY and that the density on chrX that is approximately double
+     * that of males.
+     *
+     * @return a Map of sample name to sex.
+     */
+    public Map<String, Sex> determineSexes() {
+        final Map<String, Sex> sampleSexes = new HashMap<>();
+        log.info("getting Chromosomal Coverage");
+        final List<SampleXy> samples = getSexChromCoverageDensity();
+
+        // Now cluster the coverage values.
+        final double[][] data = new double[samples.size()][];
+        for (int i = 0; i < data.length; ++i) {
+            data[i] = new double[]{samples.get(i).xDensity, samples.get(i).yDensity};
+        }
+        log.info("Clustering sex data");
+        final int[] assignments = MathUtil.kMeansCluster(data, getCentroids());
+
+        // Lastly assign gender based on cluster membership and emit debug messaging about called genders
+        final NumberFormat fmt = new DecimalFormat("00.000");
+        log.info("Assigning sex to samples");
+        for (int i = 0; i < assignments.length; ++i) {
+            final SampleXy sample = samples.get(i);
+            final Sex sex = assignments[i] == 0 ? Sex.Female : Sex.Male;
+            sampleSexes.put(sample.sample, sex);
+            log.debug(sample.sample + "\t" + data[i][0] + "\t" + data[i][1] + "\t" + sex);
+        }
+        return sampleSexes;
+    }
+
+    /**
+     * Used by determineSexes
+     *
+     * @return A list of SampleXy's - objects containing sample names and a measure of coverage on the sex chromosome.
+     */
+    abstract protected List<SampleXy> getSexChromCoverageDensity();
+
+    /**
+     * Get coordinates of the points with which to begin k means clustering in determineSexes
+     *
+     * @return Double array
+     */
+    abstract protected double[][] getCentroids();
+
+    /*A little class to encapsulate sample and the density of reads on each gender chromosome. */
+    static protected class SampleXy {
+        final public String sample;
+        private double xDensity;
+        private double yDensity;
+
+        SampleXy(final String sample, final double x, final double y) {
+            this.sample = sample;
+            this.xDensity = x;
+            this.yDensity = y;
+        }
+
+        void setxDensity(final double den) {
+            xDensity = den;
+        }
+
+        void setyDensity(final double den) {
+            yDensity = den;
+        }
+
+        public double getxDensity() {
+            return xDensity;
+        }
+
+        public double getyDensity() {
+            return yDensity;
+        }
+    }
+}

--- a/src/main/java/picard/fingerprint/SexInferenceEngineFromBAM.java
+++ b/src/main/java/picard/fingerprint/SexInferenceEngineFromBAM.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2014 The Broad Institute
+ * Copyright (c) 2019 The Broad Institute
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/picard/fingerprint/SexInferenceEngineFromBAM.java
+++ b/src/main/java/picard/fingerprint/SexInferenceEngineFromBAM.java
@@ -1,0 +1,141 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.fingerprint;
+
+import htsjdk.samtools.BAMIndex;
+import htsjdk.samtools.BAMIndexMetaData;
+import htsjdk.samtools.BamFileIoUtils;
+import htsjdk.samtools.SAMReadGroupRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.RuntimeIOException;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static java.lang.Math.max;
+
+/**
+ * Class that implements  SexInferencer for an input type of BAM. The idea here is to extract coverage information from the index directly
+ */
+public class SexInferenceEngineFromBAM extends SexInferenceEngine {
+
+    private List<File> bamList;
+
+    public SexInferenceEngineFromBAM(final Set<String> MALE_CHROMS, final Set<String> FEMALE_CHROMS, final List<File> bamList){
+        super(MALE_CHROMS, FEMALE_CHROMS);
+        this.bamList = bamList;
+    }
+
+    @Override
+    protected final List<SampleXy> getSexChromCoverageDensity() {
+        final List<File> bams = IOUtil.unrollFiles(bamList, BamFileIoUtils.BAM_FILE_EXTENSION);
+        final List<SampleXy> samples = new ArrayList<>();
+        double maxX = 0, maxY = 0;
+
+        for (final File f : bams) {
+            final SamReader sam = SamReaderFactory.make().open(f);
+            final SAMSequenceDictionary dict = sam.getFileHeader().getSequenceDictionary();
+            if (!sam.hasIndex())
+                throw new IllegalArgumentException("Input Sequence files must have an index.");
+
+            final BAMIndex index = sam.indexing().getIndex();
+            final String sample = getSampleName(sam);
+
+            double maleChromSize = 0, femaleChromSize = 0, maleMappedReads = 0, femaleMappedReads = 0;
+
+            // Compute the major values needed from the BAM index, including:
+            //   1) The total number of mapped reads in the BAM across all chromosomes
+            //   2) The number of mapped reads to female chromosomes and to male chromosomes
+            //   3) The size (in bases) of the female and male chromosomes
+            long totalMapped = 0;
+            for (final SAMSequenceRecord seq : dict.getSequences()) {
+                final String name = seq.getSequenceName();
+                final BAMIndexMetaData metadata = index.getMetaData(seq.getSequenceIndex());
+                final int mappedReads = metadata.getAlignedRecordCount();
+                totalMapped += mappedReads;
+
+                if (FEMALE_CHROMS.contains(name)) {
+                    femaleChromSize += seq.getSequenceLength();
+                    femaleMappedReads += metadata.getAlignedRecordCount();
+                } else if (MALE_CHROMS.contains(name)) {
+                    maleChromSize += seq.getSequenceLength();
+                    maleMappedReads += metadata.getAlignedRecordCount();
+                }
+            }
+
+            try {
+                sam.close();
+            } catch (final IOException e) {
+                throw new RuntimeIOException(e);
+            }
+
+            // Calculate the rpkm values and cache the highest ones we see for X and Y
+            final double xRpkm = femaleMappedReads / (femaleChromSize / 1000) / (totalMapped / 1000000);
+            final double yRpkm =   maleMappedReads / (  maleChromSize / 1000) / (totalMapped / 1000000);
+            maxX = max(maxX, xRpkm);
+            maxY = max(maxY, yRpkm);
+
+            final SampleXy yx = new SampleXy(sample, xRpkm, yRpkm);
+            samples.add(yx);
+        }
+
+        for (final SampleXy sample : samples) {
+            //The normalization of coverage is done by looking at the x and y chromes only.
+            //Since we expect the maximal coverage of X to be a 2x coverage while that on y to be a 1x coverage,
+            //we divide the normalization by 2 so that the y coverage is normalized to 1/2 rather than to 1. This means that
+            //on average coverage on y and coverage on x will have the same effect.
+            sample.setxDensity(sample.getxDensity() / maxX);
+            sample.setyDensity(sample.getyDensity() / maxY / 2);
+        }
+        return samples;
+    }
+
+    @Override
+    protected double[][] getCentroids() {return new double[][]{{1.0, 0}, {0.5, 0.5}};}
+
+    /**
+     * Gets the sample name from the read group headers.  Throws an exception if there is not one and only one unique
+     * name in the read group headers.
+     */
+    static String getSampleName(final SamReader in) {
+        String name = null;
+        for (final SAMReadGroupRecord rg : in.getFileHeader().getReadGroups()) {
+            if (name == null) {
+                name = rg.getSample() ;
+            } else if (!name.equals(rg.getSample())) throw new IllegalStateException("BAM file with multiple samples not supported.");
+        }
+
+        if (name == null) throw new IllegalStateException("BAM files without sample names in RG headers not supported.");
+
+        return name;
+    }
+}

--- a/src/main/java/picard/fingerprint/SexInferenceEngineFromVCF.java
+++ b/src/main/java/picard/fingerprint/SexInferenceEngineFromVCF.java
@@ -1,0 +1,256 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.fingerprint;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.util.CloseableIterator;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Interval;
+import htsjdk.samtools.util.IntervalList;
+import htsjdk.samtools.util.OverlapDetector;
+import htsjdk.samtools.util.ProgressLogger;
+import htsjdk.variant.variantcontext.Genotype;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.vcf.VCFFileReader;
+import htsjdk.variant.vcf.VCFHeader;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Class that implements  SexInferencer for an input type of VCF. The main issue here is that we want to extract average depth information from a VCF.
+ * This is done by looking at a more-or-less equally spaced set of variants, and collecting statistics about the coverage that they have.
+ */
+public class SexInferenceEngineFromVCF extends SexInferenceEngine {
+
+    private final OverlapDetector<Interval> parDetector = new OverlapDetector<>(0, 0);
+    private final File vcf;
+    private final int autosomalVariants;
+    private final int allosomalVariants;
+    private final ProgressLogger progressLogger;
+
+    /**
+     * Some VCFs do not have variants (called) on Y. Consequently, when determining sex, we wish to give less weight to the Y Coverage than
+     * the X coverage. We do this by the scaling the Y coverage values by a factor of yCoverageShrinkingFactor.
+     */
+    final double yCoverageShrinkFactor;
+
+    public SexInferenceEngineFromVCF(final Set<String> MALE_CHROMS, final Set<String> FEMALE_CHROMS, final File vcf, final int autosomalVariants, final int allosomalVariants, final File pseudoautosomalIntervalList, final double yCoverageShrinkFactor) {
+        super(MALE_CHROMS, FEMALE_CHROMS);
+
+        this.yCoverageShrinkFactor = yCoverageShrinkFactor;
+        this.allosomalVariants = allosomalVariants;
+        this.autosomalVariants = autosomalVariants;
+        this.vcf = vcf;
+
+        progressLogger = new ProgressLogger(log, 10000, "examined", "variants");
+
+        final IntervalList intervalList;
+        if (pseudoautosomalIntervalList != null) {
+            IOUtil.assertFileIsReadable(pseudoautosomalIntervalList);
+            intervalList = IntervalList.fromFile(pseudoautosomalIntervalList);
+            parDetector.addAll(intervalList.getIntervals(), intervalList.getIntervals());
+        }
+    }
+
+    // Check that the variant does lie on the pseudoautosomal region.
+    // Used to filter out variants for coverage sampling.
+    private boolean isPseudoautosomal(final String chrom, final int pos) {
+        // skip the overlap detection if not within a sex chromosome
+        return SEX_CHROMS.contains(chrom) &&
+                !parDetector.getOverlaps(new Interval(chrom, pos, pos)).isEmpty();
+    }
+
+    /**
+     * A class used to enumerate chromosome "types" - male, female, and non-sex - and collect coverage sampling stats on each type.
+     */
+    private enum chromStats {
+        MALE_CHROM,
+        FEMALE_CHROM,
+        NON_SEX_CHROME;
+
+        private int numVariantsUsed;
+        private Map<String, Long> coverageStats;
+
+        public static void initializeChromStats(final List<String> sampleNames) {
+            for (final chromStats type : chromStats.values()) {
+                type.coverageStats = new HashMap<>();
+                type.numVariantsUsed = 0;
+                for (final String sampleName : sampleNames) {
+                    type.coverageStats.put(sampleName, 0L);
+                }
+            }
+        }
+
+        public void incrementVariantsUsed() {
+            numVariantsUsed++;
+        }
+
+        public void addCoverage(final String sampleName, final int n) {
+            coverageStats.put(sampleName, coverageStats.get(sampleName) + n);
+        }
+
+        /**
+         * Calculate Average Coverage Per Variant (on the calling chromosome type)
+         *
+         * @return double
+         */
+        public double getAcpv(final String sampleName) {
+            return numVariantsUsed == 0 ? 0 : coverageStats.get(sampleName) / (double) numVariantsUsed;
+        }
+
+    }
+
+    private chromStats getChromType(final String chromName) {
+        if (MALE_CHROMS.contains(chromName)) {
+            return chromStats.MALE_CHROM;
+        }
+        if (FEMALE_CHROMS.contains(chromName)) {
+            return chromStats.FEMALE_CHROM;
+        }
+
+        return chromStats.NON_SEX_CHROME;
+    }
+
+    private boolean isSexChrom(final String chromName) {
+        return MALE_CHROMS.contains(chromName) || FEMALE_CHROMS.contains(chromName);
+    }
+
+    /**
+     * @return A list of XySample object, one for each sample, containing the ratio
+     * (average coverage on the female chromosomes)/(average coverage off the sex chromosomes),
+     * and the same for male chromosomes.
+     */
+    @Override
+    protected List<SampleXy> getSexChromCoverageDensity() {
+
+        final List<SampleXy> samples = new ArrayList<>();
+
+        final VCFFileReader reader = new VCFFileReader(vcf);
+        final VCFHeader header = reader.getFileHeader();
+        final SAMSequenceDictionary dict = reader.getFileHeader().getSequenceDictionary();
+        final List<String> sampleNames = header.getGenotypeSamples();
+
+        // initialize sampling coverage statistics.
+
+        chromStats.initializeChromStats(sampleNames);
+
+        // a map from true/false to size of ALLO/AUTO somal regions in the genome
+        final Map<Boolean, Long> RegionSize = new HashMap<>(2);
+        RegionSize.put(Boolean.TRUE, 0L);
+        RegionSize.put(Boolean.FALSE, 0L);
+
+        // collect total length of autosomal and allosomal regions
+        for (final SAMSequenceRecord chrom : dict.getSequences()) {
+            final Boolean isSex = isSexChrom(chrom.getSequenceName());
+            RegionSize.put(isSex, chrom.getSequenceLength() + RegionSize.get(isSex));
+        }
+
+        for (final SAMSequenceRecord chrom : dict.getSequences()) {
+            if (isSexChrom(chrom.getSequenceName())) {
+                sampleDPs(chrom, (int) (RegionSize.get(Boolean.TRUE) / allosomalVariants), reader);
+            } else {
+                sampleDPs(chrom, (int) (RegionSize.get(Boolean.FALSE) / autosomalVariants), reader);
+            }
+        }
+
+        reader.close();
+
+        /*
+         * Populate the list of sampleXy's.
+         */
+        for (final String sampleName : sampleNames) {
+            final SampleXy xy = new SampleXy(sampleName,
+                    chromStats.FEMALE_CHROM.getAcpv(sampleName) / chromStats.NON_SEX_CHROME.getAcpv(sampleName),
+                    chromStats.MALE_CHROM.getAcpv(sampleName) / (yCoverageShrinkFactor * chromStats.NON_SEX_CHROME.getAcpv(sampleName)));
+            samples.add(xy);
+        }
+
+        return samples;
+    }
+
+    /**
+     * Sample coverage depth on a given chromosome at approximately evenly spaced intervals. This method updates covStats.
+     *
+     * @param chrom     The name of the chromosome where the estimate is sought.
+     * @param blockSize The size of the block to use in the traversal
+     * @param reader    VCFFilereader of the VCF.
+     */
+    private void sampleDPs(final SAMSequenceRecord chrom, final int blockSize, final VCFFileReader reader) {
+        final int chromLength = chrom.getSequenceLength();
+
+        int pos = 1;
+        while (pos < chromLength) {
+            progressLogger.record(chrom.getSequenceName(), pos);
+
+            if (isPseudoautosomal(chrom.getSequenceName(), pos)) {
+                //skip pseudoautosomal region
+                final Interval parRegion = parDetector.getOverlaps(new Interval(chrom.getSequenceName(), pos, pos)).iterator().next();
+                pos += parRegion.length();
+            } else {
+                //not pseudoautosomal
+                final CloseableIterator<VariantContext> it = reader.query(chrom.getSequenceName(), pos, Math.min(pos + blockSize, chromLength));
+                if (it.hasNext()) {
+                    final VariantContext gc = it.next();
+                    processVariantDepth(gc);
+                }
+                pos += blockSize;
+            }
+        }
+    }
+
+    /**
+     * Extracts the coverage depth over a given context for every sample in the vcf. Updates covStats
+     *
+     * @param context a VariantContext
+     */
+    private void processVariantDepth(final VariantContext context) {
+        final chromStats type = getChromType(context.getChr());
+        type.incrementVariantsUsed();
+        for (final Genotype g : context.getGenotypes()) {
+            final String name = g.getSampleName();
+            type.addCoverage(name, Math.max(0, g.getDP()));
+        }
+    }
+
+    /**
+     * Centroids from which to begin sex chromosome coverage density k means clustering for sex determination.
+     * The starting centroid for the male cluster reflects the fact that we expect to not always have variants on the Y chromosome,
+     * thus we give the coverage on Y less weight than the coverage on X (see yCoverageShrinkingFactor) when determining sex.
+     * Consequently, we expect yDensities to be between 0 and 0.25, and we choose the centroid to be (0.5,0.125) (instead of (0.5,0.5) as in
+     * ReconstructTrios).
+     *
+     * @return Double array
+     */
+    @Override
+    protected double[][] getCentroids() {
+        return new double[][]{{1.0, 0.0}, {0.5, 0.125}};
+    }
+}


### PR DESCRIPTION
### Description


Adds 4 new CLPs:
- ReconstructTriosFromBams
- ReconstructTriosFromVCFs
- InferSexFromBams
- InferSexFromVCFs

The are supposed to do pretty much what their name claims.

I've tested these, but do not have a good sense of how to put in unit tests as they all need relatively large amounts of data on which to run. The first two use the same fingerprinting "haplotype_database" that the fingerprinting code does. You can find hg38 and hg19 ones here: gs://broad-references/


