### PR TITLE
Use a mutable list to initialize MergeBamAlignment MATCHING_DICTIONARY_TAGS arg.

### DIFF
--- a/src/main/java/picard/sam/MergeBamAlignment.java
+++ b/src/main/java/picard/sam/MergeBamAlignment.java
@@ -279,7 +279,7 @@ public class MergeBamAlignment extends CommandLineProgram {
     public int MIN_UNCLIPPED_BASES = 32;
 
     @Argument(doc = "List of Sequence Records tags that must be equal (if present) in the reference dictionary and in the aligned file. Mismatching tags will cause an error if in this list, and a warning otherwise.")
-    public List<String> MATCHING_DICTIONARY_TAGS = SAMSequenceDictionary.DEFAULT_DICTIONARY_EQUAL_TAG;
+    public List<String> MATCHING_DICTIONARY_TAGS = new ArrayList<>(SAMSequenceDictionary.DEFAULT_DICTIONARY_EQUAL_TAG);
 
     @Argument(doc = "How to deal with alignment information in reads that are being unmapped (e.g. due to cross-species contamination.) " +
             "Currently ignored unless UNMAP_CONTAMINANT_READS = true. Note that the DO_NOT_CHANGE strategy will actually reset the cigar and set the mapping quality on unmapped reads since otherwise" +


### PR DESCRIPTION
Discovered by running autogenerated tests for autogenerated WDL - MergeBamAlignment MATCHING_DICTIONARY_TAGS is currently initialized to a list that cannot be mutated by the CLP. 