### PR TITLE
Remove unused method Fingerprint.filterSuspectSites()

### DIFF
--- a/src/main/java/picard/fingerprint/Fingerprint.java
+++ b/src/main/java/picard/fingerprint/Fingerprint.java
@@ -90,25 +90,6 @@ public class Fingerprint extends TreeMap<HaplotypeBlock, HaplotypeProbabilities>
         return this;
     }
 
-    /**
-     * Attempts to filter out haplotypes that may have suspect genotyping by removing haplotypes that reach
-     * a minimum confidence score yet have a significant fraction of observations from a third or fourth allele.
-     */
-    public void filterSuspectSites() {
-        final Iterator<Map.Entry<HaplotypeBlock, HaplotypeProbabilities>> iterator = entrySet().iterator();
-        while (iterator.hasNext()) {
-            final Map.Entry<HaplotypeBlock, HaplotypeProbabilities> entry = iterator.next();
-            final HaplotypeProbabilities p = entry.getValue();
-            if (p instanceof HaplotypeProbabilitiesFromSequence) {
-                final HaplotypeProbabilitiesFromSequence probs = (HaplotypeProbabilitiesFromSequence) p;
-
-                if (probs.getLodMostProbableGenotype() >= 3 && probs.getFractionUnexpectedAlleleObs() > 0.1) {
-                    iterator.remove();
-                }
-            }
-        }
-    }
-
     public static Function<FingerprintIdDetails, String> getFingerprintIdDetailsStringFunction(CrosscheckMetric.DataType CROSSCHECK_BY) {
         final Function<FingerprintIdDetails, String> groupByTemp;
         switch (CROSSCHECK_BY) {


### PR DESCRIPTION
### Description
Deleting an unused and untested method that was last modified in 2016.    Noticed this when rebasing #1826 

I'm under the impression that picard doesn't intend to act as a stable api for downstream projects so we're free to delete locally unused public methods?
### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

