### PR TITLE
bugfix and nio access in Fingerprinting code (no need to panic)

### DIFF
--- a/src/main/java/picard/fingerprint/CalculateFingerprintMetrics.java
+++ b/src/main/java/picard/fingerprint/CalculateFingerprintMetrics.java
@@ -33,6 +33,7 @@ import org.apache.commons.math3.random.RandomGenerator;
 import org.apache.commons.math3.stat.inference.ChiSquareTest;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.Hidden;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import picard.cmdline.CommandLineProgram;
 import picard.cmdline.StandardOptionDefinitions;
@@ -70,7 +71,7 @@ public class CalculateFingerprintMetrics extends CommandLineProgram {
 
     static final String USAGE_DETAILS =
             "This tools collects various statistics that pertain to a single fingerprint (<b>not</b> the comparison, or " +
-                    "\'fingerprinting\' of two distinct samples) and reports the results in a metrics file. " +
+                    "'fingerprinting' of two distinct samples) and reports the results in a metrics file. " +
                     "<p>" +
                     "The statistics collected are p-values, where the null-hypothesis is that the fingerprint is collected from " +
                     "a non-contaminated, diploid human, whose genotypes are modelled by the probabilities given in the " +
@@ -112,6 +113,10 @@ public class CalculateFingerprintMetrics extends CommandLineProgram {
     @Argument(doc="Number of randomization trials for calculating the DISCRIMINATORY_POWER metric.")
     public final int NUMBER_OF_SAMPLING = 100;
 
+    @Hidden
+    @Argument(doc = "When true code will check for readability on input files (this can be slow on cloud access)")
+    public boolean TEST_INPUT_READABILITY = true;
+
     // a fixed random seed for reproducibility;
     private static final int RANDOM_SEED = 42;
     private static final ChiSquareTest chiSquareTest = new ChiSquareTest();
@@ -120,7 +125,9 @@ public class CalculateFingerprintMetrics extends CommandLineProgram {
     protected int doWork() {
 
         final List<Path> inputPaths = IOUtil.getPaths(INPUT);
-        IOUtil.assertPathsAreReadable(inputPaths);
+        if (TEST_INPUT_READABILITY) {
+            IOUtil.assertPathsAreReadable(inputPaths);
+        }
         IOUtil.assertFileIsReadable(HAPLOTYPE_MAP);
         IOUtil.assertFileIsWritable(OUTPUT);
 
@@ -197,7 +204,7 @@ public class CalculateFingerprintMetrics extends CommandLineProgram {
         fingerprintMetrics.LOG10_HOM_CHI_SQUARED_PVALUE = Math.log10(homsChiSquaredTest);
 
         // calculate LOD (cross-entropy)
-        fingerprintMetrics.HOM_CROSS_ENTROPY_LOD = MathUtil.klDivergance(homAllele1VsAllele2Counts, homAllele1VsAllele2Expect);;
+        fingerprintMetrics.HOM_CROSS_ENTROPY_LOD = MathUtil.klDivergance(homAllele1VsAllele2Counts, homAllele1VsAllele2Expect);
 
         final MathUtils.RunningStat randomTrials = new MathUtils.RunningStat();
 

--- a/src/main/java/picard/fingerprint/FingerprintChecker.java
+++ b/src/main/java/picard/fingerprint/FingerprintChecker.java
@@ -481,9 +481,9 @@ public class FingerprintChecker {
         checkDictionaryGoodForFingerprinting(in.getFileHeader().getSequenceDictionary());
 
         if (!in.hasIndex()) {
-            log.warn(String.format("Operating without an index! We could be here for a while. (%s)", samFile));
+            log.warn(String.format("Operating without an index! We could be here for a while. (%s)", samFile.toUri().toString()));
         } else {
-            log.info(String.format("Reading an indexed file (%s)", samFile));
+            log.info(String.format("Reading an indexed file (%s)", samFile.toUri().toString()));
         }
 
         final SamLocusIterator iterator = new SamLocusIterator(in, this.haplotypes.getIntervalList(), in.hasIndex());

--- a/src/main/java/picard/fingerprint/FingerprintUtils.java
+++ b/src/main/java/picard/fingerprint/FingerprintUtils.java
@@ -173,18 +173,19 @@ public class FingerprintUtils {
             obsAlt = haplotypeProbabilities.getObsAllele2();
         }
 
-        final double[] origPLs = haplotypeProbabilities.getLogLikelihoods();
-        final double[] PLs =  Arrays.copyOf(origPLs,origPLs.length);
+        final double[] origGLs = haplotypeProbabilities.getLogLikelihoods();
+        final double[] GLs =  Arrays.copyOf(origGLs, origGLs.length);
+
         if (swap12) {
-            ArrayUtils.reverse(PLs);
+            ArrayUtils.reverse(GLs);
         }
         final List<Allele> alleles = Arrays.asList(alleleRef, alleleAlt);
 
         final Genotype gt = new GenotypeBuilder()
                 .DP(haplotypeProbabilities.getTotalObs())
                 .noAttributes()
-                .PL(PLs)
-                .AD(new int[]{obsAlt, obsRef})
+                .PL(GLs)
+                .AD(new int[]{obsRef, obsAlt})
                 .name(sample)
                 .make();
         try {

--- a/src/main/java/picard/fingerprint/HaplotypeProbabilitiesFromContaminatorSequence.java
+++ b/src/main/java/picard/fingerprint/HaplotypeProbabilitiesFromContaminatorSequence.java
@@ -90,10 +90,11 @@ public class HaplotypeProbabilitiesFromContaminatorSequence extends HaplotypePro
 
         for (final Genotype contGeno : Genotype.values()) {
             for (final Genotype mainGeno : Genotype.values()) {
-                //theta is the expected frequency of the alternate allele
+                // theta is the expected frequency of the alternate allele
                 final double theta = 0.5 * ((1 - contamination) * mainGeno.v + contamination * contGeno.v);
-                likelihoodMap[contGeno.v][mainGeno.v] *= ((altAllele ? theta : (1 - theta)) * (1 - pErr) +
-                        (!altAllele ? theta : (1 - theta)) * pErr);
+                likelihoodMap[contGeno.v][mainGeno.v] *=
+                        (( altAllele ? theta : (1 - theta)) * (1 - pErr) +
+                         (!altAllele ? theta : (1 - theta)) * pErr         );
             }
         }
     }

--- a/src/main/java/picard/fingerprint/IdentifyContaminant.java
+++ b/src/main/java/picard/fingerprint/IdentifyContaminant.java
@@ -26,6 +26,7 @@ package picard.fingerprint;
 
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.Hidden;
 import picard.cmdline.CommandLineProgram;
 import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.programgroups.DiagnosticsAndQCProgramGroup;
@@ -48,7 +49,7 @@ import java.io.File;
 public class IdentifyContaminant extends CommandLineProgram {
 
     @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "Input SAM or BAM file.")
-    public File INPUT;
+    public String INPUT;
 
     @Argument(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "Output fingerprint file (VCF).")
     public File OUTPUT;
@@ -71,6 +72,10 @@ public class IdentifyContaminant extends CommandLineProgram {
             "It names the sample in the VCF <SAMPLE>, using the SM value from the SAM header.")
     public boolean EXTRACT_CONTAMINATED = false;
 
+    @Hidden
+    @Argument(doc = "When true code will check for readability on input files (this can be slow on cloud access)")
+    public boolean TEST_INPUT_READABILITY = true;
+
     @Override
     protected boolean requiresReference() {
         return true;
@@ -90,6 +95,7 @@ public class IdentifyContaminant extends CommandLineProgram {
         extractFingerprint.SAMPLE_ALIAS = SAMPLE_ALIAS;
         extractFingerprint.VALIDATION_STRINGENCY = VALIDATION_STRINGENCY;
         extractFingerprint.VERBOSITY = VERBOSITY;
+        extractFingerprint.TEST_INPUT_READABILITY = TEST_INPUT_READABILITY;
         extractFingerprint.referenceSequence = referenceSequence;
 
         extractFingerprint.doWork();

--- a/src/main/java/picard/util/MathUtil.java
+++ b/src/main/java/picard/util/MathUtil.java
@@ -486,19 +486,6 @@ final public class MathUtil {
     }
 
     /**
-     * Calculates the product of a scalar by an array.
-     */
-    public static double[] multiply(final double lhs, final double[] rhs) {
-
-        final int len = rhs.length;
-        final double[] result = new double[len];
-        for (int i = 0; i < len; ++i) {
-            result[i] = lhs * rhs[i];
-        }
-        return result;
-    }
-
-    /**
      * calculates the sum of the arrays as a third array.
      */
     public static double[] sum(final double[] lhs, final double[] rhs) {

--- a/src/main/java/picard/util/MathUtil.java
+++ b/src/main/java/picard/util/MathUtil.java
@@ -486,6 +486,19 @@ final public class MathUtil {
     }
 
     /**
+     * Calculates the product of a scalar by an array.
+     */
+    public static double[] multiply(final double lhs, final double[] rhs) {
+
+        final int len = rhs.length;
+        final double[] result = new double[len];
+        for (int i = 0; i < len; ++i) {
+            result[i] = lhs * rhs[i];
+        }
+        return result;
+    }
+
+    /**
      * calculates the sum of the arrays as a third array.
      */
     public static double[] sum(final double[] lhs, final double[] rhs) {


### PR DESCRIPTION
feat: Enable NIO access for three other CLPs (ExtractFingerprint, CalculateContamination, and CalculateFingerprintMetrics).
fix: A bug in ExtractFingerprint & CalculateContamination were in the resulting vcf the REF and ALT allele counts in AD were swaped (doesn't affect LOD scores since the downstream tools only looked at PL) 😌 


(https://www.conventionalcommits.org/en/v1.0.0/)