### PR TITLE
Consider "low" mapping quality reads to be unaligned for the purpose of Marking Duplicates.

### DIFF
--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -327,6 +327,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
 
                 DuplicationMetrics metrics = AbstractMarkDuplicatesCommandLineProgram.addReadToLibraryMetrics(rec, header, libraryIdGenerator);
 
+
                 // Now try and figure out the next duplicate index (if going by coordinate. if going by query name, only do this
                 // if the query name has changed.
                 nextDuplicateIndex = nextIndexIfNeeded(sortOrder, recordInFileIndex, nextDuplicateIndex, duplicateQueryName, rec, this.duplicateIndexes);
@@ -337,7 +338,6 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
 
                 if (isDuplicate) {
                     rec.setDuplicateReadFlag(true);
-
                     AbstractMarkDuplicatesCommandLineProgram.addDuplicateReadToMetrics(rec, metrics);
                 } else {
                     rec.setDuplicateReadFlag(false);
@@ -552,7 +552,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
                 final ReadEndsForMarkDuplicates fragmentEnd = buildReadEnds(header, indexForRead, rec, useBarcodes);
                 this.fragSort.add(fragmentEnd);
 
-                if (rec.getReadPairedFlag() && !rec.getMateUnmappedFlag()) {
+                if (MarkDuplicatesUtil.pairedForMarkDuplicates(rec)) {
                     final StringBuilder key = new StringBuilder();
                     key.append(ReservedTagConstants.READ_GROUP_ID);
                     key.append(rec.getReadName());
@@ -650,7 +650,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram {
         ends.score = DuplicateScoringStrategy.computeDuplicateScore(rec, this.DUPLICATE_SCORING_STRATEGY);
 
         // Doing this lets the ends object know that it's part of a pair
-        if (rec.getReadPairedFlag() && !rec.getMateUnmappedFlag()) {
+        if (MarkDuplicatesUtil.pairedForMarkDuplicates(rec)) {
             ends.read2ReferenceIndex = rec.getMateReferenceIndex();
         }
 

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicatesWithMateCigar.java
@@ -154,13 +154,14 @@ public class MarkDuplicatesWithMateCigar extends AbstractMarkDuplicatesCommandLi
                 this.SKIP_PAIRS_WITH_NO_MATE_CIGAR,
                 this.MAX_RECORDS_IN_RAM,
                 this.BLOCK_SIZE,
-                this.TMP_DIR);
+                this.TMP_DIR,
+                MIN_INFORMATIVE_MAPPING_Q);
 
         // progress logger!
         final ProgressLogger progress = new ProgressLogger(log, (int) 1e6, "Read");
 
         // Go through the records
-        for (final SAMRecord record : new IterableAdapter<SAMRecord>(iterator)) {
+        for (final SAMRecord record : new IterableAdapter<>(iterator)) {
             if (progress.record(record)) {
                 iterator.logMemoryStats(log);
             }
@@ -190,6 +191,15 @@ public class MarkDuplicatesWithMateCigar extends AbstractMarkDuplicatesCommandLi
         finalizeAndWriteMetrics(iterator.getLibraryIdGenerator(), getMetricsFile(), METRICS_FILE);
 
         return 0;
+    }
+
+    protected String[] customCommandLineValidation() {
+
+        if (0 <= MIN_INFORMATIVE_MAPPING_Q) {
+            LOG.warn("non-zero value for MIN_INFORMATIVE_MAPPING_Q is not supported in " + MarkDuplicatesWithMateCigar.class.getSimpleName());
+        }
+
+        return super.customCommandLineValidation();
     }
 
     /**

--- a/src/main/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigar.java
@@ -41,6 +41,7 @@ import picard.cmdline.programgroups.ReadDataManipulationProgramGroup;
 import picard.sam.DuplicationMetrics;
 import picard.sam.markduplicates.util.AbstractMarkDuplicatesCommandLineProgram;
 import picard.sam.markduplicates.util.LibraryIdGenerator;
+import picard.sam.markduplicates.util.MarkDuplicatesUtil;
 import picard.sam.markduplicates.util.ReadEnds;
 
 import java.util.ArrayList;
@@ -65,6 +66,7 @@ import java.util.Set;
  */
 @DocumentedFeature
 @ExperimentalFeature
+
 @CommandLineProgramProperties(
         summary = "Examines aligned records in the supplied SAM or BAM file to locate duplicate molecules. " +
                 "All records are then written to the output file with the duplicate records flagged.",
@@ -74,12 +76,7 @@ import java.util.Set;
 public class SimpleMarkDuplicatesWithMateCigar extends MarkDuplicates {
     private final Log log = Log.getInstance(MarkDuplicatesWithMateCigar.class);
 
-    private class ReadEndsForSimpleMarkDuplicatesWithMateCigar extends ReadEnds {}
-    
-    private static boolean isPairedAndBothMapped(final SAMRecord record) {
-        return record.getReadPairedFlag() &&
-                !record.getReadUnmappedFlag() &&
-                !record.getMateUnmappedFlag();
+    private class ReadEndsForSimpleMarkDuplicatesWithMateCigar extends ReadEnds {
     }
 
     /**
@@ -126,7 +123,7 @@ public class SimpleMarkDuplicatesWithMateCigar extends MarkDuplicates {
         for (final DuplicateSet duplicateSet : new IterableAdapter<>(iterator)) {
             final SAMRecord representative = duplicateSet.getRepresentative();
             final boolean doOpticalDuplicateTracking = (this.READ_NAME_REGEX != null) &&
-                    isPairedAndBothMapped(representative) &&
+                    MarkDuplicatesUtil.pairedForMarkDuplicates(representative) &&
                     representative.getFirstOfPairFlag();
             final Set<String> duplicateReadEndsSeen = new HashSet<>();
             
@@ -149,7 +146,7 @@ public class SimpleMarkDuplicatesWithMateCigar extends MarkDuplicates {
                     // First bring the simple metrics up to date
                     if (record.getReadUnmappedFlag()) {
                         ++metrics.UNMAPPED_READS;
-                    } else if (!record.getReadPairedFlag() || record.getMateUnmappedFlag()) {
+                    } else if (!MarkDuplicatesUtil.pairedForMarkDuplicates(record)) {
                         ++metrics.UNPAIRED_READS_EXAMINED;
                     } else {
                         ++metrics.READ_PAIRS_EXAMINED; // will need to be divided by 2 at the end
@@ -157,7 +154,7 @@ public class SimpleMarkDuplicatesWithMateCigar extends MarkDuplicates {
 
                     if (record.getDuplicateReadFlag()) {
                         // Update the duplication metrics
-                        if (!record.getReadPairedFlag() || record.getMateUnmappedFlag()) {
+                        if (!MarkDuplicatesUtil.pairedForMarkDuplicates(record)) {
                             ++metrics.UNPAIRED_READ_DUPLICATES;
                         } else {
                             ++metrics.READ_PAIR_DUPLICATES;// will need to be divided by 2 at the end
@@ -168,7 +165,7 @@ public class SimpleMarkDuplicatesWithMateCigar extends MarkDuplicates {
                     // To track optical duplicates, store a set of locations for mapped pairs, first end only.  We care about orientation relative
                     // to the first end of the pair for optical duplicate tracking, which is more stringent than PCR duplicate tracking.
                     if (doOpticalDuplicateTracking &&
-                            isPairedAndBothMapped(record) &&
+                            MarkDuplicatesUtil.pairedForMarkDuplicates(record) &&
                             !duplicateReadEndsSeen.contains(record.getReadName())) {
                         
                         final ReadEndsForSimpleMarkDuplicatesWithMateCigar readEnd = new ReadEndsForSimpleMarkDuplicatesWithMateCigar();

--- a/src/main/java/picard/sam/markduplicates/UmiGraph.java
+++ b/src/main/java/picard/sam/markduplicates/UmiGraph.java
@@ -62,6 +62,7 @@ public class UmiGraph {
     private final boolean allowMissingUmis;
     private final boolean duplexUmis;
 
+
     /**
      * Creates a UmiGraph object
      * @param set Set of reads that have the same start-stop positions, these will be broken up by UMI

--- a/src/main/java/picard/sam/markduplicates/UmiUtil.java
+++ b/src/main/java/picard/sam/markduplicates/UmiUtil.java
@@ -27,6 +27,7 @@ import picard.PicardException;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMUtils;
 import org.apache.commons.lang3.StringUtils;
+import picard.sam.markduplicates.util.MarkDuplicatesUtil;
 
 import java.util.regex.Pattern;
 
@@ -102,7 +103,7 @@ class UmiUtil {
      * @return Top or bottom strand, unknown if it cannot be determined.
      */
     static ReadStrand getStrand(final SAMRecord rec) {
-        if (rec.getReadUnmappedFlag() || rec.getMateUnmappedFlag()) {
+        if (!MarkDuplicatesUtil.pairedForMarkDuplicates(rec)) {
             return ReadStrand.UNKNOWN;
         }
 
@@ -185,5 +186,4 @@ class UmiUtil {
         BOTTOM,
         UNKNOWN
     }
-
 }

--- a/src/main/java/picard/sam/markduplicates/util/MarkDuplicatesUtil.java
+++ b/src/main/java/picard/sam/markduplicates/util/MarkDuplicatesUtil.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam.markduplicates.util;
+
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMTag;
+import htsjdk.samtools.util.Log;
+import htsjdk.utils.ValidationUtils;
+
+public class MarkDuplicatesUtil {
+    //singleton.
+    private MarkDuplicatesUtil() {
+    }
+
+    private static short MIN_INFORMATIVE_MAPPING_QUALITY = -1;
+    private static final Log log = Log.getInstance(MarkDuplicatesUtil.class);
+
+    private static boolean warnedForMissingMQ = false;
+
+    private static boolean readAlignedForMarkDuplicates(final SAMRecord rec, final short minInformativeMappingQuality) {
+        return !rec.getReadUnmappedFlag() && rec.getMappingQuality() >= minInformativeMappingQuality;
+    }
+
+    private static boolean mateAlignedForMarkDuplicates(final SAMRecord rec, final short minInformativeMappingQuality) {
+        final Short mateMappingQuality = rec.getShortAttribute(SAMTag.MQ.name());
+        if (null == mateMappingQuality) { // cannot rule out, so consider the pair
+            if (!warnedForMissingMQ) {
+                log.warn("Missing mate mapping quality (MQ) tag in record: " + rec.getSAMString()+ " Future such warnings wll be supressed.");
+                warnedForMissingMQ = true;
+            }
+            return !rec.getMateUnmappedFlag();
+        }
+        return !rec.getMateUnmappedFlag() && mateMappingQuality >= minInformativeMappingQuality;
+    }
+
+    public static boolean pairedForMarkDuplicates(final SAMRecord rec, final short minInformativeMappingQuality) {
+        return rec.getReadPairedFlag() &&
+                readAlignedForMarkDuplicates(rec, minInformativeMappingQuality) &&
+                mateAlignedForMarkDuplicates(rec, minInformativeMappingQuality);
+    }
+
+    public static boolean pairedForMarkDuplicates(final SAMRecord rec) {
+        ValidationUtils.validateArg(MIN_INFORMATIVE_MAPPING_QUALITY >= 0, "MIN_INFORMATIVE_MAPPING_QUALITY wasn't initialized. Must be >=0.");
+
+        return pairedForMarkDuplicates(rec, MIN_INFORMATIVE_MAPPING_QUALITY);
+    }
+
+    public static void setMinInformativeMappingQuality(final short minInformativeMappingQuality) {
+        MIN_INFORMATIVE_MAPPING_QUALITY = minInformativeMappingQuality;
+    }
+}

--- a/src/main/java/picard/sam/markduplicates/util/ReadEndsForMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/util/ReadEndsForMateCigar.java
@@ -52,9 +52,12 @@ public class ReadEndsForMateCigar extends ReadEnds {
      */
     private PhysicalLocationForMateCigarSet locationSet = null;
 
+    private final short minInformativeMappingQuality;
+
     /** Builds a read ends object that represents a single read. */
     public ReadEndsForMateCigar(final SAMFileHeader header, final SamRecordWithOrdinal samRecordWithOrdinal,
-                                final OpticalDuplicateFinder opticalDuplicateFinder, final short libraryId) {
+                                final OpticalDuplicateFinder opticalDuplicateFinder, final short libraryId, final short minInformativeMappingQuality) {
+        this.minInformativeMappingQuality = minInformativeMappingQuality;
 
         this.readGroup = -1;
         this.tile = -1;
@@ -72,7 +75,7 @@ public class ReadEndsForMateCigar extends ReadEnds {
             throw new PicardException("Found an unexpected unmapped read");
         }
 
-        if (record.getReadPairedFlag() && !record.getReadUnmappedFlag() && !record.getMateUnmappedFlag()) {
+        if (MarkDuplicatesUtil.pairedForMarkDuplicates(record, minInformativeMappingQuality)) {
             this.read2ReferenceIndex = record.getMateReferenceIndex();
             this.read2Coordinate = record.getMateNegativeStrandFlag() ? SAMUtils.getMateUnclippedEnd(record) : SAMUtils.getMateUnclippedStart(record);
 
@@ -96,7 +99,7 @@ public class ReadEndsForMateCigar extends ReadEnds {
         this.libraryId = libraryId;
 
         // Is this unmapped or its mate?
-        if (record.getReadUnmappedFlag() || (record.getReadPairedFlag() && record.getMateUnmappedFlag())) {
+        if (!MarkDuplicatesUtil.pairedForMarkDuplicates(record, minInformativeMappingQuality)) {
             this.hasUnmapped = 1;
         }
 
@@ -117,7 +120,8 @@ public class ReadEndsForMateCigar extends ReadEnds {
     }
 
     /** Creates a shallow copy from the "other" */
-    public ReadEndsForMateCigar(final ReadEndsForMateCigar other, final SamRecordWithOrdinal samRecordWithOrdinal) {
+    public ReadEndsForMateCigar(final ReadEndsForMateCigar other, final SamRecordWithOrdinal samRecordWithOrdinal, final short minInformativeMappingQuality) {
+        this.minInformativeMappingQuality = minInformativeMappingQuality;
         this.readGroup = other.readGroup;
         this.tile = other.tile;
         this.x = other.x;

--- a/src/main/java/picard/sam/util/Pair.java
+++ b/src/main/java/picard/sam/util/Pair.java
@@ -68,8 +68,7 @@ public class Pair<X extends Comparable<X>, Y extends Comparable<Y>> implements C
     }
 
     /**
-     * Basic hashcode function.  Assume hashcodes of left and right are
-     * randomly distributed and return the XOR of the two.
+     * Basic hashcode function.
      *
      * @return hashcode of the pair.
      */
@@ -85,8 +84,13 @@ public class Pair<X extends Comparable<X>, Y extends Comparable<Y>> implements C
     @Override
     public int compareTo(final Pair<X, Y> o) {
         final int leftCompare;
+
         if (this.left == null && o.left == null) {
             leftCompare = 0;
+        } else if (this.left == null) {
+            return -1;
+        } else if (o.left == null) {
+            return 1;
         } else {
             leftCompare = this.left.compareTo(o.left);
         }
@@ -95,8 +99,12 @@ public class Pair<X extends Comparable<X>, Y extends Comparable<Y>> implements C
 
         if (this.right == null && o.right == null) {
             return 0;
+        } else if (this.right == null) {
+            return -1;
+        } else if (o.right == null) {
+            return 1;
+        } else {
+            return this.right.compareTo(o.right);
         }
-
-        return this.right.compareTo(o.right);
     }
 }

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicateWithMissingBarcodeTest.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicateWithMissingBarcodeTest.java
@@ -5,23 +5,24 @@ package picard.sam.markduplicates;
  * molecular barcode tag, even if the code is trying to use the molecular barcode
  */
 
-abstract public class MarkDuplicateWithMissingBarcodeTest extends MarkDuplicatesTest {
+public abstract class MarkDuplicateWithMissingBarcodeTest extends MarkDuplicatesTest {
 
     protected AbstractMarkDuplicatesCommandLineProgramTester getTester() {
         return new MarkDuplicatesWithMissingBarcodesTester();
     }
 
-    abstract protected String getArgumentName();
+    protected abstract String getArgumentName();
 
-    abstract protected String getTagValue();
+    protected abstract String getTagValue();
 
     private class MarkDuplicatesWithMissingBarcodesTester extends MarkDuplicatesTester {
+
         @Override
         public void runTest() {
             boolean hasRX = false;
             boolean isDuplex = false;
             for (final String argument : this.getArgs()) {
-                if (argument.startsWith(getArgumentName())) {
+                if (argument.startsWith(getArgumentName())|| argument.startsWith("BARCODE_TAG")) {
                     hasRX = true;
                     break;
                 }

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicateWithMissingReadTwoBarcodeTest.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicateWithMissingReadTwoBarcodeTest.java
@@ -11,7 +11,7 @@ public class MarkDuplicateWithMissingReadTwoBarcodeTest extends MarkDuplicateWit
 
     @Override
     protected String getArgumentName() {
-        return "READ_TWO_BARCODE_TAG";
+        return "READ_ONE_BARCODE_TAG";
     }
 
     @Override

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesTest.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesTest.java
@@ -34,14 +34,17 @@ import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.CollectionUtil;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.IterableAdapter;
-import htsjdk.samtools.util.TestUtil;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * This class defines the individual test cases to run. The actual running of the test is done
@@ -322,7 +325,8 @@ public class MarkDuplicatesTest extends AbstractMarkDuplicatesCommandLineProgram
                         Arrays.asList(false, true),           // Is duplicate
                         Arrays.asList(false, false),          // Negative Strand Flag of first in pair
                         Arrays.asList(true, true),            // Negative Strand Flag of second in pair
-                },{
+                },
+                {
                         // Test case where UMIs are not duplex, but are different.  None of the reads should be duplicates.
                         false,                                // Use duplex UMI (true), or single stranded UMI (false)
                         Arrays.asList("ATC", "GCG"),          // UMIs

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesWithMateCigarTest.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesWithMateCigarTest.java
@@ -126,4 +126,10 @@ public class MarkDuplicatesWithMateCigarTest extends AbstractMarkDuplicatesComma
 
         tester.runTest();
     }
+
+    @Test(enabled = false)
+    @Override
+    public void testDuplicateWithLowMappingQ() {
+
+    }
 }

--- a/src/test/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigarTest.java
+++ b/src/test/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigarTest.java
@@ -51,4 +51,11 @@ public class SimpleMarkDuplicatesWithMateCigarTest extends AbstractMarkDuplicate
     @Override
     public void testOpticalDuplicateClusterSamePositionNoOpticalDuplicates(final String readName1, final String readName2) {
     }
+
+    // To enable this test a change in htsjdk would be required. In particular the duplicateSetIterator would need to be modified.
+    @Test(enabled = false)
+    @Override
+    public void testDuplicateWithLowMappingQ() {
+
+    }
 }

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
@@ -502,5 +502,12 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
         tester.setExpectedMetrics(expectedMetrics);
         tester.runTest();
     }
+
+    // To enable this test a change in htsjdk would be required. In particular the duplicateSetIterator would need to be modified.
+    @Test(enabled = false)
+    @Override
+    public void testDuplicateWithLowMappingQ() {
+
+    }
 }
 

--- a/src/test/java/picard/sam/testers/SamFileTester.java
+++ b/src/test/java/picard/sam/testers/SamFileTester.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -137,59 +138,59 @@ public abstract class SamFileTester extends CommandLineProgramTest {
     }
 
     // Below are a bunch of utility methods for adding records to the SAMRecordSetBuilder
-    public void addUnmappedFragment(final int referenceSequenceIndex,
+    public List<SAMRecord> addUnmappedFragment(final int referenceSequenceIndex,
                                     final int defaultQualityScore) {
-        addFragment(referenceSequenceIndex, -1, true, false, null, null, defaultQualityScore, false);
+        return addFragment(referenceSequenceIndex, -1, true, false, null, null, defaultQualityScore, false);
     }
 
-    public void addUnmappedFragment(final int referenceSequenceIndex,
+    public List<SAMRecord> addUnmappedFragment(final int referenceSequenceIndex,
                                     final String qualityString) {
-        addFragment(referenceSequenceIndex, -1, true, false, null, qualityString, -1, false);
+        return addFragment(referenceSequenceIndex, -1, true, false, null, qualityString, -1, false);
     }
 
-    public void addUnmappedPair(final int referenceSequenceIndex,
+    public List<SAMRecord> addUnmappedPair(final int referenceSequenceIndex,
                                 final int defaultQualityScore) {
-        addMatePair(referenceSequenceIndex, -1, -1, true, true, false, false, null, null, false, false, false, false, false, defaultQualityScore);
+        return addMatePair(referenceSequenceIndex, -1, -1, true, true, false, false, null, null, false, false, false, false, false, defaultQualityScore);
     }
 
-    public void addMappedFragment(final int referenceSequenceIndex, final int alignmentStart, final boolean isDuplicate,
+    public List<SAMRecord> addMappedFragment(final int referenceSequenceIndex, final int alignmentStart, final boolean isDuplicate,
                                   final int defaultQualityScore) {
-        addFragment(referenceSequenceIndex, alignmentStart, false, isDuplicate, null, null, defaultQualityScore, false);
+        return addFragment(referenceSequenceIndex, alignmentStart, false, isDuplicate, null, null, defaultQualityScore, false);
     }
 
-    public void addMappedFragment(final int referenceSequenceIndex, final int alignmentStart, final boolean isDuplicate,
+    public List<SAMRecord> addMappedFragment(final int referenceSequenceIndex, final int alignmentStart, final boolean isDuplicate,
                                   final int defaultQualityScore, final boolean isSecondary) {
-        addFragment(referenceSequenceIndex, alignmentStart, false, isDuplicate, null, null, defaultQualityScore, isSecondary);
+        return addFragment(referenceSequenceIndex, alignmentStart, false, isDuplicate, null, null, defaultQualityScore, isSecondary);
     }
 
-    public void addMappedFragment(final int referenceSequenceIndex, final int alignmentStart, final boolean isDuplicate, final String cigar,
+    public List<SAMRecord> addMappedFragment(final int referenceSequenceIndex, final int alignmentStart, final boolean isDuplicate, final String cigar,
                                   final int defaultQualityScore) {
-        addFragment(referenceSequenceIndex, alignmentStart, false, isDuplicate, cigar, null, defaultQualityScore, false);
+        return addFragment(referenceSequenceIndex, alignmentStart, false, isDuplicate, cigar, null, defaultQualityScore, false);
     }
 
-    public void addMappedFragment(final int referenceSequenceIndex, final int alignmentStart, final boolean isDuplicate, final String cigar,
+    public List<SAMRecord> addMappedFragment(final int referenceSequenceIndex, final int alignmentStart, final boolean isDuplicate, final String cigar,
                                   final String qualityString,
                                   final int defaultQualityScore) {
-        addFragment(referenceSequenceIndex, alignmentStart, false, isDuplicate, cigar, qualityString, defaultQualityScore, false);
+        return addFragment(referenceSequenceIndex, alignmentStart, false, isDuplicate, cigar, qualityString, defaultQualityScore, false);
     }
 
-    public void addMappedFragment(final String readName, final int referenceSequenceIndex, final int alignmentStart, final boolean isDuplicate, final String cigar,
+    public List<SAMRecord> addMappedFragment(final String readName, final int referenceSequenceIndex, final int alignmentStart, final boolean isDuplicate, final String cigar,
                                   final String qualityString, final boolean isSecondary, final boolean isSupplementary,
                                   final int defaultQualityScore) {
-        addFragment(readName, referenceSequenceIndex, alignmentStart, false, isDuplicate, cigar, qualityString, defaultQualityScore, isSecondary, isSupplementary);
+        return addFragment(readName, referenceSequenceIndex, alignmentStart, false, isDuplicate, cigar, qualityString, defaultQualityScore, isSecondary, isSupplementary);
     }
 
-    public void addMappedPair(final int referenceSequenceIndex,
+    public List<SAMRecord> addMappedPair(final int referenceSequenceIndex,
                               final int alignmentStart1,
                               final int alignmentStart2,
                               final boolean isDuplicate1,
                               final boolean isDuplicate2,
                               final int defaultQualityScore) {
-        addMappedPair(referenceSequenceIndex, alignmentStart1, alignmentStart2, isDuplicate1, isDuplicate2, null, null,
+        return addMappedPair(referenceSequenceIndex, alignmentStart1, alignmentStart2, isDuplicate1, isDuplicate2, null, null,
                 false, defaultQualityScore);
     }
 
-    public void addMappedPair(final int referenceSequenceIndex,
+    public List<SAMRecord> addMappedPair(final int referenceSequenceIndex,
                               final int alignmentStart1,
                               final int alignmentStart2,
                               final boolean isDuplicate1,
@@ -198,11 +199,11 @@ public abstract class SamFileTester extends CommandLineProgramTest {
                               final String cigar2,
                               final boolean firstOnly,
                               final int defaultQualityScore) {
-        addMappedPair(referenceSequenceIndex, alignmentStart1, alignmentStart2, isDuplicate1, isDuplicate2, cigar1,
+        return addMappedPair(referenceSequenceIndex, alignmentStart1, alignmentStart2, isDuplicate1, isDuplicate2, cigar1,
                 cigar2, false, true, firstOnly, defaultQualityScore);
     }
 
-    public void addMappedPair(final int referenceSequenceIndex,
+    public List<SAMRecord> addMappedPair(final int referenceSequenceIndex,
                               final int alignmentStart1,
                               final int alignmentStart2,
                               final boolean isDuplicate1,
@@ -213,11 +214,11 @@ public abstract class SamFileTester extends CommandLineProgramTest {
                               final boolean strand2,
                               final boolean firstOnly,
                               final int defaultQualityScore) {
-        addMatePair(referenceSequenceIndex, alignmentStart1, alignmentStart2, false, false, isDuplicate1, isDuplicate2, cigar1, cigar2,
+        return addMatePair(referenceSequenceIndex, alignmentStart1, alignmentStart2, false, false, isDuplicate1, isDuplicate2, cigar1, cigar2,
                 strand1, strand2, firstOnly, false, false, defaultQualityScore);
     }
 
-    public void addMatePair(final int referenceSequenceIndex,
+    public List<SAMRecord> addMatePair(final int referenceSequenceIndex,
                             final int alignmentStart1,
                             final int alignmentStart2,
                             final boolean record1Unmapped,
@@ -232,18 +233,18 @@ public abstract class SamFileTester extends CommandLineProgramTest {
                             final boolean record1NonPrimary,
                             final boolean record2NonPrimary,
                             final int defaultQualityScore) {
-        addMatePair("READ" + readNameCounter++, referenceSequenceIndex, alignmentStart1, alignmentStart2, record1Unmapped, record2Unmapped,
+        return addMatePair("READ" + readNameCounter++, referenceSequenceIndex, alignmentStart1, alignmentStart2, record1Unmapped, record2Unmapped,
                 isDuplicate1, isDuplicate2, cigar1, cigar2, strand1, strand2, firstOnly, record1NonPrimary, record2NonPrimary,
                 defaultQualityScore);
     }
 
-    private void addFragment(final int referenceSequenceIndex, final int alignmentStart, final boolean recordUnmapped, final boolean isDuplicate, final String cigar,
+    private List<SAMRecord> addFragment(final int referenceSequenceIndex, final int alignmentStart, final boolean recordUnmapped, final boolean isDuplicate, final String cigar,
                              final String qualityString, final int defaultQualityScore, final boolean isSecondary) {
-        addFragment("READ" + readNameCounter++, referenceSequenceIndex, alignmentStart, recordUnmapped, isDuplicate, cigar,
+        return addFragment("READ" + readNameCounter++, referenceSequenceIndex, alignmentStart, recordUnmapped, isDuplicate, cigar,
                 qualityString, defaultQualityScore, isSecondary, false);
     }
 
-    private void addFragment(final String readName, final int referenceSequenceIndex, final int alignmentStart, final boolean recordUnmapped, final boolean isDuplicate, final String cigar,
+    private List<SAMRecord> addFragment(final String readName, final int referenceSequenceIndex, final int alignmentStart, final boolean recordUnmapped, final boolean isDuplicate, final String cigar,
                              final String qualityString, final int defaultQualityScore, final boolean isSecondary, final boolean isSupplementary) {
 
         final SAMRecord record = samRecordSetBuilder.addFrag(readName, referenceSequenceIndex, alignmentStart, false,
@@ -252,9 +253,10 @@ public abstract class SamFileTester extends CommandLineProgramTest {
         final String key = samRecordToDuplicatesFlagsKey(record);
         Assert.assertFalse(this.duplicateFlags.containsKey(key));
         this.duplicateFlags.put(key, isDuplicate);
+        return Collections.singletonList(record);
     }
 
-    public void addMatePair(final String readName,
+    public List<SAMRecord> addMatePair(final String readName,
                             final int referenceSequenceIndex1,
                             final int referenceSequenceIndex2,
                             final int alignmentStart1,
@@ -299,9 +301,10 @@ public abstract class SamFileTester extends CommandLineProgramTest {
         final String key2 = samRecordToDuplicatesFlagsKey(record2);
         Assert.assertFalse(this.duplicateFlags.containsKey(key2));
         this.duplicateFlags.put(key2, isDuplicate2);
+        return samRecordList;
     }
 
-    public void addMatePair(final String readName,
+    public List<SAMRecord> addMatePair(final String readName,
                             final int referenceSequenceIndex1,
                             final int referenceSequenceIndex2,
                             final int alignmentStart1,
@@ -318,11 +321,11 @@ public abstract class SamFileTester extends CommandLineProgramTest {
                             final boolean record1NonPrimary,
                             final boolean record2NonPrimary,
                             final int defaultQuality) {
-        addMatePair(readName, referenceSequenceIndex1, referenceSequenceIndex2, alignmentStart1, alignmentStart2,
+        return addMatePair(readName, referenceSequenceIndex1, referenceSequenceIndex2, alignmentStart1, alignmentStart2,
                 record1Unmapped, record2Unmapped, isDuplicate1, isDuplicate2, cigar1, cigar2, strand1, strand2,
                 firstOnly, record1NonPrimary, record2NonPrimary, defaultQuality, null);
     }
-    public void addMatePair(final String readName,
+    public List<SAMRecord> addMatePair(final String readName,
                             final int referenceSequenceIndex,
                             final int alignmentStart1,
                             final int alignmentStart2,
@@ -338,7 +341,7 @@ public abstract class SamFileTester extends CommandLineProgramTest {
                             final boolean record1NonPrimary,
                             final boolean record2NonPrimary,
                             final int defaultQuality) {
-        addMatePair(readName, referenceSequenceIndex, referenceSequenceIndex, alignmentStart1, alignmentStart2, record1Unmapped, record2Unmapped,
+        return addMatePair(readName, referenceSequenceIndex, referenceSequenceIndex, alignmentStart1, alignmentStart2, record1Unmapped, record2Unmapped,
                 isDuplicate1, isDuplicate2, cigar1, cigar2, strand1, strand2, firstOnly, record1NonPrimary, record2NonPrimary, defaultQuality);
     }
 


### PR DESCRIPTION
Fixes #128 and #1285 (which are similar issues and about a factor of 10 difference in issue number...)

The main thrust here is to consider "low mapping quality" as an indication of the read being effectively unmapped, as its location is not well determined and thus two identical fragments where each have one read with low (=0, e.g) mapping quality should be considered to be duplicates, or not, based on the well-mapped reads, and not the semi-random low-mapping quality read. 

Since this uses the same mechanism of unmapped reads, it will also not mark the low-mapping quality read as duplicate when its mate is marked so. Unless the file is queryname sorted, in which case the unmapped and the low-mapping quality reads are marked like their well-aligned mate.



### Description

_Give your PR a **concise** yet **descriptive** title_
_Please explain the changes you made here._
_Explain the **motivation** for making this change. What existing problem does the pull request solve?_
_Mention any issues fixed, addressed or otherwise related to this pull request, including issue numbers or hard links for issues in other repos._
_You can delete these instructions once you have written your PR description._

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

