### PR TITLE
Set ADAPTERS_TO_CHECK to be null by default

### DIFF
--- a/src/main/java/picard/illumina/IlluminaBasecallsToFastq.java
+++ b/src/main/java/picard/illumina/IlluminaBasecallsToFastq.java
@@ -154,7 +154,7 @@ public class IlluminaBasecallsToFastq extends ExtractBarcodesProgram {
             mutex = {"OUTPUT_PREFIX"})
     public File MULTIPLEX_PARAMS;
 
-    @Argument(doc = "Which adapters to look for in the read.", optional = true)
+    @Argument(doc = "Which adapters to look for in the reads. The default value is null, meaning that no adapters will be looked for in the reads.", optional = true)
     public List<IlluminaAdapterPair> ADAPTERS_TO_CHECK = null;
 
     @Argument(doc = "For specifying adapters other than standard Illumina", optional = true)

--- a/src/main/java/picard/illumina/IlluminaBasecallsToFastq.java
+++ b/src/main/java/picard/illumina/IlluminaBasecallsToFastq.java
@@ -154,12 +154,8 @@ public class IlluminaBasecallsToFastq extends ExtractBarcodesProgram {
             mutex = {"OUTPUT_PREFIX"})
     public File MULTIPLEX_PARAMS;
 
-    @Argument(doc = "Which adapters to look for in the read.")
-    public List<IlluminaAdapterPair> ADAPTERS_TO_CHECK = new ArrayList<>(
-            Arrays.asList(IlluminaUtil.IlluminaAdapterPair.INDEXED,
-                    IlluminaUtil.IlluminaAdapterPair.DUAL_INDEXED,
-                    IlluminaUtil.IlluminaAdapterPair.NEXTERA_V2,
-                    IlluminaUtil.IlluminaAdapterPair.FLUIDIGM));
+    @Argument(doc = "Which adapters to look for in the read.", optional = true)
+    public List<IlluminaAdapterPair> ADAPTERS_TO_CHECK = null;
 
     @Argument(doc = "For specifying adapters other than standard Illumina", optional = true)
     public String FIVE_PRIME_ADAPTER;

--- a/src/main/java/picard/illumina/IlluminaBasecallsToSam.java
+++ b/src/main/java/picard/illumina/IlluminaBasecallsToSam.java
@@ -310,9 +310,9 @@ public class IlluminaBasecallsToSam extends ExtractBarcodesProgram {
         }
 
         final int numOutputRecords = readStructure.templates.length();
+
         // Combine any adapters and custom adapter pairs from the command line into an array for use in clipping
         final List<AdapterPair> adapters = new ArrayList<>(ADAPTERS_TO_CHECK);
-
         if (FIVE_PRIME_ADAPTER != null && THREE_PRIME_ADAPTER != null) {
             adapters.add(new CustomAdapterPair(FIVE_PRIME_ADAPTER, THREE_PRIME_ADAPTER));
         }

--- a/src/test/java/picard/illumina/IlluminaBasecallsToFastqTest.java
+++ b/src/test/java/picard/illumina/IlluminaBasecallsToFastqTest.java
@@ -26,21 +26,18 @@ package picard.illumina;
 import htsjdk.samtools.fastq.FastqReader;
 import htsjdk.samtools.fastq.FastqRecord;
 import htsjdk.samtools.metrics.MetricsFile;
-import htsjdk.samtools.util.BufferedLineReader;
-import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.LineReader;
-import htsjdk.samtools.util.StringUtil;
+import htsjdk.samtools.util.*;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import picard.cmdline.CommandLineProgramTest;
 import picard.illumina.parser.ReadStructure;
+import picard.util.IlluminaUtil;
 
 import java.io.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class IlluminaBasecallsToFastqTest extends CommandLineProgramTest {
@@ -86,6 +83,33 @@ public class IlluminaBasecallsToFastqTest extends CommandLineProgramTest {
 
     @Test
     public void testAdapterTrimming() throws Exception {
+        final String suffix = ".1.fastq";
+        final File outputFastq1 = File.createTempFile("adapterTrimmed.", suffix);
+        outputFastq1.deleteOnExit();
+        final String outputPrefix = outputFastq1.getAbsolutePath().substring(0, outputFastq1.getAbsolutePath().length() - suffix.length());
+        final File outputFastq2 = new File(outputPrefix + ".2.fastq");
+        outputFastq2.deleteOnExit();
+        final int lane = 1;
+        List<String> args = new ArrayList<>(CollectionUtil.makeList(
+                "BASECALLS_DIR=" + BASECALLS_DIR,
+                "LANE=" + lane,
+                "READ_STRUCTURE=25T8B25T",
+                "OUTPUT_PREFIX=" + outputPrefix,
+                "RUN_BARCODE=HiMom",
+                "MACHINE_NAME=machine1",
+                "FLOWCELL_BARCODE=abcdeACXX",
+                "MAX_RECORDS_IN_RAM=100" //force spill to disk to test encode/decode,
+        ));
+        for (final IlluminaUtil.IlluminaAdapterPair adapterPair : IlluminaUtil.IlluminaAdapterPair.values()) {
+            args.add("ADAPTERS_TO_CHECK=" + adapterPair);
+        }
+        runPicardCommandLine(args);
+        IOUtil.assertFilesEqual(outputFastq1, new File(TEST_DATA_DIR, "nonBarcoded.1.fastq"));
+        IOUtil.assertFilesEqual(outputFastq2, new File(TEST_DATA_DIR, "nonBarcoded.2.fastq"));
+    }
+
+    @Test
+    public void testCustomAdapterTrimming() throws Exception {
         final String suffix = ".1.fastq";
         final File outputFastq1 = File.createTempFile("adapterTrimmed.", suffix);
         outputFastq1.deleteOnExit();


### PR DESCRIPTION
### Description

Recently, the parameter 'ADAPTERS_TO_CHECK' in IlluminaBasecallsToFastq was set to be on (trim known adapter sequence from output fastq files). After further discussion, it was decided to leave this parameter off by default in order to prevent unexpected changes in output data.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

