### PR TITLE
Simplify handling of paths for input in BuildBamIndex.java

### DIFF
--- a/src/main/java/picard/nio/PicardHtsPath.java
+++ b/src/main/java/picard/nio/PicardHtsPath.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2022 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.nio;
+
+import htsjdk.io.HtsPath;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.RuntimeIOException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * A Subclass of {@link HtsPath} with conversion to {@link Path} making use of {@link IOUtil}
+ */
+public class PicardHtsPath extends HtsPath {
+    /**
+     * Create a PicardHtsPath from a raw input path string.
+     * <p>
+     * If the raw input string already contains a scheme (including a "file" scheme), assume its already
+     * properly escape/encoded. If no scheme component is present, assume it references a raw path on the
+     * local file system, so try to get a Path first, and then retrieve the URI from the resulting Path.
+     * This ensures that input strings that are local file references without a scheme component and contain
+     * embedded characters are valid in file names, but which would otherwise be interpreted as excluded
+     * URI characters (such as the URI fragment delimiter "#") are properly escape/encoded.
+     *
+     * @param rawInputString a string specifying an input path. May not be null.
+     */
+    public PicardHtsPath(final String rawInputString) {
+        super(rawInputString);
+    }
+
+    /**
+     * Create a PicardHtsPath from an existing {@link HtsPath} or subclass.
+     *
+     * @param htsPath an existing PathSpecifier. May not be null.
+     */
+    public PicardHtsPath(final HtsPath htsPath) {
+        super(htsPath);
+    }
+
+    /**
+     * Create a PicardHtsPath from a {@link File} reference. Uses the URI string of {@code file}.
+     * @param file the file reference to create this object from
+     */
+    public PicardHtsPath(final File file){
+        this(file.toURI().toString());
+    }
+
+    /**
+     * Resolve the URI of this object to a {@link Path} object.
+     *
+     * @return the resulting {@link Path}
+     * @throws RuntimeException if an I/O error occurs when creating the file system
+     */
+    @Override
+    public Path toPath() {
+        try {
+            return IOUtil.getPath(super.getURIString());
+        } catch (IOException e) {
+            throw new RuntimeIOException(e);
+        }
+    }
+}

--- a/src/main/java/picard/nio/PicardHtsPath.java
+++ b/src/main/java/picard/nio/PicardHtsPath.java
@@ -31,6 +31,10 @@ import htsjdk.samtools.util.RuntimeIOException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * A Subclass of {@link HtsPath} with conversion to {@link Path} making use of {@link IOUtil}
@@ -82,5 +86,25 @@ public class PicardHtsPath extends HtsPath {
         } catch (IOException e) {
             throw new RuntimeIOException(e);
         }
+    }
+
+    /**
+     * Construct a {@link PicardHtsPath} from a {@link Path}
+     * @param path may NOT be null
+     * @return a new object representing path
+     */
+    public static PicardHtsPath fromPath(final Path path){
+        Objects.requireNonNull(path);
+        return new PicardHtsPath(new HtsPath(path.toUri().toString()));
+    }
+
+    /**
+     * Create a {@link List<Path>} from {@link PicardHtsPath}s
+     * @param picardHtsPaths may NOT be null
+     * @return Path representations of the input picardHtsPaths
+     */
+    public static List<Path> toPaths(final Collection<PicardHtsPath> picardHtsPaths){
+        Objects.requireNonNull(picardHtsPaths);
+        return picardHtsPaths.stream().map(PicardHtsPath::toPath).collect(Collectors.toList());
     }
 }

