### PR TITLE
Change default compression level for greater speed.

### DIFF
--- a/src/main/java/picard/cmdline/CommandLineProgram.java
+++ b/src/main/java/picard/cmdline/CommandLineProgram.java
@@ -111,7 +111,7 @@ public abstract class CommandLineProgram {
     public ValidationStringency VALIDATION_STRINGENCY = ValidationStringency.DEFAULT_STRINGENCY;
 
     @Argument(doc = "Compression level for all compressed files created (e.g. BAM and VCF).", common=true)
-    public int COMPRESSION_LEVEL = Defaults.COMPRESSION_LEVEL;
+    public int COMPRESSION_LEVEL = 2;  // Use GATK default level of 2 for much improved writing speed.
 
     @Argument(doc = "When writing files that need to be sorted, this will specify the number of records stored in RAM before spilling to disk. " +
             "Increasing this number reduces the number of file handles needed to sort the file, and increases the amount of RAM needed.", optional=true, common=true)

--- a/src/main/java/picard/cmdline/CommandLineProgram.java
+++ b/src/main/java/picard/cmdline/CommandLineProgram.java
@@ -111,7 +111,7 @@ public abstract class CommandLineProgram {
     public ValidationStringency VALIDATION_STRINGENCY = ValidationStringency.DEFAULT_STRINGENCY;
 
     @Argument(doc = "Compression level for all compressed files created (e.g. BAM and VCF).", common=true)
-    public int COMPRESSION_LEVEL = 2;  // Use GATK default level of 2 for much improved writing speed.
+    public int COMPRESSION_LEVEL = 3;  // Level 3 uses zlib on the jdk deflater and a slightly improved version of zlib on the intel deflater. It is faster than the htsjdk default of 5.
 
     @Argument(doc = "When writing files that need to be sorted, this will specify the number of records stored in RAM before spilling to disk. " +
             "Increasing this number reduces the number of file handles needed to sort the file, and increases the amount of RAM needed.", optional=true, common=true)


### PR DESCRIPTION
### Description

As described in #1539 setting compression level to 2 has an effect of increasing the final file size with 6% but decreasing the compute time with 30+%. Also it is the default used in GATK. Therefore using level 2 seems preferable.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

