### PR TITLE
Adjust MBA read overhang clipping to be consistent with past behavior

### DIFF
--- a/src/main/java/picard/sam/AbstractAlignmentMerger.java
+++ b/src/main/java/picard/sam/AbstractAlignmentMerger.java
@@ -765,7 +765,35 @@ public abstract class AbstractAlignmentMerger {
 
     /**
      * Checks to see whether the ends of the reads overlap and clips reads
-     * if necessary.
+     * if necessary.  For inward facing read pairs, this method will soft clip the 5'
+     * end of each read so that the 5' aligned end of each read does not extend past
+     * the 3' aligned end of its mate.  If useHardClipping is true, this method will
+     * additionally hard clip the 5' end of each read if necessary so that the 5' end of
+     * each read (including soft clipped bases) does not extend past the 3' end of its
+     * mate (including soft clipped bases).  Some examples are illustrative:
+     *
+     *              <-MMMMMMMMMMMMMMMMM
+     *                   MMMMMMMMMMMMMMMMM->
+     * will be soft-clipped to
+     *              <-SSSMMMMMMMMMMMMMM
+     *                   MMMMMMMMMMMMMMSSS->
+     * and with useHardClip true, this would then be hard-clipped to
+     *              <-HHHMMMMMMMMMMMMMM
+     *                   MMMMMMMMMMMMMMHHH->
+     *
+     * A more complicated example
+     *              <-MMMMMMMMMMMMMMMSS
+     *                   MMMMMMMMMMMMMMMMM->
+     * will be soft-clipped to
+     *              <-SSSMMMMMMMMMMMMSS
+     *                   MMMMMMMMMMMMSSSSS->
+     * and with useHardClip true, this would then be hard-clipped to
+     *              <-HHHMMMMMMMMMMMMSS
+     *                   MMMMMMMMMMMMSSHHH->
+     *
+     * Note that the soft-clipping is done such that the clipped starts and ends
+     * of each read are the same, and hard-clipping is done such that the unclipped
+     * starts and ends of each read are the same.
      */
     protected static void clipForOverlappingReads(final SAMRecord read1, final SAMRecord read2, final boolean useHardClipping) {
         // If both reads are mapped, see if we need to clip the ends due to small insert size

--- a/src/main/java/picard/sam/AbstractAlignmentMerger.java
+++ b/src/main/java/picard/sam/AbstractAlignmentMerger.java
@@ -805,34 +805,29 @@ public abstract class AbstractAlignmentMerger {
                 // Innies only -- do we need to do anything else about jumping libraries?
                 if (pos.getAlignmentStart() < neg.getAlignmentEnd()) {
                     // first we softclip the 3' end of each read so that its 3' aligned end does not extends past the 5' aligned start of it's mate
-                    int posClipFrom = getReadPositionAtReferencePositionIgnoreSoftClips(pos, neg.getEnd() + 1);
-                    int negClipFrom = getReadPositionAtReferencePositionIgnoreSoftClips(neg, pos.getStart() - 1);
-                    negClipFrom = negClipFrom > 0 ? (neg.getReadLength() + 1) - negClipFrom : 0;
-
-                    if(posClipFrom > 0) {
-                        CigarUtil.clip3PrimeEndOfRead(pos, posClipFrom, CigarOperator.SOFT_CLIP);
-                    }
-                    if(negClipFrom > 0) {
-                        CigarUtil.clip3PrimeEndOfRead(neg, negClipFrom, CigarOperator.SOFT_CLIP);
-                    }
+                    clip3primeEndsTo5primeEnds(pos, neg, false, false);
 
                     if (useHardClipping) {
-                        // if we want to hardclip, we additionally hardclip the 3' end of each read so that its 3' end (considering softclips as matches) does not extend past the 5' start (considering softclips as matches)
-                        posClipFrom = getReadPositionAtReferencePositionIgnoreSoftClips(pos, neg.getUnclippedEnd() + 1);
-                        negClipFrom = getReadPositionAtReferencePositionIgnoreSoftClips(neg, pos.getUnclippedStart() - 1);
-                        negClipFrom = negClipFrom > 0 ? (neg.getReadLength() + 1) - negClipFrom : 0;
-
-                        if(posClipFrom > 0) {
-                            moveClippedBasesToTag(pos, posClipFrom);
-                            CigarUtil.clip3PrimeEndOfRead(pos, posClipFrom, CigarOperator.HARD_CLIP);
-                        }
-                        if(negClipFrom > 0) {
-                            moveClippedBasesToTag(neg, negClipFrom);
-                            CigarUtil.clip3PrimeEndOfRead(neg, negClipFrom, CigarOperator.HARD_CLIP);
-                        }
+                        // if we want to hardclip, we additionally hardclip the 3' end of each read so that its 3' unclipped end does not extend past the 5' unclipped start of its mate
+                        clip3primeEndsTo5primeEnds(pos, neg, true, true);
                     }
                 }
             }
+        }
+    }
+
+    private static void clip3primeEndsTo5primeEnds(final SAMRecord pos, final SAMRecord neg, final boolean hardClipReads, final boolean useUnclippedEnds) {
+        final int negEnd = useUnclippedEnds? neg.getUnclippedEnd() : neg.getEnd();
+        final int posStart = useUnclippedEnds? pos.getUnclippedStart() : pos.getStart();
+        final int posClipFrom = getReadPositionAtReferencePositionIgnoreSoftClips(pos, negEnd + 1);
+        int negClipFrom = getReadPositionAtReferencePositionIgnoreSoftClips(neg, posStart - 1);
+        negClipFrom = negClipFrom > 0 ? (neg.getReadLength() + 1) - negClipFrom : 0;
+
+        if(posClipFrom > 0) {
+            clip3PrimeEndOfRead(pos, posClipFrom, hardClipReads);
+        }
+        if(negClipFrom > 0) {
+            clip3PrimeEndOfRead(neg, negClipFrom, hardClipReads);
         }
     }
 

