### PR TITLE
Fix bug where ADAPTERS_TO_CHECK could not be set as a CLP argument.

### DIFF
--- a/src/main/java/picard/illumina/IlluminaBasecallsToFastq.java
+++ b/src/main/java/picard/illumina/IlluminaBasecallsToFastq.java
@@ -225,7 +225,7 @@ public class IlluminaBasecallsToFastq extends ExtractBarcodesProgram {
         CASAVA_1_8, ILLUMINA
     }
 
-    private final Map<String, Writer<ClusterData>> sampleBarcodeClusterWriterMap = new HashMap<String, Writer<ClusterData>>(1, 0.5f);
+    private final Map<String, Writer<ClusterData>> sampleBarcodeClusterWriterMap = new HashMap<>(1, 0.5f);
     final BclQualityEvaluationStrategy bclQualityEvaluationStrategy = new BclQualityEvaluationStrategy(MINIMUM_QUALITY);
     private BasecallsConverter<?> basecallsConverter;
     private static final Log log = Log.getInstance(IlluminaBasecallsToFastq.class);
@@ -233,7 +233,7 @@ public class IlluminaBasecallsToFastq extends ExtractBarcodesProgram {
     private ReadNameEncoder readNameEncoder;
     boolean demultiplex;
     private AsyncWriterPool writerPool;
-    final List<AdapterPair> adapters = new ArrayList<>(ADAPTERS_TO_CHECK);
+    private List<AdapterPair> adapters;
 
     @Override
     protected int doWork() {
@@ -302,6 +302,7 @@ public class IlluminaBasecallsToFastq extends ExtractBarcodesProgram {
         fastqWriterFactory.setCreateMd5(CREATE_MD5_FILE);
 
         // Combine any adapters and custom adapter pairs from the command line into an array for use in clipping
+        adapters = new ArrayList<>(ADAPTERS_TO_CHECK);
         if (FIVE_PRIME_ADAPTER != null && THREE_PRIME_ADAPTER != null) {
             adapters.add(new CustomAdapterPair(FIVE_PRIME_ADAPTER, THREE_PRIME_ADAPTER));
         }
@@ -435,7 +436,7 @@ public class IlluminaBasecallsToFastq extends ExtractBarcodesProgram {
      * @return AsyncClusterWriter that contains one or more ClusterWriters (amount depends on read structure), all using
      * outputPrefix to determine the filename(s).
      */
-    private Writer<ClusterData> buildWriter(final File outputPrefix, int numSamples) {
+    private Writer<ClusterData> buildWriter(final File outputPrefix, final int numSamples) {
         final File outputDir = outputPrefix.getAbsoluteFile().getParentFile();
         IOUtil.assertDirectoryIsWritable(outputDir);
         final String prefixString = outputPrefix.getName();


### PR DESCRIPTION
### Description

The argument ADAPTERS_TO_CHECK was being set in a way such that CLP arguments would not override it.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

