### PR TITLE
fix: underflow in HaplotypeProbabilitiesFromContaminatorSequence

### DIFF
--- a/src/main/java/picard/fingerprint/FingerprintUtils.java
+++ b/src/main/java/picard/fingerprint/FingerprintUtils.java
@@ -24,6 +24,7 @@
 
 package picard.fingerprint;
 
+import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
@@ -143,7 +144,8 @@ public class FingerprintUtils {
         return variantContexts;
     }
 
-    private static VariantContext getVariantContext(final ReferenceSequenceFile reference,
+    @VisibleForTesting
+    static VariantContext getVariantContext(final ReferenceSequenceFile reference,
                                                     final String sample,
                                                     final HaplotypeProbabilities haplotypeProbabilities) {
         final Snp snp = haplotypeProbabilities.getRepresentativeSnp();

--- a/src/main/java/picard/fingerprint/HaplotypeProbabilitiesFromContaminatorSequence.java
+++ b/src/main/java/picard/fingerprint/HaplotypeProbabilitiesFromContaminatorSequence.java
@@ -39,9 +39,9 @@ public class HaplotypeProbabilitiesFromContaminatorSequence extends HaplotypePro
 
     public double contamination;
 
-    // for each model (contGenotype, mainGenotype) there's a likelihood of the data. These need to be collected separately
+    // for each model (contGenotype, mainGenotype) there's a LogLikelihood of the data. These need to be collected separately
     // and only collated once all the data is in.
-    private final double[][] likelihoodMap = {{1, 1, 1}, {1, 1, 1}, {1, 1, 1}};
+    private final double[][] logLikelihoodMap = {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}};
     private boolean valuesNeedUpdating = true;
 
     public HaplotypeProbabilitiesFromContaminatorSequence(final HaplotypeBlock haplotypeBlock, final double contamination) {
@@ -58,7 +58,7 @@ public class HaplotypeProbabilitiesFromContaminatorSequence extends HaplotypePro
 
         contamination = other.contamination;
         for (final Genotype g : Genotype.values()) {
-            System.arraycopy(other.likelihoodMap[g.v], 0, likelihoodMap[g.v], 0, NUM_GENOTYPES);
+            System.arraycopy(other.logLikelihoodMap[g.v], 0, logLikelihoodMap[g.v], 0, NUM_GENOTYPES);
         }
     }
 
@@ -92,9 +92,9 @@ public class HaplotypeProbabilitiesFromContaminatorSequence extends HaplotypePro
             for (final Genotype mainGeno : Genotype.values()) {
                 // theta is the expected frequency of the alternate allele
                 final double theta = 0.5 * ((1 - contamination) * mainGeno.v + contamination * contGeno.v);
-                likelihoodMap[contGeno.v][mainGeno.v] *=
-                        (( altAllele ? theta : (1 - theta)) * (1 - pErr) +
-                         (!altAllele ? theta : (1 - theta)) * pErr         );
+                logLikelihoodMap[contGeno.v][mainGeno.v] +=
+                        Math.log10((( altAllele ? theta : (1 - theta)) * (1 - pErr) +
+                         (!altAllele ? theta : (1 - theta)) * pErr         ));
             }
         }
     }
@@ -108,7 +108,7 @@ public class HaplotypeProbabilitiesFromContaminatorSequence extends HaplotypePro
         final double[] ll = new double[NUM_GENOTYPES];
         for (final Genotype contGeno : Genotype.values()) {
             // p(a | g_c) = \sum_g_m { P(g_m) \prod_i P(a_i| g_m, g_c)}
-            ll[contGeno.v] = Math.log10(Double.MIN_VALUE + MathUtil.sum(MathUtil.multiply(this.getPriorProbablities(), likelihoodMap[contGeno.v])));
+            ll[contGeno.v] = MathUtil.LOG_10_MATH.sum( MathUtil.sum(MathUtil.LOG_10_MATH.getLogValue(this.getPriorProbablities()), logLikelihoodMap[contGeno.v]));
         }
         setLogLikelihoods(ll);
     }
@@ -137,7 +137,7 @@ public class HaplotypeProbabilitiesFromContaminatorSequence extends HaplotypePro
         }
 
         for (final Genotype contGeno : Genotype.values()) {
-            this.likelihoodMap[contGeno.v] = MathUtil.multiply(this.likelihoodMap[contGeno.v], o.likelihoodMap[contGeno.v]);
+            this.logLikelihoodMap[contGeno.v] = MathUtil.sum(this.logLikelihoodMap[contGeno.v], o.logLikelihoodMap[contGeno.v]);
         }
         valuesNeedUpdating = true;
         return this;

--- a/src/test/java/picard/fingerprint/FingerprintCheckerTest.java
+++ b/src/test/java/picard/fingerprint/FingerprintCheckerTest.java
@@ -351,7 +351,6 @@ public class FingerprintCheckerTest {
         }
     }
 
-
     @DataProvider()
     Object[][] mergeIsSafeProvider() {
         final HaplotypeProbabilitiesFromSequence hp1 = new HaplotypeProbabilitiesFromSequence(hb);

--- a/src/test/java/picard/util/TestNGUtil.java
+++ b/src/test/java/picard/util/TestNGUtil.java
@@ -22,11 +22,24 @@ import static java.lang.Math.abs;
  */
 public class TestNGUtil {
 
+    // Not actually the smallest possible value on purpose, since that would be indistinguishable from 0 and then useless.
+    // This is small enough to be meaningless, but representable.
     static final double EPSILON = 1e-300; //a constant near the smallest possible positive value representable in double,
 
-     // not actually the smallest possible value on purpose, since that would be indistinguishable from 0 and then useless.
-    // This is small enough to be meaningless, but representable.
+    // A method that takes two Object[][] (normally from two data providers) and creates a third of all possible combinations
+    public static Iterator<Object[]> interaction(final Object[][] dataprovider1, final Object[][] dataprovider2) {
+        final List<Object[]> testcases = new ArrayList<>(dataprovider1.length * dataprovider2.length);
 
+        for (final Object[] objects1 : dataprovider1) {
+            for (final Object[] objects2 : dataprovider2) {
+                final Object[] objects = new Object[objects1.length + objects2.length];
+                System.arraycopy(objects1, 0, objects, 0, objects1.length);
+                System.arraycopy(objects2, 0, objects, objects1.length, objects2.length);
+                testcases.add(objects);
+            }
+        }
+        return testcases.iterator();
+    }
 
     public static abstract class SingleTestUnitTest<TestClazz extends TestNGParameterizable> {
         @DataProvider(name = "testcases")


### PR DESCRIPTION
This PR fixes an underflow (reported to me in private by @sidwekhande) which affects both IdentifyContamination and ExtractFingerprint in deep coverage. This was leading to non-informative sites in RNA and similar sequencing data.

The problem was that internally the code was using linear likelihood to collect the information about the possible combinations of contamination and this quickly led to underflows. 

Here I added tests (that initially failed!) and moved the entire calculation to log10 space.
