### PR TITLE
Fixed a bug where the merging of fingerprints changes

### DIFF
--- a/src/main/java/picard/fingerprint/Fingerprint.java
+++ b/src/main/java/picard/fingerprint/Fingerprint.java
@@ -81,7 +81,7 @@ public class Fingerprint extends TreeMap<HaplotypeBlock, HaplotypeProbabilities>
             HaplotypeProbabilities probabilities = get(haplotype);
             final HaplotypeProbabilities otherProbabilities = other.get(haplotype);
             if (probabilities == null) {
-                probabilities = otherProbabilities;
+                probabilities = otherProbabilities.deepCopy();
                 put(haplotype, probabilities);
             } else if (otherProbabilities != null) {
                 probabilities.merge(otherProbabilities);

--- a/src/main/java/picard/fingerprint/HaplotypeBlock.java
+++ b/src/main/java/picard/fingerprint/HaplotypeBlock.java
@@ -154,14 +154,19 @@ public class HaplotypeBlock implements Comparable<HaplotypeBlock> {
         return retval;
     }
 
-    @Override public boolean equals(final Object o) {
+    @Override
+    public boolean equals(final Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         else return this.compareTo((HaplotypeBlock) o) == 0;
     }
 
-    @Override public int hashCode() {
-        return this.start;
+    @Override
+    public int hashCode() {
+        int result = chrom.hashCode();
+        result = 31 * result + start;
+        result = 31 * result + end;
+        return result;
     }
 
     @Override public String toString() {

--- a/src/main/java/picard/fingerprint/HaplotypeProbabilitiesFromGenotype.java
+++ b/src/main/java/picard/fingerprint/HaplotypeProbabilitiesFromGenotype.java
@@ -32,6 +32,16 @@ public class HaplotypeProbabilitiesFromGenotype extends HaplotypeProbabilities {
     private final Snp snp;
     private final double[] likelihoods;
 
+    @Override
+    public HaplotypeProbabilitiesFromGenotype deepCopy()  {
+        return new HaplotypeProbabilitiesFromGenotype(this);
+    }
+
+    @SuppressWarnings("CopyConstructorMissesField")
+    public HaplotypeProbabilitiesFromGenotype(final HaplotypeProbabilitiesFromGenotype other) {
+        this(other.snp, other.getHaplotype(), other.likelihoods[0], other.likelihoods[1], other.likelihoods[2]);
+    }
+
     public HaplotypeProbabilitiesFromGenotype(final Snp snp, final HaplotypeBlock haplotypeBlock,
                                               final double AA, final double Aa, final double aa) {
         super(haplotypeBlock);
@@ -42,18 +52,13 @@ public class HaplotypeProbabilitiesFromGenotype extends HaplotypeProbabilities {
     /** Returns the SNP who's genotype was used to construct the likelihoods. */
     @Override public Snp getRepresentativeSnp() { return snp; }
 
-
-    // TODO: this can't be right in general. At least one needs to divide by the prior to set things straight.
-    // TODO: The only saving grace is that this is normally used for cases where the priors are large and similar to each other.
-
-
     // simply returns the _likelihoods_ that were passed into the constructor.
     public double[] getLikelihoods() {
         return likelihoods;
     }
 
     @Override
-    public void merge(final HaplotypeProbabilities other) {
+    public HaplotypeProbabilitiesFromGenotype merge(final HaplotypeProbabilities other) {
         if (!this.getHaplotype().equals(other.getHaplotype())) {
             throw new IllegalArgumentException("Mismatched haplotypes in call to HaplotypeProbabilities.merge(): " +
                     getHaplotype() + ", " + other.getHaplotype());
@@ -62,9 +67,9 @@ public class HaplotypeProbabilitiesFromGenotype extends HaplotypeProbabilities {
         if (!(other instanceof HaplotypeProbabilitiesFromGenotype)) {
             throw new IllegalArgumentException("Can only merge HaplotypeProbabilities of same class.");
         }
-
-        this.likelihoods[0] = this.likelihoods[0] * other.getLikelihoods()[0];
-        this.likelihoods[1] = this.likelihoods[1] * other.getLikelihoods()[1];
-        this.likelihoods[2] = this.likelihoods[2] * other.getLikelihoods()[2];
+        for (Genotype g : Genotype.values()) {
+            this.likelihoods[g.v] = this.likelihoods[g.v] * other.getLikelihoods()[g.v];
+        }
+        return this;
     }
 }

--- a/src/main/java/picard/fingerprint/HaplotypeProbabilitiesFromGenotypeLikelihoods.java
+++ b/src/main/java/picard/fingerprint/HaplotypeProbabilitiesFromGenotypeLikelihoods.java
@@ -24,6 +24,7 @@
 
 package picard.fingerprint;
 
+import htsjdk.utils.ValidationUtils;
 import htsjdk.variant.variantcontext.Allele;
 import picard.util.MathUtil;
 
@@ -41,6 +42,10 @@ public class HaplotypeProbabilitiesFromGenotypeLikelihoods extends HaplotypeProb
         super(haplotypeBlock);
     }
 
+    public HaplotypeProbabilitiesFromGenotypeLikelihoods(final HaplotypeProbabilitiesFromGenotypeLikelihoods other) {
+        super(other);
+    }
+
     /**
      * Adds a base observation with the observed quality to the evidence for this haplotype
      * based on the fact that the SNP is part of the haplotype.
@@ -54,12 +59,15 @@ public class HaplotypeProbabilitiesFromGenotypeLikelihoods extends HaplotypeProb
         assertSnpPartOfHaplotype(snp);
 
         // only allow biallelic snps
-        assert (logGenotypeLikelihoods.length == Genotype.values().length);
-        assert (alleles.size() == 2);
+        ValidationUtils.validateArg(logGenotypeLikelihoods.length == NUM_GENOTYPES,
+                () -> "LogGenotypueLikelihoods must be length 3, found " + logGenotypeLikelihoods.length);
+
+        ValidationUtils.validateArg(alleles.size() == 2,
+                () -> "alleles must be length 2, found " + alleles.size());
 
         //make sure that alleles are comparable to SNPs
-        for (int i = 0; i < 2; i++) {
-            assert (alleles.get(i).getBases().length == 1);
+        for (final Allele a : alleles) {
+            ValidationUtils.validateArg(a.getBases().length == 1, () -> "allele is supposed to be a SNP, found " + a.getBaseString());
         }
 
         final byte allele1 = alleles.get(0).getBases()[0];
@@ -85,6 +93,11 @@ public class HaplotypeProbabilitiesFromGenotypeLikelihoods extends HaplotypeProb
         }
 
         // if we are here it means that there was a mismatch in alleles...
-        assert false;
+        ValidationUtils.nonNull(null,"We really should not have reached this point in the code...");
+    }
+
+    @Override
+    public HaplotypeProbabilitiesFromGenotypeLikelihoods deepCopy() {
+        return new HaplotypeProbabilitiesFromGenotypeLikelihoods(this);
     }
 }

--- a/src/main/java/picard/fingerprint/HaplotypeProbabilitiesUsingLogLikelihoods.java
+++ b/src/main/java/picard/fingerprint/HaplotypeProbabilitiesUsingLogLikelihoods.java
@@ -24,9 +24,9 @@
 
 package picard.fingerprint;
 
+import htsjdk.utils.ValidationUtils;
 import picard.util.MathUtil;
-
-import static java.lang.Math.log10;
+import java.util.Arrays;
 
 /**
  * Represents the probability of the underlying haplotype using log likelihoods as the basic datum for each of the SNPs. By convention the
@@ -39,18 +39,30 @@ abstract class HaplotypeProbabilitiesUsingLogLikelihoods extends HaplotypeProbab
 
     // some derived classes might need to incorporate accumulated data before logLikelihood is usable.
     // use the getter to allow these classes to calculate the likelihood from the data.
-    private final double[] loglikelihoods = new double[Genotype.values().length];
+    private final double[] loglikelihoods = new double[NUM_GENOTYPES];
+
     private boolean likelihoodsNeedUpdating = true;
 
     // stored in order to reduce computation we store these partial results.
     // they need to be recalculated if loglikelihoodNeedsUpdating
-    private double[] likelihoods = new double[Genotype.values().length];
-    private double[] posteriorProbabilities = new double[Genotype.values().length];
-    private double[] shiftedLogPosteriors = new double[Genotype.values().length];
 
+    private final double[] likelihoods = new double[NUM_GENOTYPES];
+    private final double[] posteriorProbabilities = new double[NUM_GENOTYPES];
+
+    //normalized (likeihood * prior / normalization_factor)
+    private final double[] shiftedLogPosteriors = new double[NUM_GENOTYPES];
 
     public HaplotypeProbabilitiesUsingLogLikelihoods(final HaplotypeBlock haplotypeBlock) {
         super(haplotypeBlock);
+    }
+
+    public HaplotypeProbabilitiesUsingLogLikelihoods(final HaplotypeProbabilitiesUsingLogLikelihoods other) {
+        super(other.getHaplotype());
+        System.arraycopy(other.loglikelihoods, 0, loglikelihoods, 0, NUM_GENOTYPES);
+        System.arraycopy(other.likelihoods, 0, likelihoods, 0, NUM_GENOTYPES);
+        System.arraycopy(other.posteriorProbabilities, 0, posteriorProbabilities, 0, NUM_GENOTYPES);
+        System.arraycopy(other.shiftedLogPosteriors, 0, shiftedLogPosteriors, 0, NUM_GENOTYPES);
+        likelihoodsNeedUpdating = other.likelihoodsNeedUpdating;
     }
 
     /**
@@ -63,10 +75,7 @@ abstract class HaplotypeProbabilitiesUsingLogLikelihoods extends HaplotypeProbab
 
     @Override
     public boolean hasEvidence() {
-        final double[] ll = this.getLogLikelihoods();
-        return ll[Genotype.HOM_ALLELE1.v] != 0 ||
-                ll[Genotype.HET_ALLELE12.v] != 0 ||
-                ll[Genotype.HOM_ALLELE2.v] != 0;
+        return Arrays.stream(getLogLikelihoods()).anyMatch(d -> d != 0);
     }
 
     /**
@@ -75,21 +84,24 @@ abstract class HaplotypeProbabilitiesUsingLogLikelihoods extends HaplotypeProbab
      * read group, e.g. the sample or individual.
      *
      * @param other Another haplotype probabilities object to merge in (must of the the same class and for the same HaplotypeBlock)
+     * @return
      */
     @Override
-    public void merge(final HaplotypeProbabilities other) {
+    public HaplotypeProbabilitiesUsingLogLikelihoods merge(final HaplotypeProbabilities other) {
         if (!this.getHaplotype().equals(other.getHaplotype())) {
             throw new IllegalArgumentException("Mismatched haplotypes in call to HaplotypeProbabilities.merge(): " +
                     getHaplotype() + ", " + other.getHaplotype());
         }
 
         if (!(other instanceof HaplotypeProbabilitiesUsingLogLikelihoods)) {
-            throw new IllegalArgumentException("Can only merge HaplotypeProbabilities of same class.");
+            throw new IllegalArgumentException(String.format("Can only merge HaplotypeProbabilities of same class. Found %s and %s",
+                    this.getClass().toString(), other.getClass().toString()));
         }
 
         final HaplotypeProbabilitiesUsingLogLikelihoods o = (HaplotypeProbabilitiesUsingLogLikelihoods) other;
 
         setLogLikelihoods(MathUtil.sum(getLogLikelihoods(), o.getLogLikelihoods()));
+        return this;
     }
 
     /**
@@ -117,10 +129,10 @@ abstract class HaplotypeProbabilitiesUsingLogLikelihoods extends HaplotypeProbab
      */
     private double[] getShiftedLogPosterior0() {
         final double[] ll = this.getLogLikelihoods();
-        final double[] shiftedLogPosterior = new double [Genotype.values().length];
+        final double[] shiftedLogPosterior = new double[NUM_GENOTYPES];
         final double[] haplotypeFrequencies = getPriorProbablities();
-        for (final Genotype g : Genotype.values()){
-            shiftedLogPosterior[g.v] = ll[g.v] + log10(haplotypeFrequencies[g.v]);
+        for (final Genotype g : Genotype.values()) {
+            shiftedLogPosterior[g.v] = ll[g.v] + Math.log10(haplotypeFrequencies[g.v]);
         }
         return shiftedLogPosterior;
     }
@@ -157,9 +169,10 @@ abstract class HaplotypeProbabilitiesUsingLogLikelihoods extends HaplotypeProbab
     }
 
     public void setLogLikelihoods(final double[] ll) {
-        assert (ll.length == Genotype.values().length);
+        ValidationUtils.validateArg(ll.length == NUM_GENOTYPES,
+                ()->"logLikelihood must have length 3, found " + ll.length);
 
-        System.arraycopy(ll, 0, loglikelihoods, 0, ll.length);
+        System.arraycopy(ll, 0, loglikelihoods, 0, NUM_GENOTYPES);
         likelihoodsNeedUpdating = true;
     }
 
@@ -187,10 +200,11 @@ abstract class HaplotypeProbabilitiesUsingLogLikelihoods extends HaplotypeProbab
     }
 
     private void updateDependentValues() {
-        if (likelihoodsNeedUpdating){
-            likelihoods = getLikelihoods0();
-            posteriorProbabilities = getPosteriorProbabilities0();
-            shiftedLogPosteriors = getShiftedLogPosterior0();
+        if (likelihoodsNeedUpdating) {
+            System.arraycopy(getLikelihoods0(), 0, likelihoods, 0, NUM_GENOTYPES);
+            System.arraycopy(getPosteriorProbabilities0(), 0, posteriorProbabilities, 0, NUM_GENOTYPES);
+            System.arraycopy(getShiftedLogPosterior0(), 0, shiftedLogPosteriors, 0, NUM_GENOTYPES);
+
             likelihoodsNeedUpdating = false;
         }
     }

--- a/src/test/java/picard/fingerprint/CrosscheckFingerprintsTest.java
+++ b/src/test/java/picard/fingerprint/CrosscheckFingerprintsTest.java
@@ -12,14 +12,10 @@ import picard.util.TabbedTextFileWithHeaderParser;
 import picard.vcf.SamTestUtils;
 import picard.vcf.VcfTestUtils;
 
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
@@ -197,7 +193,7 @@ public class CrosscheckFingerprintsTest extends CommandLineProgramTest {
             args.add("HAPLOTYPE_MAP=" + HAPLOTYPE_MAP);
         }
 
-        doTest(args.toArray(new String[args.size()]), metrics, expectedRetVal, expectedNMetrics, CrosscheckMetric.DataType.READGROUP, expectAllMatch);
+        doTest(args.toArray(new String[0]), metrics, expectedRetVal, expectedNMetrics, CrosscheckMetric.DataType.READGROUP, expectAllMatch);
     }
 
     @DataProvider(name = "cramsWithNoReference")
@@ -486,7 +482,7 @@ public class CrosscheckFingerprintsTest extends CommandLineProgramTest {
                 args.add("LOD_THRESHOLD=" + -1.0);
                 args.add("CROSSCHECK_BY=SAMPLE");
 
-        doTest(args.toArray(new String[args.size()]), metrics, expectedRetVal, numberOfSamples , CrosscheckMetric.DataType.SAMPLE, ExpectAllMatch);
+        doTest(args.toArray(new String[0]), metrics, expectedRetVal, numberOfSamples , CrosscheckMetric.DataType.SAMPLE, ExpectAllMatch);
     }
 
     @DataProvider(name = "checkSamplesCrosscheckAllData")
@@ -592,7 +588,7 @@ public class CrosscheckFingerprintsTest extends CommandLineProgramTest {
         if(inputSampleMap!=null)  args.add("INPUT_SAMPLE_MAP="+inputSampleMap.getAbsolutePath());
         if(secondInputSampleMap!=null)  args.add("SECOND_INPUT_SAMPLE_MAP="+secondInputSampleMap.getAbsolutePath());
 
-        doTest(args.toArray(new String[args.size()]), metrics, expectedRetVal, numberOfSamples1 * numberOfSamples2 , CrosscheckMetric.DataType.SAMPLE, ExpectAllMatch);
+        doTest(args.toArray(new String[0]), metrics, expectedRetVal, numberOfSamples1 * numberOfSamples2 , CrosscheckMetric.DataType.SAMPLE, ExpectAllMatch);
     }
 
     @DataProvider
@@ -627,8 +623,8 @@ public class CrosscheckFingerprintsTest extends CommandLineProgramTest {
         final List<File> files2 = Collections.singletonList(NA12892_g_vcf);
 
         final List<String> args = new ArrayList<>();
-        files1.forEach(f->args.add("INPUT="+f.getAbsolutePath()));
-        files2.forEach(f->args.add("SECOND_INPUT="+f.getAbsolutePath()));
+        files1.forEach(f -> args.add("INPUT=" + f.getAbsolutePath()));
+        files2.forEach(f -> args.add("SECOND_INPUT=" + f.getAbsolutePath()));
 
         args.add("OUTPUT=" + metrics.getAbsolutePath());
         args.add("HAPLOTYPE_MAP=" + HAPLOTYPE_MAP);
@@ -703,16 +699,16 @@ public class CrosscheckFingerprintsTest extends CommandLineProgramTest {
         metrics.deleteOnExit();
 
         final List<String> args = new ArrayList<>();
-        files1.forEach(f->args.add("INPUT="+f.getAbsolutePath()));
-        files2.forEach(f->args.add("SECOND_INPUT="+f.getAbsolutePath()));
+        files1.forEach(f -> args.add("INPUT=" + f.getAbsolutePath()));
+        files2.forEach(f -> args.add("SECOND_INPUT=" + f.getAbsolutePath()));
 
-                args.add("OUTPUT=" + metrics.getAbsolutePath());
+        args.add("OUTPUT=" + metrics.getAbsolutePath());
                 args.add("HAPLOTYPE_MAP=" + HAPLOTYPE_MAP);
                 args.add("LOD_THRESHOLD=" + -1.0);
                 args.add("CROSSCHECK_BY=SAMPLE");
                 args.add("CROSSCHECK_MODE=CHECK_ALL_OTHERS");
 
-        doTest(args.toArray(new String[args.size()]), metrics, expectedRetVal, numberOfSamples1 * numberOfSamples2 , CrosscheckMetric.DataType.SAMPLE, ExpectAllMatch);
+        doTest(args.toArray(new String[0]), metrics, expectedRetVal, numberOfSamples1 * numberOfSamples2 , CrosscheckMetric.DataType.SAMPLE, ExpectAllMatch);
     }
 
     @DataProvider(name = "checkFilesData")
@@ -748,7 +744,7 @@ public class CrosscheckFingerprintsTest extends CommandLineProgramTest {
         metrics.deleteOnExit();
 
         final List<String> args = new ArrayList<>();
-        files.forEach(f->args.add("INPUT="+f.getAbsolutePath()));
+        files.forEach(f -> args.add("INPUT=" + f.getAbsolutePath()));
 
         args.add("OUTPUT=" + metrics.getAbsolutePath());
         args.add("HAPLOTYPE_MAP=" + HAPLOTYPE_MAP);
@@ -877,7 +873,7 @@ public class CrosscheckFingerprintsTest extends CommandLineProgramTest {
 
         final CrosscheckMetric.DataType dataType = mode == Fingerprint.CrosscheckMode.CHECK_SAME_SAMPLE ? CrosscheckMetric.DataType.SAMPLE : by;
 
-        doTest(args.toArray(new String[args.size()]), metrics, exptectRetVal, expectedNMetrics, dataType, expectAllMatch);
+        doTest(args.toArray(new String[0]), metrics, exptectRetVal, expectedNMetrics, dataType, expectAllMatch);
 
         //swap input and second input
         if (second_input != null) {
@@ -886,7 +882,7 @@ public class CrosscheckFingerprintsTest extends CommandLineProgramTest {
 
             input.forEach(f -> args.add("SECOND_INPUT=" + f));
             second_input.forEach(f -> args.add("INPUT=" + f));
-            doTest(args.toArray(new String[args.size()]), metrics, exptectRetVal, expectedNMetrics, dataType, expectAllMatch);
+            doTest(args.toArray(new String[0]), metrics, exptectRetVal, expectedNMetrics, dataType, expectAllMatch);
         }
     }
 
@@ -951,17 +947,5 @@ public class CrosscheckFingerprintsTest extends CommandLineProgramTest {
                 assert false;
             }
         }
-    }
-
-    @Test
-    public void canWriteToDevNull() throws IOException {
-        File f = new File("/dev/null");
-        Assert.assertTrue(f.canRead());
-
-        final OutputStream stream = new FileOutputStream(f);
-        final BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(stream));
-
-        writer.write("Just a test");
-        writer.close();
     }
 }

--- a/src/test/java/picard/fingerprint/CrosscheckReadGroupFingerprintsTest.java
+++ b/src/test/java/picard/fingerprint/CrosscheckReadGroupFingerprintsTest.java
@@ -102,7 +102,7 @@ public class CrosscheckReadGroupFingerprintsTest {
         doTest(args, metrics, expectedRetVal, expectedNMetrics * expectedNMetrics , CrosscheckMetric.DataType.READGROUP, expectAllMatch);
     }
 
-    @DataProvider(name = "bamFilesLBs")
+    @DataProvider
     public Object[][] bamFilesLBs() {
 
         return new Object[][]{
@@ -251,19 +251,6 @@ public class CrosscheckReadGroupFingerprintsTest {
                 });
             }
         }
-    }
-
-    @Test
-    public void canWriteToDevNull() throws IOException {
-        File f = new File("/dev/null");
-        Assert.assertTrue(f.canRead());
-
-        final OutputStream stream = new FileOutputStream(f);
-        final BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(stream));
-
-        writer.write("Just a test");
-        writer.close();
-
     }
 
     @DataProvider(name = "newParametersData")

--- a/src/test/java/picard/fingerprint/FingerprintingTestUtils.java
+++ b/src/test/java/picard/fingerprint/FingerprintingTestUtils.java
@@ -1,0 +1,40 @@
+package picard.fingerprint;
+
+import org.testng.Assert;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public class FingerprintingTestUtils {
+
+    public static boolean areHaplotypeProbabilitiesEqual(final HaplotypeProbabilities lhs, final HaplotypeProbabilities rhs) {
+        if (lhs == rhs) {
+            return true;
+        }
+        if (lhs == null || rhs == null || lhs.getClass() != rhs.getClass()) {
+            return false;
+        }
+
+        if (!Objects.equals(lhs.getHaplotype(), rhs.getHaplotype())) {
+            return false;
+        }
+
+        return Arrays.equals(lhs.getLikelihoods(), rhs.getLikelihoods());
+    }
+
+    public static void assertHaplotypeProbabilitiesEqual(final HaplotypeProbabilities lhs, final HaplotypeProbabilities rhs) {
+        Assert.assertTrue(areHaplotypeProbabilitiesEqual(lhs, rhs),
+                "Expected HaplotypeProbabilities to be equal, but they differ: " +
+                        lhs + ", " + rhs);
+    }
+
+    public static void assertFingerPrintHPsAreEqual(final Fingerprint lhs, final Fingerprint rhs) {
+        Assert.assertEquals(lhs.keySet().size(), rhs.keySet().size());
+
+        for (final HaplotypeBlock block : lhs.keySet()) {
+            Assert.assertTrue(lhs.containsKey(block), "HaplotypeBlock was missing from lhs" + block);
+            Assert.assertTrue(rhs.containsKey(block), "HaplotypeBlock was missing from rhs" + block);
+            FingerprintingTestUtils.assertHaplotypeProbabilitiesEqual(lhs.get(block), rhs.get(block));
+        }
+    }
+}

--- a/src/test/java/picard/fingerprint/HaplotypeProbabilitiesTest.java
+++ b/src/test/java/picard/fingerprint/HaplotypeProbabilitiesTest.java
@@ -21,8 +21,8 @@ import static java.lang.Math.log10;
  */
 public class HaplotypeProbabilitiesTest {
 
-    static Snp snp1, snp2;
-    static HaplotypeBlock hb1, hb2;
+    private static Snp snp1, snp2;
+    private static HaplotypeBlock hb1, hb2;
 
     @BeforeTest
     public static void initializeHaplotypeBlock() {
@@ -152,7 +152,7 @@ public class HaplotypeProbabilitiesTest {
         };
     }
 
-    static final int[] genotypes = {0, 1, 2};
+    private static final int[] genotypes = {0, 1, 2};
 
     @Test(dataProvider = "dataTestHaplotypeProbabilitiesFromContaminatorSequenceAddToProbs")
     public void testHaplotypeProbabilitiesFromContaminatorSequenceAddToProbs(final HaplotypeProbabilitiesFromContaminatorSequence hp, final Snp snp, final int nAlt, final int nTotal) throws Exception {

--- a/src/test/java/picard/util/MiscTest.java
+++ b/src/test/java/picard/util/MiscTest.java
@@ -1,0 +1,26 @@
+package picard.util;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+
+public class MiscTest {
+
+    @Test
+    public void canWriteToDevNull() throws IOException {
+        File f = new File("/dev/null");
+        Assert.assertTrue(f.canRead());
+
+        final OutputStream stream = new FileOutputStream(f);
+        final BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(stream));
+
+        writer.write("Just a test");
+        writer.close();
+    }
+}


### PR DESCRIPTION
The original list of fingerprints leading to incorrect results in the self-LOD case when using Crosscheck without SECOND_INPUT.


HT: David Wine and David Loginov for reporting.

### Description

_Give your PR a **concise** yet **descriptive** title_
_Please explain the changes you made here._
_Explain the **motivation** for making this change. What existing problem does the pull request solve?_
_Mention any issues fixed, addressed or otherwise related to this pull request, including issue numbers or hard links for issues in other repos._
_You can delete these instructions once you have written your PR description._

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