--- a/src/main/java/picard/nio/PicardHtsPath.java
+++ b/src/main/java/picard/nio/PicardHtsPath.java
@@ -74,6 +74,16 @@ public class PicardHtsPath extends HtsPath {
     }
 
     /**
+     * Create a {@link List<PicardHtsPath>} from path representations.
+     * @param paths URIs or local paths. May not be null but may be empty.
+     * @return the converted {@link List}
+     */
+    public static List<PicardHtsPath> fromPaths(Collection<String> paths) {
+        Objects.requireNonNull(paths);
+        return paths.stream().map(PicardHtsPath::new).collect(Collectors.toList());
+    }
+
+    /**
      * Resolve the URI of this object to a {@link Path} object.
      *
      * @return the resulting {@link Path}

--- a/src/main/java/picard/sam/BuildBamIndex.java
+++ b/src/main/java/picard/sam/BuildBamIndex.java
@@ -30,19 +30,20 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SamInputResource;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
-import htsjdk.samtools.util.*;
+import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.FileExtensions;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Log;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import picard.cmdline.CommandLineProgram;
-import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.programgroups.ReadDataManipulationProgramGroup;
+import picard.nio.PicardHtsPath;
 
 import java.io.File;
-import java.io.IOException;
-import java.net.URI;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * Command line program to generate a BAM index (.bai) file from a BAM (.bam) file
@@ -69,7 +70,7 @@ public class BuildBamIndex extends CommandLineProgram {
 
     @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME,
             doc = "A BAM file or GA4GH URL to process. Must be sorted in coordinate order.")
-    public String INPUT;
+    public PicardHtsPath INPUT;
 
     @Argument(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME,
             doc = "The BAM index file. Defaults to x.bai if INPUT is x.bam, otherwise INPUT.bai.\n" +
@@ -82,12 +83,7 @@ public class BuildBamIndex extends CommandLineProgram {
      * all the records generating a BAM Index, then writes the bai file.
      */
     protected int doWork() {
-        Path inputPath;
-        try {
-            inputPath = IOUtil.getPath(INPUT);
-        } catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
+        final Path inputPath = INPUT.toPath();
 
         // set default output file - input-file.bai
         if (OUTPUT == null) {

--- a/src/main/java/picard/util/DbSnpBitSetUtil.java
+++ b/src/main/java/picard/util/DbSnpBitSetUtil.java
@@ -34,6 +34,7 @@ import picard.nio.PicardHtsPath;
 import picard.vcf.ByIntervalListVariantContextIterator;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -66,7 +67,7 @@ public class DbSnpBitSetUtil {
     }
 
     /** Constructor that creates a bit set with bits set to true for all variant types. */
-    public DbSnpBitSetUtil(final PicardHtsPath dbSnpFile, final SAMSequenceDictionary sequenceDictionary) {
+    public DbSnpBitSetUtil(final Path dbSnpFile, final SAMSequenceDictionary sequenceDictionary) {
         this(dbSnpFile, sequenceDictionary, EnumSet.noneOf(VariantType.class));
     }
 
@@ -78,7 +79,7 @@ public class DbSnpBitSetUtil {
     }
 
     /** Constructor that creates a bit set with bits set to true for the given variant types. */
-    public DbSnpBitSetUtil(final PicardHtsPath dbSnpFile,
+    public DbSnpBitSetUtil(final Path dbSnpFile,
                            final SAMSequenceDictionary sequenceDictionary,
                            final Collection<VariantType> variantsToMatch) {
         this(dbSnpFile, sequenceDictionary, variantsToMatch, null);
@@ -94,7 +95,7 @@ public class DbSnpBitSetUtil {
     }
 
     /** Constructor that creates a bit set with bits set to true for the given variant types over the given regions. */
-    public DbSnpBitSetUtil(final PicardHtsPath dbSnpFile,
+    public DbSnpBitSetUtil(final Path dbSnpFile,
                            final SAMSequenceDictionary sequenceDictionary,
                            final Collection<VariantType> variantsToMatch,
                            final IntervalList intervals) {
@@ -121,7 +122,7 @@ public class DbSnpBitSetUtil {
                            final IntervalList intervals,
                            final Optional<Log> log) {
 
-        this(new PicardHtsPath(dbSnpFile), sequenceDictionary, variantsToMatch, intervals, log);
+        this(dbSnpFile.toPath(), sequenceDictionary, variantsToMatch, intervals, log);
     }
 
     /**
@@ -138,7 +139,7 @@ public class DbSnpBitSetUtil {
      * @param variantsToMatch what types of variants to load.
      * @param intervals an interval list specifying the regions to load, or null, if we are return all dbSNP sites.
      */
-    public DbSnpBitSetUtil(final PicardHtsPath dbSnpFile,
+    public DbSnpBitSetUtil(final Path dbSnpFile,
                            final SAMSequenceDictionary sequenceDictionary,
                            final Collection<VariantType> variantsToMatch,
                            final IntervalList intervals,
@@ -147,7 +148,7 @@ public class DbSnpBitSetUtil {
         if (dbSnpFile == null) throw new IllegalArgumentException("null dbSnpFile");
         final Map<DbSnpBitSetUtil, Set<VariantType>> tmp = new HashMap<>();
         tmp.put(this, EnumSet.copyOf(variantsToMatch));
-        loadVcf(dbSnpFile, sequenceDictionary, tmp, intervals, log);
+        loadVcf(PicardHtsPath.fromPath(dbSnpFile), sequenceDictionary, tmp, intervals, log);
     }
 
     /** Factory method to create both a SNP bitmask and an indel bitmask in a single pass of the VCF. */

--- a/src/main/java/picard/util/DbSnpBitSetUtil.java
+++ b/src/main/java/picard/util/DbSnpBitSetUtil.java
@@ -33,6 +33,7 @@ import htsjdk.variant.vcf.VCFFileReader;
 import picard.vcf.ByIntervalListVariantContextIterator;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.*;
 
 /**
@@ -57,8 +58,20 @@ public class DbSnpBitSetUtil {
         this(dbSnpFile, sequenceDictionary, EnumSet.noneOf(VariantType.class));
     }
 
+    /** Constructor that creates a bit set with bits set to true for all variant types. */
+    public DbSnpBitSetUtil(final Path dbSnpFile, final SAMSequenceDictionary sequenceDictionary) {
+        this(dbSnpFile, sequenceDictionary, EnumSet.noneOf(VariantType.class));
+    }
+
     /** Constructor that creates a bit set with bits set to true for the given variant types. */
     public DbSnpBitSetUtil(final File dbSnpFile,
+                           final SAMSequenceDictionary sequenceDictionary,
+                           final Collection<VariantType> variantsToMatch) {
+        this(dbSnpFile, sequenceDictionary, variantsToMatch, null);
+    }
+
+    /** Constructor that creates a bit set with bits set to true for the given variant types. */
+    public DbSnpBitSetUtil(final Path dbSnpFile,
                            final SAMSequenceDictionary sequenceDictionary,
                            final Collection<VariantType> variantsToMatch) {
         this(dbSnpFile, sequenceDictionary, variantsToMatch, null);
@@ -67,6 +80,14 @@ public class DbSnpBitSetUtil {
 
     /** Constructor that creates a bit set with bits set to true for the given variant types over the given regions. */
     public DbSnpBitSetUtil(final File dbSnpFile,
+                           final SAMSequenceDictionary sequenceDictionary,
+                           final Collection<VariantType> variantsToMatch,
+                           final IntervalList intervals) {
+        this(dbSnpFile, sequenceDictionary, variantsToMatch, intervals, Optional.empty());
+    }
+
+    /** Constructor that creates a bit set with bits set to true for the given variant types over the given regions. */
+    public DbSnpBitSetUtil(final Path dbSnpFile,
                            final SAMSequenceDictionary sequenceDictionary,
                            final Collection<VariantType> variantsToMatch,
                            final IntervalList intervals) {
@@ -93,6 +114,29 @@ public class DbSnpBitSetUtil {
                            final IntervalList intervals,
                            final Optional<Log> log) {
 
+        this(dbSnpFile.toPath(), sequenceDictionary, variantsToMatch, intervals, log);
+    }
+
+    /**
+     * Constructor.
+     *
+     * For each sequence, creates  a BitSet that denotes whether a dbSNP entry
+     * is present at each base in the reference sequence.  The set is
+     * reference.length() + 1 so that it can be indexed by 1-based reference base.
+     * True means dbSNP present, false means no dbSNP present.
+     *
+     * @param dbSnpFile in VCF format.
+     * @param sequenceDictionary Optionally, a sequence dictionary corresponding to the dbSnp file, else null.
+     * If present, BitSets will be allocated more efficiently because the maximum size will be known.
+     * @param variantsToMatch what types of variants to load.
+     * @param intervals an interval list specifying the regions to load, or null, if we are return all dbSNP sites.
+     */
+    public DbSnpBitSetUtil(final Path dbSnpFile,
+                           final SAMSequenceDictionary sequenceDictionary,
+                           final Collection<VariantType> variantsToMatch,
+                           final IntervalList intervals,
+                           final Optional<Log> log) {
+
         if (dbSnpFile == null) throw new IllegalArgumentException("null dbSnpFile");
         final Map<DbSnpBitSetUtil, Set<VariantType>> tmp = new HashMap<>();
         tmp.put(this, EnumSet.copyOf(variantsToMatch));
@@ -110,6 +154,14 @@ public class DbSnpBitSetUtil {
     public static DbSnpBitSets createSnpAndIndelBitSets(final File dbSnpFile,
                                                         final SAMSequenceDictionary sequenceDictionary,
                                                         final IntervalList intervals) {
+        return createSnpAndIndelBitSets(dbSnpFile.toPath(), sequenceDictionary, intervals);
+    }
+
+    /** Factory method to create both a SNP bitmask and an indel bitmask in a single pass of the VCF.
+     * If intervals are given, consider only SNP and indel sites that overlap the intervals. */
+    public static DbSnpBitSets createSnpAndIndelBitSets(final Path dbSnpFile,
+                                                        final SAMSequenceDictionary sequenceDictionary,
+                                                        final IntervalList intervals) {
         return createSnpAndIndelBitSets(dbSnpFile, sequenceDictionary, intervals, Optional.empty());
     }
 
@@ -121,6 +173,18 @@ public class DbSnpBitSetUtil {
                                                         final IntervalList intervals,
                                                         final Optional<Log> log) {
 
+        return createSnpAndIndelBitSets(dbSnpFile.toPath(), sequenceDictionary, intervals, log);
+    }
+
+    /**
+     * Factory method to create both a SNP bitmask and an indel bitmask in a single pass of the VCF. If intervals are
+     * given, consider only SNP and indel sites that overlap the intervals. If log is given, progress loading the
+     * variants will be written to the log.
+     */
+    public static DbSnpBitSets createSnpAndIndelBitSets(final Path dbSnpFile,
+                                                        final SAMSequenceDictionary sequenceDictionary,
+                                                        final IntervalList intervals,
+                                                        final Optional<Log> log){
         final DbSnpBitSets sets = new DbSnpBitSets();
         sets.snps   = new DbSnpBitSetUtil();
         sets.indels = new DbSnpBitSetUtil();
@@ -133,7 +197,7 @@ public class DbSnpBitSetUtil {
     }
 
     /** Private helper method to read through the VCF and create one or more bit sets. */
-    private static void loadVcf(final File dbSnpFile,
+    private static void loadVcf(final Path dbSnpFile,
                                 final SAMSequenceDictionary sequenceDictionary,
                                 final Map<DbSnpBitSetUtil, Set<VariantType>> bitSetsToVariantTypes,
                                 final IntervalList intervals,

--- a/src/main/java/picard/vcf/AccumulateVariantCallingMetrics.java
+++ b/src/main/java/picard/vcf/AccumulateVariantCallingMetrics.java
@@ -32,6 +32,7 @@ import picard.PicardException;
 import picard.cmdline.CommandLineProgram;
 import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.programgroups.DiagnosticsAndQCProgramGroup;
+import picard.nio.PicardHtsPath;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,6 +42,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Combines multiple Variant Calling Metrics files into a single file.
@@ -57,7 +59,7 @@ import java.util.Map;
 public class AccumulateVariantCallingMetrics extends CommandLineProgram {
 
     @Argument(shortName= StandardOptionDefinitions.INPUT_SHORT_NAME, doc="Paths (except for the file extensions) of Variant Calling Metrics files to read and merge.", minElements=1)
-    public List<String> INPUT;
+    public List<PicardHtsPath> INPUT;
 
     @Argument(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "Path (except for the file extension) of output metrics files to write.")
     public File OUTPUT;
@@ -75,7 +77,7 @@ public class AccumulateVariantCallingMetrics extends CommandLineProgram {
         final Map<String, CollectVariantCallingMetrics.VariantCallingDetailMetrics> collapsedSampleDetailsMap = new HashMap<>();
         final CollectVariantCallingMetrics.VariantCallingSummaryMetrics collapsedSummary = new CollectVariantCallingMetrics.VariantCallingSummaryMetrics();
 
-        List<Path> inputPaths = IOUtil.getPaths(INPUT);
+        final List<Path> inputPaths = INPUT.stream().map(PicardHtsPath::toPath).collect(Collectors.toList());
         for (final Path path : inputPaths) {
             final FileSystem fs = path.getFileSystem();
             final String inputPrefix = path.toAbsolutePath()+ ".";

--- a/src/main/java/picard/vcf/AccumulateVariantCallingMetrics.java
+++ b/src/main/java/picard/vcf/AccumulateVariantCallingMetrics.java
@@ -42,7 +42,6 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Combines multiple Variant Calling Metrics files into a single file.
@@ -77,7 +76,7 @@ public class AccumulateVariantCallingMetrics extends CommandLineProgram {
         final Map<String, CollectVariantCallingMetrics.VariantCallingDetailMetrics> collapsedSampleDetailsMap = new HashMap<>();
         final CollectVariantCallingMetrics.VariantCallingSummaryMetrics collapsedSummary = new CollectVariantCallingMetrics.VariantCallingSummaryMetrics();
 
-        final List<Path> inputPaths = INPUT.stream().map(PicardHtsPath::toPath).collect(Collectors.toList());
+        final List<Path> inputPaths = PicardHtsPath.toPaths(INPUT);
         for (final Path path : inputPaths) {
             final FileSystem fs = path.getFileSystem();
             final String inputPrefix = path.toAbsolutePath()+ ".";

--- a/src/main/java/picard/vcf/GatherVcfs.java
+++ b/src/main/java/picard/vcf/GatherVcfs.java
@@ -1,8 +1,9 @@
 package picard.vcf;
 
 import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.seekablestream.SeekablePathStream;
+import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.*;
-import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextComparator;
 import htsjdk.variant.variantcontext.writer.Options;
@@ -11,7 +12,6 @@ import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 import htsjdk.variant.vcf.VCFFileReader;
 import htsjdk.variant.vcf.VCFHeader;
 import htsjdk.variant.vcf.VCFHeaderLine;
-
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
@@ -21,7 +21,6 @@ import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.programgroups.VariantManipulationProgramGroup;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -44,7 +43,7 @@ import java.util.stream.Collectors;
 public class GatherVcfs extends CommandLineProgram {
 
     @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "Input VCF file(s).")
-    public List<File> INPUT;
+    public List<String> INPUT;
 
     @Argument(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "Output VCF file.")
     public File OUTPUT;
@@ -63,9 +62,9 @@ public class GatherVcfs extends CommandLineProgram {
 
     /** class used to reorder input VCFs using the first variant */
     private static class FirstVariantInVcf {
-        final File vcfFile;
+        final Path vcfFile;
         VariantContext firstVariant = null;   // may be null if the vcf is empty
-        FirstVariantInVcf(final File vcfFile) {
+        FirstVariantInVcf(final Path vcfFile) {
             this.vcfFile = vcfFile;
         }
     }
@@ -77,11 +76,13 @@ public class GatherVcfs extends CommandLineProgram {
     @Override
     protected int doWork() {
         log.info("Checking inputs.");
-        INPUT = IOUtil.unrollFiles(INPUT, IOUtil.VCF_EXTENSIONS);
-        for (final File f : INPUT) IOUtil.assertFileIsReadable(f);
+        final List<Path> paths = IOUtil.getPaths(INPUT);
+        List<Path> unrolledPaths = IOUtil.unrollPaths(paths, FileExtensions.VCF_LIST.toArray(new String[]{}));
+
+        IOUtil.assertPathsAreReadable(unrolledPaths);
         IOUtil.assertFileIsWritable(OUTPUT);
 
-        final SAMSequenceDictionary sequenceDictionary = VCFFileReader.getSequenceDictionary(INPUT.get(0));
+        final SAMSequenceDictionary sequenceDictionary = VCFFileReader.getSequenceDictionary(unrolledPaths.get(0));
 
         if (CREATE_INDEX && sequenceDictionary == null) {
             throw new PicardException("In order to index the resulting VCF input VCFs must contain ##contig lines.");
@@ -89,16 +90,16 @@ public class GatherVcfs extends CommandLineProgram {
 
         log.info("Checking file headers and first records to ensure compatibility.");
         try {
-            INPUT = assertSameSamplesAndValidOrdering(INPUT);
-            if (areAllBlockCompressed(INPUT) && areAllBlockCompressed(Collections.singletonList(OUTPUT))) {
+            unrolledPaths = assertSameSamplesAndValidOrdering(unrolledPaths);
+            if (areAllBlockCompressed(unrolledPaths) && areAllBlockCompressed(Collections.singletonList(OUTPUT.toPath()))) {
                 log.info("Gathering by copying gzip blocks. Will not be able to validate position non-overlap of files.");
                 if (CREATE_INDEX) {
                     log.warn("Index creation not currently supported when gathering block compressed VCFs.");
                 }
-                gatherWithBlockCopying(INPUT, OUTPUT);
+                gatherWithBlockCopying(unrolledPaths, OUTPUT);
             } else {
                 log.info("Gathering by conventional means.");
-                gatherConventionally(sequenceDictionary, CREATE_INDEX, INPUT, OUTPUT, COMMENT);
+                gatherConventionally(sequenceDictionary, CREATE_INDEX, unrolledPaths, OUTPUT, COMMENT);
             }
         } catch (RuntimeException e) {
             log.error("There was a problem with gathering the INPUT.", e);
@@ -115,9 +116,9 @@ public class GatherVcfs extends CommandLineProgram {
     /**
      * Checks (via filename checking) that all files appear to be block compressed files.
      */
-    private boolean areAllBlockCompressed(final List<File> input) {
-        for (final File f : input) {
-            if (VCFFileReader.isBCF(f) || !AbstractFeatureReader.hasBlockCompressedExtension(f)) {
+    private boolean areAllBlockCompressed(final List<Path> input) {
+        for (final Path path : input) {
+            if (VCFFileReader.isBCF(path) || !IOUtil.hasBlockCompressedExtension(path)) {
                 return false;
             }
         }
@@ -129,7 +130,7 @@ public class GatherVcfs extends CommandLineProgram {
      * Validates that all headers contain the same set of genotyped samples and that files are in order by position of first record.
      * @return the reordered list of files
      */
-    private List<File> assertSameSamplesAndValidOrdering(final List<File> inputFiles) {
+    private List<Path> assertSameSamplesAndValidOrdering(final List<Path> inputFiles) {
         final VCFHeader header;
         try (VCFFileReader reader = new VCFFileReader(inputFiles.get(0), false)) {
             header = reader.getFileHeader();
@@ -138,50 +139,50 @@ public class GatherVcfs extends CommandLineProgram {
         final VariantContextComparator comparator = new VariantContextComparator(header.getSequenceDictionary());
         final List<String> samples = header.getGenotypeSamples();
 
-        File lastFile = null;
+        Path lastFile = null;
         VariantContext lastContext = null;
         
         if (REORDER_INPUT_BY_FIRST_VARIANT) {
             final List<FirstVariantInVcf> filesandvariants = new ArrayList<>(inputFiles.size());
             /* open each input file and get the first variant */
-            for (final File f : inputFiles) {
-                final FirstVariantInVcf vcfcxt = new FirstVariantInVcf(f);
-                try (VCFFileReader in = new VCFFileReader(f, false)) {
+            for (final Path path : inputFiles) {
+                final FirstVariantInVcf vcfcxt = new FirstVariantInVcf(path);
+                try (VCFFileReader in = new VCFFileReader(path, false)) {
                     try (CloseableIterator<VariantContext> iter = in.iterator()) {
                         vcfcxt.firstVariant = ( iter.hasNext() ? iter.next() : null );
                         if (vcfcxt.firstVariant == null) {
-                            log.info("No variant in " + f);
+                            log.info("No variant in " + path);
                          }
                     }
                 }
                 filesandvariants.add(vcfcxt);
             }
             /* order the files according to the position of their 1st variant */
-            Collections.sort(filesandvariants, (A,B)->{
+            filesandvariants.sort((A, B) -> {
                 if (A.firstVariant == null) {
                     if (B.firstVariant == null) {
                         return 0;
                     }
                     return 1;
                 }
-                if (A.firstVariant != null && B.firstVariant == null) {
+                if (B.firstVariant == null) {
                     return -1;
                 }
                 return comparator.compare(A.firstVariant, B.firstVariant);
-                });
+            });
             
             /* reset inputFiles with the new order */
             inputFiles.clear();
             inputFiles.addAll(filesandvariants.stream().map(FV->FV.vcfFile).collect(Collectors.toList()));
         }
 
-        for (final File f : inputFiles) {
-            final VCFFileReader in = new VCFFileReader(f, false);
+        for (final Path path : inputFiles) {
+            final VCFFileReader in = new VCFFileReader(path, false);
             try {
                 dict.assertSameDictionary(in.getFileHeader().getSequenceDictionary());
             } catch (final AssertionError e) {
                 log.error("File #1: " + inputFiles.get(0));
-                log.error("File #2: " + f);
+                log.error("File #2: " + path);
                 throw e;
             }
             final List<String> theseSamples = in.getFileHeader().getGenotypeSamples();
@@ -193,19 +194,19 @@ public class GatherVcfs extends CommandLineProgram {
                 s2.removeAll(samples);
 
                 throw new IllegalArgumentException("VCFs do not have identical sample lists." +
-                        " Samples unique to first file: " + s1 + ". Samples unique to " + f.getAbsolutePath() + ": " + s2 + ".");
+                        " Samples unique to first file: " + s1 + ". Samples unique to " + path.toAbsolutePath() + ": " + s2 + ".");
             }
 
             final CloseableIterator<VariantContext> variantIterator = in.iterator();
             if (variantIterator.hasNext()) {
                 final VariantContext currentContext = variantIterator.next();
                 if (lastContext != null && comparator.compare(lastContext, currentContext) >= 0) {
-                    throw new IllegalArgumentException("First record in file " + f.getAbsolutePath() + " is not after first record in " +
-                            "previous file " + lastFile.getAbsolutePath());
+                    throw new IllegalArgumentException("First record in file " + path.toAbsolutePath() + " is not after first record in " +
+                            "previous file " + lastFile.toAbsolutePath());
                 }
 
                 lastContext = currentContext;
-                lastFile = f;
+                lastFile = path;
             }
 
             CloserUtil.close(in);
@@ -218,7 +219,7 @@ public class GatherVcfs extends CommandLineProgram {
      */
     private static void gatherConventionally(final SAMSequenceDictionary sequenceDictionary,
                                              final boolean createIndex,
-                                             final List<File> inputFiles,
+                                             final List<Path> inputFiles,
                                              final File outputFile,
                                              final List<String> comments) {
         final EnumSet<Options> options = EnumSet.copyOf(VariantContextWriterBuilder.DEFAULT_OPTIONS);
@@ -235,13 +236,13 @@ public class GatherVcfs extends CommandLineProgram {
 
         final ProgressLogger progress = new ProgressLogger(log, 10000);
         VariantContext lastContext = null;
-        File lastFile = null;
+        Path lastFile = null;
         VCFHeader firstHeader = null;
         VariantContextComparator comparator = null;
 
-        for (final File f : inputFiles) {
-            log.debug("Gathering from file: ", f.getAbsolutePath());
-            final VCFFileReader variantReader = new VCFFileReader(f, false);
+        for (final Path path : inputFiles) {
+            log.debug("Gathering from file: ", path.toAbsolutePath());
+            final VCFFileReader variantReader = new VCFFileReader(path, false);
             final PeekableIterator<VariantContext> variantIterator = new PeekableIterator<>(variantReader.iterator());
             final VCFHeader header = variantReader.getFileHeader();
 
@@ -259,8 +260,8 @@ public class GatherVcfs extends CommandLineProgram {
             if (lastContext != null && variantIterator.hasNext()) {
                 final VariantContext vc = variantIterator.peek();
                 if (comparator.compare(vc, lastContext) <= 0) {
-                    throw new IllegalArgumentException("First variant in file " + f.getAbsolutePath() + " is at " + vc.getContig() + ":" + vc.getStart() +
-                            " but last variant in earlier file " + lastFile.getAbsolutePath() + " is at " + lastContext.getContig() + ":" + lastContext.getStart());
+                    throw new IllegalArgumentException("First variant in file " + path.toAbsolutePath() + " is at " + vc.getContig() + ":" + vc.getStart() +
+                            " but last variant in earlier file " + lastFile.toAbsolutePath() + " is at " + lastContext.getContig() + ":" + lastContext.getStart());
                 }
             }
 
@@ -270,7 +271,7 @@ public class GatherVcfs extends CommandLineProgram {
                 progress.record(lastContext.getContig(), lastContext.getStart());
             }
 
-            lastFile = f;
+            lastFile = path;
 
             CloserUtil.close(variantIterator);
             CloserUtil.close(variantReader);
@@ -285,23 +286,23 @@ public class GatherVcfs extends CommandLineProgram {
      * (often the first block) and re-compress any data remaining in that block into a new block in the output file. Subsequent
      * blocks (excluding a terminator block if present) are copied directly from input to output.
      */
-    private static void gatherWithBlockCopying(final List<File> vcfs, final File output) {
+    private static void gatherWithBlockCopying(final List<Path> vcfs, final File output) {
         try {
             final FileOutputStream out = new FileOutputStream(output);
             boolean isFirstFile = true;
 
-            for (final File f : vcfs) {
-                log.info("Gathering " + f.getAbsolutePath());
-                final FileInputStream in = new FileInputStream(f);
+            for (final Path path : vcfs) {
+                log.info("Gathering " + path.toAbsolutePath());
+                final SeekableStream seekableStream = new SeekablePathStream(path);
 
                 // a) It's good to check that the end of the file is valid and b) we need to know if there's a terminator block and not copy it
-                final BlockCompressedInputStream.FileTermination term = BlockCompressedInputStream.checkTermination(f);
+                final BlockCompressedInputStream.FileTermination term = BlockCompressedInputStream.checkTermination(path);
                 if (term == BlockCompressedInputStream.FileTermination.DEFECTIVE) {
-                    throw new PicardException(f.getAbsolutePath() + " does not have a valid GZIP block at the end of the file.");
+                    throw new PicardException(path.toAbsolutePath() + " does not have a valid GZIP block at the end of the file.");
                 }
 
                 if (!isFirstFile) {
-                    final BlockCompressedInputStream blockIn = new BlockCompressedInputStream(in, false);
+                    final BlockCompressedInputStream blockIn = new BlockCompressedInputStream(seekableStream, false);
                     boolean lastByteNewline = true;
 
                     while (blockIn.available() > 0) {
@@ -341,14 +342,14 @@ public class GatherVcfs extends CommandLineProgram {
                 }
 
                 // Copy remainder of input stream into output stream
-                final long currentPos = in.getChannel().position();
-                final long length = f.length();
+                final long currentPos = seekableStream.position();
+                final long length = Files.size(path);
                 final long skipLast = (term == BlockCompressedInputStream.FileTermination.HAS_TERMINATOR_BLOCK) ?
                         BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK.length : 0;
                 final long bytesToWrite = length - skipLast - currentPos;
 
-                IOUtil.transferByStream(in, out, bytesToWrite);
-                in.close();
+                IOUtil.transferByStream(seekableStream, out, bytesToWrite);
+                seekableStream.close();
                 isFirstFile = false;
             }
 

--- a/src/main/java/picard/vcf/GatherVcfs.java
+++ b/src/main/java/picard/vcf/GatherVcfs.java
@@ -1,9 +1,20 @@
 package picard.vcf;
 
+import htsjdk.io.HtsPath;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.seekablestream.SeekablePathStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
-import htsjdk.samtools.util.*;
+import htsjdk.samtools.util.BlockCompressedInputStream;
+import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.samtools.util.BlockCompressedStreamConstants;
+import htsjdk.samtools.util.CloseableIterator;
+import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.FileExtensions;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Log;
+import htsjdk.samtools.util.PeekableIterator;
+import htsjdk.samtools.util.ProgressLogger;
+import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextComparator;
 import htsjdk.variant.variantcontext.writer.Options;
@@ -25,7 +36,12 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 /**
@@ -43,7 +59,7 @@ import java.util.stream.Collectors;
 public class GatherVcfs extends CommandLineProgram {
 
     @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "Input VCF file(s).")
-    public List<String> INPUT;
+    public List<HtsPath> INPUT;
 
     @Argument(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "Output VCF file.")
     public File OUTPUT;
@@ -76,7 +92,7 @@ public class GatherVcfs extends CommandLineProgram {
     @Override
     protected int doWork() {
         log.info("Checking inputs.");
-        final List<Path> paths = IOUtil.getPaths(INPUT);
+        final List<Path> paths = INPUT.stream().map(HtsPath::toPath).collect(Collectors.toList());
         List<Path> unrolledPaths = IOUtil.unrollPaths(paths, FileExtensions.VCF_LIST.toArray(new String[]{}));
 
         IOUtil.assertPathsAreReadable(unrolledPaths);

--- a/src/main/java/picard/vcf/MergeVcfs.java
+++ b/src/main/java/picard/vcf/MergeVcfs.java
@@ -25,7 +25,13 @@ package picard.vcf;
 
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SamReaderFactory;
-import htsjdk.samtools.util.*;
+import htsjdk.samtools.util.CloseableIterator;
+import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.FileExtensions;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Log;
+import htsjdk.samtools.util.MergingIterator;
+import htsjdk.samtools.util.ProgressLogger;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextComparator;
 import htsjdk.variant.variantcontext.writer.Options;
@@ -42,14 +48,15 @@ import picard.PicardException;
 import picard.cmdline.CommandLineProgram;
 import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.programgroups.VariantManipulationProgramGroup;
+import picard.nio.PicardHtsPath;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Combines multiple variant files into a single variant file.
@@ -137,13 +144,13 @@ public class MergeVcfs extends CommandLineProgram {
 	  	
     @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME,
               doc="VCF or BCF input files (File format is determined by file extension), or a file having a '.list' suffix containing the path to the files, one per line.", minElements=1)
-    public List<String> INPUT;
+    public List<PicardHtsPath> INPUT;
 
     @Argument(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "The merged VCF or BCF file. File format is determined by file extension.")
     public File OUTPUT;
 
     @Argument(shortName = "D", doc = "The index sequence dictionary to use instead of the sequence dictionary in the input files", optional = true)
-    public String SEQUENCE_DICTIONARY;
+    public PicardHtsPath SEQUENCE_DICTIONARY;
 
     @Argument(doc = "Comment(s) to include in the merged output file's header.", optional = true, shortName = "CO")
     public List<String>  COMMENT = new ArrayList<>();
@@ -160,20 +167,15 @@ public class MergeVcfs extends CommandLineProgram {
     protected int doWork() {
         final ProgressLogger progress = new ProgressLogger(log, 10000);
         final List<String> sampleList = new ArrayList<>();
-        final List<Path> inputPaths = IOUtil.getPaths(INPUT);
+        final List<Path> inputPaths = INPUT.stream().map(PicardHtsPath::toPath).collect(Collectors.toList());
         final List<Path> unrolledPaths = IOUtil.unrollPaths(inputPaths, FileExtensions.VCF_LIST.toArray(new String[]{}));
         final Collection<CloseableIterator<VariantContext>> iteratorCollection = new ArrayList<>(unrolledPaths.size());
         final Collection<VCFHeader> headers = new HashSet<>(unrolledPaths.size());
         VariantContextComparator variantContextComparator = null;
         SAMSequenceDictionary sequenceDictionary = null;
 
-        if (SEQUENCE_DICTIONARY != null) {
-            try {
-                sequenceDictionary = SamReaderFactory.makeDefault().referenceSequence(REFERENCE_SEQUENCE).open(IOUtil.getPath(SEQUENCE_DICTIONARY)).getFileHeader().getSequenceDictionary();
-            } catch (IOException e) {
-                throw new RuntimeIOException(e);
-            }
-        }
+        if (SEQUENCE_DICTIONARY != null)
+            sequenceDictionary = SamReaderFactory.makeDefault().referenceSequence(REFERENCE_SEQUENCE).open(SEQUENCE_DICTIONARY.toPath()).getFileHeader().getSequenceDictionary();
 
         for (final Path path : unrolledPaths) {
             IOUtil.assertFileIsReadable(path);

--- a/src/main/java/picard/vcf/MergeVcfs.java
+++ b/src/main/java/picard/vcf/MergeVcfs.java
@@ -25,12 +25,7 @@ package picard.vcf;
 
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SamReaderFactory;
-import htsjdk.samtools.util.CloseableIterator;
-import htsjdk.samtools.util.CloserUtil;
-import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.MergingIterator;
-import htsjdk.samtools.util.ProgressLogger;
+import htsjdk.samtools.util.*;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextComparator;
 import htsjdk.variant.variantcontext.writer.Options;
@@ -41,14 +36,16 @@ import htsjdk.variant.vcf.VCFHeader;
 import htsjdk.variant.vcf.VCFHeaderLine;
 import htsjdk.variant.vcf.VCFUtils;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import picard.PicardException;
 import picard.cmdline.CommandLineProgram;
-import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.programgroups.VariantManipulationProgramGroup;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -140,13 +137,13 @@ public class MergeVcfs extends CommandLineProgram {
 	  	
     @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME,
               doc="VCF or BCF input files (File format is determined by file extension), or a file having a '.list' suffix containing the path to the files, one per line.", minElements=1)
-    public List<File> INPUT;
+    public List<String> INPUT;
 
     @Argument(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc = "The merged VCF or BCF file. File format is determined by file extension.")
     public File OUTPUT;
 
     @Argument(shortName = "D", doc = "The index sequence dictionary to use instead of the sequence dictionary in the input files", optional = true)
-    public File SEQUENCE_DICTIONARY;
+    public String SEQUENCE_DICTIONARY;
 
     @Argument(doc = "Comment(s) to include in the merged output file's header.", optional = true, shortName = "CO")
     public List<String>  COMMENT = new ArrayList<>();
@@ -162,20 +159,25 @@ public class MergeVcfs extends CommandLineProgram {
     @Override
     protected int doWork() {
         final ProgressLogger progress = new ProgressLogger(log, 10000);
-        final List<String> sampleList = new ArrayList<String>();
-        INPUT = IOUtil.unrollFiles(INPUT, IOUtil.VCF_EXTENSIONS);
-        final Collection<CloseableIterator<VariantContext>> iteratorCollection = new ArrayList<CloseableIterator<VariantContext>>(INPUT.size());
-        final Collection<VCFHeader> headers = new HashSet<VCFHeader>(INPUT.size());
+        final List<String> sampleList = new ArrayList<>();
+        final List<Path> inputPaths = IOUtil.getPaths(INPUT);
+        final List<Path> unrolledPaths = IOUtil.unrollPaths(inputPaths, FileExtensions.VCF_LIST.toArray(new String[]{}));
+        final Collection<CloseableIterator<VariantContext>> iteratorCollection = new ArrayList<>(unrolledPaths.size());
+        final Collection<VCFHeader> headers = new HashSet<>(unrolledPaths.size());
         VariantContextComparator variantContextComparator = null;
         SAMSequenceDictionary sequenceDictionary = null;
 
         if (SEQUENCE_DICTIONARY != null) {
-            sequenceDictionary = SamReaderFactory.makeDefault().referenceSequence(REFERENCE_SEQUENCE).open(SEQUENCE_DICTIONARY).getFileHeader().getSequenceDictionary();
+            try {
+                sequenceDictionary = SamReaderFactory.makeDefault().referenceSequence(REFERENCE_SEQUENCE).open(IOUtil.getPath(SEQUENCE_DICTIONARY)).getFileHeader().getSequenceDictionary();
+            } catch (IOException e) {
+                throw new RuntimeIOException(e);
+            }
         }
 
-        for (final File file : INPUT) {
-            IOUtil.assertFileIsReadable(file);
-            final VCFFileReader fileReader = new VCFFileReader(file, false);
+        for (final Path path : unrolledPaths) {
+            IOUtil.assertFileIsReadable(path);
+            final VCFFileReader fileReader = new VCFFileReader(path, false);
             final VCFHeader fileHeader = fileReader.getFileHeader();
             if (fileHeader.getContigLines().isEmpty()) {
                 if (sequenceDictionary == null) {
@@ -190,7 +192,7 @@ public class MergeVcfs extends CommandLineProgram {
             } else {
                 if (!variantContextComparator.isCompatible(fileHeader.getContigLines())) {
                     throw new IllegalArgumentException(
-                            "The contig entries in input file " + file.getAbsolutePath() + " are not compatible with the others.");
+                            "The contig entries in input path " + path.toAbsolutePath() + " are not compatible with the others.");
                 }
             }
 
@@ -200,13 +202,13 @@ public class MergeVcfs extends CommandLineProgram {
                 sampleList.addAll(fileHeader.getSampleNamesInOrder());
             } else {
                 if (!sampleList.equals(fileHeader.getSampleNamesInOrder())) {
-                    throw new IllegalArgumentException("Input file " + file.getAbsolutePath() + " has sample entries that don't match the other files.");
+                    throw new IllegalArgumentException("Input path " + path.toAbsolutePath() + " has sample entries that don't match the other files.");
                 }
             }
             
             // add comments in the first header
             if (headers.isEmpty()) {
-                COMMENT.stream().forEach(C -> fileHeader.addMetaDataLine(new VCFHeaderLine("MergeVcfs.comment", C)));
+                COMMENT.forEach(C -> fileHeader.addMetaDataLine(new VCFHeaderLine("MergeVcfs.comment", C)));
             }
 
             headers.add(fileHeader);
@@ -230,7 +232,7 @@ public class MergeVcfs extends CommandLineProgram {
 
         writer.writeHeader(new VCFHeader(VCFUtils.smartMergeHeaders(headers, false), sampleList));
 
-        final MergingIterator<VariantContext> mergingIterator = new MergingIterator<VariantContext>(variantContextComparator, iteratorCollection);
+        final MergingIterator<VariantContext> mergingIterator = new MergingIterator<>(variantContextComparator, iteratorCollection);
         while (mergingIterator.hasNext()) {
             final VariantContext context = mergingIterator.next();
             writer.add(context);

--- a/src/main/java/picard/vcf/processor/VariantIteratorProducer.java
+++ b/src/main/java/picard/vcf/processor/VariantIteratorProducer.java
@@ -26,23 +26,15 @@ package picard.vcf.processor;
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
-import htsjdk.samtools.util.CloseableIterator;
-import htsjdk.samtools.util.CollectionUtil;
-import htsjdk.samtools.util.Interval;
-import htsjdk.samtools.util.IntervalList;
-import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.OverlapDetector;
+import htsjdk.samtools.util.*;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFFileReader;
 import picard.vcf.processor.util.PredicateFilterDecoratingClosableIterator;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * A mechanism for iterating over {@link CloseableIterator} of {@link VariantContext}s in in some fashion, given VCF files and optionally
@@ -68,17 +60,30 @@ public abstract class VariantIteratorProducer {
      * filtering of {@link VariantContext}
      */
     public static VariantIteratorProducer byHundredMegabaseChunksWithOnTheFlyFilteringByInterval(final List<File> vcfs, final IntervalList intervalList) {
-        return new Threadsafe(VcfFileSegmentGenerator.byWholeContigSubdividingWithWidth(ONE_HUNDRED_MILLION), vcfs, intervalList);
+        return new Threadsafe(VcfPathSegmentGenerator.byWholeContigSubdividingWithWidth(ONE_HUNDRED_MILLION), vcfs.stream().map(File::toPath).collect(Collectors.toList()), intervalList);
+    }
+
+    /**
+     * Produces a chunking with segments of size 100 megabases (or less if a contig boundary is reached), that also performs on-the-fly
+     * filtering of {@link VariantContext}
+     */
+    public static VariantIteratorProducer byHundredMegabasePathChunksWithOnTheFlyFilteringByInterval(final List<Path> vcfs, final IntervalList intervalList) {
+        return new Threadsafe(VcfPathSegmentGenerator.byWholeContigSubdividingWithWidth(ONE_HUNDRED_MILLION), vcfs, intervalList);
     }
 
     /** Produces a chunking with segments of size 100 megabases (or less if a contig boundary is reached). */
     public static VariantIteratorProducer byHundredMegabaseChunks(final List<File> vcfs) {
-        return new Threadsafe(VcfFileSegmentGenerator.byWholeContigSubdividingWithWidth(ONE_HUNDRED_MILLION), vcfs, null);
+        return new Threadsafe(VcfPathSegmentGenerator.byWholeContigSubdividingWithWidth(ONE_HUNDRED_MILLION), vcfs.stream().map(File::toPath).collect(Collectors.toList()), null);
+    }
+
+    /** Produces a chunking with segments of size 100 megabases (or less if a contig boundary is reached). */
+    public static VariantIteratorProducer byHundredMegabasePathChunks(final List<Path> vcfs) {
+        return new Threadsafe(VcfPathSegmentGenerator.byWholeContigSubdividingWithWidth(ONE_HUNDRED_MILLION), vcfs, null);
     }
 
     /**
-     * A {@link VariantIteratorProducer} that is based on a given {@link VcfFileSegmentGenerator} and a list of VCFs.  The chunks are ordered by VCF, and
-     * then by whatever ordering of segments are produced by {@link VcfFileSegmentGenerator#forVcf(java.io.File)} for each of those VCFs.
+     * A {@link VariantIteratorProducer} that is based on a given {@link VcfPathSegmentGenerator} and a list of VCFs.  The chunks are ordered by VCF, and
+     * then by whatever ordering of segments are produced by {@link VcfPathSegmentGenerator#forVcf(java.nio.file.Path)} for each of those VCFs.
      * <p/>
      * The iterators produced by this class are safe to share between multiple threads.
      * <p/>
@@ -95,19 +100,18 @@ public abstract class VariantIteratorProducer {
         final static Log LOG = Log.getInstance(Threadsafe.class);
 
         /** A list of the segments for which the corresponding {@link VariantContext}s will be produced. */
-        final List<VcfFileSegment> segments;
+        final List<VcfPathSegment> segments;
         final OverlapDetector<Interval> intervalsOfInterestDetector;
 
         /** Maps directly to {@link #segments}; useful for determining if a given variant falls into multiple segments (don't double-count!). */
-        final Map<File, OverlapDetector<VcfFileSegment>> multiSegmentDetectorPerFile =
+        final Map<Path, OverlapDetector<VcfPathSegment>> multiSegmentDetectorPerFile =
                 new CollectionUtil.DefaultingMap<>(f -> new OverlapDetector<>(0, 0), true);
 
-
-        Threadsafe(final VcfFileSegmentGenerator segmenter, final List<File> vcfs) {
+        Threadsafe(final VcfPathSegmentGenerator segmenter, final List<Path> vcfs) {
             this(segmenter, vcfs, null);
         }
 
-        Threadsafe(final VcfFileSegmentGenerator segmenter, final List<File> vcfs, final IntervalList intervals) {
+        Threadsafe(final VcfPathSegmentGenerator segmenter, final List<Path> vcfs, final IntervalList intervals) {
             if (intervals != null) {
                 final List<Interval> uniques = intervals.uniqued(false).getIntervals();
                 this.intervalsOfInterestDetector = new OverlapDetector<>(0, 0);
@@ -116,28 +120,28 @@ public abstract class VariantIteratorProducer {
                 intervalsOfInterestDetector = null;
             }
 
-            /**
-             * Prepare {@link #segments} and {@link multiSegmentDetectorPerFile}.  First, we only want to accumulate segments that are
-             * interesting, e.g., only ones that do not lie completely outside of the interval list provided by the consumer (if it was
-             * provided).
-             *
-             * Then, break up our {@link VcfFileSegment}s by file, and build a corresponding {@link OverlapDetector} for those segments.  This
-             * will be used downstream to ensure that we don't emit a given VC from a VCF more than once.
-             *
-             * While we're at it, since this class expects the provided {@link VcfFileSegmentGenerator} produces non-overlapping segments, 
-             * assert that this is true.
+            /*
+              Prepare {@link #segments} and {@link multiSegmentDetectorPerFile}.  First, we only want to accumulate segments that are
+              interesting, e.g., only ones that do not lie completely outside of the interval list provided by the consumer (if it was
+              provided).
+
+              Then, break up our {@link VcfPathSegment}s by file, and build a corresponding {@link OverlapDetector} for those segments.  This
+              will be used downstream to ensure that we don't emit a given VC from a VCF more than once.
+
+              While we're at it, since this class expects the provided {@link VcfFileSegmentGenerator} produces non-overlapping segments,
+              assert that this is true.
              */
-            final VcfFileSegmentGenerator interestingSegmentSegmenter =
-                    intervalsOfInterestDetector == null ? segmenter : VcfFileSegmentGenerator.excludingNonOverlaps(segmenter, intervalsOfInterestDetector);
+            final VcfPathSegmentGenerator interestingSegmentSegmenter =
+                    intervalsOfInterestDetector == null ? segmenter : VcfPathSegmentGenerator.excludingNonOverlaps(segmenter, intervalsOfInterestDetector);
             segments = new ArrayList<>();
-            for (final File vcf : vcfs) {
-                for (final VcfFileSegment segment : interestingSegmentSegmenter.forVcf(vcf)) {
+            for (final Path vcf : vcfs) {
+                for (final VcfPathSegment segment : interestingSegmentSegmenter.forVcf(vcf)) {
                     segments.add(segment);
                 }
             }
-            for (final VcfFileSegment segment : segments) {
+            for (final VcfPathSegment segment : segments) {
                 final Interval segmentInterval = segment.correspondingInterval();
-                final OverlapDetector<VcfFileSegment> vcfSpecificDetector = multiSegmentDetectorPerFile.get(segment.vcf());
+                final OverlapDetector<VcfPathSegment> vcfSpecificDetector = multiSegmentDetectorPerFile.get(segment.vcf());
                 if (vcfSpecificDetector.getOverlaps(segmentInterval).isEmpty()) {
                     vcfSpecificDetector.addLhs(segment, new Interval(segment.contig(), segment.start(), segment.stop()));
                 } else {
@@ -163,24 +167,19 @@ public abstract class VariantIteratorProducer {
          * This is a {@link CollectionUtil.DefaultingMap} to effectively produce readers on-the-fly.  Note that it also adds every produced
          * reader into {@link #allReaders}.
          */
-        final ThreadLocal<CollectionUtil.DefaultingMap<File, VCFFileReader>> localVcfFileReaders =
-                new ThreadLocal<CollectionUtil.DefaultingMap<File, VCFFileReader>>() {
-                    @Override
-                    protected CollectionUtil.DefaultingMap<File, VCFFileReader> initialValue() {
-                        return new CollectionUtil.DefaultingMap<>(file -> {
-                            final VCFFileReader reader = new VCFFileReader(file);
-                            LOG.debug(String.format("Producing a reader of %s for %s.", file, Thread.currentThread()));
-                            allReaders.add(reader);
-                            return reader;
-                        }, true);
-                    }
-                };
+        final ThreadLocal<CollectionUtil.DefaultingMap<Path, VCFFileReader>> localVcfFileReaders =
+                ThreadLocal.withInitial(() -> new CollectionUtil.DefaultingMap<>(path -> {
+                    final VCFFileReader reader = new VCFFileReader(path);
+                    LOG.debug(String.format("Producing a reader of %s for %s.", path, Thread.currentThread()));
+                    allReaders.add(reader);
+                    return reader;
+                }, true));
 
         /**
-         * Converts a {@link VcfFileSegment} into a {@link VariantContext} iterator.  Applies filtering via {@link #intervalsOfInterestDetector}
+         * Converts a {@link VcfPathSegment} into a {@link VariantContext} iterator.  Applies filtering via {@link #intervalsOfInterestDetector}
          * if it is defined.
          */
-        private CloseableIterator<VariantContext> iteratorForSegment(final VcfFileSegment segment) {
+        private CloseableIterator<VariantContext> iteratorForSegment(final VcfPathSegment segment) {
             final CloseableIterator<VariantContext> query =
                     localVcfFileReaders.get() // Get the collection of VCF file readers local to this thread
                             .get(segment.vcf()) // Get or generate the reader for this segment's VCF file
@@ -212,14 +211,14 @@ public abstract class VariantIteratorProducer {
         /**
          * A predicate that I had difficulty naming. The value of this predicate is that it ensures that no single variant is produced multiple
          * times from a call to {@link Threadsafe#iterators()}.  It works by asking each variant "Hey variant, which of the
-         * {@link VcfFileSegment}s that this {@link Threadsafe} is producing variants from do you fall into (and thus,
+         * {@link VcfPathSegment}s that this {@link Threadsafe} is producing variants from do you fall into (and thus,
          * would be produced by a corresponding call to {@link VCFFileReader#query(String, int, int)}?  If it's more than one, we're only going
-         * to emit you from the query for the very first of those {@link VcfFileSegment}s."
+         * to emit you from the query for the very first of those {@link VcfPathSegment}s."
          */
         final class NonUniqueVariantPredicate implements Predicate<VariantContext> {
-            final VcfFileSegment sourceSegment;
+            final VcfPathSegment sourceSegment;
 
-            NonUniqueVariantPredicate(final VcfFileSegment sourceSegment) {
+            NonUniqueVariantPredicate(final VcfPathSegment sourceSegment) {
                 this.sourceSegment = sourceSegment;
             }
 
@@ -229,7 +228,7 @@ public abstract class VariantIteratorProducer {
                     // This isn't a multi-allelic segment, so it can only be produced by a single segment.
                     return true;
                 }
-                final Collection<VcfFileSegment> intersectingSegments =
+                final Collection<VcfPathSegment> intersectingSegments =
                         multiSegmentDetectorPerFile.get(sourceSegment.vcf()).getOverlaps(new Interval(vc.getContig(), vc.getStart(), vc.getEnd()));
                 if (intersectingSegments.size() < 2) {
                     // There's only one segment that produces this variant
@@ -239,7 +238,7 @@ public abstract class VariantIteratorProducer {
                 // The convention is: only emit the VC if it is produced from the first segment that can produce it in the list.
                 final int sourceSegmentIndex = segments.indexOf(sourceSegment);
                 LOG.debug("Found wide variant spanning multiple source segments: ", vc);
-                for (final VcfFileSegment intersectingSegment : intersectingSegments) {
+                for (final VcfPathSegment intersectingSegment : intersectingSegments) {
                     if (segments.indexOf(intersectingSegment) < sourceSegmentIndex) {
                         // There is a segment that produces this variant earlier in the segment list, exclude it.
                         return false;

--- a/src/main/java/picard/vcf/processor/VariantProcessor.java
+++ b/src/main/java/picard/vcf/processor/VariantProcessor.java
@@ -25,10 +25,14 @@ package picard.vcf.processor;
 
 import htsjdk.samtools.util.IntervalList;
 import htsjdk.variant.variantcontext.VariantContext;
+import picard.nio.PicardHtsPath;
 
 import java.io.File;
-import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 
 /**
@@ -107,7 +111,7 @@ public class VariantProcessor<RESULT, ACCUMULATOR extends VariantProcessor.Accum
         final AccumulatorGenerator<A, R> accumulatorGenerator;
         ResultMerger<R> reducer = null;
         IntervalList intervals = null;
-        final List<Path> inputs = new ArrayList<>();
+        final List<PicardHtsPath> inputs = new ArrayList<>();
         int threadCount = 1;
 
         Builder(final AccumulatorGenerator<A, R> accumulatorGenerator) {
@@ -121,11 +125,11 @@ public class VariantProcessor<RESULT, ACCUMULATOR extends VariantProcessor.Accum
         }
 
         public Builder<A, R> withInput(final File... vcfs) {
-            final List<Path> paths = Arrays.stream(vcfs).map(File::toPath).collect(Collectors.toList());
-            return withInput(paths.toArray(new Path[]{}));
+            final List<PicardHtsPath> paths = Arrays.stream(vcfs).map(PicardHtsPath::new).collect(Collectors.toList());
+            return withInput(paths.toArray(new PicardHtsPath[]{}));
         }
 
-        public Builder<A, R> withInput(final Path... vcfs) {
+        public Builder<A, R> withInput(final PicardHtsPath... vcfs) {
             Collections.addAll(inputs, vcfs);
             return this;
         }

--- a/src/main/java/picard/vcf/processor/VariantProcessor.java
+++ b/src/main/java/picard/vcf/processor/VariantProcessor.java
@@ -27,10 +27,9 @@ import htsjdk.samtools.util.IntervalList;
 import htsjdk.variant.variantcontext.VariantContext;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Describes an object that processes variants and produces a result.
@@ -40,7 +39,7 @@ import java.util.List;
  * <p/>
  * Future work...?
  * - Make more efficient for the single-thread case.
- * - A {@link VcfFileSegmentGenerator} that is based on an interval list, so that segments' span a constant-size total-base-count overlap with
+ * - A {@link VcfPathSegmentGenerator} that is based on an interval list, so that segments' span a constant-size total-base-count overlap with
  * the interval list (or something in that vein).
  *
  * @author mccowan
@@ -53,7 +52,7 @@ public class VariantProcessor<RESULT, ACCUMULATOR extends VariantProcessor.Accum
      *
      * @author mccowan
      */
-    public static interface Accumulator<RESULT> {
+    public interface Accumulator<RESULT> {
         void accumulate(final VariantContext vc);
 
         RESULT result();
@@ -64,7 +63,7 @@ public class VariantProcessor<RESULT, ACCUMULATOR extends VariantProcessor.Accum
      *
      * @author mccowan
      */
-    public static interface AccumulatorGenerator<ACCUMULATOR extends Accumulator<RESULT>, RESULT> {
+    public interface AccumulatorGenerator<ACCUMULATOR extends Accumulator<RESULT>, RESULT> {
         ACCUMULATOR build();
     }
 
@@ -73,7 +72,7 @@ public class VariantProcessor<RESULT, ACCUMULATOR extends VariantProcessor.Accum
      *
      * @author mccowan
      */
-    public static interface ResultMerger<RESULT> {
+    public interface ResultMerger<RESULT> {
         RESULT merge(final Collection<RESULT> resultsToReduce);
     }
 
@@ -96,7 +95,7 @@ public class VariantProcessor<RESULT, ACCUMULATOR extends VariantProcessor.Accum
             throw new RuntimeException(e);
         }
 
-        final List<RESULT> results = new ArrayList<RESULT>();
+        final List<RESULT> results = new ArrayList<>();
         for (final ACCUMULATOR a : executor.accumulators()) {
             results.add(a.result());
         }
@@ -108,7 +107,7 @@ public class VariantProcessor<RESULT, ACCUMULATOR extends VariantProcessor.Accum
         final AccumulatorGenerator<A, R> accumulatorGenerator;
         ResultMerger<R> reducer = null;
         IntervalList intervals = null;
-        final List<File> inputs = new ArrayList<File>();
+        final List<Path> inputs = new ArrayList<>();
         int threadCount = 1;
 
         Builder(final AccumulatorGenerator<A, R> accumulatorGenerator) {
@@ -122,6 +121,11 @@ public class VariantProcessor<RESULT, ACCUMULATOR extends VariantProcessor.Accum
         }
 
         public Builder<A, R> withInput(final File... vcfs) {
+            final List<Path> paths = Arrays.stream(vcfs).map(File::toPath).collect(Collectors.toList());
+            return withInput(paths.toArray(new Path[]{}));
+        }
+
+        public Builder<A, R> withInput(final Path... vcfs) {
             Collections.addAll(inputs, vcfs);
             return this;
         }
@@ -139,14 +143,14 @@ public class VariantProcessor<RESULT, ACCUMULATOR extends VariantProcessor.Accum
         }
 
         public static <A extends Accumulator<R>, R> Builder<A, R> generatingAccumulatorsBy(final AccumulatorGenerator<A, R> generator) {
-            return new Builder<A, R>(generator);
+            return new Builder<>(generator);
         }
 
         public VariantProcessor<R, A> build() {
             if (inputs.isEmpty()) throw new IllegalStateException("You need to provided some inputs before building.");
             if (reducer == null) throw new IllegalStateException("You must provide a reducer before building.");
 
-            return new VariantProcessor<R, A>(reducer, new VariantAccumulatorExecutor.MultiThreadedChunkBased<A, R>(
+            return new VariantProcessor<>(reducer, new VariantAccumulatorExecutor.MultiThreadedChunkBased<>(
                     threadCount,
                     composeVcfIteratorProducerFromBuilderArguments(),
                     accumulatorGenerator
@@ -154,16 +158,16 @@ public class VariantProcessor<RESULT, ACCUMULATOR extends VariantProcessor.Accum
         }
 
         private VariantIteratorProducer composeVcfIteratorProducerFromBuilderArguments() {
-            /**
+            /*
              * Be careful; if we pick chunkings that are highly granular (e.g., a chunking based on each interval in an exome-like 
              * interval list), it will result in a {@link htsjdk.variant.vcf.VCFFileReader#query(String, int, int)} call
              * per tiny chunk, which is very non-performant due to some implementations of that method.
              */
             final VariantIteratorProducer ret;
             if (intervals == null) {
-                ret = VariantIteratorProducer.byHundredMegabaseChunks(inputs);
+                ret = VariantIteratorProducer.byHundredMegabasePathChunks(inputs);
             } else {
-                ret = VariantIteratorProducer.byHundredMegabaseChunksWithOnTheFlyFilteringByInterval(inputs, intervals);
+                ret = VariantIteratorProducer.byHundredMegabasePathChunksWithOnTheFlyFilteringByInterval(inputs, intervals);
             }
             return ret;
         }

--- a/src/main/java/picard/vcf/processor/VcfFileSegment.java
+++ b/src/main/java/picard/vcf/processor/VcfFileSegment.java
@@ -32,7 +32,7 @@ import java.io.File;
  * Describes a segment of a particular VCF file.
  * 
  * @author mccowan
- * @deprecated Use VcfPathSegment
+ * @deprecated from 2022-03-17, Use VcfPathSegment
  */
 @Deprecated
 public abstract class VcfFileSegment {

--- a/src/main/java/picard/vcf/processor/VcfFileSegmentGenerator.java
+++ b/src/main/java/picard/vcf/processor/VcfFileSegmentGenerator.java
@@ -41,7 +41,7 @@ import java.util.stream.StreamSupport;
 /**
  * Describes a mechanism for producing {@link VcfFileSegment}s from a VCF file.
  *
- * @deprecated Use {@link VcfPathSegmentGenerator}
+ * @deprecated from 2022-03-17, Use {@link VcfPathSegmentGenerator}
  * @author mccowan
  */
 @Deprecated

--- a/src/main/java/picard/vcf/processor/VcfPathSegment.java
+++ b/src/main/java/picard/vcf/processor/VcfPathSegment.java
@@ -23,23 +23,18 @@
  */
 package picard.vcf.processor;
 
-import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.util.Interval;
 
-import java.io.File;
-
+import java.nio.file.Path;
 /**
  * Describes a segment of a particular VCF file.
- * 
- * @author mccowan
- * @deprecated Use VcfPathSegment
  */
-@Deprecated
-public abstract class VcfFileSegment {
+public abstract class VcfPathSegment {
     abstract public int start();
     abstract public int stop();
     abstract public String contig();
-    abstract public File vcf();
+    abstract public Path vcf();
     
     public Interval correspondingInterval() {
         return new Interval(contig(), start(), stop());
@@ -47,25 +42,25 @@ public abstract class VcfFileSegment {
 
     @Override
     public String toString() {
-        return vcf().getName() + "::" + contig() + ":" + start() + "-" + stop();
+        return vcf().getFileName() + "::" + contig() + ":" + start() + "-" + stop();
     }
 
-    static VcfFileSegment ofWholeSequence(final SAMSequenceRecord sequence, final File vcf) {
+    static VcfPathSegment ofWholeSequence(final SAMSequenceRecord sequence, final Path vcf) {
         return new SequenceSizedChunk(sequence, vcf);
     }
     
-    static final class SequenceSizedChunk extends VcfFileSegment {
+    static final class SequenceSizedChunk extends VcfPathSegment {
         final SAMSequenceRecord sequence;
-        final File vcf;
+        final Path vcf;
 
-        private SequenceSizedChunk(final SAMSequenceRecord sequence, final File vcf) {
+        private SequenceSizedChunk(final SAMSequenceRecord sequence, final Path vcf) {
             this.sequence = sequence;
             this.vcf = vcf;
         }
 
         @Override
         public String toString() {
-            return vcf().getAbsolutePath() + "::" + sequence.getSequenceName() + ":1-" + sequence.getSequenceLength();
+            return vcf().toAbsolutePath() + "::" + sequence.getSequenceName() + ":1-" + sequence.getSequenceLength();
         }
 
         @Override
@@ -84,7 +79,7 @@ public abstract class VcfFileSegment {
         }
 
         @Override
-        public File vcf() {
+        public Path vcf() {
             return vcf;
         }
     }

--- a/src/main/java/picard/vcf/processor/VcfPathSegment.java
+++ b/src/main/java/picard/vcf/processor/VcfPathSegment.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2015 The Broad Institute
+ * Copyright (c) 2022 The Broad Institute
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,8 +25,7 @@ package picard.vcf.processor;
 
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.util.Interval;
-
-import java.nio.file.Path;
+import picard.nio.PicardHtsPath;
 /**
  * Describes a segment of a particular VCF file.
  */
@@ -34,7 +33,7 @@ public abstract class VcfPathSegment {
     abstract public int start();
     abstract public int stop();
     abstract public String contig();
-    abstract public Path vcf();
+    abstract public PicardHtsPath vcf();
     
     public Interval correspondingInterval() {
         return new Interval(contig(), start(), stop());
@@ -42,25 +41,25 @@ public abstract class VcfPathSegment {
 
     @Override
     public String toString() {
-        return vcf().getFileName() + "::" + contig() + ":" + start() + "-" + stop();
+        return vcf() + "::" + contig() + ":" + start() + "-" + stop();
     }
 
-    static VcfPathSegment ofWholeSequence(final SAMSequenceRecord sequence, final Path vcf) {
+    static VcfPathSegment ofWholeSequence(final SAMSequenceRecord sequence, final PicardHtsPath vcf) {
         return new SequenceSizedChunk(sequence, vcf);
     }
     
     static final class SequenceSizedChunk extends VcfPathSegment {
         final SAMSequenceRecord sequence;
-        final Path vcf;
+        final PicardHtsPath vcf;
 
-        private SequenceSizedChunk(final SAMSequenceRecord sequence, final Path vcf) {
+        private SequenceSizedChunk(final SAMSequenceRecord sequence, final PicardHtsPath vcf) {
             this.sequence = sequence;
             this.vcf = vcf;
         }
 
         @Override
         public String toString() {
-            return vcf().toAbsolutePath() + "::" + sequence.getSequenceName() + ":1-" + sequence.getSequenceLength();
+            return vcf() + "::" + sequence.getSequenceName() + ":1-" + sequence.getSequenceLength();
         }
 
         @Override
@@ -79,7 +78,7 @@ public abstract class VcfPathSegment {
         }
 
         @Override
-        public Path vcf() {
+        public PicardHtsPath vcf() {
             return vcf;
         }
     }

--- a/src/test/java/picard/sam/BuildBamIndexTest.java
+++ b/src/test/java/picard/sam/BuildBamIndexTest.java
@@ -3,9 +3,10 @@ package picard.sam;
 import htsjdk.samtools.SAMException;
 import org.apache.commons.io.FileUtils;
 import org.testng.Assert;
-import org.testng.annotations.Test;
 import org.testng.annotations.AfterTest;
+import org.testng.annotations.Test;
 import picard.cmdline.CommandLineProgramTest;
+import picard.nio.PicardHtsPath;
 
 import java.io.File;
 import java.io.IOException;
@@ -15,7 +16,7 @@ import java.util.List;
 public class BuildBamIndexTest extends CommandLineProgramTest {
 
     private static final File TEST_DATA_DIR = new File("testdata/picard/indices/");
-    private static final File INPUT_FILE = new File(TEST_DATA_DIR, "index_test.sam");
+    private static final PicardHtsPath INPUT_FILE = new PicardHtsPath(new File(TEST_DATA_DIR, "index_test.sam").getPath());
     private static final File OUTPUT_SORTED_FILE = new File(TEST_DATA_DIR, "index_test_sorted.bam");
     private static final File OUTPUT_UNSORTED_FILE = new File(TEST_DATA_DIR, "/index_test_unsorted.bam");
     private static final File OUTPUT_INDEX_FILE = new File(TEST_DATA_DIR, "/index_test.bam.bai");
@@ -27,7 +28,7 @@ public class BuildBamIndexTest extends CommandLineProgramTest {
     // Test that the index file for a sorted BAM is created
     @Test
     public void testBuildBamIndexOK() throws IOException {
-        final List<String> args = new ArrayList<String>();
+        final List<String> args = new ArrayList<>();
         /* First sort, before indexing */
         new SortSam().instanceMain(new String[]{
                 "I=" + INPUT_FILE,
@@ -43,7 +44,7 @@ public class BuildBamIndexTest extends CommandLineProgramTest {
     // Test that the index creation fails when presented with a SAM file
     @Test(expectedExceptions = SAMException.class)
     public void testBuildSamIndexFail() {
-        final List<String> args = new ArrayList<String>();
+        final List<String> args = new ArrayList<>();
         args.add("INPUT=" + INPUT_FILE);
         args.add("OUTPUT=" + OUTPUT_INDEX_FILE);
         runPicardCommandLine(args);
@@ -52,7 +53,7 @@ public class BuildBamIndexTest extends CommandLineProgramTest {
     // Test that the index creation fails when presented with an unsorted BAM file
     @Test(expectedExceptions = SAMException.class)
     public void testBuildBamIndexFail() {
-        final List<String> args = new ArrayList<String>();
+        final List<String> args = new ArrayList<>();
         new SamFormatConverter().instanceMain(new String[]{
                 "INPUT=" + INPUT_FILE,
                 "OUTPUT=" + OUTPUT_UNSORTED_FILE});

--- a/src/test/java/picard/vcf/AccumulateVariantCallingMetricsTest.java
+++ b/src/test/java/picard/vcf/AccumulateVariantCallingMetricsTest.java
@@ -28,6 +28,7 @@ import htsjdk.samtools.metrics.MetricsFile;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import picard.nio.PicardHtsPath;
 
 import java.io.File;
 import java.io.FileReader;
@@ -36,6 +37,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Test for AccumulateVariantCallingMetrics
@@ -67,7 +69,7 @@ public class AccumulateVariantCallingMetricsTest {
         mergedDetailFile.deleteOnExit();
 
         final AccumulateVariantCallingMetrics program = new AccumulateVariantCallingMetrics();
-        program.INPUT = inputs;
+        program.INPUT = inputs.stream().map(PicardHtsPath::new).collect(Collectors.toList());
         program.OUTPUT = mergedFilePrefix;
 
         Assert.assertEquals(program.doWork(), 0);

--- a/src/test/java/picard/vcf/AccumulateVariantCallingMetricsTest.java
+++ b/src/test/java/picard/vcf/AccumulateVariantCallingMetricsTest.java
@@ -37,7 +37,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Test for AccumulateVariantCallingMetrics
@@ -69,7 +68,7 @@ public class AccumulateVariantCallingMetricsTest {
         mergedDetailFile.deleteOnExit();
 
         final AccumulateVariantCallingMetrics program = new AccumulateVariantCallingMetrics();
-        program.INPUT = inputs.stream().map(PicardHtsPath::new).collect(Collectors.toList());
+        program.INPUT = PicardHtsPath.fromPaths(inputs);
         program.OUTPUT = mergedFilePrefix;
 
         Assert.assertEquals(program.doWork(), 0);

--- a/src/test/java/picard/vcf/AccumulateVariantCallingMetricsTest.java
+++ b/src/test/java/picard/vcf/AccumulateVariantCallingMetricsTest.java
@@ -32,6 +32,8 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
@@ -41,13 +43,13 @@ import java.util.List;
  * @author Eric Banks
  */
 public class AccumulateVariantCallingMetricsTest {
-    private static final File TEST_DATA_DIR = new File("testdata/picard/vcf");
+    private static final Path TEST_DATA_DIR = Paths.get("testdata/picard/vcf");
 
     @DataProvider(name = "shardDataProvider")
     public Object[][] shardDataProvider() {
-        final File filePrefix1 = new File(TEST_DATA_DIR, "mergeTest.shard1");
-        final File filePrefix2 = new File(TEST_DATA_DIR, "mergeTest.shard2");
-        final File filePrefix3 = new File(TEST_DATA_DIR, "mergeTest.emptyShard");
+        final String filePrefix1 = TEST_DATA_DIR.resolve("mergeTest.shard1").toString();
+        final String filePrefix2 =TEST_DATA_DIR.resolve("mergeTest.shard2").toString();
+        final String filePrefix3 = TEST_DATA_DIR.resolve("mergeTest.emptyShard").toString();
 
         return new Object[][] {
                 {Arrays.asList(filePrefix1, filePrefix2)},
@@ -57,7 +59,7 @@ public class AccumulateVariantCallingMetricsTest {
 
 
     @Test(dataProvider = "shardDataProvider")
-    public void testMerge(final List<File> inputs) throws IOException {
+    public void testMerge(final List<String> inputs) throws IOException {
         final File mergedFilePrefix = new File(TEST_DATA_DIR + "mergeTest");
         final File mergedSummaryFile = new File(mergedFilePrefix.getAbsolutePath() + ".variant_calling_summary_metrics");
         final File mergedDetailFile = new File(mergedFilePrefix.getAbsolutePath() + ".variant_calling_detail_metrics");

--- a/src/test/java/picard/vcf/CollectVariantCallingMetricsTest.java
+++ b/src/test/java/picard/vcf/CollectVariantCallingMetricsTest.java
@@ -31,6 +31,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 /**
@@ -43,8 +44,8 @@ public class CollectVariantCallingMetricsTest {
 
     @Test
     public void testMetricsTiny() throws IOException {
-        final File dbSnpFile = new File(TEST_DATA_DIR, "mini.dbsnp.vcf");
-        final File vcfFile = new File(TEST_DATA_DIR, "mini.vcf");
+        final Path dbSnpFile = new File(TEST_DATA_DIR, "mini.dbsnp.vcf").toPath();
+        final Path vcfFile = new File(TEST_DATA_DIR, "mini.vcf").toPath();
 
         final File outFile = new File(TEST_DATA_DIR, "vcmetrics_tiny");
         final File summaryFile = new File(TEST_DATA_DIR, "vcmetrics_tiny.variant_calling_summary_metrics");
@@ -54,8 +55,8 @@ public class CollectVariantCallingMetricsTest {
         detailFile.deleteOnExit();
 
         final CollectVariantCallingMetrics program = new CollectVariantCallingMetrics();
-        program.INPUT = vcfFile;
-        program.DBSNP = dbSnpFile;
+        program.INPUT = vcfFile.toString();
+        program.DBSNP = dbSnpFile.toString();
         program.OUTPUT = outFile;
 
         Assert.assertEquals(program.doWork(), 0);
@@ -119,8 +120,8 @@ public class CollectVariantCallingMetricsTest {
 
     @Test
     public void testMetricsTinyGVCF() throws IOException {
-        final File dbSnpFile = new File(TEST_DATA_DIR, "mini.dbsnp.vcf");
-        final File vcfFile = new File(TEST_DATA_DIR, "mini_gvcf.vcf");
+        final Path dbSnpFile = new File(TEST_DATA_DIR, "mini.dbsnp.vcf").toPath();
+        final Path vcfFile = new File(TEST_DATA_DIR, "mini_gvcf.vcf").toPath();
 
         final File outFile = new File(TEST_DATA_DIR, "vcmetrics_tiny_gvcf");
         final File summaryFile = new File(outFile+".variant_calling_summary_metrics");
@@ -130,8 +131,8 @@ public class CollectVariantCallingMetricsTest {
         detailFile.deleteOnExit();
 
         final CollectVariantCallingMetrics program = new CollectVariantCallingMetrics();
-        program.INPUT = vcfFile;
-        program.DBSNP = dbSnpFile;
+        program.INPUT = vcfFile.toString();
+        program.DBSNP = dbSnpFile.toString();
         program.OUTPUT = outFile;
         program.GVCF_INPUT = true;
         Assert.assertEquals(program.doWork(), 0);
@@ -194,9 +195,9 @@ public class CollectVariantCallingMetricsTest {
 
     @Test
     public void testAllHomRefVCF() throws IOException {
-        final File dbSnpFile = new File(TEST_DATA_DIR, "mini.dbsnp.vcf");
-        final File vcfFile = new File(TEST_DATA_DIR, "allHomRef.vcf");
-        final File indexedVcfFile = VcfTestUtils.createTemporaryIndexedVcfFromInput(vcfFile, "allHomRef.tmp.");
+        final Path dbSnpFile = new File(TEST_DATA_DIR, "mini.dbsnp.vcf").toPath();
+        final Path vcfFile = new File(TEST_DATA_DIR, "allHomRef.vcf").toPath();
+        final Path indexedVcfFile = VcfTestUtils.createTemporaryIndexedVcfFromInput(vcfFile.toFile(), "allHomRef.tmp.").toPath();
         final File outFile = new File(TEST_DATA_DIR, "vcmetrics_allHomRef");
         final File summaryFile = new File(outFile + ".variant_calling_summary_metrics");
         final File detailFile = new File(outFile + ".variant_calling_detail_metrics");
@@ -206,8 +207,8 @@ public class CollectVariantCallingMetricsTest {
         detailFile.deleteOnExit();
 
         final CollectVariantCallingMetrics program = new CollectVariantCallingMetrics();
-        program.INPUT = indexedVcfFile;
-        program.DBSNP = dbSnpFile;
+        program.INPUT = indexedVcfFile.toUri().toString();
+        program.DBSNP = dbSnpFile.toUri().toString();
         program.OUTPUT = outFile;
         Assert.assertEquals(program.doWork(), 0);
 

--- a/src/test/java/picard/vcf/CollectVariantCallingMetricsTest.java
+++ b/src/test/java/picard/vcf/CollectVariantCallingMetricsTest.java
@@ -27,11 +27,11 @@ package picard.vcf;
 import htsjdk.samtools.metrics.MetricsFile;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import picard.nio.PicardHtsPath;
 
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.List;
 
 /**
@@ -44,8 +44,8 @@ public class CollectVariantCallingMetricsTest {
 
     @Test
     public void testMetricsTiny() throws IOException {
-        final Path dbSnpFile = new File(TEST_DATA_DIR, "mini.dbsnp.vcf").toPath();
-        final Path vcfFile = new File(TEST_DATA_DIR, "mini.vcf").toPath();
+        final PicardHtsPath dbSnpFile = new PicardHtsPath(new File(TEST_DATA_DIR, "mini.dbsnp.vcf"));
+        final PicardHtsPath vcfFile = new PicardHtsPath(new File(TEST_DATA_DIR, "mini.vcf"));
 
         final File outFile = new File(TEST_DATA_DIR, "vcmetrics_tiny");
         final File summaryFile = new File(TEST_DATA_DIR, "vcmetrics_tiny.variant_calling_summary_metrics");
@@ -55,8 +55,8 @@ public class CollectVariantCallingMetricsTest {
         detailFile.deleteOnExit();
 
         final CollectVariantCallingMetrics program = new CollectVariantCallingMetrics();
-        program.INPUT = vcfFile.toString();
-        program.DBSNP = dbSnpFile.toString();
+        program.INPUT = vcfFile;
+        program.DBSNP = dbSnpFile;
         program.OUTPUT = outFile;
 
         Assert.assertEquals(program.doWork(), 0);
@@ -120,8 +120,8 @@ public class CollectVariantCallingMetricsTest {
 
     @Test
     public void testMetricsTinyGVCF() throws IOException {
-        final Path dbSnpFile = new File(TEST_DATA_DIR, "mini.dbsnp.vcf").toPath();
-        final Path vcfFile = new File(TEST_DATA_DIR, "mini_gvcf.vcf").toPath();
+        final PicardHtsPath dbSnpFile = new PicardHtsPath( new File(TEST_DATA_DIR, "mini.dbsnp.vcf"));
+        final PicardHtsPath vcfFile = new PicardHtsPath(new File(TEST_DATA_DIR, "mini_gvcf.vcf"));
 
         final File outFile = new File(TEST_DATA_DIR, "vcmetrics_tiny_gvcf");
         final File summaryFile = new File(outFile+".variant_calling_summary_metrics");
@@ -131,8 +131,8 @@ public class CollectVariantCallingMetricsTest {
         detailFile.deleteOnExit();
 
         final CollectVariantCallingMetrics program = new CollectVariantCallingMetrics();
-        program.INPUT = vcfFile.toString();
-        program.DBSNP = dbSnpFile.toString();
+        program.INPUT = vcfFile;
+        program.DBSNP = dbSnpFile;
         program.OUTPUT = outFile;
         program.GVCF_INPUT = true;
         Assert.assertEquals(program.doWork(), 0);
@@ -195,9 +195,9 @@ public class CollectVariantCallingMetricsTest {
 
     @Test
     public void testAllHomRefVCF() throws IOException {
-        final Path dbSnpFile = new File(TEST_DATA_DIR, "mini.dbsnp.vcf").toPath();
-        final Path vcfFile = new File(TEST_DATA_DIR, "allHomRef.vcf").toPath();
-        final Path indexedVcfFile = VcfTestUtils.createTemporaryIndexedVcfFromInput(vcfFile.toFile(), "allHomRef.tmp.").toPath();
+        final PicardHtsPath dbSnpFile = new PicardHtsPath(new File(TEST_DATA_DIR, "mini.dbsnp.vcf"));
+        final File vcfFile = new File(TEST_DATA_DIR, "allHomRef.vcf");
+        final PicardHtsPath indexedVcfFile = new PicardHtsPath(VcfTestUtils.createTemporaryIndexedVcfFromInput(vcfFile, "allHomRef.tmp."));
         final File outFile = new File(TEST_DATA_DIR, "vcmetrics_allHomRef");
         final File summaryFile = new File(outFile + ".variant_calling_summary_metrics");
         final File detailFile = new File(outFile + ".variant_calling_detail_metrics");
@@ -207,8 +207,8 @@ public class CollectVariantCallingMetricsTest {
         detailFile.deleteOnExit();
 
         final CollectVariantCallingMetrics program = new CollectVariantCallingMetrics();
-        program.INPUT = indexedVcfFile.toUri().toString();
-        program.DBSNP = dbSnpFile.toUri().toString();
+        program.INPUT = indexedVcfFile;
+        program.DBSNP = dbSnpFile;
         program.OUTPUT = outFile;
         Assert.assertEquals(program.doWork(), 0);
 

--- a/src/test/java/picard/vcf/FixVcfHeaderTest.java
+++ b/src/test/java/picard/vcf/FixVcfHeaderTest.java
@@ -43,22 +43,22 @@ import java.io.IOException;
  * @author Nils Homer
  */
 public class FixVcfHeaderTest {
-    private File INPUT_VCF;
+    private String INPUT_VCF;
     private File OUTPUT_VCF;
-    private File HEADER_VCF;
-    private File HEADER_VCF_WITH_EXTRA_SAMPLE;
+    private String HEADER_VCF;
+    private String HEADER_VCF_WITH_EXTRA_SAMPLE;
 
     @BeforeTest
     void setup() {
         final File testDataPath      = new File("testdata/picard/vcf/FixVcfHeaderTest/");
-        INPUT_VCF                    = new File(testDataPath, "input.vcf");
+        INPUT_VCF                    = new File(testDataPath, "input.vcf").toURI().toString();
         OUTPUT_VCF                   = new File(testDataPath, "output.vcf");
-        HEADER_VCF                   = new File(testDataPath, "header.vcf");
-        HEADER_VCF_WITH_EXTRA_SAMPLE = new File(testDataPath, "header_with_extra_sample.vcf");
+        HEADER_VCF                   = new File(testDataPath, "header.vcf").toURI().toString();
+        HEADER_VCF_WITH_EXTRA_SAMPLE = new File(testDataPath, "header_with_extra_sample.vcf").toURI().toString();
     }
 
     private void runFixVcfHeader(final int checkFirstNRecords,
-                                 final File replacementHeader,
+                                 final String replacementHeader,
                                  final boolean enforceSampleSamples) throws IOException {
         final FixVcfHeader program = new FixVcfHeader();
         final File outputVcf = VcfTestUtils.createTemporaryIndexedFile("output.", ".vcf");
@@ -94,7 +94,7 @@ public class FixVcfHeaderTest {
 
     @Test(dataProvider = "testFixVcfHeaderDataProvider")
     public void testFixVcfHeader(final int checkFirstNRecords,
-                                 final File replacementHeader,
+                                 final String replacementHeader,
                                  final boolean enforceSampleSamples) throws IOException {
         runFixVcfHeader(checkFirstNRecords, replacementHeader, enforceSampleSamples);
     }

--- a/src/test/java/picard/vcf/FixVcfHeaderTest.java
+++ b/src/test/java/picard/vcf/FixVcfHeaderTest.java
@@ -33,6 +33,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import picard.PicardException;
+import picard.nio.PicardHtsPath;
 
 import java.io.File;
 import java.io.IOException;
@@ -43,22 +44,22 @@ import java.io.IOException;
  * @author Nils Homer
  */
 public class FixVcfHeaderTest {
-    private String INPUT_VCF;
+    private PicardHtsPath INPUT_VCF;
     private File OUTPUT_VCF;
-    private String HEADER_VCF;
-    private String HEADER_VCF_WITH_EXTRA_SAMPLE;
+    private PicardHtsPath HEADER_VCF;
+    private PicardHtsPath HEADER_VCF_WITH_EXTRA_SAMPLE;
 
     @BeforeTest
     void setup() {
         final File testDataPath      = new File("testdata/picard/vcf/FixVcfHeaderTest/");
-        INPUT_VCF                    = new File(testDataPath, "input.vcf").toURI().toString();
+        INPUT_VCF                    = new PicardHtsPath(new File(testDataPath, "input.vcf"));
         OUTPUT_VCF                   = new File(testDataPath, "output.vcf");
-        HEADER_VCF                   = new File(testDataPath, "header.vcf").toURI().toString();
-        HEADER_VCF_WITH_EXTRA_SAMPLE = new File(testDataPath, "header_with_extra_sample.vcf").toURI().toString();
+        HEADER_VCF                   = new PicardHtsPath(new File(testDataPath, "header.vcf"));
+        HEADER_VCF_WITH_EXTRA_SAMPLE = new PicardHtsPath(new File(testDataPath, "header_with_extra_sample.vcf"));
     }
 
     private void runFixVcfHeader(final int checkFirstNRecords,
-                                 final String replacementHeader,
+                                 final PicardHtsPath replacementHeader,
                                  final boolean enforceSampleSamples) throws IOException {
         final FixVcfHeader program = new FixVcfHeader();
         final File outputVcf = VcfTestUtils.createTemporaryIndexedFile("output.", ".vcf");
@@ -94,7 +95,7 @@ public class FixVcfHeaderTest {
 
     @Test(dataProvider = "testFixVcfHeaderDataProvider")
     public void testFixVcfHeader(final int checkFirstNRecords,
-                                 final String replacementHeader,
+                                 final PicardHtsPath replacementHeader,
                                  final boolean enforceSampleSamples) throws IOException {
         runFixVcfHeader(checkFirstNRecords, replacementHeader, enforceSampleSamples);
     }

--- a/src/test/java/picard/vcf/GatherVcfsTest.java
+++ b/src/test/java/picard/vcf/GatherVcfsTest.java
@@ -70,7 +70,7 @@ public class GatherVcfsTest extends CommandLineProgramTest {
 
         final File output = VcfTestUtils.createTemporaryIndexedFile("result", expectedOutput.getAbsolutePath().endsWith(".vcf") ? ".vcf" : ".vcf.gz");
 
-        inputFiles.forEach(f -> args.add("INPUT=" + f.toPath().toUri()));
+        inputFiles.forEach(f -> args.add("INPUT=" + f.getURI()));
         args.add("OUTPUT=" + output.getAbsolutePath());
         args.add("COMMENT=" + comment1);
         args.add("REORDER_INPUT_BY_FIRST_VARIANT=" +  reorder);

--- a/src/test/java/picard/vcf/GatherVcfsTest.java
+++ b/src/test/java/picard/vcf/GatherVcfsTest.java
@@ -1,11 +1,13 @@
 package picard.vcf;
 
+import htsjdk.io.HtsPath;
 import htsjdk.variant.vcf.VCFFileReader;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import picard.cmdline.CommandLineProgramTest;
+import picard.nio.PicardHtsPath;
 
 import java.io.File;
 import java.io.IOException;
@@ -24,23 +26,24 @@ public class GatherVcfsTest extends CommandLineProgramTest {
         return GatherVcfs.class.getSimpleName();
     }
 
-    private File vcf,shard1, shard2, shard3, shard2_bad;
-    private File vcf_gz,shard1_gz, shard2_gz, shard3_gz, shard2_bad_gz;
+    private File vcf, vcf_gz;
+    private PicardHtsPath shard1, shard2, shard3, shard2_bad;
+    private HtsPath shard1_gz, shard2_gz, shard3_gz, shard2_bad_gz;
 
     @BeforeClass
     public void setup() throws IOException {
         final File TEST_DIR = new File("testdata/picard/vcf/GatherVcf");
         vcf = VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DIR,"input.vcf"),"whole.");
-        shard1 = VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DIR,"shard1.vcf"),"shard1.");
-        shard2 = VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DIR,"shard2.vcf"),"shard2.");
-        shard2_bad = VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DIR,"shard2_bad.vcf"),"shard2_bad.");
-        shard3 = VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DIR,"shard3.vcf"),"shard3");
+        shard1 = new PicardHtsPath(VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DIR,"shard1.vcf"),"shard1."));
+        shard2 = new PicardHtsPath(VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DIR,"shard2.vcf"),"shard2."));
+        shard2_bad = new PicardHtsPath(VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DIR,"shard2_bad.vcf"),"shard2_bad."));
+        shard3 = new PicardHtsPath(VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DIR,"shard3.vcf"),"shard3"));
 
         vcf_gz = VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DIR,"input.vcf"),"whole.",".vcf.gz");
-        shard1_gz = VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DIR,"shard1.vcf"),"shard1.",".vcf.gz");
-        shard2_gz = VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DIR,"shard2.vcf"),"shard2.",".vcf.gz");
-        shard2_bad_gz = VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DIR,"shard2_bad.vcf"),"shard2_bad.",".vcf.gz");
-        shard3_gz = VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DIR,"shard3.vcf"),"shard3.",".vcf.gz");
+        shard1_gz = new PicardHtsPath(VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DIR,"shard1.vcf"),"shard1.",".vcf.gz"));
+        shard2_gz = new PicardHtsPath(VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DIR,"shard2.vcf"),"shard2.",".vcf.gz"));
+        shard2_bad_gz = new PicardHtsPath(VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DIR,"shard2_bad.vcf"),"shard2_bad.",".vcf.gz"));
+        shard3_gz = new PicardHtsPath(VcfTestUtils.createTemporaryIndexedVcfFromInput(new File(TEST_DIR,"shard3.vcf"),"shard3.",".vcf.gz"));
 
     }
 
@@ -61,7 +64,7 @@ public class GatherVcfsTest extends CommandLineProgramTest {
     }
 
     @Test(dataProvider = "vcfshards")
-    public void TestGatherFiles(final List<File> inputFiles, final File expectedOutput, final int expectedRetVal, boolean reorder) throws IOException {
+    public void TestGatherFiles(final List<HtsPath> inputFiles, final File expectedOutput, final int expectedRetVal, boolean reorder) throws IOException {
         final String comment1 = "This is a comment";
         final List<String> args = new ArrayList<>();
 

--- a/src/test/java/picard/vcf/GatherVcfsTest.java
+++ b/src/test/java/picard/vcf/GatherVcfsTest.java
@@ -67,12 +67,12 @@ public class GatherVcfsTest extends CommandLineProgramTest {
 
         final File output = VcfTestUtils.createTemporaryIndexedFile("result", expectedOutput.getAbsolutePath().endsWith(".vcf") ? ".vcf" : ".vcf.gz");
 
-        inputFiles.forEach(f -> args.add("INPUT=" + f.getAbsolutePath()));
+        inputFiles.forEach(f -> args.add("INPUT=" + f.toPath().toUri()));
         args.add("OUTPUT=" + output.getAbsolutePath());
         args.add("COMMENT=" + comment1);
         args.add("REORDER_INPUT_BY_FIRST_VARIANT=" +  reorder);
 
-        Assert.assertEquals(runPicardCommandLine(args.toArray(new String[args.size()])), expectedRetVal, "Program was expected to run successfully, but didn't.");
+        Assert.assertEquals(runPicardCommandLine(args.toArray(new String[]{})), expectedRetVal, "Program was expected to run successfully, but didn't.");
 
         if (expectedRetVal == 0) {
             final VCFFileReader expectedReader = new VCFFileReader(expectedOutput, false);

--- a/src/test/java/picard/vcf/GenotypeConcordanceGA4GHSchemeTest.java
+++ b/src/test/java/picard/vcf/GenotypeConcordanceGA4GHSchemeTest.java
@@ -38,11 +38,11 @@ import java.util.List;
  * Created by kbergin on 6/24/15.
  */
 public class GenotypeConcordanceGA4GHSchemeTest{
-    private static final File TEST_DATA_PATH = new File("testdata/picard/vcf/");
-    final File ceuTrioSnpsVcf = new File(TEST_DATA_PATH, "CEUTrio-snps.vcf");
+    private static final String TEST_DATA_PATH = new File("testdata/picard/vcf/").toString();
+    final String ceuTrioSnpsVcf = new File(TEST_DATA_PATH, "CEUTrio-snps.vcf").toURI().toString();
     private final GenotypeConcordanceSchemeFactory schemeFactory = new GenotypeConcordanceSchemeFactory();
     final GenotypeConcordanceScheme scheme = schemeFactory.getScheme(false);
-    final List<File> intervalList = Collections.singletonList(new File(TEST_DATA_PATH, "IntervalListChr1Small.interval_list"));
+    final List<String> intervalList = Collections.singletonList(new File(TEST_DATA_PATH, "IntervalListChr1Small.interval_list").toURI().toString());
 
     @Test
     public void testGA4GHScheme() throws Exception {

--- a/src/test/java/picard/vcf/GenotypeConcordanceGA4GHSchemeTest.java
+++ b/src/test/java/picard/vcf/GenotypeConcordanceGA4GHSchemeTest.java
@@ -38,11 +38,11 @@ import java.util.List;
  * Created by kbergin on 6/24/15.
  */
 public class GenotypeConcordanceGA4GHSchemeTest{
-    private static final String TEST_DATA_PATH = new File("testdata/picard/vcf/").toString();
-    final String ceuTrioSnpsVcf = new File(TEST_DATA_PATH, "CEUTrio-snps.vcf").toURI().toString();
+    private static final File TEST_DATA_PATH = new File("testdata/picard/vcf/");
+    final File ceuTrioSnpsVcf = new File(TEST_DATA_PATH, "CEUTrio-snps.vcf");
     private final GenotypeConcordanceSchemeFactory schemeFactory = new GenotypeConcordanceSchemeFactory();
     final GenotypeConcordanceScheme scheme = schemeFactory.getScheme(false);
-    final List<String> intervalList = Collections.singletonList(new File(TEST_DATA_PATH, "IntervalListChr1Small.interval_list").toURI().toString());
+    final List<File> intervalList = Collections.singletonList(new File(TEST_DATA_PATH, "IntervalListChr1Small.interval_list"));
 
     @Test
     public void testGA4GHScheme() throws Exception {

--- a/src/test/java/picard/vcf/GenotypeConcordanceGA4GHSchemeWithMissingTest.java
+++ b/src/test/java/picard/vcf/GenotypeConcordanceGA4GHSchemeWithMissingTest.java
@@ -38,12 +38,12 @@ import java.util.List;
  * Created by kbergin on 6/24/15.
  */
 public class GenotypeConcordanceGA4GHSchemeWithMissingTest{
-    private static final String TEST_DATA_PATH = new File("testdata/picard/vcf/").toString();
-    final String ceuTrioSNPSVCF = new File(TEST_DATA_PATH, "CEUTrio-snps.vcf").toURI().toString();
-    final String nistTruthVCF = new File(TEST_DATA_PATH, "NIST.selected.vcf").toURI().toString();
+    private static final File TEST_DATA_PATH = new File("testdata/picard/vcf/");
+    final File ceuTrioSNPSVCF = new File(TEST_DATA_PATH, "CEUTrio-snps.vcf");
+    final File nistTruthVCF = new File(TEST_DATA_PATH, "NIST.selected.vcf");
     private final GenotypeConcordanceSchemeFactory schemeFactory = new GenotypeConcordanceSchemeFactory();
     final GenotypeConcordanceScheme scheme = schemeFactory.getScheme(true);
-    final List<String> intervalList = Collections.singletonList(new File(TEST_DATA_PATH, "IntervalList1PerChrom.interval_list").toURI().toString());
+    final List<File> intervalList = Collections.singletonList(new File(TEST_DATA_PATH, "IntervalList1PerChrom.interval_list"));
 
     @Test
     public void testMissingHomRefSchemeWithIntervals() {

--- a/src/test/java/picard/vcf/GenotypeConcordanceGA4GHSchemeWithMissingTest.java
+++ b/src/test/java/picard/vcf/GenotypeConcordanceGA4GHSchemeWithMissingTest.java
@@ -38,12 +38,12 @@ import java.util.List;
  * Created by kbergin on 6/24/15.
  */
 public class GenotypeConcordanceGA4GHSchemeWithMissingTest{
-    private static final File TEST_DATA_PATH = new File("testdata/picard/vcf/");
-    final File ceuTrioSNPSVCF = new File(TEST_DATA_PATH, "CEUTrio-snps.vcf");
-    final File nistTruthVCF = new File(TEST_DATA_PATH, "NIST.selected.vcf");
+    private static final String TEST_DATA_PATH = new File("testdata/picard/vcf/").toString();
+    final String ceuTrioSNPSVCF = new File(TEST_DATA_PATH, "CEUTrio-snps.vcf").toURI().toString();
+    final String nistTruthVCF = new File(TEST_DATA_PATH, "NIST.selected.vcf").toURI().toString();
     private final GenotypeConcordanceSchemeFactory schemeFactory = new GenotypeConcordanceSchemeFactory();
     final GenotypeConcordanceScheme scheme = schemeFactory.getScheme(true);
-    final List<File> intervalList = Collections.singletonList(new File(TEST_DATA_PATH, "IntervalList1PerChrom.interval_list"));
+    final List<String> intervalList = Collections.singletonList(new File(TEST_DATA_PATH, "IntervalList1PerChrom.interval_list").toURI().toString());
 
     @Test
     public void testMissingHomRefSchemeWithIntervals() {

--- a/src/test/java/picard/vcf/MergeVcfsTest.java
+++ b/src/test/java/picard/vcf/MergeVcfsTest.java
@@ -1,15 +1,15 @@
 package picard.vcf;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
+import htsjdk.variant.vcf.VCFFileReader;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import htsjdk.variant.vcf.VCFFileReader;
 import picard.cmdline.CommandLineProgram;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by bradt on 9/3/14.
@@ -27,11 +27,11 @@ public class MergeVcfsTest extends AbstractVcfMergingClpTester {
         final List<String> args = new ArrayList<>();
         final File output = VcfTestUtils.createTemporaryIndexedFile("result", ".vcf");
 
-        args.add("INPUT=" + TEST_DATA_PATH + "mini.vcf");
+        args.add("INPUT=" + Paths.get(TEST_DATA_PATH + "mini.vcf").toUri());
         args.add("OUTPUT=" + output.getAbsolutePath());
         args.add("COMMENT=" + comment1);
 
-        Assert.assertEquals(new MergeVcfs().instanceMain(args.toArray(new String[args.size()])), 0);
+        Assert.assertEquals(new MergeVcfs().instanceMain(args.toArray(new String[]{})), 0);
 
        try (VCFFileReader reader = new VCFFileReader(output, false)) {
             Assert.assertTrue(reader.getFileHeader().getMetaDataInInputOrder().stream().anyMatch(H->H.getKey().equals("MergeVcfs.comment") && H.getValue().equals(comment1)));

--- a/src/test/java/picard/vcf/MergeVcfsTest.java
+++ b/src/test/java/picard/vcf/MergeVcfsTest.java
@@ -4,10 +4,10 @@ import htsjdk.variant.vcf.VCFFileReader;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import picard.cmdline.CommandLineProgram;
+import picard.nio.PicardHtsPath;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,7 +27,7 @@ public class MergeVcfsTest extends AbstractVcfMergingClpTester {
         final List<String> args = new ArrayList<>();
         final File output = VcfTestUtils.createTemporaryIndexedFile("result", ".vcf");
 
-        args.add("INPUT=" + Paths.get(TEST_DATA_PATH + "mini.vcf").toUri());
+        args.add("INPUT=" + new PicardHtsPath(TEST_DATA_PATH + "mini.vcf"));
         args.add("OUTPUT=" + output.getAbsolutePath());
         args.add("COMMENT=" + comment1);
 

--- a/src/test/java/picard/vcf/SplitVcfsTest.java
+++ b/src/test/java/picard/vcf/SplitVcfsTest.java
@@ -7,16 +7,15 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 import picard.cmdline.CommandLineProgramTest;
+import picard.nio.PicardHtsPath;
 
 import java.io.File;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Queue;
 
 public class SplitVcfsTest extends CommandLineProgramTest {
 
     private static final File OUTPUT_DATA_PATH = IOUtil.createTempDir("SplitVcfsTest", null);
-    private static final Path TEST_DATA_PATH = Paths.get("testdata/picard/vcf/");
+    private static final File TEST_DATA_PATH = new File("testdata/picard/vcf/");
 
     public String getCommandLineProgramName() {
         return SplitVcfs.class.getSimpleName();
@@ -31,13 +30,13 @@ public class SplitVcfsTest extends CommandLineProgramTest {
     public void testSplit() {
         final File indelOutputFile = new File(OUTPUT_DATA_PATH, "split-vcfs-test-indels-delete-me.vcf");
         final File snpOutputFile = new File(OUTPUT_DATA_PATH, "split-vcfs-test-snps-delete-me.vcf");
-        final Path input = Paths.get(TEST_DATA_PATH.toString(), "CEUTrio-merged-indels-snps.vcf");
+        final PicardHtsPath input = new PicardHtsPath(new File(TEST_DATA_PATH, "CEUTrio-merged-indels-snps.vcf"));
 
         indelOutputFile.deleteOnExit();
         snpOutputFile.deleteOnExit();
 
         final String[] args = new String[]{
-                "INPUT=" + input.toAbsolutePath(),
+                "INPUT=" + input.toPath().toAbsolutePath(),
                 "SNP_OUTPUT=" + snpOutputFile.getAbsolutePath(),
                 "INDEL_OUTPUT=" + indelOutputFile.getAbsolutePath()
         };
@@ -46,7 +45,7 @@ public class SplitVcfsTest extends CommandLineProgramTest {
         final Queue<String> indelContigPositions = AbstractVcfMergingClpTester.loadContigPositions(indelOutputFile);
         final Queue<String> snpContigPositions = AbstractVcfMergingClpTester.loadContigPositions(snpOutputFile);
 
-        final VCFFileReader reader = new VCFFileReader(input);
+        final VCFFileReader reader = new VCFFileReader(input.toPath());
         for (final VariantContext inputContext : reader) {
             if (inputContext.isIndel())
                 Assert.assertEquals(AbstractVcfMergingClpTester.getContigPosition(inputContext), indelContigPositions.poll());

--- a/src/test/java/picard/vcf/SplitVcfsTest.java
+++ b/src/test/java/picard/vcf/SplitVcfsTest.java
@@ -9,12 +9,14 @@ import org.testng.annotations.Test;
 import picard.cmdline.CommandLineProgramTest;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Queue;
 
 public class SplitVcfsTest extends CommandLineProgramTest {
 
     private static final File OUTPUT_DATA_PATH = IOUtil.createTempDir("SplitVcfsTest", null);
-    private static final File TEST_DATA_PATH = new File("testdata/picard/vcf/");
+    private static final Path TEST_DATA_PATH = Paths.get("testdata/picard/vcf/");
 
     public String getCommandLineProgramName() {
         return SplitVcfs.class.getSimpleName();
@@ -29,13 +31,13 @@ public class SplitVcfsTest extends CommandLineProgramTest {
     public void testSplit() {
         final File indelOutputFile = new File(OUTPUT_DATA_PATH, "split-vcfs-test-indels-delete-me.vcf");
         final File snpOutputFile = new File(OUTPUT_DATA_PATH, "split-vcfs-test-snps-delete-me.vcf");
-        final File input = new File(TEST_DATA_PATH, "CEUTrio-merged-indels-snps.vcf");
+        final Path input = Paths.get(TEST_DATA_PATH.toString(), "CEUTrio-merged-indels-snps.vcf");
 
         indelOutputFile.deleteOnExit();
         snpOutputFile.deleteOnExit();
 
         final String[] args = new String[]{
-                "INPUT=" + input.getAbsolutePath(),
+                "INPUT=" + input.toAbsolutePath(),
                 "SNP_OUTPUT=" + snpOutputFile.getAbsolutePath(),
                 "INDEL_OUTPUT=" + indelOutputFile.getAbsolutePath()
         };

--- a/src/test/java/picard/vcf/VcfTestUtils.java
+++ b/src/test/java/picard/vcf/VcfTestUtils.java
@@ -56,6 +56,7 @@ public class VcfTestUtils {
         return out;
     }
 
+
     /**
      * Given a VCF file, create a temporary VCF file with an index file. Both the temporary file and its index are
      * deleted when the JVM exits.

--- a/src/test/java/picard/vcf/processor/ThreadsafeTest.java
+++ b/src/test/java/picard/vcf/processor/ThreadsafeTest.java
@@ -25,14 +25,12 @@ package picard.vcf.processor;
 
 import com.google.common.base.Joiner;
 import htsjdk.samtools.util.CloseableIterator;
-import htsjdk.samtools.util.IOUtil;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFFileReader;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import picard.nio.PicardHtsPath;
 
-import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -42,15 +40,7 @@ import java.util.Set;
  */
 public class ThreadsafeTest {
     static final int TEN_MILLION = (int) 10e6;
-    static Path VCF_WITH_MULTI_ALLELIC_VARIANT_AT_POSITION_10MILLION = null;
-
-    static {
-        try {
-            VCF_WITH_MULTI_ALLELIC_VARIANT_AT_POSITION_10MILLION = IOUtil.getPath("testdata/picard/vcf/chunking/multi_allelic_at_10M.vcf");
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
+    static PicardHtsPath VCF_WITH_MULTI_ALLELIC_VARIANT_AT_POSITION_10MILLION = new PicardHtsPath("testdata/picard/vcf/chunking/multi_allelic_at_10M.vcf");
 
     @Test
     public void ensureUniqueVariantObservationsEspeciallyMultiAllelicOnesThatAppearAtChunkingBoundaries() {
@@ -72,7 +62,7 @@ public class ThreadsafeTest {
     @Test
     public void ensureTestDataActuallyHasWideVariantAtTenMillion() {
         final Joiner joiner = Joiner.on(":"); // Cheat: do a string compare
-        final VCFFileReader r = new VCFFileReader(VCF_WITH_MULTI_ALLELIC_VARIANT_AT_POSITION_10MILLION);
+        final VCFFileReader r = new VCFFileReader(VCF_WITH_MULTI_ALLELIC_VARIANT_AT_POSITION_10MILLION.toPath());
         Assert.assertEquals(
                 joiner.join(r.query("1", TEN_MILLION, TEN_MILLION)),
                 joiner.join(r.query("1", TEN_MILLION + 5, TEN_MILLION + 5))
@@ -89,7 +79,7 @@ public class ThreadsafeTest {
                 );
         final Set<String> observedVcs = new HashSet<>();
         final Set<String> actual = new HashSet<>();
-        final VCFFileReader actualVcs = new VCFFileReader(VCF_WITH_MULTI_ALLELIC_VARIANT_AT_POSITION_10MILLION);
+        final VCFFileReader actualVcs = new VCFFileReader(VCF_WITH_MULTI_ALLELIC_VARIANT_AT_POSITION_10MILLION.toPath());
         for (final VariantContext actualVc : actualVcs) {
             actual.add(actualVc.toString());
         }

--- a/src/test/java/picard/vcf/processor/VcfPathSegmentGeneratorTest.java
+++ b/src/test/java/picard/vcf/processor/VcfPathSegmentGeneratorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2015 The Broad Institute
+ * Copyright (c) 2022 The Broad Institute
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,12 +28,12 @@ import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.OverlapDetector;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import picard.nio.PicardHtsPath;
 
 import java.io.File;
-import java.nio.file.Path;
 
 public class VcfPathSegmentGeneratorTest {
-    final Path VCF_WITH_LOGS_OF_GAPS =  new File("testdata/picard/vcf/chunking/multi_allelic_at_10M.vcf").toPath();
+    final PicardHtsPath VCF_WITH_LOGS_OF_GAPS =  new PicardHtsPath(new File("testdata/picard/vcf/chunking/multi_allelic_at_10M.vcf"));
     static final int TEN_MILLION = (int) 10e6;
 
     @Test

--- a/src/test/java/picard/vcf/processor/VcfPathSegmentGeneratorTest.java
+++ b/src/test/java/picard/vcf/processor/VcfPathSegmentGeneratorTest.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package picard.vcf.processor;
+
+import com.google.common.collect.Iterables;
+import htsjdk.samtools.util.Interval;
+import htsjdk.samtools.util.OverlapDetector;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Path;
+
+public class VcfPathSegmentGeneratorTest {
+    final Path VCF_WITH_LOGS_OF_GAPS =  new File("testdata/picard/vcf/chunking/multi_allelic_at_10M.vcf").toPath();
+    static final int TEN_MILLION = (int) 10e6;
+
+    @Test
+    public void ensureOverlapExclusionTest() {
+        final OverlapDetector<Interval> oneTinyIntervalDetector = new OverlapDetector<>(0, 0);
+        final Interval theInterval = new Interval("1", 5, 10);
+        oneTinyIntervalDetector.addLhs(theInterval, theInterval);
+        final VcfPathSegmentGenerator noFilter = VcfPathSegmentGenerator.byWholeContigSubdividingWithWidth(TEN_MILLION);
+        Assert.assertEquals(Iterables.size(noFilter.forVcf(VCF_WITH_LOGS_OF_GAPS)), 382); // The number of subdivisions of 10 million of this vcf
+        
+        final VcfPathSegmentGenerator allFiltered = VcfPathSegmentGenerator.excludingNonOverlaps(noFilter, oneTinyIntervalDetector);
+        Assert.assertEquals(Iterables.size(allFiltered.forVcf(VCF_WITH_LOGS_OF_GAPS)), 1);
+    }
+}


### PR DESCRIPTION
### Description

Changed to treat all input as a `Path` and use `IOUtil` to choose the path type so that paths with schemes handled by SPI providers are correctly handled as well as paths that have no scheme and are local files.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

