### PR TITLE
Bugfix for IdentifyContamiant + small improvements to Fingerprinting

### DIFF
--- a/src/main/java/picard/fingerprint/CappedHaplotypeProbabilities.java
+++ b/src/main/java/picard/fingerprint/CappedHaplotypeProbabilities.java
@@ -1,4 +1,27 @@
 package picard.fingerprint;
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2010-2020 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 import picard.util.MathUtil;
 
@@ -12,12 +35,12 @@ public class CappedHaplotypeProbabilities extends HaplotypeProbabilitiesUsingLog
         this.cap = cap;
         final double[] logLikelihoods = haplotypeProbabilities.getLogLikelihoods();
         final double max = MathUtil.max(logLikelihoods);
-        final double[] cappedLogLikelihoods = MathUtil.sum(logLikelihoods,-max);
-        this.setLogLikelihoods(MathUtil.max(cappedLogLikelihoods,cap));
+        final double[] cappedLogLikelihoods = MathUtil.sum(logLikelihoods, -max);
+        this.setLogLikelihoods(MathUtil.max(cappedLogLikelihoods, cap));
     }
 
     @Override
     public HaplotypeProbabilities deepCopy() {
-        return new CappedHaplotypeProbabilities(this,cap);
+        return new CappedHaplotypeProbabilities(this, cap);
     }
 }

--- a/src/main/java/picard/fingerprint/CappedHaplotypeProbabilities.java
+++ b/src/main/java/picard/fingerprint/CappedHaplotypeProbabilities.java
@@ -2,7 +2,7 @@ package picard.fingerprint;
 /*
  * The MIT License
  *
- * Copyright (c) 2010-2020 The Broad Institute
+ * Copyright (c) 2020 The Broad Institute
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/picard/fingerprint/CappedHaplotypeProbabilities.java
+++ b/src/main/java/picard/fingerprint/CappedHaplotypeProbabilities.java
@@ -1,0 +1,23 @@
+package picard.fingerprint;
+
+import picard.util.MathUtil;
+
+public class CappedHaplotypeProbabilities extends HaplotypeProbabilitiesUsingLogLikelihoods {
+    private final double cap;
+
+    // cap should be negative to indicate that you can never be too sure of anything (since the log likelihood is the
+    //    log probability of an error, it's negative)
+    public CappedHaplotypeProbabilities(final HaplotypeProbabilities haplotypeProbabilities, double cap) {
+        super(haplotypeProbabilities.getHaplotype());
+        this.cap = cap;
+        final double[] logLikelihoods = haplotypeProbabilities.getLogLikelihoods();
+        final double max = MathUtil.max(logLikelihoods);
+        final double[] cappedLogLikelihoods = MathUtil.sum(logLikelihoods,-max);
+        this.setLogLikelihoods(MathUtil.max(cappedLogLikelihoods,cap));
+    }
+
+    @Override
+    public HaplotypeProbabilities deepCopy() {
+        return new CappedHaplotypeProbabilities(this,cap);
+    }
+}

--- a/src/main/java/picard/fingerprint/CappedHaplotypeProbabilities.java
+++ b/src/main/java/picard/fingerprint/CappedHaplotypeProbabilities.java
@@ -34,10 +34,10 @@ public class CappedHaplotypeProbabilities extends HaplotypeProbabilitiesUsingLog
         super(haplotypeProbabilities.getHaplotype());
         this.cap = cap;
         final double[] logLikelihoods = haplotypeProbabilities.getLogLikelihoods();
-        final double max = MathUtil.max(logLikelihoods);
-        final double[] cappedLogLikelihoods = MathUtil.sum(logLikelihoods, -max);
-        this.setLogLikelihoods(MathUtil.max(cappedLogLikelihoods, cap));
+        final double[] cappedLogLikelihoods = MathUtil.subtractMax(logLikelihoods);
+        this.setLogLikelihoods(MathUtil.capFromBelow(cappedLogLikelihoods, cap));
     }
+
 
     @Override
     public HaplotypeProbabilities deepCopy() {

--- a/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
+++ b/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
@@ -459,6 +459,8 @@ public class CrosscheckFingerprints extends CommandLineProgram {
         }
 
         log.info("Fingerprinting " + unrolledFiles.size() + " INPUT files.");
+
+        checker.setmaximalPLDifference(Integer.MAX_VALUE);
         final Map<FingerprintIdDetails, Fingerprint> fpMap = checker.fingerprintFiles(unrolledFiles, NUM_THREADS, 1, TimeUnit.DAYS);
 
         if (INPUT_SAMPLE_MAP != null) {

--- a/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
+++ b/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
@@ -460,7 +460,7 @@ public class CrosscheckFingerprints extends CommandLineProgram {
 
         log.info("Fingerprinting " + unrolledFiles.size() + " INPUT files.");
 
-        checker.setmaximalPLDifference(Integer.MAX_VALUE);
+        checker.setMaximalPLDifference(Integer.MAX_VALUE);
         final Map<FingerprintIdDetails, Fingerprint> fpMap = checker.fingerprintFiles(unrolledFiles, NUM_THREADS, 1, TimeUnit.DAYS);
 
         if (INPUT_SAMPLE_MAP != null) {

--- a/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
+++ b/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
@@ -355,7 +355,7 @@ public class CrosscheckFingerprints extends CommandLineProgram {
     @Argument(doc = "When all LOD score are zero, exit with this value.")
     public int EXIT_CODE_WHEN_NO_VALID_CHECKS = 1;
 
-    @Argument(doc = "Maximal effect of any single haplotype block on outcome (-log10 of maximal liklihood difference between the different values for the three possible genotypes).", minValue = 0)
+    @Argument(doc = "Maximal effect of any single haplotype block on outcome (-log10 of maximal likelihood difference between the different values for the three possible genotypes).", minValue = 0)
     public double MAX_EFFECT_OF_EACH_HAPLOTYPE_BLOCK = 3.0;
 
     @Hidden

--- a/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
+++ b/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
@@ -356,7 +356,7 @@ public class CrosscheckFingerprints extends CommandLineProgram {
     public int EXIT_CODE_WHEN_NO_VALID_CHECKS = 1;
 
     @Argument(doc = "Maximal effect of any single haplotype block on outcome (positive).", minValue = 0)
-    public double MAX_EFFECT_OF_EACH_HAPLOTYPE_BLOCK = 3D;
+    public double MAX_EFFECT_OF_EACH_HAPLOTYPE_BLOCK = 1000000D;
 
     @Hidden
     @Argument(doc = "When true code will check for readability on input files (this can be slow on cloud access)")
@@ -465,16 +465,16 @@ public class CrosscheckFingerprints extends CommandLineProgram {
         log.info("Fingerprinting " + unrolledFiles.size() + " INPUT files.");
 
         final Map<FingerprintIdDetails, Fingerprint> fpMap = checker.fingerprintFiles(unrolledFiles, NUM_THREADS, 1, TimeUnit.DAYS);
+        capFingerprints(fpMap);
 
         if (INPUT_SAMPLE_MAP != null) {
             remapFingerprints(fpMap, INPUT_SAMPLE_MAP, "INPUT_SAMPLE_MAP");
-            capFingerprints(fpMap);
         }
 
         if (INPUT_SAMPLE_FILE_MAP != null) {
             remapFingerprintsFromFiles(fpMap, INPUT_SAMPLE_FILE_MAP);
-            capFingerprints(fpMap);
         }
+
 
         final List<CrosscheckMetric> metrics = new ArrayList<>();
         final int numUnexpected;
@@ -485,6 +485,8 @@ public class CrosscheckFingerprints extends CommandLineProgram {
         } else {
             log.info("Fingerprinting " + unrolledFiles2.size() + " SECOND_INPUT files.");
             final Map<FingerprintIdDetails, Fingerprint> fpMap2 = checker.fingerprintFiles(unrolledFiles2, NUM_THREADS, 1, TimeUnit.DAYS);
+            capFingerprints(fpMap);
+
 
             if (SECOND_INPUT_SAMPLE_MAP != null) {
                 remapFingerprints(fpMap2, SECOND_INPUT_SAMPLE_MAP, "SECOND_INPUT_SAMPLE_MAP");

--- a/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
+++ b/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
@@ -355,8 +355,8 @@ public class CrosscheckFingerprints extends CommandLineProgram {
     @Argument(doc = "When all LOD score are zero, exit with this value.")
     public int EXIT_CODE_WHEN_NO_VALID_CHECKS = 1;
 
-    @Argument(doc = "Maximal effect of any single haplotype block on outcome (positive).", minValue = 0)
-    public double MAX_EFFECT_OF_EACH_HAPLOTYPE_BLOCK = 1000000D;
+    @Argument(doc = "Maximal effect of any single haplotype block on outcome (-log10 of maximal liklihood difference between the different values for the three possible genotypes).", minValue = 0)
+    public double MAX_EFFECT_OF_EACH_HAPLOTYPE_BLOCK = 3.0;
 
     @Hidden
     @Argument(doc = "When true code will check for readability on input files (this can be slow on cloud access)")

--- a/src/main/java/picard/fingerprint/ExtractFingerprint.java
+++ b/src/main/java/picard/fingerprint/ExtractFingerprint.java
@@ -87,7 +87,7 @@ public class ExtractFingerprint extends CommandLineProgram {
         IOUtil.assertFileIsReadable(INPUT);
         IOUtil.assertFileIsReadable(HAPLOTYPE_MAP);
         IOUtil.assertFileIsWritable(OUTPUT);
-        IOUtil.assertFileIsReadable(REFERENCE_SEQUENCE);
+        IOUtil.assertFileIsReadable(referenceSequence.getReferenceFile());
 
         final FingerprintChecker checker = new FingerprintChecker(HAPLOTYPE_MAP);
 
@@ -113,7 +113,7 @@ public class ExtractFingerprint extends CommandLineProgram {
         final String sampleToUse = getSampleToUse(soleEntry.getKey());
 
         try {
-            FingerprintUtils.writeFingerPrint(soleEntry.getValue(), OUTPUT, REFERENCE_SEQUENCE, sampleToUse, "PLs derived from " + INPUT + " using an assumed contamination of " + this.CONTAMINATION);
+            FingerprintUtils.writeFingerPrint(soleEntry.getValue(), OUTPUT, referenceSequence.getReferenceFile(), sampleToUse, "PLs derived from " + INPUT + " using an assumed contamination of " + this.CONTAMINATION);
         } catch (Exception e) {
             log.error(e);
         }

--- a/src/main/java/picard/fingerprint/ExtractFingerprint.java
+++ b/src/main/java/picard/fingerprint/ExtractFingerprint.java
@@ -1,0 +1,131 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.fingerprint;
+
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Log;
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import picard.cmdline.CommandLineProgram;
+import picard.cmdline.StandardOptionDefinitions;
+import picard.cmdline.programgroups.DiagnosticsAndQCProgramGroup;
+
+import java.io.File;
+import java.util.Map;
+
+/**
+ * Program to create a fingerprint for the <b>contaminating</b> sample when the level of contamination is both known and
+ * uniform in the genome.
+ *
+ * @author Yossi Farjoun
+ */
+@CommandLineProgramProperties(
+        summary = "Computes/Extracts the fingerprint genotype likelihoods from the supplied SAM/BAM/VCF file." +
+                "It is given as a list of PLs at the fingerprinting sites.",
+        oneLineSummary = "Computes a fingerprint from the supplied SAM/BAM file.",
+        programGroup = DiagnosticsAndQCProgramGroup.class)
+
+public class ExtractFingerprint extends CommandLineProgram {
+
+    @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "Input SAM or BAM file.")
+    public File INPUT;
+
+    @Argument(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "Output fingerprint file (VCF).")
+    public File OUTPUT;
+
+    @Argument(shortName = "H", doc = "A file of haplotype information. The file lists a set of SNPs, optionally arranged in high-LD blocks, to be used for fingerprinting. See " +
+            "https://software.broadinstitute.org/gatk/documentation/article?id=9526 for details.")
+    public File HAPLOTYPE_MAP;
+
+    @Argument(shortName = "C", doc = "A value of estimated contamination in the input. A non-zero value will cause the program to provide a better estimate of the fingerprint in the presence of contaminating reads",
+            minValue = 0D, maxValue = 1D)
+    public double CONTAMINATION;
+
+    @Argument(doc = "The sample alias to associate with the resulting fingerprint. When null, <SAMPLE> is extracted from the input file and \"<SAMPLE>\" is used. " +
+            "If argument EXTRACT_CONTAMINATION=true the resulting samplename will be \"<SAMPLE>-contamination\" (if not provided).", optional = true)
+    public String SAMPLE_ALIAS = null;
+
+    @Argument(doc = "The maximum number of reads to use as evidence for any given locus. This is provided as a way to limit the " +
+            "effect that any given locus may have.")
+    public int LOCUS_MAX_READS = 200;
+
+    @Argument(doc = "Extract a fingerprint for the contaminat sample (instead of the contaminant). Setting to true changes the effect of SAMPLE_ALIAS when null. " +
+            "It names the sample in the VCF <SAMPLE>-contaminated, using the SM value from the SAM header.")
+    public boolean EXTRACT_CONTAMINATION = false;
+
+    @Override
+    protected boolean requiresReference() {
+        return true;
+    }
+
+    private final Log log = Log.getInstance(ExtractFingerprint.class);
+
+    @Override
+    protected int doWork() {
+        IOUtil.assertFileIsReadable(INPUT);
+        IOUtil.assertFileIsReadable(HAPLOTYPE_MAP);
+        IOUtil.assertFileIsWritable(OUTPUT);
+        IOUtil.assertFileIsReadable(REFERENCE_SEQUENCE);
+
+        final FingerprintChecker checker = new FingerprintChecker(HAPLOTYPE_MAP);
+
+        // if we want the contaminated fingerprint instead, we need to change the value of CONTAMINATION:
+        if (!EXTRACT_CONTAMINATION) CONTAMINATION = 1 - CONTAMINATION;
+
+        checker.setLocusMaxReads(LOCUS_MAX_READS);
+        checker.setValidationStringency(VALIDATION_STRINGENCY);
+
+        if (SAMPLE_ALIAS != null) {
+            checker.setDefaultSampleID(SAMPLE_ALIAS);
+        }
+
+        final Map<String, Fingerprint> fingerprintMap = checker.identifyContaminant(INPUT.toPath(), CONTAMINATION);
+
+        if (fingerprintMap.size() != 1) {
+            log.error("Expected exactly 1 fingerprint, found " + fingerprintMap.size());
+            throw new IllegalArgumentException("Expected exactly 1 fingerprint in Input file, found " + fingerprintMap.size());
+        }
+
+        final Map.Entry<String, Fingerprint> soleEntry = fingerprintMap.entrySet().iterator().next();
+
+        final String sampleToUse = getSampleToUse(soleEntry.getKey());
+
+        try {
+            FingerprintUtils.writeFingerPrint(soleEntry.getValue(), OUTPUT, REFERENCE_SEQUENCE, sampleToUse, "PLs derived from " + INPUT + " using an assumed contamination of " + this.CONTAMINATION);
+        } catch (Exception e) {
+            log.error(e);
+        }
+        return 0;
+    }
+
+    private String getSampleToUse(final String fpSample) {
+
+        if (SAMPLE_ALIAS == null) {
+            return String.format("%s%s", fpSample, EXTRACT_CONTAMINATION ? "-contamination" : "");
+        } else {
+            return SAMPLE_ALIAS;
+        }
+    }
+}

