### PR TITLE
Upgrade to Barclay 3.0.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     compile 'org.apache.commons:commons-collections4:4.3'
     compile 'commons-lang:commons-lang:2.6'
     compile 'com.github.samtools:htsjdk:' + htsjdkVersion
-    compile 'org.broadinstitute:barclay:2.0.0'
+    compile 'org.broadinstitute:barclay:3.0.0'
     compileOnly(googleNio) {
         transitive = false
     }


### PR DESCRIPTION
Most changes in this Barclay release only affect the new command line parser. However, it does contain some new annotations that can be used to target Picard tools for GATK [WDL auto-gen](https://github.com/broadinstitute/gatk/wiki/How-to-Prepare-a-GATK-tool-for-WDL-auto-generation) once https://github.com/broadinstitute/gatk/pull/6504 goes in.