### PR TITLE
Upgrade google-cloud-nio to fix broken requester pays support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ def ensureBuildPrerequisites(buildPrerequisitesMessage) {
 ensureBuildPrerequisites(buildPrerequisitesMessage)
 
 final htsjdkVersion = System.getProperty('htsjdk.version', '2.24.1')
-final googleNio = 'com.google.cloud:google-cloud-nio:0.107.0-alpha:shaded'
+final googleNio = 'com.google.cloud:google-cloud-nio:0.123.25'
 
 // Get the jdk files we need to run javaDoc. We need to use these during compile, testCompile,
 // test execution, and gatkDoc generation, but we don't want them as part of the runtime
@@ -94,9 +94,7 @@ dependencies {
     compile 'org.broadinstitute:barclay:4.0.2'
     compile 'org.apache.logging.log4j:log4j-api:2.17.1'
     compile 'org.apache.logging.log4j:log4j-core:2.17.1'
-    compileOnly(googleNio) {
-        transitive = false
-    }
+    compileOnly(googleNio)
 
     // javadoc utilities; compile/test only to prevent redistribution of sdk jars
     compileOnly(javadocJDKFiles)

--- a/src/main/java/picard/nio/GoogleStorageUtils.java
+++ b/src/main/java/picard/nio/GoogleStorageUtils.java
@@ -28,10 +28,10 @@ package picard.nio;
 import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.storage.contrib.nio.CloudStorageConfiguration;
 import com.google.cloud.storage.contrib.nio.CloudStorageFileSystemProvider;
-import shaded.cloud_nio.com.google.api.client.util.Strings;
-import shaded.cloud_nio.com.google.api.gax.retrying.RetrySettings;
-import shaded.cloud_nio.com.google.cloud.http.HttpTransportOptions;
-import shaded.cloud_nio.org.threeten.bp.Duration;
+import com.google.api.client.util.Strings;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.cloud.http.HttpTransportOptions;
+import org.threeten.bp.Duration;
 
 /**
  * This class serves as a connection to google's implementation of nio support for GCS housed files.


### PR DESCRIPTION
### Description

This upgrade the google-cloud-nio version to match the one that GATK is using (well, the one gatk is moving too).  It also switches from using the shaded version -> standard version.  We initially used the shaded version because of horrible downstream dependency issues in GATK, but those have been resolved so we can switch to the unshaded version now.  

When using the shaded version we ignored transitive dependencies since the actual dependencies were included in the shaded jar and the transitive ones imported additional unnecessary things.  Switching to unshaded means we need the transitive ones.  

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

