### PR TITLE
Fix picard doc on java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ script:
       echo "Running tests using the legacy Picard command line parser.";
       ./gradlew jacocoTestReport;
     fi
+  - ./gradlew
 after_success:
   - ./gradlew coveralls
   - if [ "$TRAVIS_BRANCH" == "master" ]; then

--- a/build.gradle
+++ b/build.gradle
@@ -156,7 +156,7 @@ javadoc {
 
 // Generate Picard Online Doc
 task picardDoc(type: Javadoc, dependsOn: ['cleanPicardDoc', classes]) {
-    final File picardDocDir = new File("build/docs/picarddoc")
+    final File picardDocDir = file("build/docs/picarddoc")
     doFirst {
         // make sure the output folder exists or we can create it
         if (!picardDocDir.exists() && !picardDocDir.mkdirs()) {
@@ -192,7 +192,7 @@ task picardDoc(type: Javadoc, dependsOn: ['cleanPicardDoc', classes]) {
 
 task currentJar(type: Copy){
     from shadowJar
-    into new File(buildDir, "libs")
+    into file("$buildDir/libs")
     rename { string -> "picard.jar"}
 }
 
@@ -370,7 +370,7 @@ uploadArchives {
     }
 }
 
-ext.htmlDir = new File("build/docs/html")
+ext.htmlDir = file("build/docs/html")
 
 //update static web docs
 task copyJavadoc(dependsOn: 'javadoc', type: Copy) {


### PR DESCRIPTION
### Description
I noticed that running `/gradlew picardDoc` crashes on java 11.  This seems to be happening because of a mixup between the gradle daemon working directory and the project working directory.  Files were being creating using `new File()` in the `build.gradle` and not the `file()` function which accounts for this discrepancy.  

See [this build](https://app.travis-ci.com/github/broadinstitute/picard/builds/241886299) to see how it fails on 11 when you run `./gradlew` 

The following commit fixes it.
### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

