### PR TITLE
GL-1941. Handle Out of Range Values in GTC metrics

### DIFF
--- a/src/main/java/picard/arrays/GtcToVcf.java
+++ b/src/main/java/picard/arrays/GtcToVcf.java
@@ -508,7 +508,7 @@ public class GtcToVcf extends CommandLineProgram {
     }
 
     public static String formatFloatForVcf(final float value) {
-        if (Float.isNaN(value)) {
+        if (Float.isNaN(value) || Float.isInfinite(value)) {
             return DOT;
         }
         return df.format(value);

--- a/src/main/java/picard/arrays/VcfToAdpc.java
+++ b/src/main/java/picard/arrays/VcfToAdpc.java
@@ -215,7 +215,7 @@ public class VcfToAdpc extends CommandLineProgram {
 
     private Float getFloatAttribute(final Genotype genotype, final String key) {
         final Object value = genotype.getAnyAttribute(key);
-        if (value != null) {
+        if ((value != null) && (!value.equals("?"))) {
             return Float.parseFloat(value.toString());
         }
         return null;


### PR DESCRIPTION
### Description

https://broadinstitute.atlassian.net/browse/GL-1941

In GtcToVcf, set infinite values to missing ('.') in the VCF.
In VcfToAdpc, if value is a '?' (which was what had been encoded for infinite) treat as missing.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

