### PR TITLE
Update CombineGenotypingArrayVcfs to ignore differences in the refSNP field of INFO

### DIFF
--- a/src/main/java/picard/arrays/CombineGenotypingArrayVcfs.java
+++ b/src/main/java/picard/arrays/CombineGenotypingArrayVcfs.java
@@ -228,19 +228,20 @@ public class CombineGenotypingArrayVcfs extends CommandLineProgram {
                 depth += vc.getAttributeAsInt(VCFConstants.DEPTH_KEY, 0);
 
             // Go through all attributes - Ignore differences in AC, AF and AN as we recal later.
-            // Ignore differences in dev[XY]_AB and SOURCE as there are minor allowable changes
+            // Ignore differences in dev[XY]_AB and SOURCE/refSNP as there are minor allowable changes
             for (final Map.Entry<String, Object> p : vc.getAttributes().entrySet()) {
                 final String key = p.getKey();
                 if ((!key.equals("AC")) && (!key.equals("AF")) && (!key.equals("AN")) &&
-                        (!key.equals("devX_AB")) && (!key.equals("devY_AB")) && (!key.equals("SOURCE"))) {
+                        (!key.equals("devX_AB")) && (!key.equals("devY_AB")) &&
+                        (!key.equals("SOURCE")) && (!key.equals("refSNP"))) {
                     final Object value = p.getValue();
                     final Object extantValue = firstAttributes.get(key);
                     if (extantValue == null) {
-                        // attribute in one VCF but not another.  Die!
+                        // attribute in one VCF but not another.
                         throw new PicardException("Attribute '" + key + "' not found in all VCFs");
                     }
                     else if (!extantValue.equals(value)) {
-                        // Attribute disagrees in value between one VCF Die! (if not AC, AF, nor AN, skipped above)
+                        // Attribute disagrees in value between one VCF and the other
                         throw new PicardException("Values for attribute '" + key + "' disagrees among input VCFs");
                     }
                 }


### PR DESCRIPTION
### Description

Update CombineGenotypingArrayVcfs to ignore differences in the refSNP field of INFO
(left out of previous PR)

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

