### PR TITLE
Jc fix small data race condition

### DIFF
--- a/src/main/java/picard/illumina/IlluminaBasecallsToSam.java
+++ b/src/main/java/picard/illumina/IlluminaBasecallsToSam.java
@@ -312,7 +312,8 @@ public class IlluminaBasecallsToSam extends CommandLineProgram {
                 .withApplyEamssFiltering(APPLY_EAMSS_FILTER)
                 .withIncludeNonPfReads(INCLUDE_NON_PF_READS)
                 .withIgnoreUnexpectedBarcodes(IGNORE_UNEXPECTED_BARCODES)
-                .withBclQualityEvaluationStrategy(bclQualityEvaluationStrategy);
+                .withBclQualityEvaluationStrategy(bclQualityEvaluationStrategy)
+                .withMaxRecordsInRam(MAX_RECORDS_IN_RAM);
 
         if (SORT) {
             converterBuilder = converterBuilder
@@ -551,7 +552,7 @@ public class IlluminaBasecallsToSam extends CommandLineProgram {
         // Remove once deprecated parameter is deleted.
         if (MAX_READS_IN_RAM_PER_TILE != -1) {
             log.warn("Setting deprecated parameter `MAX_READS_IN_RAM_PER_TILE` use ` MAX_RECORDS_IN_RAM` instead");
-            MAX_RECORDS_IN_RAM = MAX_READS_IN_RAM_PER_TILE;
+            MAX_RECORDS_IN_RAM = MAX_READS_IN_RAM_PER_TILE * NUM_PROCESSORS;
         }
 
         final ArrayList<String> messages = new ArrayList<>();

--- a/src/main/java/picard/illumina/SortedBasecallsConverter.java
+++ b/src/main/java/picard/illumina/SortedBasecallsConverter.java
@@ -104,7 +104,7 @@ public class SortedBasecallsConverter<CLUSTER_OUTPUT_RECORD> extends BasecallsCo
         this.codecPrototype = codecPrototype;
         this.outputRecordComparator = outputRecordComparator;
         this.outputRecordClass = outputRecordClass;
-        tileWriteExecutor = new ThreadPoolExecutorWithExceptions(barcodeRecordWriterMap.keySet().size());
+        tileWriteExecutor = new ThreadPoolExecutorWithExceptions(numThreads);
         tileReadExecutor = new ThreadPoolExecutorWithExceptions(numThreads);
     }
 

--- a/src/main/java/picard/illumina/SortedBasecallsConverter.java
+++ b/src/main/java/picard/illumina/SortedBasecallsConverter.java
@@ -230,9 +230,8 @@ public class SortedBasecallsConverter<CLUSTER_OUTPUT_RECORD> extends BasecallsCo
         ThreadPoolExecutorWithExceptions tileWriteExecutor = null;
         while (tileProcessingIndex < tiles.size()) {
                 awaitExecutor(tileWriteExecutor);
-                ThreadPoolExecutorWithExceptions finalTileWriters = new ThreadPoolExecutorWithExceptions(numThreads);
-                tileWriteExecutor = finalTileWriters;
-                completedWork.get(tiles.get(tileProcessingIndex)).forEach(finalTileWriters::submit);
+                tileWriteExecutor = new ThreadPoolExecutorWithExceptions(numThreads);
+                completedWork.get(tiles.get(tileProcessingIndex)).forEach(tileWriteExecutor::submit);
                 tileProcessingIndex++;
         }
 

--- a/src/main/java/picard/illumina/SortedBasecallsConverter.java
+++ b/src/main/java/picard/illumina/SortedBasecallsConverter.java
@@ -227,7 +227,7 @@ public class SortedBasecallsConverter<CLUSTER_OUTPUT_RECORD> extends BasecallsCo
         awaitExecutor(tileReadExecutor);
 
         int tileProcessingIndex = 0;
-        ThreadPoolExecutorWithExceptions tileWriteExecutor = null;// = new ThreadPoolExecutorWithExceptions(numThreads);
+        ThreadPoolExecutorWithExceptions tileWriteExecutor = null;
         while (tileProcessingIndex < tiles.size()) {
                 awaitExecutor(tileWriteExecutor);
                 ThreadPoolExecutorWithExceptions finalTileWriters = new ThreadPoolExecutorWithExceptions(numThreads);

--- a/src/main/java/picard/util/ThreadPoolExecutorWithExceptions.java
+++ b/src/main/java/picard/util/ThreadPoolExecutorWithExceptions.java
@@ -61,4 +61,13 @@ public class ThreadPoolExecutorWithExceptions extends ThreadPoolExecutor {
     public boolean hasError() {
         return exception != null;
     }
+
+    /**
+     * Calls `shutdownNow, adjusts the core size to 0 and low timeout to ensure threads get killed an GCd
+     */
+    public void cleanUp() {
+        shutdownNow();
+        setCorePoolSize(0);
+        setKeepAliveTime(1, TimeUnit.MINUTES);
+    }
 }

--- a/src/main/java/picard/util/ThreadPoolExecutorWithExceptions.java
+++ b/src/main/java/picard/util/ThreadPoolExecutorWithExceptions.java
@@ -63,7 +63,7 @@ public class ThreadPoolExecutorWithExceptions extends ThreadPoolExecutor {
     }
 
     /**
-     * Calls `shutdownNow, adjusts the core size to 0 and low timeout to ensure threads get killed an GCd
+     * Calls `shutdownNow, adjusts the core size to 0 and low timeout to ensure threads get killed and garbage collected.
      */
     public void cleanUp() {
         shutdownNow();


### PR DESCRIPTION
Thread pool executors often say they are done when in fact there is lingering processing being done in a worker thread. This causes issues with race conditions when tile data is tiny (unit tests)

The performance hit is negligible for using a different pool for each tile and then shutting it down and cleaning it up to ensure that a race condition can not occur.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

