### PR TITLE
Update Picard to Log4J 2.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,8 @@ dependencies {
     compile 'commons-lang:commons-lang:2.6'
     compile 'com.github.samtools:htsjdk:' + htsjdkVersion
     compile 'org.broadinstitute:barclay:4.0.2'
+    compile 'org.apache.logging.log4j:log4j-api:2.16.0'
+    compile 'org.apache.logging.log4j:log4j-core:2.16.0'
     compileOnly(googleNio) {
         transitive = false
     }


### PR DESCRIPTION
### Description

This PR updates Picard to Log4J 2.16.0. 
Previously was at 2.15.0 but that was found to be an incomplete solution to 
CVE-2021-44228
----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