--- a/src/main/java/picard/sam/MergeBamAlignment.java
+++ b/src/main/java/picard/sam/MergeBamAlignment.java
@@ -258,8 +258,10 @@ public class MergeBamAlignment extends CommandLineProgram {
     public PrimaryAlignmentStrategy PRIMARY_ALIGNMENT_STRATEGY = PrimaryAlignmentStrategy.BestMapq;
 
     @Argument(doc = "For paired reads, clip the 3' end of each read if necessary so that it does not extend past the 5' end of its mate.  " +
-            "Clipping will be either soft or hard clipping, depending on CLIP_OVERLAPPING_READS_OPERATOR setting. " +
-            "Hard clipped bases and their qualities will be stored in the XB and XQ tags respectively.")
+            "Reads are first soft clipped so that the 3' aligned end of each read does not extend past the 5' aligned end of its mate.  " +
+            "If HARD_CLIP_OVERLAPPING_READS is also true, then reads are additionally hard clipped so that the 3' unclipped end of each read " +
+            "does not extend past the 5' unclipped end of its mate.  Hard clipped bases and their qualities are stored in the XB and XQ " +
+            "tags, respectively.")
     public boolean CLIP_OVERLAPPING_READS = true;
 
     @Argument(doc = "If true, hard clipping will be applied to overlapping reads.  By default, soft clipping is used.")

--- a/src/test/java/picard/sam/AbstractAlignmentMergerTest.java
+++ b/src/test/java/picard/sam/AbstractAlignmentMergerTest.java
@@ -60,11 +60,31 @@ public class AbstractAlignmentMergerTest extends CommandLineProgramTest {
                         default110LongR1Bases, default110LongR2Bases, default110LongR1Bases, default110LongR2Bases, null, null,
                         default110LongR1BaseQualities, default110LongR2BaseQualities, default110LongR1BaseQualities, default110LongR2BaseQualities, null, null}, // Non overlapping reads
 
