### PR TITLE
Throw an exception if one of the pooled threads has an error.

### DIFF
--- a/src/main/java/picard/illumina/ExtractIlluminaBarcodes.java
+++ b/src/main/java/picard/illumina/ExtractIlluminaBarcodes.java
@@ -265,9 +265,9 @@ public class ExtractIlluminaBarcodes extends CommandLineProgram {
         pool.shutdown();
         ThreadPoolExecutorUtil.awaitThreadPoolTermination("Per tile extractor executor", pool, Duration.ofMinutes(5));
 
-        if(pool.hasError()){
+        if (pool.hasError()) {
             throw new PicardException("Exceptions in tile processing. There were " + pool.shutdownNow().size()
-                    + " tasks were still running or queued and have been cancelled. Errors: " + pool.exception.toString());
+                    + " tasks that were still running or queued and have been cancelled. Errors: " + pool.exception.toString());
         }
 
         LOG.info("Processed " + extractors.size() + " tiles.");


### PR DESCRIPTION
### Description

The threaded pool executors for `ExtractIlluminaBarcode` never actually checks to see if there was an error. This would cause the run to incorrectly return success when in fact one more more of the extractor threads may have had an error.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

