### PR TITLE
Added 3 "r" s to make gradlew showing appropriate error messages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,13 +45,13 @@ def ensureBuildPrerequisites(rbuildPrerequisitesMessage) {
     if (!JavaVersion.current().isJava8Compatible()) {
         throw new GradleException(
                 "Java 8 or later is required to build Picard, but ${JavaVersion.current()} was found. "
-                        + "$buildPrerequisitesMessage")
+                        + "$rbuildPrerequisitesMessage")
     }
     // Make sure we can get a ToolProvider class loader (for Java 8). If not we may have just a JRE.
     if (JavaVersion.current().isJava8() && ToolProvider.getSystemToolClassLoader() == null) {
         throw new GradleException(
                 "The ClassLoader obtained from the Java ToolProvider is null. "
-                        + "If using Java 8 you must have a full JDK installed and not just a JRE. $buildPrerequisitesMessage")
+                        + "If using Java 8 you must have a full JDK installed and not just a JRE. $rbuildPrerequisitesMessage")
     }
     if (!JavaVersion.current().isJava8() && !JavaVersion.current().isJava11()) {
         println("Warning: using Java ${JavaVersion.current()} but only Java 8 and Java 11 have been tested.")
@@ -59,7 +59,7 @@ def ensureBuildPrerequisites(rbuildPrerequisitesMessage) {
     if (!looksLikeWereInAGitRepository()) {
         throw new GradleException("This doesn't appear to be a git folder. " +
                 "The Picard Github repository must be cloned using \"git clone\" to run the build. " +
-                "\n$buildPrerequisitesMessage")
+                "\n$rbuildPrerequisitesMessage")
     }
 }
 


### PR DESCRIPTION
### Description

I added "r"s to the heads of the variable "buildPrerequisitesMessage"
because gradlew told me that 
```
FAILURE: Build failed with an exception.

* Where:
Build file '/home/odatl5/apps/picard_test/picard/build.gradle' line: 60

* What went wrong:
A problem occurred evaluating root project 'picard'.
> Could not get unknown property 'buildPrerequisitesMessage' for root project 'picard' of type org.gradle.api.Project.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 677ms

```

if there was not .git directory 
when I typed 
./gradlew
.

As I don't know much about gradlew so much, my changes might be incorrect.
I apologize if it is the case.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

------------
I didn't make any tests and reviews because I thought it was just for issues showing error messages.
