### PR TITLE
Safely run DownsampleSam multiple times

### DIFF
--- a/src/main/java/picard/cmdline/CommandLineProgram.java
+++ b/src/main/java/picard/cmdline/CommandLineProgram.java
@@ -446,7 +446,7 @@ public abstract class CommandLineProgram {
         this.defaultHeaders.addAll(headers);
     }
 
-    public void addPGRecordToHeader(final SAMFileHeader header) {
+    public SAMProgramRecord getPGRecord(final SAMFileHeader header) {
         final SAMFileHeader.PgIdGenerator pgIdGenerator = new SAMFileHeader.PgIdGenerator(header);
 
         final String pgProgramName = getClass().getSimpleName();
@@ -455,7 +455,7 @@ public abstract class CommandLineProgram {
         programRecord.setProgramName(pgProgramName);
         programRecord.setCommandLine(getCommandLine());
         programRecord.setProgramVersion(getVersion());
-        header.addProgramRecord(programRecord);
+        return programRecord;
     }
 
     public List<Header> getDefaultHeaders() {

--- a/src/main/java/picard/cmdline/CommandLineProgram.java
+++ b/src/main/java/picard/cmdline/CommandLineProgram.java
@@ -26,8 +26,10 @@ package picard.cmdline;
 import com.intel.gkl.compression.IntelDeflaterFactory;
 import com.intel.gkl.compression.IntelInflaterFactory;
 import htsjdk.samtools.Defaults;
+import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMFileWriterFactory;
 import htsjdk.samtools.SAMFileWriterImpl;
+import htsjdk.samtools.SAMProgramRecord;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.ValidationStringency;
 import htsjdk.samtools.metrics.Header;
@@ -442,6 +444,18 @@ public abstract class CommandLineProgram {
     public void setDefaultHeaders(final List<Header> headers) {
         this.defaultHeaders.clear();
         this.defaultHeaders.addAll(headers);
+    }
+
+    public void addPGRecordToHeader(final SAMFileHeader header) {
+        final SAMFileHeader.PgIdGenerator pgIdGenerator = new SAMFileHeader.PgIdGenerator(header);
+
+        final String pgProgramName = getClass().getSimpleName();
+        final SAMProgramRecord programRecord = new SAMProgramRecord(pgIdGenerator.getNonCollidingId(pgProgramName));
+
+        programRecord.setProgramName(pgProgramName);
+        programRecord.setCommandLine(getCommandLine());
+        programRecord.setProgramVersion(getVersion());
+        header.addProgramRecord(programRecord);
     }
 
     public List<Header> getDefaultHeaders() {

--- a/src/main/java/picard/sam/DownsampleSam.java
+++ b/src/main/java/picard/sam/DownsampleSam.java
@@ -238,6 +238,7 @@ public class DownsampleSam extends CommandLineProgram {
 
         SAMProgramRecord pgRecord = getPGRecord(header);
         pgRecord.setAttribute(RANDOM_SEED_TAG, RANDOM_SEED.toString());
+        header.addProgramRecord(pgRecord);
         final SAMFileWriter out = new SAMFileWriterFactory().makeSAMOrBAMWriter(header, true, OUTPUT);
         final ProgressLogger progress = new ProgressLogger(log, (int) 1e7, "Wrote");
         final DownsamplingIterator iterator = DownsamplingIteratorFactory.make(in, STRATEGY, PROBABILITY, ACCURACY, RANDOM_SEED);

--- a/src/main/java/picard/sam/DownsampleSam.java
+++ b/src/main/java/picard/sam/DownsampleSam.java
@@ -239,7 +239,7 @@ public class DownsampleSam extends CommandLineProgram {
                             //are the random seeds the same?
                             if (RANDOM_SEED.equals(previousDownsample.RANDOM_SEED)) {
                                 throw new PicardException("Attempting to downsample using STRATEGY " + STRATEGY + " on data that has already been downsampled using STRATEGY " + previousDownsample.STRATEGY + " and same " +
-                                        "RANDOM_SEED  " + RANDOM_SEED + ".  In order to downsample this data further, you must either supply a different RANDOM_SEED, or use STRATEGY HighAccuracy");
+                                        "RANDOM_SEED  " + RANDOM_SEED + ".  In order to downsample this data further, you must either supply a different RANDOM_SEED, or use STRATEGY HighAccuracy or Chained");
                             }
                         }
                     }

--- a/src/main/java/picard/sam/DownsampleSam.java
+++ b/src/main/java/picard/sam/DownsampleSam.java
@@ -246,13 +246,8 @@ public class DownsampleSam extends CommandLineProgram {
                 }
             }
         }
-        final SAMFileHeader.PgIdGenerator pgIdGenerator = new SAMFileHeader.PgIdGenerator(header);
 
-        final SAMProgramRecord programRecord = new SAMProgramRecord(pgIdGenerator.getNonCollidingId(PG_PROGRAM_NAME));
-        programRecord.setProgramName(PG_PROGRAM_NAME);
-        programRecord.setCommandLine(getCommandLine());
-        programRecord.setProgramVersion(getVersion());
-        header.addProgramRecord(programRecord);
+        addPGRecordToHeader(header);
         final SAMFileWriter out = new SAMFileWriterFactory().makeSAMOrBAMWriter(header, true, OUTPUT);
         final ProgressLogger progress = new ProgressLogger(log, (int) 1e7, "Wrote");
         final DownsamplingIterator iterator = DownsamplingIteratorFactory.make(in, STRATEGY, PROBABILITY, ACCURACY, RANDOM_SEED);

--- a/src/main/java/picard/sam/DownsampleSam.java
+++ b/src/main/java/picard/sam/DownsampleSam.java
@@ -237,8 +237,9 @@ public class DownsampleSam extends CommandLineProgram {
                         RANDOM_SEED = new Random(pg.hashCode()).nextInt();
                         log.warn("DownsampleSam has been run before on this data, but the previous seed was not recorded.  The used seed will be changed to minimize the chance of using" +
                                 " the same seed as in a previous run.");
+                    } else {
+                        previousSeeds.add(Integer.parseInt(previousSeedString));
                     }
-                    previousSeeds.add(Integer.parseInt(previousSeedString));
                 }
             }
 

