### PR TITLE
Remove commons.lang dependency because it is redundant with commons lang3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,6 @@ dependencies {
     compile 'com.google.guava:guava:15.0'
     compile 'org.apache.commons:commons-math3:3.5'
     compile 'org.apache.commons:commons-collections4:4.3'
-    compile 'commons-lang:commons-lang:2.6'
     compile 'com.github.samtools:htsjdk:' + htsjdkVersion
     compile 'org.broadinstitute:barclay:4.0.2'
     compile 'org.apache.logging.log4j:log4j-api:2.17.1'

--- a/src/main/java/picard/arrays/CollectArraysVariantCallingMetrics.java
+++ b/src/main/java/picard/arrays/CollectArraysVariantCallingMetrics.java
@@ -1,6 +1,6 @@
 package picard.arrays;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import picard.analysis.MergeableMetricBase;
 import picard.arrays.illumina.ArraysControlInfo;

--- a/src/main/java/picard/arrays/GtcToVcf.java
+++ b/src/main/java/picard/arrays/GtcToVcf.java
@@ -52,7 +52,7 @@ import htsjdk.variant.vcf.VCFInfoHeaderLine;
 import htsjdk.variant.vcf.VCFRecordCodec;
 import htsjdk.variant.vcf.VCFStandardHeaderLines;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;

--- a/src/main/java/picard/arrays/VcfToAdpc.java
+++ b/src/main/java/picard/arrays/VcfToAdpc.java
@@ -32,7 +32,7 @@ import htsjdk.variant.variantcontext.Genotype;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFFileReader;
 import htsjdk.variant.vcf.VCFHeader;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;

--- a/src/main/java/picard/arrays/illumina/Build37ExtendedIlluminaManifest.java
+++ b/src/main/java/picard/arrays/illumina/Build37ExtendedIlluminaManifest.java
@@ -24,7 +24,7 @@
 
 package picard.arrays.illumina;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/main/java/picard/arrays/illumina/Build37ExtendedIlluminaManifestRecord.java
+++ b/src/main/java/picard/arrays/illumina/Build37ExtendedIlluminaManifestRecord.java
@@ -26,7 +26,7 @@ package picard.arrays.illumina;
 
 import htsjdk.tribble.annotation.Strand;
 import htsjdk.variant.variantcontext.Allele;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -240,6 +240,6 @@ public class Build37ExtendedIlluminaManifestRecord extends IlluminaManifestRecor
         extensions.add(rsId);
         extensions.add(flag.name());
 
-        return originalLine + "," + StringUtils.join(extensions, ",");
+        return originalLine + "," + String.join(",", extensions);
     }
 }

--- a/src/main/java/picard/arrays/illumina/CreateExtendedIlluminaManifest.java
+++ b/src/main/java/picard/arrays/illumina/CreateExtendedIlluminaManifest.java
@@ -13,7 +13,7 @@ import htsjdk.tribble.annotation.Strand;
 import htsjdk.variant.utils.SAMSequenceDictionaryExtractor;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFFileReader;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;

--- a/src/main/java/picard/arrays/illumina/IlluminaManifestRecord.java
+++ b/src/main/java/picard/arrays/illumina/IlluminaManifestRecord.java
@@ -25,7 +25,7 @@
 package picard.arrays.illumina;
 
 import htsjdk.tribble.annotation.Strand;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import picard.PicardException;
 
 import java.util.Map;

--- a/src/main/java/picard/fingerprint/FingerprintUtils.java
+++ b/src/main/java/picard/fingerprint/FingerprintUtils.java
@@ -40,7 +40,7 @@ import htsjdk.variant.vcf.VCFConstants;
 import htsjdk.variant.vcf.VCFHeader;
 import htsjdk.variant.vcf.VCFHeaderLine;
 import htsjdk.variant.vcf.VCFStandardHeaderLines;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import picard.PicardException;
 
 import java.io.File;

--- a/src/main/java/picard/illumina/parser/IlluminaFileUtil.java
+++ b/src/main/java/picard/illumina/parser/IlluminaFileUtil.java
@@ -25,7 +25,6 @@ package picard.illumina.parser;
 
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
-import org.apache.commons.lang.NotImplementedException;
 import picard.PicardException;
 import picard.illumina.parser.fakers.*;
 import picard.illumina.parser.readers.TileMetricsOutReader;
@@ -127,12 +126,12 @@ public class IlluminaFileUtil {
 
                         @Override
                         public List<String> verify(List<Integer> expectedTiles, int[] expectedCycles) {
-                            throw new NotImplementedException("`verify()` is not implemented for CBCLs");
+                            throw new UnsupportedOperationException("`verify()` is not implemented for CBCLs");
                         }
 
                         @Override
                         public List<String> fakeFiles(List<Integer> expectedTiles, int[] cycles, SupportedIlluminaFormat format) {
-                            throw new NotImplementedException("`fakeFiles()` is not implemented for CBCLs");
+                            throw new UnsupportedOperationException("`fakeFiles()` is not implemented for CBCLs");
                         }
 
                         @Override


### PR DESCRIPTION
I noticed that we have both commons lang and lang3.  I removed all lang uses so we only need lang3 now.

The only thing that might change for users is replacing a deprecated `NotImplementedException` with the standard  `UnsupportedOperationException`