### PR TITLE
Clarified comment for purpose of GatherVcfs

### DIFF
--- a/src/main/java/picard/vcf/GatherVcfs.java
+++ b/src/main/java/picard/vcf/GatherVcfs.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 
 /**
  * Simple little class that combines multiple VCFs that have exactly the same set of samples
- * and totally discrete sets of loci.
+ * and nonoverlapping sets of loci.
  *
  * @author Tim Fennell
  */


### PR DESCRIPTION
### Description

This very very short PR clarifies the purpose of the `GatherVcfs` tool, changing the phrase "totally discrete" to the more accurate "nonoverlapping." Compare with the Picard documentation [here](https://broadinstitute.github.io/picard/command-line-overview.html#GatherVcfs) to see this is the intended purpose. The reason this confused me a bit was that technically you could have two vcfs with discrete sets of intervals which _do_ overlap (e.g. chr1:100-101 + chr2:100-101 and chr1:100-101 + chr3:100-101), which certainly should not be used as input into this tool. Changing it here should eventually change the corresponding text on the [GATK documentation](https://gatk.broadinstitute.org/hc/en-us/articles/360037422071-GatherVcfs-Picard-) page as well, once it's incorporated into GATK. 

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

