### PR TITLE
Make Fingerprint checking fail when run on a truly unsorted file (currently it returns a non-informative fingerprint)

### DIFF
--- a/src/main/java/picard/fingerprint/FingerprintChecker.java
+++ b/src/main/java/picard/fingerprint/FingerprintChecker.java
@@ -480,7 +480,7 @@ public class FingerprintChecker {
 
         checkDictionaryGoodForFingerprinting(in.getFileHeader().getSequenceDictionary());
 
-        if(!in.hasIndex()){
+        if (!in.hasIndex()) {
             log.warn(String.format("Operating without an index! We could be here for a while. (%s)", samFile));
         } else {
             log.info(String.format("Reading an indexed file (%s)", samFile));
@@ -562,7 +562,7 @@ public class FingerprintChecker {
                 }
 
                 if (fingerprintIdDetailsMap.containsKey(rg)) {
-                    foundALocus=true;
+                    foundALocus = true;
                     details = fingerprintIdDetailsMap.get(rg);
 
                     final String readName = rec.getRecord().getReadName();
@@ -575,17 +575,13 @@ public class FingerprintChecker {
                         usedReadNames.add(readName);
                     }
                 } else {
-                    final PicardException e = new PicardException("Unknown read group: " + rg + " in file: " + samFile);
-                    log.error(e);
-                    throw e;
+                    throw new PicardException("Unknown read group: " + rg + " in file: " + samFile);
                 }
             }
         }
 
-        if (!foundALocus && in.getFileHeader().getSortOrder()!= SAMFileHeader.SortOrder.coordinate) {
-            final PicardException noReadsFound = new PicardException(String.format("Couldn't even find one locus with reads to fingerprint in file %s, which in addition isn't coordinate-sorted. Please sort the file and try again.", samFile));
-            log.error(noReadsFound);
-            throw noReadsFound;
+        if (!foundALocus && in.getFileHeader().getSortOrder() != SAMFileHeader.SortOrder.coordinate) {
+            throw new PicardException(String.format("Couldn't even find one locus with reads to fingerprint in file %s, which in addition isn't coordinate-sorted. Please sort the file and try again.", samFile));
         }
 
         return fingerprintsByReadGroup;

--- a/src/test/java/picard/fingerprint/FingerprintCheckerTest.java
+++ b/src/test/java/picard/fingerprint/FingerprintCheckerTest.java
@@ -154,9 +154,9 @@ public class FingerprintCheckerTest {
     @DataProvider
     Object[][] samFilesforFingerprinting() {
         return new Object[][]{
-                new Object[]{"NA12891.over.fingerprints.r1.sam", true},
-                new Object[]{"aligned_queryname_sorted.sam", false},
-                new Object[]{"aligned_unsorted.sam", false},
+                {"NA12891.over.fingerprints.r1.sam", true},
+                {"aligned_queryname_sorted.sam", false},
+                {"aligned_unsorted.sam", false},
         };
     }
 
@@ -335,14 +335,14 @@ public class FingerprintCheckerTest {
         addObservation(hpcs2, hb, 1, hb.getFirstSnp().getAllele1());
 
         return new Object[][]{
-                new Object[]{new HaplotypeProbabilitiesFromGenotype(snp, hb, 5D, 0D, 10D), new HaplotypeProbabilitiesFromGenotype(snp, hb, 0D, 10D, 100D)},
-                new Object[]{
+                {new HaplotypeProbabilitiesFromGenotype(snp, hb, 5D, 0D, 10D), new HaplotypeProbabilitiesFromGenotype(snp, hb, 0D, 10D, 100D)},
+                {
                         new HaplotypeProbabilityOfNormalGivenTumor(
                                 new HaplotypeProbabilitiesFromGenotype(snp, hb, 5D, 0D, 10D), .05),
                         new HaplotypeProbabilityOfNormalGivenTumor(
                                 new HaplotypeProbabilitiesFromGenotype(snp, hb, 0D, 10D, 100D), 0.05)},
-                new Object[]{hp1, hp2},
-                new Object[]{hpcs1, hpcs2},
+                {hp1, hp2},
+                {hpcs1, hpcs2},
         };
     }
 

--- a/src/test/java/picard/fingerprint/FingerprintCheckerTest.java
+++ b/src/test/java/picard/fingerprint/FingerprintCheckerTest.java
@@ -151,11 +151,26 @@ public class FingerprintCheckerTest {
         }
     }
 
-    @Test(expectedExceptions = PicardException.class)
-    public void testTerminateOnBadFile() {
+    @DataProvider
+    Object[][] samFilesforFingerprinting() {
+        return new Object[][]{
+                new Object[]{"NA12891.over.fingerprints.r1.sam", true},
+                new Object[]{"aligned_queryname_sorted.sam", false},
+                new Object[]{"aligned_unsorted.sam", false},
+        };
+    }
+
+    @Test(dataProvider = "samFilesforFingerprinting")
+    public void testTerminateOnBadFile(final String fileName, final boolean shouldSucceed) throws Throwable {
         final FingerprintChecker fpChecker = new FingerprintChecker(SUBSETTED_HAPLOTYPE_DATABASE_FOR_TESTING);
-        final File badSam = new File(TEST_DATA_DIR, "aligned_queryname_sorted.sam");
-        fpChecker.fingerprintFiles(Collections.singletonList(badSam.toPath()), 1, 1, TimeUnit.DAYS);
+        final File samFile = new File(TEST_DATA_DIR, fileName);
+
+        final Assert.ThrowingRunnable runnable = () -> fpChecker.fingerprintFiles(Collections.singletonList(samFile.toPath()), 1, 2, TimeUnit.MINUTES);
+        if (shouldSucceed) {
+            runnable.run();
+        } else {
+            Assert.assertThrows(PicardException.class, runnable);
+        }
     }
 
     @DataProvider(name = "checkFingerprintsSamDataProvider")

--- a/testdata/picard/fingerprint/aligned_unsorted.sam
+++ b/testdata/picard/fingerprint/aligned_unsorted.sam
@@ -1,4 +1,4 @@
-@HD	VN:1.0	SO:queryname
+@HD	VN:1.0	SO:unsorted
 @SQ	SN:1	LN:249250621	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:1b22b98cdeb4a9304cb5d48026a85128	SP:Homo Sapiens
 @SQ	SN:2	LN:243199373	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:a0d9851da00400dec1098a9255ac712e	SP:Homo Sapiens
 @SQ	SN:3	LN:198022430	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:fdfd811849cc2fadebc929bb925902e5	SP:Homo Sapiens


### PR DESCRIPTION
- fix fingerprintChecker test
- make sure that fingerprint checker fails on sam file with "unsorted" sort order if it fails to find any information.
- add test.
- add logging to inform whether (sam) file is being read using an index or not.

### Description

_Give your PR a **concise** yet **descriptive** title_
_Please explain the changes you made here._
_Explain the **motivation** for making this change. What existing problem does the pull request solve?_
_Mention any issues fixed, addressed or otherwise related to this pull request, including issue numbers or hard links for issues in other repos._
_You can delete these instructions once you have written your PR description._

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

