### PR TITLE
[bugfix] Pass MAX_RECORDS_IN_RAM to BasecallsConverter

### DIFF
--- a/src/main/java/picard/illumina/IlluminaBasecallsToSam.java
+++ b/src/main/java/picard/illumina/IlluminaBasecallsToSam.java
@@ -312,7 +312,8 @@ public class IlluminaBasecallsToSam extends CommandLineProgram {
                 .withApplyEamssFiltering(APPLY_EAMSS_FILTER)
                 .withIncludeNonPfReads(INCLUDE_NON_PF_READS)
                 .withIgnoreUnexpectedBarcodes(IGNORE_UNEXPECTED_BARCODES)
-                .withBclQualityEvaluationStrategy(bclQualityEvaluationStrategy);
+                .withBclQualityEvaluationStrategy(bclQualityEvaluationStrategy)
+                .withMaxRecordsInRam(MAX_RECORDS_IN_RAM);
 
         if (SORT) {
             converterBuilder = converterBuilder
@@ -551,7 +552,7 @@ public class IlluminaBasecallsToSam extends CommandLineProgram {
         // Remove once deprecated parameter is deleted.
         if (MAX_READS_IN_RAM_PER_TILE != -1) {
             log.warn("Setting deprecated parameter `MAX_READS_IN_RAM_PER_TILE` use ` MAX_RECORDS_IN_RAM` instead");
-            MAX_RECORDS_IN_RAM = MAX_READS_IN_RAM_PER_TILE;
+            MAX_RECORDS_IN_RAM = MAX_READS_IN_RAM_PER_TILE * NUM_PROCESSORS;
         }
 
         final ArrayList<String> messages = new ArrayList<>();

--- a/src/main/java/picard/illumina/SortedBasecallsConverter.java
+++ b/src/main/java/picard/illumina/SortedBasecallsConverter.java
@@ -104,7 +104,7 @@ public class SortedBasecallsConverter<CLUSTER_OUTPUT_RECORD> extends BasecallsCo
         this.codecPrototype = codecPrototype;
         this.outputRecordComparator = outputRecordComparator;
         this.outputRecordClass = outputRecordClass;
-        tileWriteExecutor = new ThreadPoolExecutorWithExceptions(barcodeRecordWriterMap.keySet().size());
+        tileWriteExecutor = new ThreadPoolExecutorWithExceptions(numThreads);
         tileReadExecutor = new ThreadPoolExecutorWithExceptions(numThreads);
     }
 


### PR DESCRIPTION
### Description

`MAX_RECORDS_IN_RAM` was not being passed to the `BasecallsConvereter` in `IlluminaBasecallsToSam`.  Prior to this fix it would have always been set to default.

Also the deprecated `MAX_RECORDS_IN_RAM_PER_TILE` should be multiplied by the number of tile processing threads.

Additionally, we set the writer threads to numThreads instead of the number of samples (to avoid oversubscribing threads when there is high plexity)

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