+                {110, 100, 200, "110M", "110M", false, true, 100, 200, "110M", "110M", true,
+                        default110LongR1Bases, default110LongR2Bases, default110LongR1Bases, default110LongR2Bases, null, null,
+                        default110LongR1BaseQualities, default110LongR2BaseQualities, default110LongR1BaseQualities, default110LongR2BaseQualities, null, null},
+
+                {110, 100, 200, "110M", "110M", false, false, 100, 200, "110M", "110M", false,
+                        default110LongR1Bases, default110LongR2Bases, default110LongR1Bases, default110LongR2Bases, null, null,
+                        default110LongR1BaseQualities, default110LongR2BaseQualities, default110LongR1BaseQualities, default110LongR2BaseQualities, null, null}, // F1F2
+
+                {110, 100, 200, "110M", "110M", false, false, 100, 200, "110M", "110M", true,
+                        default110LongR1Bases, default110LongR2Bases, default110LongR1Bases, default110LongR2Bases, null, null,
+                        default110LongR1BaseQualities, default110LongR2BaseQualities, default110LongR1BaseQualities, default110LongR2BaseQualities, null, null},
+
+                {110, 100, 200, "110M", "110M", true, true, 100, 200, "110M", "110M", false,
+                        default110LongR1Bases, default110LongR2Bases, default110LongR1Bases, default110LongR2Bases, null, null,
+                        default110LongR1BaseQualities, default110LongR2BaseQualities, default110LongR1BaseQualities, default110LongR2BaseQualities, null, null}, // R1R2
+
+                {110, 100, 200, "110M", "110M", true, true, 100, 200, "110M", "110M", true,
+                        default110LongR1Bases, default110LongR2Bases, default110LongR1Bases, default110LongR2Bases, null, null,
+                        default110LongR1BaseQualities, default110LongR2BaseQualities, default110LongR1BaseQualities, default110LongR2BaseQualities, null, null},
+
                 {110, 100, 300, "110M", "110M", true, false, 100, 300, "110M", "110M", false,
                         default110LongR1Bases, default110LongR2Bases, default110LongR1Bases, default110LongR2Bases, null, null,
                         default110LongR1BaseQualities, default110LongR2BaseQualities, default110LongR1BaseQualities, default110LongR2BaseQualities, null, null}, // Non overlapping "outies"
 
