### PR TITLE
Add validation of existence of input directories

### DIFF
--- a/src/main/java/picard/illumina/IlluminaBasecallsToFastq.java
+++ b/src/main/java/picard/illumina/IlluminaBasecallsToFastq.java
@@ -226,6 +226,11 @@ public class IlluminaBasecallsToFastq extends CommandLineProgram {
     protected String[] customCommandLineValidation() {
         final LinkedList<String> errors = new LinkedList<>();
 
+        IOUtil.assertDirectoryIsReadable(BASECALLS_DIR);
+        if (BARCODES_DIR != null) {
+            IOUtil.assertDirectoryIsReadable(BARCODES_DIR);
+        }
+
         if (NUM_PROCESSORS == 0) {
             NUM_PROCESSORS = Runtime.getRuntime().availableProcessors();
         } else if (NUM_PROCESSORS < 0) {

--- a/src/main/java/picard/illumina/IlluminaBasecallsToSam.java
+++ b/src/main/java/picard/illumina/IlluminaBasecallsToSam.java
@@ -275,6 +275,10 @@ public class IlluminaBasecallsToSam extends CommandLineProgram {
      * Prepares loggers, initiates garbage collection thread, parses arguments and initialized variables appropriately/
      */
     private void initialize() {
+        IOUtil.assertDirectoryIsReadable(BASECALLS_DIR);
+        if (BARCODES_DIR != null) {
+            IOUtil.assertDirectoryIsReadable(BARCODES_DIR);
+        }
         if (OUTPUT != null) {
             IOUtil.assertFileIsWritable(OUTPUT);
         }


### PR DESCRIPTION
### Description

If an invalid directory was provided to IlluminaBasecallsTo[Sam|Fastq] the resultant error was uninformative.
This PR changes the behavior to have the program report a more useful error message.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

