### PR TITLE
Make truncating the histogram optional in CollectInsertSizeMetrics

### DIFF
--- a/src/main/java/picard/analysis/CollectInsertSizeMetrics.java
+++ b/src/main/java/picard/analysis/CollectInsertSizeMetrics.java
@@ -105,6 +105,9 @@ public class CollectInsertSizeMetrics extends SinglePassSamProgram {
             "truncated to a shorter range of sizes, the MIN_HISTOGRAM_WIDTH will enforce a minimum range.", optional=true)
     public Integer MIN_HISTOGRAM_WIDTH = null;
 
+    @Argument(shortName = "TR", doc="Truncate the insert size histogram to throw out outliers", optional = true)
+    public boolean TRUNCATE_HISTOGRAMS = true;
+
     @Argument(shortName="M", doc="When generating the Histogram, discard any data categories (out of FR, TANDEM, RF) that have fewer than this " +
             "percentage of overall reads. (Range: 0 to 1).")
     public float MINIMUM_PCT = 0.05f;
@@ -148,7 +151,7 @@ public class CollectInsertSizeMetrics extends SinglePassSamProgram {
 
         //Delegate actual collection to InsertSizeMetricCollector
         multiCollector = new InsertSizeMetricsCollector(METRIC_ACCUMULATION_LEVEL, header.getReadGroups(), MINIMUM_PCT,
-                HISTOGRAM_WIDTH, MIN_HISTOGRAM_WIDTH, DEVIATIONS, INCLUDE_DUPLICATES);
+                HISTOGRAM_WIDTH, MIN_HISTOGRAM_WIDTH, DEVIATIONS, INCLUDE_DUPLICATES, TRUNCATE_HISTOGRAMS);
     }
 
     @Override protected void acceptRead(final SAMRecord record, final ReferenceSequence ref) {

--- a/src/test/java/picard/analysis/CollectInsertSizeMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectInsertSizeMetricsTest.java
@@ -246,7 +246,7 @@ public class CollectInsertSizeMetricsTest extends CommandLineProgramTest {
     }
 
     @Test
-    public void testNotTruncatingHistogram() throws IOException {
+    public void testSkipTruncatingHistogram() throws IOException {
         // Make a test file
         final File testSamFile = File.createTempFile("CollectInsertSizeMetrics", ".bam");
         testSamFile.deleteOnExit();


### PR DESCRIPTION
### Description

It's true that you can adjust some existing parameters to turn off truncating, but sometimes it's easier to just turn it off and the user should have that option.

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

