### PR TITLE
Minor updates: https, new urls, license year

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Broad Institute
+Copyright (c) 2017-2021 Broad Institute
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -156,5 +156,5 @@ Picard is migrating to [semantic versioning](https://semver.org/). We will event
 Please see the [Picard Documentation](https://broadinstitute.github.io/picard) for more information.
 
 [1]: https://github.com/samtools/htsjdk
-[2]: https://www.htslib.org/
-[3]: https://vcftools.github.io/specs.html
+[2]: https://samtools.github.io/hts-specs/
+[3]: https://samtools.github.io/hts-specs/

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ As of version 2.0.1 (Nov. 2015) Picard requires Java 1.8 (jdk8u66). The last ver
     cd picard/
 ```
 
-* Picard is now built using [gradle](http://gradle.org/). A wrapper script (`gradlew`) is included which will download the appropriate version of gradle on the first invocation.
+* Picard is now built using [gradle](https://gradle.org/). A wrapper script (`gradlew`) is included which will download the appropriate version of gradle on the first invocation.
     
 * To build a fully-packaged, runnable Picard jar with all dependencies included, run:
 ```
@@ -137,7 +137,7 @@ jar, and should thus "Just Work".
 
 Please cite this repository when using Picard tools for your publications.
 
-“Picard Toolkit.” 2019. Broad Institute, GitHub Repository. http://broadinstitute.github.io/picard/; Broad Institute
+“Picard Toolkit.” 2019. Broad Institute, GitHub Repository. https://broadinstitute.github.io/picard/; Broad Institute
 
 ```
 @misc{Picard2019toolkit,
@@ -145,16 +145,16 @@ Please cite this repository when using Picard tools for your publications.
   year = {2019},
   publisher = {Broad Institute},
   journal = {Broad Institute, GitHub repository},
-  howpublished = {\url{http://broadinstitute.github.io/picard/}}
+  howpublished = {\url{https://broadinstitute.github.io/picard/}}
 }
 ```
 
 Identifiers from software registries are increasingly accepted by journals, as in (biotools:picard_tools) or (RRID:SCR_006525).
 
-Picard is migrating to semantic versioning (http://semver.org/). We will eventually adhere to it strictly and bump our major version whenever there are breaking changes to our API, but until we more clearly define what constitutes our official API, clients should assume that every release potentially contains at least minor changes to public methods.
+Picard is migrating to [semantic versioning](https://semver.org/). We will eventually adhere to it strictly and bump our major version whenever there are breaking changes to our API, but until we more clearly define what constitutes our official API, clients should assume that every release potentially contains at least minor changes to public methods.
 
-Please see the [Picard Documentation](http://broadinstitute.github.io/picard) for more information.
+Please see the [Picard Documentation](https://broadinstitute.github.io/picard) for more information.
 
-[1]: http://github.com/samtools/htsjdk
-[2]: http://samtools.sourceforge.net
-[3]: http://vcftools.sourceforge.net/specs.html
+[1]: https://github.com/samtools/htsjdk
+[2]: https://www.htslib.org/
+[3]: https://vcftools.github.io/specs.html


### PR DESCRIPTION
### Description

I noticed some links pointed to old Sourceforge pages that are described as outdated. I tried to find the best current equivalent of that URL and updated the README to link directly to them. I also noticed a few spots using HTTP when HTTPS is supported, so switched those over. 

The goal is to make the README and License more useful and accurate.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

