### PR TITLE
Expose new CLI option in CheckFingerprint 

### DIFF
--- a/src/test/java/picard/fingerprint/CheckFingerprintTest.java
+++ b/src/test/java/picard/fingerprint/CheckFingerprintTest.java
@@ -323,7 +323,7 @@ public class CheckFingerprintTest extends CommandLineProgramTest {
         final File outputSummary = File.createTempFile("fingerprint", "summary_metrics");
         outputSummary.deleteOnExit();
         final File outputDetail = File.createTempFile("fingerprint", "detail_metrics");
-        outputSummary.deleteOnExit();
+        outputDetail.deleteOnExit();
         args.add("SUMMARY_OUTPUT=" + outputSummary.getAbsolutePath());
         args.add("DETAIL_OUTPUT=" + outputDetail.getAbsolutePath());
         args.add("MIN_BASE_QUAL=" + String.valueOf(minBaseQ));

--- a/src/test/java/picard/fingerprint/CheckFingerprintTest.java
+++ b/src/test/java/picard/fingerprint/CheckFingerprintTest.java
@@ -306,7 +306,7 @@ public class CheckFingerprintTest extends CommandLineProgramTest {
         final File outputSummary = File.createTempFile("fingerprint", "summary_metrics");
         outputSummary.deleteOnExit();
         final File outputDetail = File.createTempFile("fingerprint", "detail_metrics");
-        outputSummary.deleteOnExit();
+        outputDetail.deleteOnExit();
         args.add("SUMMARY_OUTPUT=" + outputSummary.getAbsolutePath());
         args.add("DETAIL_OUTPUT=" + outputDetail.getAbsolutePath());
 


### PR DESCRIPTION
 allowing user to set a minimal base quality to be used for checking.

### Description

Some type of long read data have base qualities all set to 0 from the sequencer.
We are proposing to allow `CheckFingerprint` to use a custom minimal base quality&mdash;an option available to `FingerprintChecker` but not exposed through CLI.
We've tested `CheckFingerprint` on these types of data with this update, and it works mostly as expected (there's no guarantee, and honestly, base qual all == 0 is the root cause, which we have no control over).

----

### Checklist (never delete this)

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [ ] (NA) Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