-                {110, 100, 200, "110M", "110M", false, true, 100, 200, "110M", "110M", true,
+                {110, 100, 300, "110M", "110M", true, false, 100, 300, "110M", "110M", true,
                         default110LongR1Bases, default110LongR2Bases, default110LongR1Bases, default110LongR2Bases, null, null,
                         default110LongR1BaseQualities, default110LongR2BaseQualities, default110LongR1BaseQualities, default110LongR2BaseQualities, null, null},
 
@@ -96,6 +116,20 @@ public class AbstractAlignmentMergerTest extends CommandLineProgramTest {
                         default120LongR1Bases, default120LongR2Bases, sharedBases, sharedBases, default120LongR1ClippedBases, default120LongR2ClippedBases,
                         default120LongR1BaseQualities, default120LongR2BaseQualities, sharedQualities, sharedQualities, r1ClippedQualities20, r2ClippedQualities20},
 
+                // 5' end soft clip tests
+                /*
+                                       SSSSSSSSSSSMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM->
+                                 <-MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMSSSSSSSSS
+
+                                 soft clipping becomes:
+                                       SSSSSSSSSSSMMMMMMMMMMMMMMMMMMMMMMMMMMSSSSSSSSSSSSS->
+                                 <-SSSSSSSSSSSSSSSMMMMMMMMMMMMMMMMMMMMMMMMMMSSSSSSSSS
+
+                                 hard clipping becomes:
+                                       SSSSSSSSSSSMMMMMMMMMMMMMMMMMMMMMMMMMMSSSSSSSSSHHHH->
+                                 <-HHHHSSSSSSSSSSSMMMMMMMMMMMMMMMMMMMMMMMMMMSSSSSSSSS
+                */
+
                 {110, 105, 90, "5S105M", "103M7S", false, true, 105, 105, "5S88M17S", "15S88M7S", false,
                         default110LongR1Bases, default110LongR2Bases, default110LongR1Bases, default110LongR2Bases, null, null,
                         default110LongR1BaseQualities, default110LongR2BaseQualities, default110LongR1BaseQualities, default110LongR2BaseQualities, null, null}, // Already soft clipped at 5' end
@@ -104,6 +138,67 @@ public class AbstractAlignmentMergerTest extends CommandLineProgramTest {
                         default110LongR1Bases, default110LongR2Bases, sharedBases, sharedBases, default110LongR1ClippedBases, default110LongR2ClippedBases,
                         default110LongR1BaseQualities, default110LongR2BaseQualities, sharedQualities, sharedQualities, r1ClippedQualities10, r2ClippedQualities10},
 
+                /*
+                                SSSSSSSSSSSMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM->
+                                     <-MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMSSSSSSSSS
+
+                                soft clipping becomes:
+                                SSSSSSSSSSSMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMSS->
+                                     <-SSSSMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMSSSSSSSSS
+
+                                hard clipping leaves as from soft clipping
+
+                 */
+
+                {110, 105, 100, "10S100M", "103M7S", false, true, 105, 105, "10S98M2S", "5S98M7S", false,
+                        default110LongR1Bases, default110LongR2Bases, default110LongR1Bases, default110LongR2Bases, null, null,
+                        default110LongR1BaseQualities, default110LongR2BaseQualities, default110LongR1BaseQualities, default110LongR2BaseQualities, null, null},
+
+                {110, 105, 100, "10S100M", "103M7S", false, true, 105, 105, "10S98M2S", "5S98M7S", false,
+                        default110LongR1Bases, default110LongR2Bases, default110LongR1Bases, default110LongR2Bases, null, null,
+                        default110LongR1BaseQualities, default110LongR2BaseQualities, default110LongR1BaseQualities, default110LongR2BaseQualities, null, null},
+
+                /*
+                                SSSSSSSSSSSMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMSSSSS->
+                                     <-MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMSSSSSSSSSSSSSSSSSSSSSS
+
+                                soft clipping becomes:
+                                SSSSSSSSSSSMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMSSSSSSSSSSSSSS->
+                                     <-SSSSMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMSSSSSSSSSSSSSSSSSSSSSS
+
+                                hard clipping leaves as from soft clipping
+
+                 */
+                {110, 105, 100, "10S97M3S", "99M11S", false, true, 105, 105, "10S94M6S", "5S94M11S", false,
+                        default110LongR1Bases, default110LongR2Bases, default110LongR1Bases, default110LongR2Bases, null, null,
+                        default110LongR1BaseQualities, default110LongR2BaseQualities, default110LongR1BaseQualities, default110LongR2BaseQualities, null, null},
+
+                {110, 105, 100, "10S97M3S", "99M11S", false, true, 105, 105, "10S94M6S", "5S94M11S", false,
+                        default110LongR1Bases, default110LongR2Bases, default110LongR1Bases, default110LongR2Bases, null, null,
+                        default110LongR1BaseQualities, default110LongR2BaseQualities, default110LongR1BaseQualities, default110LongR2BaseQualities, null, null},
+
+                /*
+                                          SSSSSSSSSSSMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMSSSSSS->
+                                     <-SSSSSMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+
+                                soft clipping becomes:
+                                          SSSSSSSSSSSMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMSSSSSS->
+                                     <-SSSSSSSSSSSSSSMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+
+
+                                hard clipping becomes:
+                                          SSSSSSSSSSSMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMSSSHHH->
+                                     <-HHHSSSSSSSSSSSMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+
+                 */
+
+                {110, 105, 96, "12S80M18S", "13S97M", false, true, 105, 105, "12S80M18S", "22S88M", false,
+                        default110LongR1Bases, default110LongR2Bases, default110LongR1Bases, default110LongR2Bases, null, null,
+                        default110LongR1BaseQualities, default110LongR2BaseQualities, default110LongR1BaseQualities, default110LongR2BaseQualities, null, null},
+
+                {110, 105, 96, "12S80M18S", "13S97M", false, true, 105, 105, "12S80M8S10H", "10H12S88M", true,
+                        default110LongR1Bases, default110LongR2Bases, sharedBases, sharedBases, default110LongR1ClippedBases, default110LongR2ClippedBases,
+                        default110LongR1BaseQualities, default110LongR2BaseQualities, sharedQualities, sharedQualities, r1ClippedQualities10, r2ClippedQualities10},
         };
     }
 

--- a/src/test/java/picard/sam/AbstractAlignmentMergerTest.java
+++ b/src/test/java/picard/sam/AbstractAlignmentMergerTest.java
@@ -60,6 +60,10 @@ public class AbstractAlignmentMergerTest extends CommandLineProgramTest {
                         default110LongR1Bases, default110LongR2Bases, default110LongR1Bases, default110LongR2Bases, null, null,
                         default110LongR1BaseQualities, default110LongR2BaseQualities, default110LongR1BaseQualities, default110LongR2BaseQualities, null, null}, // Non overlapping reads
 
+                {110, 100, 300, "110M", "110M", true, false, 100, 300, "110M", "110M", false,
+                        default110LongR1Bases, default110LongR2Bases, default110LongR1Bases, default110LongR2Bases, null, null,
+                        default110LongR1BaseQualities, default110LongR2BaseQualities, default110LongR1BaseQualities, default110LongR2BaseQualities, null, null}, // Non overlapping "outies"
+
                 {110, 100, 200, "110M", "110M", false, true, 100, 200, "110M", "110M", true,
                         default110LongR1Bases, default110LongR2Bases, default110LongR1Bases, default110LongR2Bases, null, null,
                         default110LongR1BaseQualities, default110LongR2BaseQualities, default110LongR1BaseQualities, default110LongR2BaseQualities, null, null},

