### PR TITLE
Detect worker thread exception sooner, and stop other workers.

### DIFF
--- a/src/main/java/picard/util/ThreadPoolExecutorUtil.java
+++ b/src/main/java/picard/util/ThreadPoolExecutorUtil.java
@@ -3,16 +3,21 @@ package picard.util;
 import htsjdk.samtools.util.Log;
 
 import java.time.Duration;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 public class ThreadPoolExecutorUtil {
     private static final Log log = Log.getInstance(ThreadPoolExecutorUtil.class);
 
-    public static void awaitThreadPoolTermination(final String executorName, final ThreadPoolExecutor executorService,
+    public static void awaitThreadPoolTermination(final String executorName, final ThreadPoolExecutorWithExceptions executorService,
                                                   final Duration timeBetweenChecks) {
         try {
             while (!executorService.awaitTermination(timeBetweenChecks.getSeconds(), TimeUnit.SECONDS)) {
+                if (executorService.hasError()) {
+                    log.error(executorService.exception,
+                            String.format("%s terminating because a worker thread had an exception.", executorName));
+                    executorService.shutdownNow();
+                    break;
+                }
                 log.info(String.format("%s waiting for job completion. Finished jobs - %d : Running jobs - %d : Queued jobs  - %d",
                         executorName, executorService.getCompletedTaskCount(), executorService.getActiveCount(),
                         executorService.getQueue().size()));


### PR DESCRIPTION
### Detect when a worker thread has an exception, and shutdown the executor, rather than waiting for the thread pool to drain.

If a worker thread has an exception, the program is going to fail.  However, the ThreadPoolExecutor continues to execute the other workers, which can take quite a while.  See #1770.  

To fix, check for failed worker threads in the code that reports on thread pool progress every 5 minutes.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

