### PR TITLE
Account for overlapping reads in Theoretical Sensitivity model

### DIFF
--- a/src/main/java/picard/analysis/CollectWgsMetrics.java
+++ b/src/main/java/picard/analysis/CollectWgsMetrics.java
@@ -139,6 +139,9 @@ static final String USAGE_DETAILS = "<p>This tool collects metrics about the fra
     @Argument(doc="Allele fraction for which to calculate theoretical sensitivity.", optional = true)
     public List<Double> ALLELE_FRACTION = new ArrayList<>(Arrays.asList(0.001, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.3, 0.5));
 
+    @Argument(doc="Phred scaled PCR Error Rate for Theoretical Sensitivity model.", optional = true)
+    public int PCR_ERROR_RATE = 45;
+
     @Argument(doc = "If true, fast algorithm is used.")
     public boolean USE_FAST_ALGORITHM = false;
 
@@ -245,7 +248,7 @@ static final String USAGE_DETAILS = "<p>This tool collects metrics about the fra
             log.info("Calculating theoretical sensitivity at " + ALLELE_FRACTION.size() + " allele fractions.");
 
             List<TheoreticalSensitivityMetrics> tsm = TheoreticalSensitivity.calculateSensitivities(SAMPLE_SIZE,
-                    collector.getUnfilteredDepthHistogram(), collector.getUnfilteredBaseQHistogram(), ALLELE_FRACTION, collector.basesExcludedByOverlap);
+                    collector.getUnfilteredDepthHistogram(), collector.getUnfilteredBaseQHistogram(), ALLELE_FRACTION, collector.basesExcludedByOverlap, PCR_ERROR_RATE);
             theoreticalSensitivityMetrics.addAllMetrics(tsm);
             theoreticalSensitivityMetrics.write(THEORETICAL_SENSITIVITY_OUTPUT);
         }

--- a/src/main/java/picard/analysis/CollectWgsMetrics.java
+++ b/src/main/java/picard/analysis/CollectWgsMetrics.java
@@ -243,7 +243,8 @@ static final String USAGE_DETAILS = "<p>This tool collects metrics about the fra
             // Write out theoretical sensitivity results.
             final MetricsFile<TheoreticalSensitivityMetrics, ?> theoreticalSensitivityMetrics = getMetricsFile();
             log.info("Calculating theoretical sentitivity at " + ALLELE_FRACTION.size() + " allele fractions.");
-            List<TheoreticalSensitivityMetrics> tsm = TheoreticalSensitivity.calculateSensitivities(SAMPLE_SIZE, collector.getUnfilteredDepthHistogram(), collector.getUnfilteredBaseQHistogram(), ALLELE_FRACTION);
+            List<TheoreticalSensitivityMetrics> tsm = TheoreticalSensitivity.calculateSensitivities(SAMPLE_SIZE,
+                    collector.getUnfilteredDepthHistogram(), collector.getUnfilteredBaseQHistogram(), ALLELE_FRACTION, 0.0);
             theoreticalSensitivityMetrics.addAllMetrics(tsm);
             theoreticalSensitivityMetrics.write(THEORETICAL_SENSITIVITY_OUTPUT);
         }

--- a/src/main/java/picard/analysis/CollectWgsMetrics.java
+++ b/src/main/java/picard/analysis/CollectWgsMetrics.java
@@ -242,9 +242,10 @@ static final String USAGE_DETAILS = "<p>This tool collects metrics about the fra
         if (THEORETICAL_SENSITIVITY_OUTPUT != null) {
             // Write out theoretical sensitivity results.
             final MetricsFile<TheoreticalSensitivityMetrics, ?> theoreticalSensitivityMetrics = getMetricsFile();
-            log.info("Calculating theoretical sentitivity at " + ALLELE_FRACTION.size() + " allele fractions.");
+            log.info("Calculating theoretical sensitivity at " + ALLELE_FRACTION.size() + " allele fractions.");
+
             List<TheoreticalSensitivityMetrics> tsm = TheoreticalSensitivity.calculateSensitivities(SAMPLE_SIZE,
-                    collector.getUnfilteredDepthHistogram(), collector.getUnfilteredBaseQHistogram(), ALLELE_FRACTION, 0.0);
+                    collector.getUnfilteredDepthHistogram(), collector.getUnfilteredBaseQHistogram(), ALLELE_FRACTION, collector.basesExcludedByOverlap);
             theoreticalSensitivityMetrics.addAllMetrics(tsm);
             theoreticalSensitivityMetrics.write(THEORETICAL_SENSITIVITY_OUTPUT);
         }

