### PR TITLE
Change docker base image for security reasons.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM adoptopenjdk:8
 MAINTAINER Broad Institute DSDE <dsde-engineering@broadinstitute.org>
 
 ARG build_command=shadowJar


### PR DESCRIPTION
### Description

The trivvy security check failed, flagging issues with the openjdk:8 docker image we are using for a base.  This PR updates this to adoptopenjdk:8

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

