### PR TITLE
Re-add DecimalFormat, but get rid of comma

### DIFF
--- a/src/main/java/picard/arrays/GtcToVcf.java
+++ b/src/main/java/picard/arrays/GtcToVcf.java
@@ -74,6 +74,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -165,7 +166,14 @@ public class GtcToVcf extends CommandLineProgram {
 
     private static ReferenceSequenceFile refSeq;
 
+    private static final DecimalFormat df = new DecimalFormat();
+
     private static final String DOT = ".";
+
+    static {
+        df.setMaximumFractionDigits(3);
+        df.setGroupingSize(0);
+    }
 
     @Override
     protected boolean requiresReference() {
@@ -473,7 +481,7 @@ public class GtcToVcf extends CommandLineProgram {
         if (Float.isNaN(value)) {
             return DOT;
         }
-        return Float.toString(value);
+        return df.format(value);
     }
 
     /**


### PR DESCRIPTION
### Description

We want to continue not having comma separators in Floats in GtcToVcf, but we still want to round the decimal to 3 places. This means re-adding the DecimalFormat, but setting it to not group the places.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

