### PR TITLE
Revert gkl to 0.8.5 as it is breaking jdk 11 support in Picard.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ configurations {
 }
 
 dependencies {
-    compile('com.intel.gkl:gkl:0.8.8') {
+    compile('com.intel.gkl:gkl:0.8.5') {
         exclude module: 'htsjdk'
     }
     compile 'com.google.guava:guava:15.0'


### PR DESCRIPTION
### Description

This PR reverts a recent update to gkl 0.8.8 (https://github.com/broadinstitute/picard/pull/1733).
The upgrade to 0.8.8 has broken support for java 11 in Picard as reported in:
https://github.com/broadinstitute/picard/issues/1747
and 
https://github.com/broadinstitute/picard/issues/1746

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

