### PR TITLE
Cleaned up some variable names and order in the alignment metrics code.

### DIFF
--- a/src/main/java/picard/analysis/AlignmentSummaryMetrics.java
+++ b/src/main/java/picard/analysis/AlignmentSummaryMetrics.java
@@ -122,22 +122,6 @@ public class AlignmentSummaryMetrics extends MultilevelMetrics {
      */
     public double PF_INDEL_RATE;
 
-    /** The median read length. Computed using all read lengths including clipped bases. */
-    public double MEDIAN_READ_LENGTH;
-
-    /**
-     * The median absolute deviation of the distribution of all read lengths.  If the distribution is
-     * essentially normal then the standard deviation can be estimated as ~1.4826 * MAD. Computed using all
-     * read lengths including clipped bases.
-     */
-    public double MEDIAN_ABSOLUTE_DEVIATION;
-
-    /** The minimum read length. Computed using all read lengths including clipped bases. */
-    public double MIN_READ_LENGTH;
-
-    /** The maximum read length. Computed using all read lengths including clipped bases. */
-    public double MAX_READ_LENGTH;
-
     /**
      * The mean read length of the set of reads examined.  When looking at the data for a single lane with
      * equal length reads this number is just the read length.  When looking at data for merged lanes with
@@ -147,7 +131,23 @@ public class AlignmentSummaryMetrics extends MultilevelMetrics {
     public double MEAN_READ_LENGTH;
 
     /** The standard deviation of the read lengths. Computed using all read lengths including clipped bases. */
-    public double STANDARD_DEVIATION;
+    public double SD_READ_LENGTH;
+
+    /** The median read length. Computed using all read lengths including clipped bases. */
+    public double MEDIAN_READ_LENGTH;
+
+    /**
+     * The median absolute deviation of the distribution of all read lengths.  If the distribution is
+     * essentially normal then the standard deviation can be estimated as ~1.4826 * MAD. Computed using all
+     * read lengths including clipped bases.
+     */
+    public double MAD_READ_LENGTH;
+
+    /** The minimum read length. Computed using all read lengths including clipped bases. */
+    public double MIN_READ_LENGTH;
+
+    /** The maximum read length. Computed using all read lengths including clipped bases. */
+    public double MAX_READ_LENGTH;
 
     /**
      * The number of aligned reads whose mate pair was also aligned to the reference.

--- a/src/main/java/picard/analysis/AlignmentSummaryMetricsCollector.java
+++ b/src/main/java/picard/analysis/AlignmentSummaryMetricsCollector.java
@@ -265,11 +265,11 @@ public class AlignmentSummaryMetricsCollector extends SAMRecordAndReferenceMulti
                 metrics.PCT_PF_READS = (double) metrics.PF_READS / (double) metrics.TOTAL_READS;
                 metrics.PCT_ADAPTER = adapterReads / (double) metrics.PF_READS;
                 metrics.MEAN_READ_LENGTH = readLengthHistogram.getMean();
-                metrics.STANDARD_DEVIATION = readLengthHistogram.getStandardDeviation();
+                metrics.SD_READ_LENGTH = readLengthHistogram.getStandardDeviation();
+                metrics.MEDIAN_READ_LENGTH = readLengthHistogram.getMedian();
+                metrics.MAD_READ_LENGTH = readLengthHistogram.getMedianAbsoluteDeviation();
                 metrics.MIN_READ_LENGTH = readLengthHistogram.getMin();
                 metrics.MAX_READ_LENGTH = readLengthHistogram.getMax();
-                metrics.MEDIAN_READ_LENGTH = readLengthHistogram.getMedian();
-                metrics.MEDIAN_ABSOLUTE_DEVIATION = readLengthHistogram.getMedianAbsoluteDeviation();
 
                 //Calculate BAD_CYCLES
                 metrics.BAD_CYCLES = 0;

--- a/src/test/java/picard/analysis/CollectAlignmentSummaryMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectAlignmentSummaryMetricsTest.java
@@ -303,9 +303,9 @@ public class CollectAlignmentSummaryMetricsTest extends CommandLineProgramTest {
                     Assert.assertEquals(metrics.PF_MISMATCH_RATE, 0.0);
                     Assert.assertEquals(metrics.BAD_CYCLES, 22);
                     Assert.assertEquals(metrics.MEAN_READ_LENGTH, 101.0);
-                    Assert.assertEquals(metrics.STANDARD_DEVIATION, 0.0);
+                    Assert.assertEquals(metrics.SD_READ_LENGTH, 0.0);
                     Assert.assertEquals(metrics.MEDIAN_READ_LENGTH, 101.0);
-                    Assert.assertEquals(metrics.MEDIAN_ABSOLUTE_DEVIATION, 0.0);
+                    Assert.assertEquals(metrics.MAD_READ_LENGTH, 0.0);
                     Assert.assertEquals(metrics.MIN_READ_LENGTH, 101.0);
                     Assert.assertEquals(metrics.MAX_READ_LENGTH, 101.0);
                     break;


### PR DESCRIPTION
This small revision reorders some declarations/methods for consistency across classes, as well as using a better naming convention for the longer variable names (e.g. STANDARD_DEVIATION -> SD_READ_LENGTH). 

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

