### PR TITLE
Check "CHART_OUTPUT != null" before generating a pdf

### DIFF
--- a/src/main/java/picard/analysis/CollectBaseDistributionByCycle.java
+++ b/src/main/java/picard/analysis/CollectBaseDistributionByCycle.java
@@ -137,7 +137,10 @@ public class CollectBaseDistributionByCycle extends SinglePassSamProgram {
         metrics.write(OUTPUT);
         if (hist.isEmpty()) {
             log.warn("No valid bases found in input file. No plot will be produced.");
-        } else {
+            return;
+        }
+
+        if (CHART_OUTPUT != null) {
             final int rResult = RExecutor.executeFromClasspath("picard/analysis/baseDistributionByCycle.R",
                     OUTPUT.getAbsolutePath(),
                     CHART_OUTPUT.getAbsolutePath().replaceAll("%", "%%"),

--- a/src/main/java/picard/analysis/CollectGcBiasMetrics.java
+++ b/src/main/java/picard/analysis/CollectGcBiasMetrics.java
@@ -206,13 +206,15 @@ public class CollectGcBiasMetrics extends SinglePassSamProgram {
         detailMetricsFile.write(OUTPUT);
         summaryMetricsFile.write(SUMMARY_OUTPUT);
 
-        final NumberFormat fmt = NumberFormat.getIntegerInstance();
-        fmt.setGroupingUsed(true);
-        RExecutor.executeFromClasspath(R_SCRIPT,
-                OUTPUT.getAbsolutePath(),
-                SUMMARY_OUTPUT.getAbsolutePath(),
-                CHART_OUTPUT.getAbsolutePath().replaceAll("%", "%%"),
-                String.valueOf(SCAN_WINDOW_SIZE));
+        if (CHART_OUTPUT != null) {
+            final NumberFormat fmt = NumberFormat.getIntegerInstance();
+            fmt.setGroupingUsed(true);
+            RExecutor.executeFromClasspath(R_SCRIPT,
+                    OUTPUT.getAbsolutePath(),
+                    SUMMARY_OUTPUT.getAbsolutePath(),
+                    CHART_OUTPUT.getAbsolutePath().replaceAll("%", "%%"),
+                    String.valueOf(SCAN_WINDOW_SIZE));
+        }
     }
 }
 

--- a/src/main/java/picard/analysis/CollectInsertSizeMetrics.java
+++ b/src/main/java/picard/analysis/CollectInsertSizeMetrics.java
@@ -167,10 +167,12 @@ public class CollectInsertSizeMetrics extends SinglePassSamProgram {
                      " of the total aligned paired data.");
             final InsertSizeMetricsCollector.PerUnitInsertSizeMetricsCollector allReadsCollector = (InsertSizeMetricsCollector.PerUnitInsertSizeMetricsCollector) multiCollector.getAllReadsCollector();
             log.warn("Total mapped pairs in all categories: " + (allReadsCollector == null ? allReadsCollector : allReadsCollector.getTotalInserts()));
+            return;
         }
-        else  {
-            file.write(OUTPUT);
 
+        file.write(OUTPUT);
+
+        if (Histogram_FILE != null) {
             final List<String> plotArgs = new ArrayList<>();
             Collections.addAll(plotArgs, OUTPUT.getAbsolutePath(), Histogram_FILE.getAbsolutePath().replaceAll("%", "%%"), INPUT.getName());
 

--- a/src/main/java/picard/analysis/MeanQualityByCycle.java
+++ b/src/main/java/picard/analysis/MeanQualityByCycle.java
@@ -135,8 +135,10 @@ public class MeanQualityByCycle extends SinglePassSamProgram {
 
         if (q.isEmpty() && oq.isEmpty()) {
             log.warn("No valid bases found in input file. No plot will be produced.");
+            return;
         }
-        else {
+
+        if(CHART_OUTPUT != null) {
             // Now run R to generate a chart
             final int rResult = RExecutor.executeFromClasspath(
                     "picard/analysis/meanQualityByCycle.R",

--- a/src/main/java/picard/analysis/QualityScoreDistribution.java
+++ b/src/main/java/picard/analysis/QualityScoreDistribution.java
@@ -158,8 +158,10 @@ public class QualityScoreDistribution extends SinglePassSamProgram {
         metrics.write(OUTPUT);
         if (qHisto.isEmpty() && oqHisto.isEmpty()) {
             log.warn("No valid bases found in input file. No plot will be produced.");
+            return;
         }
-        else {
+
+        if (CHART_OUTPUT != null) {
             // Now run R to generate a chart
             final int rResult = RExecutor.executeFromClasspath(
                     "picard/analysis/qualityScoreDistribution.R",


### PR DESCRIPTION
### Description

Check if "CHART_OUTPUT" command line parameter was provided before generating a pdf report.

This is to match the logic in the "customCommandLineValidation" method which checks if R is installed 
when "CHART_OUTPUT != null"
This can be helpful when running on environments that do not have or cannot have R installed.
You should be able to use this tool on such environments provided you do not ask for a pdf report.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