--- a/src/main/java/picard/fingerprint/ExtractFingerprint.java
+++ b/src/main/java/picard/fingerprint/ExtractFingerprint.java
@@ -80,7 +80,7 @@ public class ExtractFingerprint extends CommandLineProgram {
         return true;
     }
 
-    private final Log log = Log.getInstance(ExtractFingerprint.class);
+    private static final Log log = Log.getInstance(ExtractFingerprint.class);
 
     @Override
     protected int doWork() {
@@ -92,7 +92,9 @@ public class ExtractFingerprint extends CommandLineProgram {
         final FingerprintChecker checker = new FingerprintChecker(HAPLOTYPE_MAP);
 
         // if we want the contaminated fingerprint instead, we need to change the value of CONTAMINATION:
-        if (!EXTRACT_CONTAMINATION) CONTAMINATION = 1 - CONTAMINATION;
+        if (!EXTRACT_CONTAMINATION) {
+            CONTAMINATION = 1 - CONTAMINATION;
+        }
 
         checker.setLocusMaxReads(LOCUS_MAX_READS);
         checker.setValidationStringency(VALIDATION_STRINGENCY);

--- a/src/main/java/picard/fingerprint/ExtractFingerprint.java
+++ b/src/main/java/picard/fingerprint/ExtractFingerprint.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2018 The Broad Institute
+ * Copyright (c) 2020 The Broad Institute
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -69,10 +69,10 @@ public class ExtractFingerprint extends CommandLineProgram {
 
     @Argument(doc = "The maximum number of reads to use as evidence for any given locus. This is provided as a way to limit the " +
             "effect that any given locus may have.")
-    public int LOCUS_MAX_READS = 200;
+    public int LOCUS_MAX_READS = 50;
 
-    @Argument(doc = "Extract a fingerprint for the contaminat sample (instead of the contaminant). Setting to true changes the effect of SAMPLE_ALIAS when null. " +
-            "It names the sample in the VCF <SAMPLE>-contaminated, using the SM value from the SAM header.")
+    @Argument(doc = "Extract a fingerprint for the contaminating sample (instead of the contaminated sample). Setting to true changes the effect of SAMPLE_ALIAS when null. " +
+            "It names the sample in the VCF <SAMPLE>-contaminant, using the SM value from the SAM header.")
     public boolean EXTRACT_CONTAMINATION = false;
 
     @Override
@@ -125,7 +125,7 @@ public class ExtractFingerprint extends CommandLineProgram {
     private String getSampleToUse(final String fpSample) {
 
         if (SAMPLE_ALIAS == null) {
-            return String.format("%s%s", fpSample, EXTRACT_CONTAMINATION ? "-contamination" : "");
+            return String.format("%s%s", fpSample, EXTRACT_CONTAMINATION ? "-contaminant" : "");
         } else {
             return SAMPLE_ALIAS;
         }

--- a/src/main/java/picard/fingerprint/Fingerprint.java
+++ b/src/main/java/picard/fingerprint/Fingerprint.java
@@ -72,7 +72,7 @@ public class Fingerprint extends TreeMap<HaplotypeBlock, HaplotypeProbabilities>
     /**
      * Merges the likelihoods from the supplied Fingerprint into the likelihoods for this fingerprint.
      */
-    public void merge(final Fingerprint other) {
+    public Fingerprint merge(final Fingerprint other) {
         final Set<HaplotypeBlock> haps = new HashSet<>();
         haps.addAll(keySet());
         haps.addAll(other.keySet());
@@ -87,6 +87,7 @@ public class Fingerprint extends TreeMap<HaplotypeBlock, HaplotypeProbabilities>
                 probabilities.merge(otherProbabilities);
             }
         }
+        return this;
     }
 
     /**

--- a/src/main/java/picard/fingerprint/FingerprintChecker.java
+++ b/src/main/java/picard/fingerprint/FingerprintChecker.java
@@ -158,7 +158,13 @@ public class FingerprintChecker {
         this.genotypingErrorRate = genotypingErrorRate;
     }
 
-    @Deprecated //non-compliant method name.
+    /**
+     * Does same thing as {@link #setMaximalPLDifference(int)} but named in the compliant way.
+     *
+     * @deprecated use {@link #setMaximalPLDifference(int)} instead.
+     * @since 16/4/2020
+     */
+    @Deprecated
     public void setmaximalPLDifference(final int maximalPLDifference) {
         setMaximalPLDifference(maximalPLDifference);
     }
@@ -473,7 +479,13 @@ public class FingerprintChecker {
         }
     };
 
-    @Deprecated // no need to provide the loci, since it should be available from the haplotypeBlocks
+    /**
+     * Does same thing as {@link #fingerprintSamFile(Path, Function)} but in the old way that required that you pass in the loci of interest.
+     * Since the loci are always the same as in {@link #haplotypes} there's no need for this method signature anymore
+     *
+     * @deprecated use {@link #fingerprintSamFile(Path, Function)} instead.
+     */
+    @Deprecated
     public Map<FingerprintIdDetails, Fingerprint> fingerprintSamFile(final Path samFile, final IntervalList loci) {
         return fingerprintSamFile(samFile, HaplotypeProbabilitiesFromSequence::new);
     }

--- a/src/main/java/picard/fingerprint/FingerprintChecker.java
+++ b/src/main/java/picard/fingerprint/FingerprintChecker.java
@@ -843,15 +843,9 @@ public class FingerprintChecker {
 
                 if (calculateTumorAwareLod) {
                     lodExpectedSampleTumorNormal += prob1AssumingDataFromTumor.shiftedLogEvidenceProbabilityGivenOtherEvidence(probs2) -
-                            prob1AssumingDataFromTumor.shiftedLogEvidenceProbability();
-
-                    lodExpectedSampleNormalTumor += probs1.shiftedLogEvidenceProbabilityGivenOtherEvidence(prob2AssumingDataFromTumor) -
-                            probs1.shiftedLogEvidenceProbability();
-
-//                    lodExpectedSampleTumorNormal += prob1AssumingDataFromTumor.shiftedLogEvidenceProbabilityGivenOtherEvidence(probs2) -
-//                            prob1AssumingDataFromTumor.shiftedLogEvidenceProbability() - probs2.shiftedLogEvidenceProbability();
-//                    lodExpectedSampleNormalTumor += prob2AssumingDataFromTumor.shiftedLogEvidenceProbabilityGivenOtherEvidence(probs1) -
-//                            prob2AssumingDataFromTumor.shiftedLogEvidenceProbability() - probs1.shiftedLogEvidenceProbability();
+                            prob1AssumingDataFromTumor.shiftedLogEvidenceProbability() - probs2.shiftedLogEvidenceProbability();
+                    lodExpectedSampleNormalTumor += prob2AssumingDataFromTumor.shiftedLogEvidenceProbabilityGivenOtherEvidence(probs1) -
+                            prob2AssumingDataFromTumor.shiftedLogEvidenceProbability() - probs1.shiftedLogEvidenceProbability();
 
                 }
             }

--- a/src/main/java/picard/fingerprint/FingerprintChecker.java
+++ b/src/main/java/picard/fingerprint/FingerprintChecker.java
@@ -156,24 +156,6 @@ public class FingerprintChecker {
         this.genotypingErrorRate = genotypingErrorRate;
     }
 
-    /**
-     * Does same thing as {@link #setMaximalPLDifference(int)} but named in the compliant way.
-     *
-     * @deprecated use {@link #setMaximalPLDifference(int)} instead.
-     * @since 16/4/2020
-     */
-    @Deprecated
-    public void setmaximalPLDifference(final int maximalPLDifference) {
-        setMaximalPLDifference(maximalPLDifference);
-    }
-
-    /**
-     * Sets the maximal difference in PL scores considered when reading PLs from a VCF.
-     * @deprecated since 04/2020. use CappedHaplotypeProbabilities and explicitly cap your probabilities.
-     */
-    @Deprecated
-    public void setMaximalPLDifference(final int maximalPLDifference) { }
-
     public SAMFileHeader getHeader() {
         return haplotypes.getHeader();
     }
@@ -865,6 +847,12 @@ public class FingerprintChecker {
 
                     lodExpectedSampleNormalTumor += probs1.shiftedLogEvidenceProbabilityGivenOtherEvidence(prob2AssumingDataFromTumor) -
                             probs1.shiftedLogEvidenceProbability();
+
+//                    lodExpectedSampleTumorNormal += prob1AssumingDataFromTumor.shiftedLogEvidenceProbabilityGivenOtherEvidence(probs2) -
+//                            prob1AssumingDataFromTumor.shiftedLogEvidenceProbability() - probs2.shiftedLogEvidenceProbability();
+//                    lodExpectedSampleNormalTumor += prob2AssumingDataFromTumor.shiftedLogEvidenceProbabilityGivenOtherEvidence(probs1) -
+//                            prob2AssumingDataFromTumor.shiftedLogEvidenceProbability() - probs1.shiftedLogEvidenceProbability();
+
                 }
             }
         }

--- a/src/main/java/picard/fingerprint/FingerprintChecker.java
+++ b/src/main/java/picard/fingerprint/FingerprintChecker.java
@@ -87,7 +87,6 @@ public class FingerprintChecker {
     public static final double DEFAULT_GENOTYPING_ERROR_RATE = 0.01;
     public static final int DEFAULT_MINIMUM_MAPPING_QUALITY = 10;
     public static final int DEFAULT_MINIMUM_BASE_QUALITY = 20;
-    public static final int DEFAULT_MAXIMAL_PL_DIFFERENCE = 30;
 
     // used sometimes to subset loci. Fix the random seed so that the results are deterministic
     private static final Random random = new Random(42);

--- a/src/main/java/picard/fingerprint/FingerprintChecker.java
+++ b/src/main/java/picard/fingerprint/FingerprintChecker.java
@@ -116,7 +116,7 @@ public class FingerprintChecker {
     private int locusMaxReads = 0;
     private String defaultSampleID = "<UNKNOWN>";
 
-    private Set<Path> missingRGFiles = new HashSet<>();
+    private final Set<Path> missingRGFiles = new HashSet<>();
 
     private final Log log = Log.getInstance(FingerprintChecker.class);
 
@@ -539,7 +539,7 @@ public class FingerprintChecker {
         // Now go through the data at each locus and figure stuff out!
         for (final SamLocusIterator.LocusInfo info : iterator) {
 
-            log.debug(() -> "At locus " + info.toString());
+            log.debug(() -> "At locus " + info);
 
             // TODO: Filter out the locus if the allele balance doesn't make sense for either a
             // TODO: 50/50 het or a hom with some errors; in HS data with deep coverage any base
@@ -573,7 +573,7 @@ public class FingerprintChecker {
                     }
                 }
 
-                if (rg == null || fingerprintIdDetailsMap.containsKey(rg)) {
+                if (fingerprintIdDetailsMap.containsKey(rg)) {
                     details = fingerprintIdDetailsMap.get(rg);
 
                     final String readName = rec.getRecord().getReadName();
@@ -622,15 +622,13 @@ public class FingerprintChecker {
      */
     public Map<String, Fingerprint> identifyContaminant(final Path samFile, final double contamination) {
 
-        final Map<FingerprintIdDetails, Fingerprint> fingerprintIdDetailsFingerprintMap = this.fingerprintSamFile(samFile, (h) -> new HaplotypeProbabilitiesFromContaminatorSequence(h, contamination));
+        final Map<FingerprintIdDetails, Fingerprint> fpIdDetailsMap = this.fingerprintSamFile(samFile, h -> new HaplotypeProbabilitiesFromContaminatorSequence(h, contamination));
 
-        final Map<FingerprintIdDetails, Fingerprint> fingerprintIdDetailsFingerprintbySample = Fingerprint.mergeFingerprintsBy(fingerprintIdDetailsFingerprintMap,
+        final Map<FingerprintIdDetails, Fingerprint> fpIdDetailsBySample = Fingerprint.mergeFingerprintsBy(fpIdDetailsMap,
                 Fingerprint.getFingerprintIdDetailsStringFunction(CrosscheckMetric.DataType.SAMPLE));
 
-        final Map<String,Fingerprint> fingerprintsBySample = fingerprintIdDetailsFingerprintbySample.entrySet().stream()
+        return fpIdDetailsBySample.entrySet().stream()
                 .collect(Collectors.toMap(e -> e.getKey().sample, Map.Entry::getValue));
-
-        return fingerprintsBySample;
     }
 
     /**

--- a/src/main/java/picard/fingerprint/FingerprintUtils.java
+++ b/src/main/java/picard/fingerprint/FingerprintUtils.java
@@ -152,7 +152,7 @@ public class FingerprintUtils {
                 snp.getPos(),
                 snp.getPos()).getBases()[0]);
 
-        if (snp.getAllele1() != refAllele && snp.getAllele2() != refAllele){
+        if (snp.getAllele1() != refAllele && snp.getAllele2() != refAllele) {
             throw new PicardException("Don't know how to deal with missing reference allele in fingerprinting map");
         }
 
@@ -173,7 +173,8 @@ public class FingerprintUtils {
             obsAlt = haplotypeProbabilities.getObsAllele2();
         }
 
-        final double[] PLs =  Arrays.copyOf(haplotypeProbabilities.getLogLikelihoods(),HaplotypeProbabilities.NUM_GENOTYPES);
+        final double[] origPLs = haplotypeProbabilities.getLogLikelihoods();
+        final double[] PLs =  Arrays.copyOf(origPLs,origPLs.length);
         if (swap12) {
             ArrayUtils.reverse(PLs);
         }

--- a/src/main/java/picard/fingerprint/HaplotypeProbabilitiesFromContaminatorSequence.java
+++ b/src/main/java/picard/fingerprint/HaplotypeProbabilitiesFromContaminatorSequence.java
@@ -62,11 +62,10 @@ public class HaplotypeProbabilitiesFromContaminatorSequence extends HaplotypePro
         }
     }
 
-
-        /**
-         * Adds a base observation with the observed quality to the evidence for this haplotype
-         * based on the fact that the SNP is part of the haplotype.
-         */
+    /**
+     * Adds a base observation with the observed quality to the evidence for this haplotype
+     * based on the fact that the SNP is part of the haplotype.
+     */
     public void addToProbs(final Snp snp, final byte base, final byte qual) {
         assertSnpPartOfHaplotype(snp);
         valuesNeedUpdating = true;
@@ -104,13 +103,13 @@ public class HaplotypeProbabilitiesFromContaminatorSequence extends HaplotypePro
         if (!valuesNeedUpdating) {
             return;
         }
+        valuesNeedUpdating = false;
         final double[] ll = new double[NUM_GENOTYPES];
         for (final Genotype contGeno : Genotype.values()) {
             // p(a | g_c) = \sum_g_m { P(g_m) \prod_i P(a_i| g_m, g_c)}
             ll[contGeno.v] = Math.log10(MathUtil.sum(MathUtil.multiply(this.getPriorProbablities(), likelihoodMap[contGeno.v])));
         }
         setLogLikelihoods(ll);
-        valuesNeedUpdating = false;
     }
 
     @Override
@@ -151,6 +150,7 @@ public class HaplotypeProbabilitiesFromContaminatorSequence extends HaplotypePro
 
     @Override
     public double[] getLogLikelihoods() {
+        updateLikelihoods();
         return super.getLogLikelihoods();
     }
 }

--- a/src/main/java/picard/fingerprint/HaplotypeProbabilitiesFromContaminatorSequence.java
+++ b/src/main/java/picard/fingerprint/HaplotypeProbabilitiesFromContaminatorSequence.java
@@ -107,7 +107,7 @@ public class HaplotypeProbabilitiesFromContaminatorSequence extends HaplotypePro
         final double[] ll = new double[NUM_GENOTYPES];
         for (final Genotype contGeno : Genotype.values()) {
             // p(a | g_c) = \sum_g_m { P(g_m) \prod_i P(a_i| g_m, g_c)}
-            ll[contGeno.v] = Math.log10(MathUtil.sum(MathUtil.multiply(this.getPriorProbablities(), likelihoodMap[contGeno.v])));
+            ll[contGeno.v] = Math.log10(Double.MIN_VALUE + MathUtil.sum(MathUtil.multiply(this.getPriorProbablities(), likelihoodMap[contGeno.v])));
         }
         setLogLikelihoods(ll);
     }

--- a/src/main/java/picard/fingerprint/HaplotypeProbabilitiesUsingLogLikelihoods.java
+++ b/src/main/java/picard/fingerprint/HaplotypeProbabilitiesUsingLogLikelihoods.java
@@ -26,6 +26,7 @@ package picard.fingerprint;
 
 import htsjdk.utils.ValidationUtils;
 import picard.util.MathUtil;
+
 import java.util.Arrays;
 
 /**
@@ -168,11 +169,15 @@ abstract class HaplotypeProbabilitiesUsingLogLikelihoods extends HaplotypeProbab
 
     public void setLogLikelihoods(final double[] ll) {
         ValidationUtils.validateArg(ll.length == NUM_GENOTYPES,
-                ()->"logLikelihood must have length 3, found " + ll.length);
+                () -> "logLikelihood must have length 3, found " + ll.length);
 
-        double sum = MathUtil.sum(MathUtil.getProbabilityFromLog(ll));
+//        protect from underflow
+        double max = MathUtil.max(ll);
+        final double[] maxRemoved = MathUtil.sum(ll, -max);
+
+        double sum = MathUtil.sum(MathUtil.getProbabilityFromLog(maxRemoved));
         // normalize log rawLikelihoods:
-        System.arraycopy(MathUtil.sum(ll, -Math.log10(sum)), 0, loglikelihoods, 0, NUM_GENOTYPES);
+        System.arraycopy(MathUtil.sum(maxRemoved, -Math.log10(sum)), 0, loglikelihoods, 0, NUM_GENOTYPES);
 
         likelihoodsNeedUpdating = true;
         updateDependentValues();

--- a/src/main/java/picard/fingerprint/HaplotypeProbabilitiesUsingLogLikelihoods.java
+++ b/src/main/java/picard/fingerprint/HaplotypeProbabilitiesUsingLogLikelihoods.java
@@ -171,9 +171,8 @@ abstract class HaplotypeProbabilitiesUsingLogLikelihoods extends HaplotypeProbab
         ValidationUtils.validateArg(ll.length == NUM_GENOTYPES,
                 () -> "logLikelihood must have length 3, found " + ll.length);
 
-//        protect from underflow
-        double max = MathUtil.max(ll);
-        final double[] maxRemoved = MathUtil.sum(ll, -max);
+        // protect from underflow
+        final double[] maxRemoved = MathUtil.subtractMax(ll);
 
         double sum = MathUtil.sum(MathUtil.getProbabilityFromLog(maxRemoved));
         // normalize log rawLikelihoods:

--- a/src/main/java/picard/fingerprint/HaplotypeProbabilitiesUsingLogLikelihoods.java
+++ b/src/main/java/picard/fingerprint/HaplotypeProbabilitiesUsingLogLikelihoods.java
@@ -169,7 +169,7 @@ abstract class HaplotypeProbabilitiesUsingLogLikelihoods extends HaplotypeProbab
 
     public void setLogLikelihoods(final double[] ll) {
         ValidationUtils.validateArg(ll.length == NUM_GENOTYPES,
-                () -> "logLikelihood must have length 3, found " + ll.length);
+                () -> String.format("logLikelihood must have length %d, found %d", NUM_GENOTYPES, ll.length));
 
         // protect from underflow
         final double[] maxRemoved = MathUtil.subtractMax(ll);

--- a/src/main/java/picard/fingerprint/MatchResults.java
+++ b/src/main/java/picard/fingerprint/MatchResults.java
@@ -45,7 +45,7 @@ public class MatchResults implements Comparable<MatchResults> {
     private final double LOD;
     //the lod score when assuming the left sample is tumor and the right is normal
     private final double lodTN;
-    //the lod score when assuming the left sample is tumor and the right is normal
+    //the lod score when assuming the left sample is normal and the right is tumor
     private final double lodNT;
 
     public double getLodNT() {

--- a/src/main/java/picard/util/MathUtil.java
+++ b/src/main/java/picard/util/MathUtil.java
@@ -169,6 +169,18 @@ final public class MathUtil {
     }
 
     /**
+     * Returns the array capped (from below) by the value of scalar
+     */
+    public static double[] max(final double[] nums, final double scalar) {
+        final double[] max = new double[nums.length];
+        for (int i = 1; i < nums.length; ++i) {
+            max[i] = Math.max(nums[i], scalar);
+        }
+
+        return max;
+    }
+
+    /**
      * Returns the index of the largest element in the array.  If there are multiple equal maxima then
      * the earliest one in the array is returned.
      */
@@ -246,6 +258,18 @@ final public class MathUtil {
             if (nums[i] < min) {
                 min = nums[i];
             }
+        }
+
+        return min;
+    }
+
+    /**
+     * Returns the array capped by the value of scalar
+     */
+    public static double[] min(final double[] nums, final double scalar) {
+        final double[] min = new double[nums.length];
+        for (int i = 1; i < nums.length; ++i) {
+            min[i] = Math.min(nums[i], scalar);
         }
 
         return min;
@@ -536,7 +560,6 @@ final public class MathUtil {
      */
     public static double klDivergance(double[] measured, double[] distribution) {
         ValidationUtils.validateArg(measured.length == distribution.length, () -> "length of measuered and distribution differ. Found " + measured.length + " and " + distribution.length + ".");
-
 
         final double[] normalizedMeasured = pNormalizeVector(measured);
         final double[] normalizedDistribution = pNormalizeVector(distribution);

--- a/src/main/java/picard/util/MathUtil.java
+++ b/src/main/java/picard/util/MathUtil.java
@@ -272,7 +272,7 @@ final public class MathUtil {
     }
 
     /**
-     * Returns the array capped (from above) by the value of floor
+     * Returns the array capped (from above) by the value of top
      */
     public static double[] capFromAbove(final double[] nums, final double top) {
         final double[] capped = new double[nums.length];

--- a/src/main/java/picard/util/MathUtil.java
+++ b/src/main/java/picard/util/MathUtil.java
@@ -173,7 +173,7 @@ final public class MathUtil {
      */
     public static double[] max(final double[] nums, final double scalar) {
         final double[] max = new double[nums.length];
-        for (int i = 1; i < nums.length; ++i) {
+        for (int i = 0; i < nums.length; ++i) {
             max[i] = Math.max(nums[i], scalar);
         }
 
@@ -268,7 +268,7 @@ final public class MathUtil {
      */
     public static double[] min(final double[] nums, final double scalar) {
         final double[] min = new double[nums.length];
-        for (int i = 1; i < nums.length; ++i) {
+        for (int i = 0; i < nums.length; ++i) {
             min[i] = Math.min(nums[i], scalar);
         }
 

--- a/src/main/java/picard/util/MathUtil.java
+++ b/src/main/java/picard/util/MathUtil.java
@@ -169,15 +169,14 @@ final public class MathUtil {
     }
 
     /**
-     * Returns the array capped (from below) by the value of scalar
+     * Returns the array capped (from below) by the value of floor
      */
-    public static double[] max(final double[] nums, final double scalar) {
-        final double[] max = new double[nums.length];
+    public static double[] capFromBelow(final double[] nums, final double floor) {
+        final double[] floored = new double[nums.length];
         for (int i = 0; i < nums.length; ++i) {
-            max[i] = Math.max(nums[i], scalar);
+            floored[i] = Math.max(nums[i], floor);
         }
-
-        return max;
+        return floored;
     }
 
     /**
@@ -220,6 +219,15 @@ final public class MathUtil {
 
         return index;
     }
+
+    /* Find the maximal value of the array and return a new array
+    consisting of that value subtracted from the original array
+     */
+    public static double[] subtractMax(final double[] logLikelihoods) {
+        final double max = MathUtil.max(logLikelihoods);
+        return MathUtil.sum(logLikelihoods, -max);
+    }
+
 
     /**
      * Returns the smallest value stored in the array.
@@ -264,15 +272,15 @@ final public class MathUtil {
     }
 
     /**
-     * Returns the array capped by the value of scalar
+     * Returns the array capped (from above) by the value of floor
      */
-    public static double[] min(final double[] nums, final double scalar) {
-        final double[] min = new double[nums.length];
+    public static double[] capFromAbove(final double[] nums, final double top) {
+        final double[] capped = new double[nums.length];
         for (int i = 0; i < nums.length; ++i) {
-            min[i] = Math.min(nums[i], scalar);
+            capped[i] = Math.min(nums[i], top);
         }
 
-        return min;
+        return capped;
     }
 
     /**

--- a/src/test/java/picard/fingerprint/CheckFingerprintTest.java
+++ b/src/test/java/picard/fingerprint/CheckFingerprintTest.java
@@ -25,6 +25,10 @@ public class CheckFingerprintTest extends CommandLineProgramTest {
     private static final File TEST_DATA_DIR = new File("testdata/picard/fingerprint/");
     private static final File SUBSETTED_HAPLOTYPE_DATABASE_FOR_TESTING =
             new File(TEST_DATA_DIR, "Homo_sapiens_assembly19.haplotype_database.subset.txt");
+    private static final File SHIFTED_HAPLOTYPE_DATABASE_FOR_TESTING =
+            new File(TEST_DATA_DIR, "Homo_sapiens_assembly19.haplotype_database.subset.shifted.for.crams.txt");
+  private static final File SHIFTED_REFERENCE =
+            new File(TEST_DATA_DIR, "reference.shifted.for.crams.fasta");
     private static final String TEST_INPUT_VCF1 = new File(TEST_DATA_DIR, "NA12892.vcf").getAbsolutePath();
     private static final String TEST_INPUT_VCF_EMPTY = new File(TEST_DATA_DIR, "/tempCheckFPDir/void.vcf").getAbsolutePath();
     private static final String TEST_INPUT_VCF_NO_FILE = new File(TEST_DATA_DIR, "noFile.vcf").getAbsolutePath();
@@ -180,6 +184,62 @@ public class CheckFingerprintTest extends CommandLineProgramTest {
         Assert.assertTrue(FingerprintChecker.calculateMatchResults(fpContaminant, fpContamination).getLOD() > 1D);
         Assert.assertTrue(FingerprintChecker.calculateMatchResults(fpContaminant, fpContaminated).getLOD() < -4D);
     }
+
+    @Test
+    public void testFPToVC() throws IOException {
+
+        final File Na12892 = new File(TEST_DATA_DIR, "NA12892.over.fingerprints.shifted.for.crams.r1.sam");
+        final File Na12891 = new File(TEST_DATA_DIR, "NA12891.over.fingerprints.shifted.for.crams.r1.sam");
+
+       final FingerprintChecker checker = new FingerprintChecker(SHIFTED_HAPLOTYPE_DATABASE_FOR_TESTING);
+
+        checker.setLocusMaxReads(100);
+        final Fingerprint fingerprint = checker.identifyContaminant(Na12892.toPath(), 1).get("NA12892");
+        Assert.assertNotNull(fingerprint);
+
+        final File tempFile = File.createTempFile("testWriteFingerprint",".vcf");
+        tempFile.deleteOnExit();
+
+        FingerprintUtils.writeFingerPrint(fingerprint,tempFile,SHIFTED_REFERENCE,
+                "NA12892",null);
+
+        final Fingerprint NA12892FromVCF = checker.fingerprintFiles(Collections.singleton(tempFile.toPath()), 1, 1, TimeUnit.DAYS)
+                .values().stream()
+                .reduce((a, b) -> {
+                    a.merge(b);
+                    return a;
+                })
+                .orElseThrow(() -> new IllegalArgumentException("Did not find any data for contaminant"));
+        Assert.assertNotNull(NA12892FromVCF);
+
+        Assert.assertTrue(FingerprintChecker.calculateMatchResults(fingerprint, NA12892FromVCF).getLOD() > 1D);
+
+
+        final Fingerprint NA12891_fp = checker.fingerprintFiles(Collections.singleton(Na12891.toPath()), 1, 1, TimeUnit.DAYS)
+                .values().stream()
+                .reduce((a, b) -> {
+                    a.merge(b);
+                    return a;
+                })
+                .orElseThrow(() -> new IllegalArgumentException("Did not find any data for contaminated"));
+        Assert.assertNotNull(NA12891_fp);
+
+        Assert.assertTrue(FingerprintChecker.calculateMatchResults(NA12891_fp, NA12892FromVCF).getLOD() < -4D);
+
+        final Fingerprint NA12892_fp = checker.fingerprintFiles(Collections.singleton(Na12892.toPath()), 1, 1, TimeUnit.DAYS)
+                .values().stream()
+                .reduce((a, b) -> {
+                    a.merge(b);
+                    return a;
+                })
+                .orElseThrow(() -> new IllegalArgumentException("Did not find any data for contaminated"));
+        Assert.assertNotNull(NA12892_fp);
+
+        Assert.assertTrue(FingerprintChecker.calculateMatchResults(NA12892FromVCF, NA12892_fp).getLOD() >1D);
+    }
+
+
+
 
     @Override
     public String getCommandLineProgramName() {

--- a/src/test/java/picard/fingerprint/CheckFingerprintTest.java
+++ b/src/test/java/picard/fingerprint/CheckFingerprintTest.java
@@ -19,7 +19,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-
 public class CheckFingerprintTest extends CommandLineProgramTest {
 
     private final File tempFolder = new File(TEST_DATA_DIR + "/tempCheckFPDir/");
@@ -156,7 +155,8 @@ public class CheckFingerprintTest extends CommandLineProgramTest {
         final String sample = "NA12892";
         final FingerprintChecker checker = new FingerprintChecker(SUBSETTED_HAPLOTYPE_DATABASE_FOR_TESTING);
 
-        final Fingerprint fpContaminant = checker.identifyContaminant(mixture.toPath(), contamAmount, 100).get(sample);
+        checker.setLocusMaxReads(100);
+        final Fingerprint fpContaminant = checker.identifyContaminant(mixture.toPath(), contamAmount).get(sample);
         Assert.assertNotNull(fpContaminant);
 
         final Fingerprint fpContamination = checker.fingerprintFiles(Collections.singleton(contaminant.toPath()), 1, 1, TimeUnit.DAYS)

--- a/src/test/java/picard/fingerprint/CheckFingerprintTest.java
+++ b/src/test/java/picard/fingerprint/CheckFingerprintTest.java
@@ -27,7 +27,7 @@ public class CheckFingerprintTest extends CommandLineProgramTest {
             new File(TEST_DATA_DIR, "Homo_sapiens_assembly19.haplotype_database.subset.txt");
     private static final File SHIFTED_HAPLOTYPE_DATABASE_FOR_TESTING =
             new File(TEST_DATA_DIR, "Homo_sapiens_assembly19.haplotype_database.subset.shifted.for.crams.txt");
-  private static final File SHIFTED_REFERENCE =
+    private static final File SHIFTED_REFERENCE =
             new File(TEST_DATA_DIR, "reference.shifted.for.crams.fasta");
     private static final String TEST_INPUT_VCF1 = new File(TEST_DATA_DIR, "NA12892.vcf").getAbsolutePath();
     private static final String TEST_INPUT_VCF_EMPTY = new File(TEST_DATA_DIR, "/tempCheckFPDir/void.vcf").getAbsolutePath();
@@ -51,11 +51,18 @@ public class CheckFingerprintTest extends CommandLineProgramTest {
     private static final File na12891_fp = new File(TEST_DATA_DIR, "NA12891.fp.vcf");
     private static final File na12892_fp = new File(TEST_DATA_DIR, "NA12892.fp.vcf");
 
+    @Override
+    public String getCommandLineProgramName() {
+        return CheckFingerprint.class.getSimpleName();
+    }
+
     @BeforeClass
-    private void mkTemp() {
+    public void setup() throws IOException {
         if (!tempFolder.exists()) {
             tempFolder.mkdir();
         }
+        NA12891_named_NA12892_vcf = VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DATA_DIR, "NA12891_named_NA12892.vcf"), "fingerprint");
+        NA12892_1_vcf = VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DATA_DIR, "NA12892.vcf"), "fingerprint");
     }
 
     @AfterClass
@@ -119,7 +126,7 @@ public class CheckFingerprintTest extends CommandLineProgramTest {
     }
 
     @Test
-    public void     testSummaryAndDetailOutputs() {
+    public void testSummaryAndDetailOutputs() {
         String[] args = new String[]{
                 "I=" + TEST_INPUT_VCF1,
                 "S=" + TEST_DATA_DIR + "/tempCheckFPDir/summary",
@@ -191,36 +198,29 @@ public class CheckFingerprintTest extends CommandLineProgramTest {
         final File Na12892 = new File(TEST_DATA_DIR, "NA12892.over.fingerprints.shifted.for.crams.r1.sam");
         final File Na12891 = new File(TEST_DATA_DIR, "NA12891.over.fingerprints.shifted.for.crams.r1.sam");
 
-       final FingerprintChecker checker = new FingerprintChecker(SHIFTED_HAPLOTYPE_DATABASE_FOR_TESTING);
+        final FingerprintChecker checker = new FingerprintChecker(SHIFTED_HAPLOTYPE_DATABASE_FOR_TESTING);
 
         checker.setLocusMaxReads(100);
         final Fingerprint fingerprint = checker.identifyContaminant(Na12892.toPath(), 1).get("NA12892");
         Assert.assertNotNull(fingerprint);
 
-        final File tempFile = File.createTempFile("testWriteFingerprint",".vcf");
+        final File tempFile = File.createTempFile("testWriteFingerprint", ".vcf");
         tempFile.deleteOnExit();
 
-        FingerprintUtils.writeFingerPrint(fingerprint,tempFile,SHIFTED_REFERENCE,
-                "NA12892",null);
+        FingerprintUtils.writeFingerPrint(fingerprint, tempFile, SHIFTED_REFERENCE,
+                "NA12892", null);
 
         final Fingerprint NA12892FromVCF = checker.fingerprintFiles(Collections.singleton(tempFile.toPath()), 1, 1, TimeUnit.DAYS)
                 .values().stream()
-                .reduce((a, b) -> {
-                    a.merge(b);
-                    return a;
-                })
+                .reduce(Fingerprint::merge)
                 .orElseThrow(() -> new IllegalArgumentException("Did not find any data for contaminant"));
         Assert.assertNotNull(NA12892FromVCF);
 
         Assert.assertTrue(FingerprintChecker.calculateMatchResults(fingerprint, NA12892FromVCF).getLOD() > 1D);
 
-
         final Fingerprint NA12891_fp = checker.fingerprintFiles(Collections.singleton(Na12891.toPath()), 1, 1, TimeUnit.DAYS)
                 .values().stream()
-                .reduce((a, b) -> {
-                    a.merge(b);
-                    return a;
-                })
+                .reduce(Fingerprint::merge)
                 .orElseThrow(() -> new IllegalArgumentException("Did not find any data for contaminated"));
         Assert.assertNotNull(NA12891_fp);
 
@@ -228,28 +228,11 @@ public class CheckFingerprintTest extends CommandLineProgramTest {
 
         final Fingerprint NA12892_fp = checker.fingerprintFiles(Collections.singleton(Na12892.toPath()), 1, 1, TimeUnit.DAYS)
                 .values().stream()
-                .reduce((a, b) -> {
-                    a.merge(b);
-                    return a;
-                })
+                .reduce(Fingerprint::merge)
                 .orElseThrow(() -> new IllegalArgumentException("Did not find any data for contaminated"));
         Assert.assertNotNull(NA12892_fp);
 
-        Assert.assertTrue(FingerprintChecker.calculateMatchResults(NA12892FromVCF, NA12892_fp).getLOD() >1D);
-    }
-
-
-
-
-    @Override
-    public String getCommandLineProgramName() {
-        return CheckFingerprint.class.getSimpleName();
-    }
-
-    @BeforeClass
-    public void setup() throws IOException {
-        NA12891_named_NA12892_vcf = VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DATA_DIR, "NA12891_named_NA12892.vcf"), "fingerprint");
-        NA12892_1_vcf = VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DATA_DIR, "NA12892.vcf"), "fingerprint");
+        Assert.assertTrue(FingerprintChecker.calculateMatchResults(NA12892FromVCF, NA12892_fp).getLOD() > 1D);
     }
 
     @DataProvider(name = "samsToFingerprint")
@@ -292,7 +275,9 @@ public class CheckFingerprintTest extends CommandLineProgramTest {
 
         args.add("INPUT=" + file.getAbsolutePath());
         args.add("G=" + genotypes.getAbsolutePath());
-        if (ignoreRG) args.add("IGNORE_RG=true");
+        if (ignoreRG) {
+            args.add("IGNORE_RG=true");
+        }
         args.add("H=" + HAPLOTYPE_MAP.getAbsolutePath());
         args.add("SUMMARY_OUTPUT=" + outputSummary.getAbsolutePath());
         args.add("DETAIL_OUTPUT=" + outputDetail.getAbsolutePath());

--- a/src/test/java/picard/fingerprint/CheckFingerprintTest.java
+++ b/src/test/java/picard/fingerprint/CheckFingerprintTest.java
@@ -119,7 +119,7 @@ public class CheckFingerprintTest extends CommandLineProgramTest {
     }
 
     @Test
-    public void testSummaryAndDetailOutputs() {
+    public void     testSummaryAndDetailOutputs() {
         String[] args = new String[]{
                 "I=" + TEST_INPUT_VCF1,
                 "S=" + TEST_DATA_DIR + "/tempCheckFPDir/summary",

--- a/src/test/java/picard/fingerprint/FingerprintCheckerTest.java
+++ b/src/test/java/picard/fingerprint/FingerprintCheckerTest.java
@@ -205,7 +205,7 @@ public class FingerprintCheckerTest {
 
         final Map<Set<String>, Set<String>> collected = metrics.stream()
 //                we sometimes get -0.0, and so the comparison fails...
-                .collect(Collectors.groupingBy(s -> CollectionUtil.makeSet(s.LEFT_GROUP_VALUE, s.RIGHT_GROUP_VALUE), Collectors.mapping(s -> Double.toString(s.LOD_SCORE + 0), Collectors.toSet())));
+                .collect(Collectors.groupingBy(s -> CollectionUtil.makeSet(s.LEFT_GROUP_VALUE, s.RIGHT_GROUP_VALUE), Collectors.mapping(s -> String.valueOf(s.LOD_SCORE + 0), Collectors.toSet())));
 
         for (Map.Entry<Set<String>, Set<String>> entry : collected.entrySet()) {
             if (entry.getValue().size() > 1) {

--- a/src/test/java/picard/fingerprint/FingerprintCheckerTest.java
+++ b/src/test/java/picard/fingerprint/FingerprintCheckerTest.java
@@ -89,14 +89,15 @@ public class FingerprintCheckerTest {
     public Object[][] testCheckFingerprintsVcfDataProvider() {
         return new Object[][]{
                 {new File(TEST_DATA_DIR, "NA12891.vcf"), new File(TEST_DATA_DIR, "NA12891.fp.vcf"), "NA12891", "NA12891", -1.048021, -2.053484, 1.005462},
-                {new File(TEST_DATA_DIR, "NA12891.vcf"), new File(TEST_DATA_DIR, "NA12891.g.vcf"), "NA12891", "NA12891", -1.037564, -2.049586, 1.012022},
+                {new File(TEST_DATA_DIR, "NA12891.vcf"), new File(TEST_DATA_DIR, "NA12891.g.vcf"), "NA12891", "NA12891", -1.034969, -2.048616, 1.013647},
                 {new File(TEST_DATA_DIR, "NA12892.vcf"), new File(TEST_DATA_DIR, "NA12892.fp.vcf"), "NA12892", "NA12892", -1.105025, -2.166160, 1.061135},
-                {new File(TEST_DATA_DIR, "NA12892.vcf"), new File(TEST_DATA_DIR, "NA12892.g.vcf"), "NA12892", "NA12892", -1.094570, -2.162798, 1.068227},
+                {new File(TEST_DATA_DIR, "NA12892.vcf"), new File(TEST_DATA_DIR, "NA12892.g.vcf"), "NA12892", "NA12892", -1.091976, -2.161961, 1.069985},
                 {new File(TEST_DATA_DIR, "NA12891.vcf"), new File(TEST_DATA_DIR, "NA12892.fp.vcf"), "NA12891", "NA12892", -7.024770, -2.109822, -4.914948},
-                {new File(TEST_DATA_DIR, "NA12891.vcf"), new File(TEST_DATA_DIR, "NA12892.g.vcf"), "NA12891", "NA12892", -7.718515, -2.106459, -5.612055},
+                {new File(TEST_DATA_DIR, "NA12891.vcf"), new File(TEST_DATA_DIR, "NA12892.g.vcf"), "NA12891", "NA12892", -7.981971, -2.105623, -5.876347},
                 {new File(TEST_DATA_DIR, "NA12892.vcf"), new File(TEST_DATA_DIR, "NA12891.fp.vcf"), "NA12892", "NA12891", -7.024770, -2.109822, -4.914948},
-                {new File(TEST_DATA_DIR, "NA12892.vcf"), new File(TEST_DATA_DIR, "NA12891.g.vcf"), "NA12892", "NA12891", -7.679670, -2.105924, -5.573746},
+                {new File(TEST_DATA_DIR, "NA12892.vcf"), new File(TEST_DATA_DIR, "NA12891.g.vcf"), "NA12892", "NA12891", -7.924964, -2.104955, -5.820009},
                 {new File(TEST_DATA_DIR, "emptyNA12892.vcf"), new File(TEST_DATA_DIR, "NA12891.g.vcf"), "NA12892", "NA12891", 0, 0, 0},
+
         };
     }
 
@@ -203,7 +204,8 @@ public class FingerprintCheckerTest {
         final List<CrosscheckMetric> metrics = metricsFileReader.getMetrics();
 
         final Map<Set<String>, Set<String>> collected = metrics.stream()
-                .collect(Collectors.groupingBy(s -> CollectionUtil.makeSet(s.LEFT_GROUP_VALUE, s.RIGHT_GROUP_VALUE), Collectors.mapping(s -> s.LOD_SCORE.toString(), Collectors.toSet())));
+//                we sometimes get -0.0, and so the comparison fails...
+                .collect(Collectors.groupingBy(s -> CollectionUtil.makeSet(s.LEFT_GROUP_VALUE, s.RIGHT_GROUP_VALUE), Collectors.mapping(s -> Double.toString(s.LOD_SCORE + 0), Collectors.toSet())));
 
         for (Map.Entry<Set<String>, Set<String>> entry : collected.entrySet()) {
             if (entry.getValue().size() > 1) {

--- a/src/test/java/picard/util/MathUtilTest.java
+++ b/src/test/java/picard/util/MathUtilTest.java
@@ -4,7 +4,6 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
@@ -92,7 +91,7 @@ public class MathUtilTest {
     @Test
     public void testRandomSublist() {
         final Random random = new Random();
-        final List<Integer> list = Arrays.asList(1,2,3);
+        final List<Integer> list = Arrays.asList(1, 2, 3);
 
         Assert.assertEquals(list, MathUtil.randomSublist(list, 3, random));
         Assert.assertEquals(list, MathUtil.randomSublist(list, 4, random));
@@ -155,7 +154,7 @@ public class MathUtilTest {
                         new double[]{1000D, 1000D}, new double[]{0.5, 0.5}
                 },
                 new Object[]{
-                        new double[]{1002D, 1001D, 1000D},  new double[]{1 / 1.11, .1 / 1.11, 0.01 / 1.11}
+                        new double[]{1002D, 1001D, 1000D}, new double[]{1 / 1.11, .1 / 1.11, 0.01 / 1.11}
                 },
         };
     }
@@ -163,5 +162,112 @@ public class MathUtilTest {
     @Test(dataProvider = "pNormalizeLogProbabilityTestData")
     public void pNormalizeLogProbabilityTest(final double[] input, final double[] expected) {
         TestNGUtil.assertEqualDoubleArrays(MathUtil.pNormalizeLogProbability(input), expected, 1e-8);
+    }
+
+    @DataProvider
+    public Object[][] testMaxWithArrayAndScalarData() {
+        return new Object[][]{
+                {new double[]{1, 2, 3}, 2D, new double[]{2, 2, 3}},
+                {new double[]{2, 1, 3}, 2D, new double[]{2, 2, 3}},
+                {new double[]{3, 2, 1}, 2D, new double[]{3, 2, 2}},
+                {new double[]{2, 3, 1}, 2D, new double[]{2, 3, 2}},
+                {new double[]{}, 2D, new double[]{}},
+        };
+    }
+
+    @Test(dataProvider = "testMaxWithArrayAndScalarData")
+    public void testMaxWithArrayAndScalar(final double[] array, final double scalar, final double[] expected) {
+        Assert.assertEquals(MathUtil.max(array, scalar), expected);
+    }
+
+    @DataProvider
+    public Object[][] testMinWithArrayAndScalarData() {
+        return new Object[][]{
+                {new double[]{1, 2, 3}, 2D, new double[]{1, 2, 2}},
+                {new double[]{2, 1, 3}, 2D, new double[]{2, 1, 2}},
+                {new double[]{3, 2, 1}, 2D, new double[]{2, 2, 1}},
+                {new double[]{2, 3, 1}, 2D, new double[]{2, 2, 1}},
+                {new double[]{}, 2D, new double[]{}},
+        };
+    }
+
+    @Test(dataProvider = "testMinWithArrayAndScalarData")
+    public void testMinWithArrayAndScalar(final double[] array, final double scalar, final double[] expected) {
+        Assert.assertEquals(MathUtil.min(array, scalar), expected);
+    }
+
+    @DataProvider
+    public Object[][] testMinWithArrayData() {
+        return new Object[][]{
+                {new double[]{1, 2, 3}, 1D},
+                {new double[]{2, 1, 3}, 1D},
+                {new double[]{3, 2, 1}, 1D},
+                {new double[]{2, 3, 1}, 1D},
+        };
+    }
+
+    @Test(dataProvider = "testMinWithArrayData")
+    public void testMinOfArray(final double[] array, final double expected) {
+        Assert.assertEquals(MathUtil.min(array), expected);
+    }
+
+    @DataProvider
+    public Object[][] testMaxWithArrayData() {
+        return new Object[][]{
+                {new double[]{1, 2, 3}, 3D},
+                {new double[]{2, 1, 3}, 3D},
+                {new double[]{3, 2, 1}, 3D},
+                {new double[]{2, 3, 1}, 3D},
+        };
+    }
+
+    @Test(dataProvider = "testMaxWithArrayData")
+    public void testMaxOfArray(final double[] array, final double expected) {
+        Assert.assertEquals(MathUtil.max(array), expected);
+    }
+
+    @DataProvider
+    public Object[][] testMinWithArrayIntData() {
+        return new Object[][]{
+                {new int[]{1, 2, 3}, 1},
+                {new int[]{2, 1, 3}, 1},
+                {new int[]{3, 2, 1}, 1},
+                {new int[]{2, 3, 1}, 1},
+        };
+    }
+
+    @Test(dataProvider = "testMinWithArrayIntData")
+    public void testMinOfIntArray(final int[] array, final int expected) {
+        Assert.assertEquals(MathUtil.min(array), expected);
+    }
+
+    @DataProvider
+    public Object[][] testMinWithArrayShortData() {
+        return new Object[][]{
+                {new short[]{1, 2, 3},(short) 1},
+                {new short[]{2, 1, 3},(short) 1},
+                {new short[]{3, 2, 1},(short) 1},
+                {new short[]{2, 3, 1},(short) 1},
+        };
+    }
+
+    @Test(dataProvider = "testMinWithArrayShortData")
+    public void testMinOfShortArray(final short[] array, final short expected) {
+        Assert.assertEquals(MathUtil.min(array), expected);
+    }
+
+    @DataProvider
+    public Object[][] testMinWithArrayByteData() {
+        return new Object[][]{
+                {new byte[]{1, 2, 3}, (byte)1},
+                {new byte[]{2, 1, 3}, (byte)1},
+                {new byte[]{3, 2, 1}, (byte)1},
+                {new byte[]{2, 3, 1}, (byte)1},
+        };
+    }
+
+    @Test(dataProvider = "testMinWithArrayByteData")
+    public void testMaxOfByteArray(final byte[] array, final byte expected) {
+        Assert.assertEquals(MathUtil.min(array), expected);
     }
 }

--- a/src/test/java/picard/util/MathUtilTest.java
+++ b/src/test/java/picard/util/MathUtilTest.java
@@ -177,7 +177,7 @@ public class MathUtilTest {
 
     @Test(dataProvider = "testMaxWithArrayAndScalarData")
     public void testMaxWithArrayAndScalar(final double[] array, final double scalar, final double[] expected) {
-        Assert.assertEquals(MathUtil.max(array, scalar), expected);
+        Assert.assertEquals(MathUtil.capFromBelow(array, scalar), expected);
     }
 
     @DataProvider
@@ -193,7 +193,7 @@ public class MathUtilTest {
 
     @Test(dataProvider = "testMinWithArrayAndScalarData")
     public void testMinWithArrayAndScalar(final double[] array, final double scalar, final double[] expected) {
-        Assert.assertEquals(MathUtil.min(array, scalar), expected);
+        Assert.assertEquals(MathUtil.capFromAbove(array, scalar), expected);
     }
 
     @DataProvider

--- a/src/test/java/picard/util/MathUtilTest.java
+++ b/src/test/java/picard/util/MathUtilTest.java
@@ -270,4 +270,20 @@ public class MathUtilTest {
     public void testMaxOfByteArray(final byte[] array, final byte expected) {
         Assert.assertEquals(MathUtil.min(array), expected);
     }
+
+    @DataProvider
+    public Object[][] testSubtractMaxData() {
+        return new Object[][]{
+                {new double[]{1, 2, 3}, new double[]{-2, -1, 0}},
+                {new double[]{2, 1, 3}, new double[]{-1, -2, 0}},
+                {new double[]{3, 2, 1}, new double[]{0, -1, -2}},
+                {new double[]{2, 3, 1}, new double[]{-1, 0, -2}},
+        };
+    }
+
+    @Test(dataProvider = "testSubtractMaxData")
+    public void testSubtractMax(final double[] array, final double[] expected) {
+        Assert.assertEquals(MathUtil.subtractMax(array), expected);
+    }
 }
+

--- a/testdata/picard/fingerprint/fingerprinting_summary_metrics.example
+++ b/testdata/picard/fingerprint/fingerprinting_summary_metrics.example
@@ -1,10 +1,7 @@
 ## htsjdk.samtools.metrics.StringHeader
-# CheckFingerprint INPUT=testdata/picard/fingerprint/NA12892.vcf OUTPUT=testdata/picard/fingerprint/testoutput/otp.fp GENOTYPES=testdata/picard/fingerprint/NA12892.g.vcf HAPLOTYPE_MAP=testdata/picard/fingerprint/Homo_sapiens_assembly19.haplotype_database.subset.txt    GENOTYPE_LOD_THRESHOLD=5.0 IGNORE_READ_GROUPS=false VERBOSITY=INFO QUIET=false VALIDATION_STRINGENCY=STRICT COMPRESSION_LEVEL=5 MAX_RECORDS_IN_RAM=500000 CREATE_INDEX=false CREATE_MD5_FILE=false GA4GH_CLIENT_SECRETS=client_secrets.json USE_JDK_DEFLATER=false USE_JDK_INFLATER=false
-## htsjdk.samtools.metrics.StringHeader
-# Started on: Thu Nov 16 14:50:20 MSK 2017
 
 ## METRICS CLASS	picard.analysis.FingerprintingSummaryMetrics
 READ_GROUP	SAMPLE	LL_EXPECTED_SAMPLE	LL_RANDOM_SAMPLE	LOD_EXPECTED_SAMPLE	HAPLOTYPES_WITH_GENOTYPES	HAPLOTYPES_CONFIDENTLY_CHECKED	HAPLOTYPES_CONFIDENTLY_MATCHING	HET_AS_HOM	HOM_AS_HET	HOM_AS_OTHER_HOM
-	NA12892	-1.09457	-2.162798	1.068228	3	0	0	0	0	0
+	NA12892	-1.091976	-2.161962	1.069986	3	0	0	0	0	0
 
 


### PR DESCRIPTION
- IdentifyContamiant wrote an incorrect VCF (gasp!) when the minor allele in the haplotype_map matches the reference (as opposed tot he major allele). This PR fixes that. (with a test too!)

- IdentifyContaminant can also be used to simply extract the fingerprint (in VCF format) from a bam. I've created a new CLP called ExtractFingerprint that does essentially the same as IdentifyContaminant but with the opposite intent (extracting a fingerprint for the intended sample as opposed to the contaminating sample)

- The fingerprinting code couldn't function when reads don't have an RG tag, but a lot of data in the wild misses the RG tag and so this PR also enables the user to work with these non-compliant inputs.

- Another bug was found in the Tumor-aware part of the code..fixed in this PR
 