### PR TITLE
Remove obsolete references to Google Genomics API

### DIFF
--- a/src/main/java/picard/cmdline/CommandLineProgram.java
+++ b/src/main/java/picard/cmdline/CommandLineProgram.java
@@ -131,9 +131,6 @@ public abstract class CommandLineProgram {
     // after argument parsing using the value established by the user in the referenceSequence argument collection.
     protected File REFERENCE_SEQUENCE = Defaults.REFERENCE_FASTA;
 
-    @Argument(doc="Google Genomics API client_secrets.json file path.", common = true)
-    public String GA4GH_CLIENT_SECRETS="client_secrets.json";
-
     @ArgumentCollection(doc="Special Arguments that have meaning to the argument parsing system.  " +
                 "It is unlikely these will ever need to be accessed by the command line program")
     public Object specialArgumentsCollection = useLegacyParser() ?
@@ -147,20 +144,6 @@ public abstract class CommandLineProgram {
     public Boolean USE_JDK_INFLATER = false;
 
     private static final String[] PACKAGES_WITH_WEB_DOCUMENTATION = {"picard"};
-
-    static {
-      // Register custom reader factory for reading data from Google Genomics
-      // implementation of GA4GH API.
-      // With this it will be possible to pass these urls as INPUT params.
-      // E.g. java -jar dist/picard.jar ViewSam \
-      //    INPUT=https://www.googleapis.com/genomics/v1beta2/readgroupsets/CK256frpGBD44IWHwLP22R4/ \
-      //    GA4GH_CLIENT_SECRETS=../client_secrets.json
-      if (System.getProperty("samjdk.custom_reader") == null) {
-        System.setProperty("samjdk.custom_reader",
-            "https://www.googleapis.com/genomics," +
-            "com.google.cloud.genomics.gatk.htsjdk.GA4GHReaderFactory");
-      }
-    }
 
     /**
     * Initialized in parseArgs.  Subclasses may want to access this to do their
@@ -235,9 +218,6 @@ public abstract class CommandLineProgram {
         this.defaultHeaders.add(new StringHeader("Started on: " + startDate));
 
         Log.setGlobalLogLevel(VERBOSITY);
-        if (System.getProperty("ga4gh.client_secrets") == null) {
-          System.setProperty("ga4gh.client_secrets", GA4GH_CLIENT_SECRETS);
-        }
         SamReaderFactory.setDefaultValidationStringency(VALIDATION_STRINGENCY);
 
         // Set the compression level everywhere we can think of


### PR DESCRIPTION
* The Google Genomics API was turned off years ago. This removes a global argument (GA4GH_CLIENT_SECRETS) which was used with it and several initialization steps in CommandLineProgram which are no longer meaningful.