--- a/src/test/java/picard/sam/AbstractAlignmentMergerTest.java
+++ b/src/test/java/picard/sam/AbstractAlignmentMergerTest.java
@@ -146,7 +146,7 @@ public class AbstractAlignmentMergerTest extends CommandLineProgramTest {
                                 SSSSSSSSSSSMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMSS->
                                      <-SSSSMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMSSSSSSSSS
 
-                                hard clipping leaves as from soft clipping
+                                hard-clipping results in the same as with soft-clipping in this case.
 
                  */
 
@@ -166,7 +166,7 @@ public class AbstractAlignmentMergerTest extends CommandLineProgramTest {
                                 SSSSSSSSSSSMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMSSSSSSSSSSSSSS->
                                      <-SSSSMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMSSSSSSSSSSSSSSSSSSSSSS
 
-                                hard clipping leaves as from soft clipping
+                                hard-clipping results in the same as with soft-clipping in this case.
 
                  */
                 {110, 105, 100, "10S97M3S", "99M11S", false, true, 105, 105, "10S94M6S", "5S94M11S", false,

--- a/src/test/java/picard/sam/AbstractAlignmentMergerTest.java
+++ b/src/test/java/picard/sam/AbstractAlignmentMergerTest.java
@@ -90,7 +90,15 @@ public class AbstractAlignmentMergerTest extends CommandLineProgramTest {
 
                 {120, 100, 95, "95M25S", "15S105M", false, true, 100, 100, "95M5S20H", "20H100M", true,
                         default120LongR1Bases, default120LongR2Bases, sharedBases, sharedBases, default120LongR1ClippedBases, default120LongR2ClippedBases,
-                        default120LongR1BaseQualities, default120LongR2BaseQualities, sharedQualities, sharedQualities, r1ClippedQualities20, r2ClippedQualities20}
+                        default120LongR1BaseQualities, default120LongR2BaseQualities, sharedQualities, sharedQualities, r1ClippedQualities20, r2ClippedQualities20},
+
+                {110, 105, 90, "5S105M", "103M7S", false, true, 105, 105, "5S88M17S", "15S88M7S", false,
+                        default110LongR1Bases, default110LongR2Bases, default110LongR1Bases, default110LongR2Bases, null, null,
+                        default110LongR1BaseQualities, default110LongR2BaseQualities, default110LongR1BaseQualities, default110LongR2BaseQualities, null, null}, // Already soft clipped at 5' end
+
+                {110, 105, 90, "5S105M", "103M7S", false, true, 105, 105, "5S88M7S10H", "10H5S88M7S", true,
+                        default110LongR1Bases, default110LongR2Bases, sharedBases, sharedBases, default110LongR1ClippedBases, default110LongR2ClippedBases,
+                        default110LongR1BaseQualities, default110LongR2BaseQualities, sharedQualities, sharedQualities, r1ClippedQualities10, r2ClippedQualities10},
 
         };
     }


### PR DESCRIPTION
It has been noted in #1569 that #1484 changed the behavior of MBA when soft clipping overhanging reads.  This PR reverts the behavior when soft clipping so that it is the same as "old" (pre #1484) MBA.  The behavior when hard clipping is also adjusted slightly.  The behavior implemented here is as follows:
1. overlapping reads are soft clipped so that the 3' aligned end does not extend past the 5' aligned end of the mate. This reverts to the "old" MBA behavior when soft clipping
2. if using hard clipping, reads are additionally hard clipped so that the 3' unclipped end of the read does not extend past the 5' unclipped end of the mate. This implements the "new" MBA behavior when hard clipping.

The result of this behavior is that:
 - When running in soft clipping mode, the results are identical to the "old" MBA
 - When running in hard clipping mode, the hard clipped bases are the same as in the "new" MBA.  Additionally, any bases which would have been clipped by the "old" MBA but not by the "new" MBA are soft clipped.
 - Consistency between TLEN and the cigar is maintained for both situations, ie. we won't have reads with longer matches than the 5'-5' TLEN.

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

