### PR TITLE
Added validation for existence of .bpm file to CompareGtcFiles

### DIFF
--- a/src/main/java/picard/arrays/illumina/CompareGtcFiles.java
+++ b/src/main/java/picard/arrays/illumina/CompareGtcFiles.java
@@ -68,6 +68,7 @@ public class CompareGtcFiles extends CommandLineProgram {
     @Override
     protected int doWork() {
         IOUtil.assertFilesAreReadable(INPUT);
+        IOUtil.assertFileIsReadable(ILLUMINA_BEAD_POOL_MANIFEST_FILE);
 
         try (InfiniumGTCFile gtcFileOne = new InfiniumGTCFile(INPUT.get(0), ILLUMINA_BEAD_POOL_MANIFEST_FILE);
              InfiniumGTCFile gtcFileTwo = new InfiniumGTCFile(INPUT.get(1), ILLUMINA_BEAD_POOL_MANIFEST_FILE)) {


### PR DESCRIPTION
### Description

Updated CompareGtcFiles to do an up-front existence check for the Illumina bead pool manifest (.bpm) file.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