--- a/src/main/java/picard/analysis/directed/CollectTargetedMetrics.java
+++ b/src/main/java/picard/analysis/directed/CollectTargetedMetrics.java
@@ -106,6 +106,9 @@ public abstract class CollectTargetedMetrics<METRIC extends MultilevelMetrics, C
     @Argument(doc="Output for Theoretical Sensitivity metrics where the allele fractions are provided by the ALLELE_FRACTION argument.", optional = true)
     public File THEORETICAL_SENSITIVITY_OUTPUT;
 
+    @Argument(doc="Phred scaled PCR Error Rate for Theoretical Sensitivity model.", optional = true)
+    public int PCR_ERROR_RATE = 45;
+
     @Argument(doc="Allele fraction for which to calculate theoretical sensitivity.", optional = true)
     public List<Double> ALLELE_FRACTION = new ArrayList<>(Arrays.asList(0.001, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.3, 0.5));
     /**
@@ -171,10 +174,10 @@ public abstract class CollectTargetedMetrics<METRIC extends MultilevelMetrics, C
             final MetricsFile<TheoreticalSensitivityMetrics, ?> theoreticalSensitivityMetrics = getMetricsFile();
             log.info("Calculating theoretical sentitivity at " + ALLELE_FRACTION.size() + " allele fractions.");
 
-            final double overlapProbability = ((TargetedPcrMetrics) metrics.getMetrics().toArray()[0]).PCT_EXC_OVERLAP;
+            final double overlapProbability = ((PanelMetricsBase) metrics.getMetrics().toArray()[0]).PCT_EXC_OVERLAP;
 
             List<TheoreticalSensitivityMetrics> tsm = TheoreticalSensitivity.calculateSensitivities(SAMPLE_SIZE,
-                    collector.getDepthHistogram(), collector.getBaseQualityHistogram(), ALLELE_FRACTION, overlapProbability);
+                    collector.getDepthHistogram(), collector.getBaseQualityHistogram(), ALLELE_FRACTION, overlapProbability, PCR_ERROR_RATE);
             theoreticalSensitivityMetrics.addAllMetrics(tsm);
             theoreticalSensitivityMetrics.write(THEORETICAL_SENSITIVITY_OUTPUT);
         }

--- a/src/main/java/picard/analysis/directed/CollectTargetedMetrics.java
+++ b/src/main/java/picard/analysis/directed/CollectTargetedMetrics.java
@@ -169,7 +169,8 @@ public abstract class CollectTargetedMetrics<METRIC extends MultilevelMetrics, C
             // Write out theoretical sensitivity results.
             final MetricsFile<TheoreticalSensitivityMetrics, ?> theoreticalSensitivityMetrics = getMetricsFile();
             log.info("Calculating theoretical sentitivity at " + ALLELE_FRACTION.size() + " allele fractions.");
-            List<TheoreticalSensitivityMetrics> tsm = TheoreticalSensitivity.calculateSensitivities(SAMPLE_SIZE, collector.getDepthHistogram(), collector.getBaseQualityHistogram(), ALLELE_FRACTION);
+            List<TheoreticalSensitivityMetrics> tsm = TheoreticalSensitivity.calculateSensitivities(SAMPLE_SIZE,
+                    collector.getDepthHistogram(), collector.getBaseQualityHistogram(), ALLELE_FRACTION, 0.0);
             theoreticalSensitivityMetrics.addAllMetrics(tsm);
             theoreticalSensitivityMetrics.write(THEORETICAL_SENSITIVITY_OUTPUT);
         }

--- a/src/main/java/picard/analysis/directed/CollectTargetedMetrics.java
+++ b/src/main/java/picard/analysis/directed/CollectTargetedMetrics.java
@@ -18,6 +18,7 @@ import org.broadinstitute.barclay.argparser.Argument;
 import picard.analysis.MetricAccumulationLevel;
 import picard.analysis.TheoreticalSensitivity;
 import picard.analysis.TheoreticalSensitivityMetrics;
+import picard.analysis.WgsMetrics;
 import picard.cmdline.CommandLineProgram;
 import picard.cmdline.StandardOptionDefinitions;
 import picard.metrics.MultilevelMetrics;
@@ -169,8 +170,11 @@ public abstract class CollectTargetedMetrics<METRIC extends MultilevelMetrics, C
             // Write out theoretical sensitivity results.
             final MetricsFile<TheoreticalSensitivityMetrics, ?> theoreticalSensitivityMetrics = getMetricsFile();
             log.info("Calculating theoretical sentitivity at " + ALLELE_FRACTION.size() + " allele fractions.");
+
+            final double overlapProbability = ((TargetedPcrMetrics) metrics.getMetrics().toArray()[0]).PCT_EXC_OVERLAP;
+
             List<TheoreticalSensitivityMetrics> tsm = TheoreticalSensitivity.calculateSensitivities(SAMPLE_SIZE,
-                    collector.getDepthHistogram(), collector.getBaseQualityHistogram(), ALLELE_FRACTION, 0.0);
+                    collector.getDepthHistogram(), collector.getBaseQualityHistogram(), ALLELE_FRACTION, overlapProbability);
             theoreticalSensitivityMetrics.addAllMetrics(tsm);
             theoreticalSensitivityMetrics.write(THEORETICAL_SENSITIVITY_OUTPUT);
         }

--- a/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
+++ b/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
@@ -134,8 +134,6 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
 
     private static final double LOG_ODDS_THRESHOLD = 3.0;
 
-    private final File theoreticalSensitivityOutput = null;
-
     private final int minimumMappingQuality;
     private final int minimumBaseQuality;
     private final boolean clipOverlappingReads;

--- a/src/test/java/picard/IntelInflaterDeflaterLoadTest.java
+++ b/src/test/java/picard/IntelInflaterDeflaterLoadTest.java
@@ -26,7 +26,8 @@ public class IntelInflaterDeflaterLoadTest {
     }
 
     private void checkIntelSupported(final String componentName) {
-        if (!SystemUtils.IS_OS_LINUX && !SystemUtils.IS_OS_MAC) {
+        // Check if on Linux Mac or Apple Silicon (e.g. Apple M1)
+        if ((!SystemUtils.IS_OS_LINUX && !SystemUtils.IS_OS_MAC) || SystemUtils.OS_ARCH.equals("aarch64")) {
             throw new SkipException(componentName + " is not available on this platform");
         }
 

--- a/src/test/java/picard/analysis/TheoreticalSensitivityTest.java
+++ b/src/test/java/picard/analysis/TheoreticalSensitivityTest.java
@@ -258,7 +258,7 @@ public class TheoreticalSensitivityTest {
         // We ensure that even using different random seeds we converge to roughly the same value.
         for (int i = 0; i < 3; i++) {
             double result = TheoreticalSensitivity.sensitivityAtConstantDepth(depth, qualityHistogram, 3,
-                    sampleSize, alleleFraction, i, 0.0);
+                    sampleSize, alleleFraction, i, 0.0, 45);
             Assert.assertEquals(result, expected, tolerance);
         }
     }
@@ -305,7 +305,7 @@ public class TheoreticalSensitivityTest {
         final double overlapProbability = ((WgsMetrics) metrics.getMetrics().toArray()[0]).PCT_EXC_OVERLAP;
         final double result;
         if (useOverlapProbability) {
-            result = TheoreticalSensitivity.theoreticalSensitivity(depthHistogram, qualityHistogram, sampleSize, 3, alleleFraction, overlapProbability);
+            result = TheoreticalSensitivity.theoreticalSensitivity(depthHistogram, qualityHistogram, sampleSize, 3, alleleFraction, overlapProbability, 45);
         }
         else {
             result = TheoreticalSensitivity.theoreticalSensitivity(depthHistogram, qualityHistogram, sampleSize, 3, alleleFraction);

--- a/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
+++ b/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
@@ -159,7 +159,8 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
                 "MINIMUM_MAPPING_QUALITY=" + minimumMappingQuality,
                 "MINIMUM_BASE_QUALITY=" + minimumBaseQuality,
                 "CLIP_OVERLAPPING_READS=" + clipOverlappingReads,
-                "SAMPLE_SIZE=" + sampleSize
+                "SAMPLE_SIZE=" + sampleSize,
+                "THEORETICAL_SENSITIVITY_OUTPUT=" + "ts.out"
         };
 
         Assert.assertEquals(runPicardCommandLine(args), 0);

--- a/src/test/java/picard/analysis/directed/CollectTargetedMetricsTest.java
+++ b/src/test/java/picard/analysis/directed/CollectTargetedMetricsTest.java
@@ -166,14 +166,26 @@ public class CollectTargetedMetricsTest extends CommandLineProgramTest {
                 // the tests from taking too long to run.
                 {tempSamFile, outfile, tsOutfile, perTargetOutfile, referenceFile, singleIntervals, 2000,
                         Arrays.asList(0.01, 0.05, 0.10,  0.30,  0.50), // Allele fraction
-                        Arrays.asList(0.01, 0.54, 0.93,  0.99,  0.99)  // Expected sensitivity
+                        Arrays.asList(0.01, 0.54, 0.93,  0.99,  0.99), // Expected sensitivity
+                        45 // PCR Error Rate
+                },
+
+                // This is the same as the previous test but uses a lower value for the pcrErrorRate.
+                // The important thing captured here is that the expected sensitivities should be
+                // less than or equal to the values from the previous test.
+                {tempSamFile, outfile, tsOutfile, perTargetOutfile, referenceFile, singleIntervals, 2000,
+                        Arrays.asList(0.01, 0.05, 0.10,  0.30,  0.50), // Allele fraction
+                        Arrays.asList(0.00, 0.31, 0.87,  0.99,  0.99), // Expected sensitivity
+                        10 // PCR Error Rate
                 }
         };
     }
 
     @Test(dataProvider = "theoreticalSensitivityDataProvider")
     public void runCollectTargetedMetricsTheoreticalSensitivityTest(final File input, final File outfile, final File tsOutfile, final File perTargetOutfile, final String referenceFile,
-                                              final String targetIntervals, final int sampleSize, final List<Double> alleleFractions, final List<Double> expectedSensitivities) throws IOException {
+                                              final String targetIntervals, final int sampleSize,
+                                              final List<Double> alleleFractions, final List<Double> expectedSensitivities,
+                                              final int pcrErrorRate) throws IOException {
 
         final String[] args = new String[] {
                 "TARGET_INTERVALS=" + targetIntervals,
@@ -184,6 +196,7 @@ public class CollectTargetedMetricsTest extends CommandLineProgramTest {
                 "LEVEL=ALL_READS",
                 "AMPLICON_INTERVALS=" + targetIntervals,
                 "THEORETICAL_SENSITIVITY_OUTPUT=" + tsOutfile.getAbsolutePath(),
+                "PCR_ERROR_RATE=" + pcrErrorRate,
                 "SAMPLE_SIZE=" + sampleSize
         };
 


### PR DESCRIPTION
### Description

This modifies the Theoretical Sensitivity model to account for overlapping reads.  Overlapping reads are particularly important at low allele fractions because overlaps allow for the reduction of sequencer error because overlapping bases should be identical, and generally have much higher effective base qualities.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

