### PR TITLE
Fix CollectMultipleMetrics -- CollectAlignmentSummaryMetrics interaction

### DIFF
--- a/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
+++ b/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
@@ -140,14 +140,12 @@ public class CollectAlignmentSummaryMetrics extends SinglePassSamProgram {
         IOUtil.assertFileIsWritable(OUTPUT);
         if (HISTOGRAM_FILE != null) {
             if (!METRIC_ACCUMULATION_LEVEL.contains(MetricAccumulationLevel.ALL_READS)) {
-                log.warn("ReadLength histogram is calculated on all reads only, but ALL_READS were not " +
-                        "included in the Metric Accumulation Levels. Adding ALL_READS so that you get the output you asked for.");
-                // This tools is called from "Collect Multiple Metrics" and so changing the METRIC_ACCUMULATION_LEVEL directly can
-                // have unintended consequences....only changing it for this tool.
-                METRIC_ACCUMULATION_LEVEL = new HashSet<>(METRIC_ACCUMULATION_LEVEL);
-                METRIC_ACCUMULATION_LEVEL.add(MetricAccumulationLevel.ALL_READS);
+                log.error("ReadLength histogram is calculated on all reads only, but ALL_READS were not " +
+                        "included in the Metric Accumulation Levels. Histogram will not be generated.");
+                HISTOGRAM_FILE=null;
+            } else {
+                IOUtil.assertFileIsWritable(HISTOGRAM_FILE);
             }
-            IOUtil.assertFileIsWritable(HISTOGRAM_FILE);
         }
 
         if (header.getSequenceDictionary().isEmpty()) {
@@ -176,10 +174,12 @@ public class CollectAlignmentSummaryMetrics extends SinglePassSamProgram {
         final AlignmentSummaryMetricsCollector.GroupAlignmentSummaryMetricsPerUnitMetricCollector allReadsGroupCollector =
                 (AlignmentSummaryMetricsCollector.GroupAlignmentSummaryMetricsPerUnitMetricCollector) collector.getAllReadsCollector();
 
-        addAllHistogramToMetrics(file, "PAIRED_TOTAL_LENGTH_COUNT", allReadsGroupCollector.pairCollector);
-        addAlignedHistogramToMetrics(file, "PAIRED_ALIGNED_LENGTH_COUNT", allReadsGroupCollector.pairCollector);
-        addAllHistogramToMetrics(file, "UNPAIRED_TOTAL_LENGTH_COUNT", allReadsGroupCollector.unpairedCollector);
-        addAlignedHistogramToMetrics(file, "UNPAIRED_ALIGNED_LENGTH_COUNT", allReadsGroupCollector.unpairedCollector);
+        if (allReadsGroupCollector != null) {
+            addAllHistogramToMetrics(file, "PAIRED_TOTAL_LENGTH_COUNT", allReadsGroupCollector.pairCollector);
+            addAlignedHistogramToMetrics(file, "PAIRED_ALIGNED_LENGTH_COUNT", allReadsGroupCollector.pairCollector);
+            addAllHistogramToMetrics(file, "UNPAIRED_TOTAL_LENGTH_COUNT", allReadsGroupCollector.unpairedCollector);
+            addAlignedHistogramToMetrics(file, "UNPAIRED_ALIGNED_LENGTH_COUNT", allReadsGroupCollector.unpairedCollector);
+        }
 
         file.write(OUTPUT);
 


### PR DESCRIPTION
There was a buggy interaction between CollectMultipleMetrics and CollectAlignmentSummaryMetrics with regards to the collection and emission of the read-length histogram. This PR fixes it.

### Description

_Give your PR a **concise** yet **descriptive** title_
_Please explain the changes you made here._
_Explain the **motivation** for making this change. What existing problem does the pull request solve?_
_Mention any issues fixed, addressed or otherwise related to this pull request, including issue numbers or hard links for issues in other repos._
_You can delete these instructions once you have written your PR description._

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

