### PR TITLE
Added description of the gtcCallRate field in the VCF Header.

### DIFF
--- a/src/main/java/picard/arrays/GtcToVcf.java
+++ b/src/main/java/picard/arrays/GtcToVcf.java
@@ -209,6 +209,8 @@ public class GtcToVcf extends CommandLineProgram {
             // The Call Rate in the Illumina GTC File does not take into account zeroed out SNPs.
             // So we recalculate it (and ignore zeroed out assays - which also includes intensity only probes)
             vcfHeader.addMetaDataLine(new VCFHeaderLine(InfiniumVcfFields.GTC_CALL_RATE, String.valueOf(callRate)));
+            vcfHeader.addMetaDataLine(new VCFHeaderLine(InfiniumVcfFields.GTC_CALL_RATE_DETAIL,
+                    "The gtcCallRate is the Call Rate reported in the Illumina GTC file, corrected for the presence of Zeroed-Out SNPs"));
 
             writeVcf(contexts, OUTPUT, refSeq.getSequenceDictionary(), vcfHeader);
 

--- a/src/main/java/picard/arrays/illumina/InfiniumVcfFields.java
+++ b/src/main/java/picard/arrays/illumina/InfiniumVcfFields.java
@@ -46,6 +46,7 @@ public class InfiniumVcfFields {
     public static final String EXPECTED_GENDER = "expectedGender";
     public static final String FINGERPRINT_GENDER = "fingerprintGender";
     public static final String GTC_CALL_RATE = "gtcCallRate";
+    public static final String GTC_CALL_RATE_DETAIL = "gtcCallRateDetail";
     public static final String AUTOCALL_GENDER = "autocallGender";
     public static final String AUTOCALL_DATE = "autocallDate";
     public static final String IMAGING_DATE = "imagingDate";


### PR DESCRIPTION
### Description

Adding a header line to the VCF generated by GtcToVcf to describe the gtcCallRate field.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