--- a/src/main/java/picard/sam/DownsampleSam.java
+++ b/src/main/java/picard/sam/DownsampleSam.java
@@ -33,7 +33,6 @@ import htsjdk.samtools.util.ProgressLogger;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
-import picard.PicardException;
 import picard.analysis.CollectQualityYieldMetrics.QualityYieldMetrics;
 import picard.analysis.CollectQualityYieldMetrics.QualityYieldMetricsCollector;
 import picard.cmdline.CommandLineProgram;

--- a/src/main/java/picard/sam/DownsampleSam.java
+++ b/src/main/java/picard/sam/DownsampleSam.java
@@ -222,7 +222,6 @@ public class DownsampleSam extends CommandLineProgram {
         final SamReader in = SamReaderFactory.makeDefault().referenceSequence(REFERENCE_SEQUENCE).open(SamInputResource.of(INPUT));
         final SAMFileHeader header = in.getFileHeader().clone();
 
-
         if (STRATEGY == Strategy.ConstantMemory || STRATEGY == Strategy.Chained) {
             //if running using ConstantMemory or Chained strategy, need to check if we have previously run with the same random seed
             //collect previously used seeds

--- a/src/main/java/picard/sam/DownsampleSam.java
+++ b/src/main/java/picard/sam/DownsampleSam.java
@@ -225,6 +225,7 @@ public class DownsampleSam extends CommandLineProgram {
         if (STRATEGY == Strategy.ConstantMemory || STRATEGY == Strategy.Chained) {
             //if running using ConstantMemory or Chained strategy, need to check if we have previously run with the same random seed
             //collect previously used seeds
+            final int USER_SEED = RANDOM_SEED;
             final Set<Integer> previousSeeds = new HashSet<>();
             for (final SAMProgramRecord pg : header.getProgramRecords()) {
                 if (pg.getProgramName() != null && pg.getProgramName().equals(PG_PROGRAM_NAME)) {
@@ -233,10 +234,9 @@ public class DownsampleSam extends CommandLineProgram {
                         /* The previous seed was not recorded.  In this case, the current seed may be the same as the previous seed,
                         so we will change it to a randomly selected seed, which is very likely to be unique
                          */
-                        RANDOM_SEED = new Random().nextInt();
-                        log.warn("DownsampleSam has been run before on this data, but the previous seed was not recorded.  The current seed has been set to " + RANDOM_SEED + " to avoid using the " +
-                                "same seed as previously.");
-                        break;
+                        RANDOM_SEED = new Random(pg.hashCode()).nextInt();
+                        log.warn("DownsampleSam has been run before on this data, but the previous seed was not recorded.  The used seed will be changed to minimize the chance of using the" +
+                                " same seed as in a previous run.");
                     }
                     final int previousSeed = Integer.parseInt(previousSeedString);
                     previousSeeds.add(previousSeed);
@@ -247,8 +247,11 @@ public class DownsampleSam extends CommandLineProgram {
             while (previousSeeds.contains(RANDOM_SEED)) {
                 final int previousSeed = RANDOM_SEED;
                 RANDOM_SEED = rnd.nextInt();
-                log.warn("DownsampleSam has been run before on this data with the seed. " + previousSeed + "  The random seed has been set to " + RANDOM_SEED + " to avoid using the " +
+                log.warn("DownsampleSam has been run before on this data with the seed .  The random seed will be changed to avoid using the " +
                         "same seed as previously.");
+            }
+            if (USER_SEED != RANDOM_SEED) {
+                log.warn("RANDOM_SEED has been changed to " + RANDOM_SEED + ".");
             }
         }
 

--- a/src/main/java/picard/sam/DownsampleSam.java
+++ b/src/main/java/picard/sam/DownsampleSam.java
@@ -222,6 +222,7 @@ public class DownsampleSam extends CommandLineProgram {
         final SamReader in = SamReaderFactory.makeDefault().referenceSequence(REFERENCE_SEQUENCE).open(SamInputResource.of(INPUT));
         final SAMFileHeader header = in.getFileHeader().clone();
 
+
         if (STRATEGY == Strategy.ConstantMemory || STRATEGY == Strategy.Chained) {
             //if running using ConstantMemory or Chained strategy, need to check if we have previously run with the same random seed
             //collect previously used seeds
@@ -235,8 +236,7 @@ public class DownsampleSam extends CommandLineProgram {
                         so we will change it to a randomly selected seed, which is very likely to be unique
                          */
                         RANDOM_SEED = new Random(pg.hashCode()).nextInt();
-                        log.warn("DownsampleSam has been run before on this data, but the previous seed was not recorded.  The used seed will be changed to minimize the chance of using the" +
-                                " same seed as in a previous run.");
+                        log.warn("DownsampleSam has been run before on this data, but the previous seed was not recorded.  The used seed will be changed to minimize the chance of using the same seed as in a previous run.");
                     }
                     final int previousSeed = Integer.parseInt(previousSeedString);
                     previousSeeds.add(previousSeed);
@@ -245,7 +245,6 @@ public class DownsampleSam extends CommandLineProgram {
 
             final Random rnd = new Random(RANDOM_SEED);
             while (previousSeeds.contains(RANDOM_SEED)) {
-                final int previousSeed = RANDOM_SEED;
                 RANDOM_SEED = rnd.nextInt();
                 log.warn("DownsampleSam has been run before on this data with the seed " + RANDOM_SEED + ".  The random seed will be changed to avoid using the " +
                         "same seed as previously.");
@@ -255,7 +254,7 @@ public class DownsampleSam extends CommandLineProgram {
             }
         }
 
-        SAMProgramRecord pgRecord = getPGRecord(header);
+        final SAMProgramRecord pgRecord = getPGRecord(header);
         pgRecord.setAttribute(RANDOM_SEED_TAG, RANDOM_SEED.toString());
         header.addProgramRecord(pgRecord);
         final SAMFileWriter out = new SAMFileWriterFactory().makeSAMOrBAMWriter(header, true, OUTPUT);

--- a/src/main/java/picard/sam/DownsampleSam.java
+++ b/src/main/java/picard/sam/DownsampleSam.java
@@ -225,7 +225,7 @@ public class DownsampleSam extends CommandLineProgram {
         if (STRATEGY == Strategy.ConstantMemory || STRATEGY == Strategy.Chained) {
             //if running using ConstantMemory or Chained strategy, need to check if we have previously run with the same random seed
             //collect previously used seeds
-            final int USER_SEED = RANDOM_SEED;
+            final Integer userSeed = RANDOM_SEED;
             final Set<Integer> previousSeeds = new HashSet<>();
             for (final SAMProgramRecord pg : header.getProgramRecords()) {
                 if (pg.getProgramName() != null && pg.getProgramName().equals(PG_PROGRAM_NAME)) {
@@ -247,10 +247,10 @@ public class DownsampleSam extends CommandLineProgram {
             while (previousSeeds.contains(RANDOM_SEED)) {
                 final int previousSeed = RANDOM_SEED;
                 RANDOM_SEED = rnd.nextInt();
-                log.warn("DownsampleSam has been run before on this data with the seed .  The random seed will be changed to avoid using the " +
+                log.warn("DownsampleSam has been run before on this data with the seed " + RANDOM_SEED + ".  The random seed will be changed to avoid using the " +
                         "same seed as previously.");
             }
-            if (USER_SEED != RANDOM_SEED) {
+            if (!userSeed.equals(RANDOM_SEED)) {
                 log.warn("RANDOM_SEED has been changed to " + RANDOM_SEED + ".");
             }
         }

--- a/src/main/java/picard/sam/DownsampleSam.java
+++ b/src/main/java/picard/sam/DownsampleSam.java
@@ -235,10 +235,10 @@ public class DownsampleSam extends CommandLineProgram {
                         so we will change it to a randomly selected seed, which is very likely to be unique
                          */
                         RANDOM_SEED = new Random(pg.hashCode()).nextInt();
-                        log.warn("DownsampleSam has been run before on this data, but the previous seed was not recorded.  The used seed will be changed to minimize the chance of using the same seed as in a previous run.");
+                        log.warn("DownsampleSam has been run before on this data, but the previous seed was not recorded.  The used seed will be changed to minimize the chance of using" +
+                                " the same seed as in a previous run.");
                     }
-                    final int previousSeed = Integer.parseInt(previousSeedString);
-                    previousSeeds.add(previousSeed);
+                    previousSeeds.add(Integer.parseInt(previousSeedString));
                 }
             }
 

--- a/src/test/java/picard/sam/DownsampleSamTest.java
+++ b/src/test/java/picard/sam/DownsampleSamTest.java
@@ -167,14 +167,14 @@ public class DownsampleSamTest extends CommandLineProgramTest {
     public Object[][] repeatedDownsamplingProvider() {
         final List<Object[]> rets = new ArrayList<>();
         rets.add(new Object[]{Arrays.asList(DownsamplingIteratorFactory.Strategy.ConstantMemory, ConstantMemory), Arrays.asList(2,1), Arrays.asList(false, false)}); //ok, different seeds
-        rets.add(new Object[]{Arrays.asList(ConstantMemory, ConstantMemory), Arrays.asList(1,1), Arrays.asList(false, true)}); //throws exception
+        rets.add(new Object[]{Arrays.asList(ConstantMemory, ConstantMemory), Arrays.asList(1,1), Arrays.asList(false, false)}); //ok, PROBABILITY will be adjusted internally
         rets.add(new Object[]{Arrays.asList(Chained, ConstantMemory), Arrays.asList(1,1), Arrays.asList(false, true)}); //throws exception
         rets.add(new Object[]{Arrays.asList(Chained, ConstantMemory), Arrays.asList(1,3), Arrays.asList(false, false)}); //ok, different seeds
         rets.add(new Object[]{Arrays.asList(ConstantMemory, Chained), Arrays.asList(1,1), Arrays.asList(false, false)}); //ok, Chained comes second
         rets.add(new Object[]{Arrays.asList(HighAccuracy, ConstantMemory), Arrays.asList(1,1), Arrays.asList(false, false)}); //ok, HighAccuracy
         rets.add(new Object[]{Arrays.asList(ConstantMemory, HighAccuracy), Arrays.asList(1,1), Arrays.asList(false, false)}); //ok, HighAccuracy
         rets.add(new Object[]{Arrays.asList(Chained, Chained), Arrays.asList(1,1), Arrays.asList(false, false)}); // ok, Chained
-        rets.add(new Object[]{Arrays.asList(HighAccuracy, Chained), Arrays.asList(1,1), Arrays.asList(false, false)}); 
+        rets.add(new Object[]{Arrays.asList(HighAccuracy, Chained), Arrays.asList(1,1), Arrays.asList(false, false)});
         rets.add(new Object[]{Arrays.asList(HighAccuracy, HighAccuracy), Arrays.asList(1,1), Arrays.asList(false, false)});
         rets.add(new Object[]{Arrays.asList(Chained, HighAccuracy), Arrays.asList(1,1), Arrays.asList(false, false)});
 
@@ -199,7 +199,7 @@ public class DownsampleSamTest extends CommandLineProgramTest {
                     break;
                 }
 
-                if (strategy == ConstantMemory || strategy == Chained) {
+                if (strategy == Chained) {
                     previouslyUsedSeeds.add(seed);
                 }
             }
@@ -210,7 +210,7 @@ public class DownsampleSamTest extends CommandLineProgramTest {
     }
 
     @Test(dataProvider = "RepeatedDownsamplingProvider")
-    public void testRepeatedDownsamplingCheck(List<Strategy> strategies, List<Integer> seeds, List<Boolean> doesItThrow) throws IOException {
+    public void testRepeatedDownsampling(List<Strategy> strategies, List<Integer> seeds, List<Boolean> doesItThrow) throws IOException {
         File input = tempSamFile;
 
         for (int i = 0 ; i < strategies.size(); i++) {

--- a/src/test/java/picard/sam/DownsampleSamTest.java
+++ b/src/test/java/picard/sam/DownsampleSamTest.java
@@ -8,7 +8,6 @@ import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import picard.PicardException;
 import picard.cmdline.CommandLineProgramTest;
 import picard.sam.util.SamTestUtil;
 import htsjdk.samtools.DownsamplingIteratorFactory.Strategy;
@@ -20,10 +19,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
-import java.util.Set;
 
 import static htsjdk.samtools.DownsamplingIteratorFactory.Strategy.*;
 

--- a/src/test/java/picard/sam/DownsampleSamTest.java
+++ b/src/test/java/picard/sam/DownsampleSamTest.java
@@ -22,7 +22,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
-import static htsjdk.samtools.DownsamplingIteratorFactory.Strategy.*;
+import static htsjdk.samtools.DownsamplingIteratorFactory.Strategy.Chained;
+import static htsjdk.samtools.DownsamplingIteratorFactory.Strategy.ConstantMemory;
+import static htsjdk.samtools.DownsamplingIteratorFactory.Strategy.HighAccuracy;
 
 
 /**

--- a/src/test/java/picard/sam/DownsampleSamTest.java
+++ b/src/test/java/picard/sam/DownsampleSamTest.java
@@ -160,6 +160,11 @@ public class DownsampleSamTest extends CommandLineProgramTest {
     public Object[][] repeatedDownsamplingProvider() {
         final List<Object[]> rets = new ArrayList<>();
         rets.add(new Object[]{Arrays.asList(DownsamplingIteratorFactory.Strategy.ConstantMemory, ConstantMemory), Arrays.asList(2,1)});
+        rets.add(new Object[]{Arrays.asList(DownsamplingIteratorFactory.Strategy.ConstantMemory, ConstantMemory), Arrays.asList(0,0)});
+        rets.add(new Object[]{Arrays.asList(DownsamplingIteratorFactory.Strategy.ConstantMemory, ConstantMemory), Arrays.asList(Integer.MAX_VALUE,Integer.MAX_VALUE)});
+        rets.add(new Object[]{Arrays.asList(DownsamplingIteratorFactory.Strategy.ConstantMemory, ConstantMemory), Arrays.asList(Integer.MIN_VALUE,Integer.MIN_VALUE)});
+        rets.add(new Object[]{Arrays.asList(DownsamplingIteratorFactory.Strategy.ConstantMemory, ConstantMemory), Arrays.asList(Integer.MIN_VALUE,Integer.MAX_VALUE)});
+        rets.add(new Object[]{Arrays.asList(DownsamplingIteratorFactory.Strategy.ConstantMemory, ConstantMemory), Arrays.asList(Integer.MAX_VALUE,0)});
         rets.add(new Object[]{Arrays.asList(ConstantMemory, ConstantMemory), Arrays.asList(1,1)});
         rets.add(new Object[]{Arrays.asList(Chained, ConstantMemory), Arrays.asList(1,1)});
         rets.add(new Object[]{Arrays.asList(Chained, ConstantMemory), Arrays.asList(1,3)});
@@ -194,9 +199,15 @@ public class DownsampleSamTest extends CommandLineProgramTest {
     @Test(dataProvider = "RepeatedDownsamplingProvider")
     public void testRepeatedDownsampling(List<Strategy> strategies, List<Integer> seeds) throws IOException {
         File input = tempSamFile;
-
+        final long nReadsOriginal = SamTestUtil.countSamTotalRecord(input);
+        double totalFraction = 1;
         for (int i = 0 ; i < strategies.size(); i++) {
             input = testDownsampleWorker(input, 0.5, strategies.get(i).toString(), seeds.get(i));
+            totalFraction *= 0.5;
+
+            final long nReadsNow = SamTestUtil.countSamTotalRecord(input);
+            Assert.assertTrue(nReadsNow > 0.8 * totalFraction * nReadsOriginal);
+            Assert.assertTrue(nReadsNow < 1.2 * totalFraction * nReadsOriginal);
         }
     }
 }

--- a/src/test/java/picard/sam/DownsampleSamTest.java
+++ b/src/test/java/picard/sam/DownsampleSamTest.java
@@ -156,8 +156,6 @@ public class DownsampleSamTest extends CommandLineProgramTest {
         return downsampled;
     }
 
-
-
     @DataProvider(name = "RepeatedDownsamplingProvider")
     public Object[][] repeatedDownsamplingProvider() {
         final List<Object[]> rets = new ArrayList<>();
@@ -181,7 +179,7 @@ public class DownsampleSamTest extends CommandLineProgramTest {
         //randomly generate some sequences to test out
         final Strategy[] availableStratagies = Strategy.values();
         final Random random = new Random(12345);
-        for (int i =0; i<20; i++) {
+        for (int i=0; i<20; i++) {
             final List<Strategy> strategies = new ArrayList<>();
             final List<Integer> seeds = new ArrayList<>();
 


### PR DESCRIPTION
If DownsampleSam is run twice on the same file, the results can end up being incorrect.  This is because the ConstantMemory and Chained strategies both employ a hash based sampling which is initialized with a random seed.  If the seed used in two runs is the same, then the hashes associated with each read pair will be the same.   

As an example of the problem this causes, consider a case where we have Downsampled with the ConstantMemory strategy and a probability of 0.5.  What this means is that a hash is calculated for each read pair, and the hashes are (with appropriate normalization) uniformly distributed between 0 and 1.  All read pairs which hash to values less than 0.5 will pass the downsampling and be included in the output.  We now attempt to downsample the output a second time with ConstantMemory and probability 0.5, and the same seed as in the previous run.  Since the seed is the same, each read pair hashes to the same value, which is always less than 0.5, so all reads pass the downsampling.  The second downsampling has effectively done nothing.

If we are using the HighAccuracy strategy, there will be no issue, since this is a shuffle-and-cut strategy, and so compression of the hash-space causes no problems.

If we are using the Chained strategy, there will also be no issue.  The chained strategy first uses a hash based downsample to oversample, and then uses a shuffle-and-cut to get down to the correct fraction.  Since previous runs of downsampling can only serve to compress the hash space, the hash based part of this strategy will only end up oversampling.  Since the shuffle-and-cut part of this strategy uses the measured downsampled fraction (instead of the intended downsampled fraction) in its calculations, this strategy will still work, although it's memory footprint improvement over the HighAccuracy strategy will be reduced.

So, there are really three possibilities that need to be considered:
1) ConstantMemory now, ConstantMemory previously: in this case an earlier run with ConstantMemory strategy will have compressed the hash space by a factor of p_prev (ie, the previously downsampling probability).  We can therefore get the correct downsampling by internally using a value of p_prev * p_now to compare to the hashes.  Multiple previous runs with ConstantMemory strategy can be easily chained together, with each simply compressing the hash space by a factor of its downsampling probability.  Runs which used a different seed should have no effect on the hash space, so do not need to be considered when adjusting the internal probability.

2) ConstantMemory now, HighAccuracy previously:  since the HighAccuracy strategy has no effect on the hash space, this will work unchanged.

3) ConstantMemory now, Chained previously:  This is a slightly more complicated version of "ConstantMemory now, ConstantMemory previously".  The previous Chained run will have compressed the hash space, but the proportion is defined by `ChainedDownsamplingIterator.adjustProportion`.  We could technically adjust the internally used probability in the same way as "ConstantMemory now, ConstantMemory previously", but the fact that it depends on a private method in htsjdk makes me hesitant to do this.  For now, I am throwing an exception in this case.  Perhaps if `ChainedDownsamplingIterator.adjustProportion` is made public in the future then handling this case as well would be more reasonable.  Of course, when the seed is different there is no problem.

This PR implements all of the above, as well as adds tests of these types of repeated downsampling cases.


----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

