### PR TITLE
Check Sequence Dictionaries Match in CollectWgsMetrics

### DIFF
--- a/src/main/java/picard/analysis/CollectWgsMetrics.java
+++ b/src/main/java/picard/analysis/CollectWgsMetrics.java
@@ -48,7 +48,6 @@ import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
-import picard.PicardException;
 import picard.cmdline.CommandLineProgram;
 import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.argumentcollections.IntervalArgumentCollection;
@@ -212,11 +211,7 @@ static final String USAGE_DETAILS = "<p>This tool collects metrics about the fra
 
         // Verify the sequence dictionaries match
         if (!this.header.getSequenceDictionary().isEmpty()) {
-            try {
-                SequenceUtil.assertSequenceDictionariesEqual(this.header.getSequenceDictionary(), refWalker.getSequenceDictionary());
-            } catch (SequenceUtil.SequenceListsDifferException e) {
-                throw new PicardException("The given input bam and reference sequence don't have matching sequence dictionaries", e);
-            }
+            SequenceUtil.assertSequenceDictionariesEqual(this.header.getSequenceDictionary(), refWalker.getSequenceDictionary());
         }
 
         final List<SamRecordFilter> filters = new ArrayList<>();

--- a/src/main/java/picard/analysis/CollectWgsMetrics.java
+++ b/src/main/java/picard/analysis/CollectWgsMetrics.java
@@ -210,12 +210,12 @@ static final String USAGE_DETAILS = "<p>This tool collects metrics about the fra
         final SamReader in = getSamReader();
         final AbstractLocusIterator iterator = getLocusIterator(in);
 
-        // Verify the reference sequences match
+        // Verify the sequence dictionaries match
         if (!this.header.getSequenceDictionary().isEmpty()) {
             try {
                 SequenceUtil.assertSequenceDictionariesEqual(this.header.getSequenceDictionary(), refWalker.getSequenceDictionary());
             } catch (SequenceUtil.SequenceListsDifferException e) {
-                throw new PicardException("The given input bam is aligned to a different reference sequence than the reference sequence passed in", e);
+                throw new PicardException("The given input bam and reference sequence don't have matching sequence dictionaries", e);
             }
         }
 

--- a/src/main/java/picard/analysis/CollectWgsMetrics.java
+++ b/src/main/java/picard/analysis/CollectWgsMetrics.java
@@ -48,6 +48,7 @@ import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
+import picard.PicardException;
 import picard.cmdline.CommandLineProgram;
 import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.argumentcollections.IntervalArgumentCollection;
@@ -208,6 +209,15 @@ static final String USAGE_DETAILS = "<p>This tool collects metrics about the fra
         final ReferenceSequenceFileWalker refWalker = new ReferenceSequenceFileWalker(REFERENCE_SEQUENCE);
         final SamReader in = getSamReader();
         final AbstractLocusIterator iterator = getLocusIterator(in);
+
+        // Verify the reference sequences match
+        if (!this.header.getSequenceDictionary().isEmpty()) {
+            try {
+                SequenceUtil.assertSequenceDictionariesEqual(this.header.getSequenceDictionary(), refWalker.getSequenceDictionary());
+            } catch (SequenceUtil.SequenceListsDifferException e) {
+                throw new PicardException("The given input bam is aligned to a different reference sequence than the reference sequence passed in", e);
+            }
+        }
 
         final List<SamRecordFilter> filters = new ArrayList<>();
         final CountingFilter adapterFilter = new CountingAdapterFilter();

--- a/src/test/java/picard/analysis/CollectWgsMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectWgsMetricsTest.java
@@ -34,12 +34,12 @@ import htsjdk.samtools.SAMRecordSetBuilder;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.util.Histogram;
+import htsjdk.samtools.util.SequenceUtil;
 import htsjdk.variant.utils.SAMSequenceDictionaryExtractor;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import picard.PicardException;
 import picard.cmdline.CommandLineProgramTest;
 import picard.sam.SortSam;
 import picard.util.TestNGUtil;
@@ -530,14 +530,15 @@ public class CollectWgsMetricsTest extends CommandLineProgramTest {
         }
     }
 
-    @Test(expectedExceptions = PicardException.class)
+    @Test(expectedExceptions = SequenceUtil.SequenceListsDifferException.class)
     public void testFailDifferentSequenceDictionaries() throws IOException {
         final File input = new File(TEST_DIR, "forMetrics.sam");
         final File outfile = getTempOutputFile("test", ".wgs_metrics");
+        final File ref = new File("testdata/picard/reference/", "test.fasta");
         final String[] args = new String[]{
                 "INPUT=" + input.getAbsolutePath(),
                 "OUTPUT=" + outfile.getAbsolutePath(),
-                "REFERENCE_SEQUENCE=" + CHR_M_REFERENCE.getAbsolutePath()
+                "REFERENCE_SEQUENCE=" + ref
         };
         Assert.assertEquals(runPicardCommandLine(args), 1);
     }

--- a/src/test/java/picard/analysis/CollectWgsMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectWgsMetricsTest.java
@@ -531,7 +531,7 @@ public class CollectWgsMetricsTest extends CommandLineProgramTest {
     }
 
     @Test(expectedExceptions = PicardException.class)
-    public void testFailDifferentReferenceSequences() throws IOException {
+    public void testFailDifferentSequenceDictionaries() throws IOException {
         final File input = new File(TEST_DIR, "forMetrics.sam");
         final File outfile = getTempOutputFile("test", ".wgs_metrics");
         final String[] args = new String[]{

--- a/src/test/java/picard/analysis/CollectWgsMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectWgsMetricsTest.java
@@ -39,6 +39,7 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import picard.PicardException;
 import picard.cmdline.CommandLineProgramTest;
 import picard.sam.SortSam;
 import picard.util.TestNGUtil;
@@ -527,5 +528,17 @@ public class CollectWgsMetricsTest extends CommandLineProgramTest {
             Assert.assertEquals(metrics.PCT_EXC_DUPE, 0.0);
             Assert.assertEquals(metrics.PCT_EXC_UNPAIRED, 0.0);
         }
+    }
+
+    @Test(expectedExceptions = PicardException.class)
+    public void testFailDifferentReferenceSequences() throws IOException {
+        final File input = new File(TEST_DIR, "forMetrics.sam");
+        final File outfile = getTempOutputFile("test", ".wgs_metrics");
+        final String[] args = new String[]{
+                "INPUT=" + input.getAbsolutePath(),
+                "OUTPUT=" + outfile.getAbsolutePath(),
+                "REFERENCE_SEQUENCE=" + CHR_M_REFERENCE.getAbsolutePath()
+        };
+        Assert.assertEquals(runPicardCommandLine(args), 1);
     }
 }


### PR DESCRIPTION
## Description

When a user passes in a reference sequence and an input bam that don't have the same sequence dictionary in `CollectWgsMetrics`, they get an `ArrayIndexOutOfBoundsException`. This is uninformative to the user so it was requested to create a clear error message in this issue: #366 

Changes Made:

- Throw an error in `CollectWgsMetrics` when the sequence dictionaries don't match

- Add a unit test to cover this case

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [x] Final thumbs-up from reviewer
- [x] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

