### PR TITLE
NewIlluminaDataProvider should allow for no barcode files found in the basecalling directory

### DIFF
--- a/src/main/java/picard/illumina/CheckIlluminaDirectory.java
+++ b/src/main/java/picard/illumina/CheckIlluminaDirectory.java
@@ -128,6 +128,8 @@ public class CheckIlluminaDirectory extends CommandLineProgram {
         log.info("Expected cycles: " + StringUtil.intValuesToString(outputCycles));
 
         for (final Integer lane : LANES) {
+            IOUtil.assertDirectoryIsReadable(new File(BASECALLS_DIR, IlluminaFileUtil.longLaneStr(lane)));
+
             if (IlluminaFileUtil.hasCbcls(BASECALLS_DIR, lane)) {
                 final List<Integer> tiles = new ArrayList<>();
 

--- a/src/main/java/picard/illumina/parser/NewIlluminaDataProvider.java
+++ b/src/main/java/picard/illumina/parser/NewIlluminaDataProvider.java
@@ -77,11 +77,6 @@ class NewIlluminaDataProvider extends BaseIlluminaDataProvider {
                 ParameterizedFileUtil.makeBarcodeRegex(lane)));
 
         final File[] barcodeFiles = getTiledFiles(barcodesDirectory, barcodeRegex);
-        if (Arrays.stream(barcodeFiles).noneMatch(Objects::nonNull)) {
-            throw new PicardException("No barcode files found in the barcodesDirectory " + barcodesDirectory.getAbsolutePath());
-        }
-
-        IOUtil.assertFilesAreReadable(Arrays.asList(barcodeFiles));
         this.barcodeFileMap = new HashMap<>();
         for (File barcodeFile : barcodeFiles) {
             barcodeFileMap.put(fileToTile(barcodeFile.getName()), new BarcodeFileReader(barcodeFile));

--- a/src/test/java/picard/illumina/ExtractIlluminaBarcodesTest.java
+++ b/src/test/java/picard/illumina/ExtractIlluminaBarcodesTest.java
@@ -25,6 +25,7 @@ package picard.illumina;
 
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.util.IOUtil;
+import org.apache.commons.io.FileUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
@@ -85,10 +86,12 @@ public class ExtractIlluminaBarcodesTest extends CommandLineProgramTest {
         Assert.assertTrue(basecallsDir.delete());
         Assert.assertTrue(basecallsDir.mkdir());
         IOUtil.copyDirectoryTree(SINGLE_DATA_DIR, basecallsDir);
+
         dual = File.createTempFile("eib_dual", ".tmp");
         Assert.assertTrue(dual.delete());
         Assert.assertTrue(dual.mkdir());
         IOUtil.copyDirectoryTree(DUAL_DATA_DIR, dual);
+
         qual = File.createTempFile("eib_qual", ".tmp");
         Assert.assertTrue(qual.delete());
         Assert.assertTrue(qual.mkdir());
@@ -103,6 +106,14 @@ public class ExtractIlluminaBarcodesTest extends CommandLineProgramTest {
         Assert.assertTrue(cbcl.delete());
         Assert.assertTrue(cbcl.mkdir());
         IOUtil.copyDirectoryTree(CBCL_DATA_DIR, cbcl);
+        // For the cbcl test, we are deleting the '*barcode.txt.gz' files that exist in the test Basecalls directory
+        // This is to prevent the error conditon that was briefly introduced which expected to find such files in that
+        // directory before EIB was run on it.
+        final File basecallsDir = new File(cbcl, "BaseCalls");
+        Collection<File> barcodeFiles = FileUtils.listFiles(basecallsDir, new String[]{"txt.gz"}, false);
+        for (final File barcodeFile : barcodeFiles) {
+            Assert.assertTrue(barcodeFile.delete());
+        }
     }
 
     @AfterTest
@@ -111,6 +122,7 @@ public class ExtractIlluminaBarcodesTest extends CommandLineProgramTest {
         IOUtil.deleteDirectoryTree(dual);
         IOUtil.deleteDirectoryTree(qual);
         IOUtil.deleteDirectoryTree(noSymlink);
+        IOUtil.deleteDirectoryTree(cbcl);
     }
 
     @Test


### PR DESCRIPTION

### Description

ExtractIlluminaBarcodes is throwing an Ecxception in which it reports it can't find any barcode files in the basecalling directory.  This bug was introduced when we fixed another bug in IlluminaBasecallsToSam.  The issue here is that the NewIlluminaDataProvider is used by both tools, and the case where it's used by ExtractIlluminaBarcodes, it is perfectly valid that there are no barcode files found there.

This PR removes the exception that was thrown in this case.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

