### PR TITLE
Yf fix typo in histogram column name asm

### DIFF
--- a/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
+++ b/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
@@ -159,34 +159,18 @@ public class CollectAlignmentSummaryMetrics extends SinglePassSamProgram {
     }
 
     @Override protected void finish() {
-        final String READ_LENGTH = "READ_LENGTH";
-
         collector.finish();
 
         final MetricsFile<AlignmentSummaryMetrics, Integer> file = getMetricsFile();
         collector.addAllLevelsToFile(file);
 
-        final AlignmentSummaryMetricsCollector.GroupAlignmentSummaryMetricsPerUnitMetricCollector allReadsGroupCollector = (AlignmentSummaryMetricsCollector.GroupAlignmentSummaryMetricsPerUnitMetricCollector) collector.getAllReadsCollector();
+        final AlignmentSummaryMetricsCollector.GroupAlignmentSummaryMetricsPerUnitMetricCollector allReadsGroupCollector =
+                (AlignmentSummaryMetricsCollector.GroupAlignmentSummaryMetricsPerUnitMetricCollector) collector.getAllReadsCollector();
 
-        final Histogram<Integer> pairTotalReadHistogram = allReadsGroupCollector.pairCollector.getReadHistogram();
-        pairTotalReadHistogram.setBinLabel(READ_LENGTH);
-        pairTotalReadHistogram.setValueLabel("PAIRED_TOTAL_LENGTH_COUNT");
-        file.addHistogram(pairTotalReadHistogram);
-
-        final Histogram<Integer> pairClippedReadHistogram = allReadsGroupCollector.pairCollector.getAlignedReadHistogram();
-        pairClippedReadHistogram.setBinLabel(READ_LENGTH);
-        pairClippedReadHistogram.setValueLabel("PAIRED_ALIGNED_LENGTH_COUNT");
-        file.addHistogram(pairClippedReadHistogram);
-
-        final Histogram<Integer> unpairedTotalReadHistogram = allReadsGroupCollector.unpairedCollector.getReadHistogram();
-        unpairedTotalReadHistogram.setBinLabel(READ_LENGTH);
-        unpairedTotalReadHistogram.setValueLabel("UNPAIRED_TOTAL_LENGTH_COUNT");
-        file.addHistogram(unpairedTotalReadHistogram);
-
-        final Histogram<Integer> unpairedClippedReadHistogram = allReadsGroupCollector.unpairedCollector.getAlignedReadHistogram();
-        unpairedClippedReadHistogram.setBinLabel(READ_LENGTH);
-        unpairedClippedReadHistogram.setValueLabel("UNPAIRED_ALIGNED_LENGTH_COUNT");
-        file.addHistogram(unpairedClippedReadHistogram);
+        addHistogramToMetrics(file, "PAIRED_TOTAL_LENGTH_COUNT", allReadsGroupCollector.pairCollector.getReadHistogram());
+        addHistogramToMetrics(file, "PAIRED_ALIGNED_LENGTH_COUNT", allReadsGroupCollector.pairCollector.getAlignedReadHistogram());
+        addHistogramToMetrics(file, "UNPAIRED_TOTAL_LENGTH_COUNT", allReadsGroupCollector.unpairedCollector.getReadHistogram());
+        addHistogramToMetrics(file, "UNPAIRED_ALIGNED_LENGTH_COUNT", allReadsGroupCollector.unpairedCollector.getAlignedReadHistogram());
 
         file.write(OUTPUT);
 
@@ -200,6 +184,12 @@ public class CollectAlignmentSummaryMetrics extends SinglePassSamProgram {
             }
         }
 
+    }
+
+    private static void addHistogramToMetrics(final MetricsFile<AlignmentSummaryMetrics, Integer> file, final String label, final Histogram<Integer> readHistogram) {
+        readHistogram.setBinLabel("READ_LENGTH");
+        readHistogram.setValueLabel(label);
+        file.addHistogram(readHistogram);
     }
 
     // overridden to make it visible on the commandline and to change the doc.

--- a/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
+++ b/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
@@ -159,6 +159,8 @@ public class CollectAlignmentSummaryMetrics extends SinglePassSamProgram {
     }
 
     @Override protected void finish() {
+        final String READ_LENGTH = "READ_LENGTH";
+
         collector.finish();
 
         final MetricsFile<AlignmentSummaryMetrics, Integer> file = getMetricsFile();
@@ -167,23 +169,23 @@ public class CollectAlignmentSummaryMetrics extends SinglePassSamProgram {
         final AlignmentSummaryMetricsCollector.GroupAlignmentSummaryMetricsPerUnitMetricCollector allReadsGroupCollector = (AlignmentSummaryMetricsCollector.GroupAlignmentSummaryMetricsPerUnitMetricCollector) collector.getAllReadsCollector();
 
         final Histogram<Integer> pairTotalReadHistogram = allReadsGroupCollector.pairCollector.getReadHistogram();
-        pairTotalReadHistogram.setBinLabel("READ_LENGTH");
+        pairTotalReadHistogram.setBinLabel(READ_LENGTH);
         pairTotalReadHistogram.setValueLabel("PAIRED_TOTAL_LENGTH_COUNT");
         file.addHistogram(pairTotalReadHistogram);
 
         final Histogram<Integer> pairClippedReadHistogram = allReadsGroupCollector.pairCollector.getAlignedReadHistogram();
-        pairClippedReadHistogram.setBinLabel("READ_LENGTH");
+        pairClippedReadHistogram.setBinLabel(READ_LENGTH);
         pairClippedReadHistogram.setValueLabel("PAIRED_ALIGNED_LENGTH_COUNT");
         file.addHistogram(pairClippedReadHistogram);
 
         final Histogram<Integer> unpairedTotalReadHistogram = allReadsGroupCollector.unpairedCollector.getReadHistogram();
-        unpairedTotalReadHistogram.setBinLabel("READ_LENGTH");
-        unpairedTotalReadHistogram.setValueLabel("PAIRED_TOTAL_LENGTH_COUNT");
+        unpairedTotalReadHistogram.setBinLabel(READ_LENGTH);
+        unpairedTotalReadHistogram.setValueLabel("UNPAIRED_TOTAL_LENGTH_COUNT");
         file.addHistogram(unpairedTotalReadHistogram);
 
         final Histogram<Integer> unpairedClippedReadHistogram = allReadsGroupCollector.unpairedCollector.getAlignedReadHistogram();
-        unpairedClippedReadHistogram.setBinLabel("READ_LENGTH");
-        unpairedClippedReadHistogram.setValueLabel("PAIRED_ALIGNED_LENGTH_COUNT");
+        unpairedClippedReadHistogram.setBinLabel(READ_LENGTH);
+        unpairedClippedReadHistogram.setValueLabel("UNPAIRED_ALIGNED_LENGTH_COUNT");
         file.addHistogram(unpairedClippedReadHistogram);
 
         file.write(OUTPUT);


### PR DESCRIPTION
In the recently added read-length histogram & chart (added to AlignmentSummaryMetrics) there was a typo in the histogram label and the plot. 

This PR fixes both and refactors out the repetitive part that was responsible for the typo.
