### PR TITLE
Allow empty input files for CollectAlignmentSummaryMetrics and FastqToSam

### DIFF
--- a/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
+++ b/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
@@ -190,8 +190,6 @@ public class CollectAlignmentSummaryMetrics extends SinglePassSamProgram {
 
         file.write(OUTPUT);
 
-
-
         if (HISTOGRAM_FILE != null) {
             if(file.getNumHistograms() == 0) {
                 //can happen if user sets MINIMUM_PCT = 0.5, etc.

--- a/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
+++ b/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
@@ -190,13 +190,20 @@ public class CollectAlignmentSummaryMetrics extends SinglePassSamProgram {
 
         file.write(OUTPUT);
 
-        if (HISTOGRAM_FILE != null) {
-            final List<String> plotArgs = new ArrayList<>();
-            Collections.addAll(plotArgs, OUTPUT.getAbsolutePath(), HISTOGRAM_FILE.getAbsolutePath().replaceAll("%", "%%"), INPUT.getName());
 
-            final int rResult = RExecutor.executeFromClasspath(HISTOGRAM_R_SCRIPT, plotArgs.toArray(new String[0]));
-            if (rResult != 0) {
-                throw new PicardException("R script " + HISTOGRAM_R_SCRIPT + " failed with return code " + rResult);
+
+        if (HISTOGRAM_FILE != null) {
+            if(file.getNumHistograms() == 0) {
+                //can happen if user sets MINIMUM_PCT = 0.5, etc.
+                log.warn("No Read length histograms to plot.");
+            } else {
+                final List<String> plotArgs = new ArrayList<>();
+                Collections.addAll(plotArgs, OUTPUT.getAbsolutePath(), HISTOGRAM_FILE.getAbsolutePath().replaceAll("%", "%%"), INPUT.getName());
+
+                final int rResult = RExecutor.executeFromClasspath(HISTOGRAM_R_SCRIPT, plotArgs.toArray(new String[0]));
+                if (rResult != 0) {
+                    throw new PicardException("R script " + HISTOGRAM_R_SCRIPT + " failed with return code " + rResult);
+                }
             }
         }
 

--- a/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
+++ b/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
@@ -191,8 +191,7 @@ public class CollectAlignmentSummaryMetrics extends SinglePassSamProgram {
         file.write(OUTPUT);
 
         if (HISTOGRAM_FILE != null) {
-            if(file.getNumHistograms() == 0) {
-                //can happen if user sets MINIMUM_PCT = 0.5, etc.
+            if(file.getNumHistograms() == 0 || file.getAllHistograms().stream().allMatch(Histogram::isEmpty)) {
                 log.warn("No Read length histograms to plot.");
             } else {
                 final List<String> plotArgs = new ArrayList<>();

--- a/src/main/java/picard/sam/FastqToSam.java
+++ b/src/main/java/picard/sam/FastqToSam.java
@@ -234,6 +234,9 @@ public class FastqToSam extends CommandLineProgram {
     @Argument(doc="Allow (and ignore) empty lines")
     public Boolean ALLOW_AND_IGNORE_EMPTY_LINES = false;
 
+    @Argument(doc="Allow empty input fastq")
+    public Boolean ALLOW_EMPTY_FASTQ = false;
+
     private static final SolexaQualityConverter solexaQualityConverter = SolexaQualityConverter.getSingleton();
 
     /**
@@ -324,10 +327,19 @@ public class FastqToSam extends CommandLineProgram {
         final SAMFileHeader header = createSamFileHeader();
         final SAMFileWriter writer = new SAMFileWriterFactory().makeWriter(header, false, OUTPUT, REFERENCE_SEQUENCE);
 
-        // Set the quality format
-        QUALITY_FORMAT = FastqToSam.determineQualityFormat(fileToFastqReader(FASTQ.toPath()),
-                (FASTQ2 == null) ? null : fileToFastqReader(FASTQ2.toPath()),
-                QUALITY_FORMAT);
+        final FastqReader reader1 = fileToFastqReader(FASTQ.toPath());
+        if (reader1.hasNext()) {
+            // Set the quality format
+            QUALITY_FORMAT = FastqToSam.determineQualityFormat(reader1,
+                    (FASTQ2 == null) ? null : fileToFastqReader(FASTQ2.toPath()),
+                    QUALITY_FORMAT);
+        } else {
+            if (ALLOW_EMPTY_FASTQ) {
+                LOG.warn("Input FASTQ is empty, will write out SAM/BAM file with no reads.");
+            } else {
+                throw new PicardException("Input fastq is empty.  Set ALLOW_EMPTY_FASTQ if you still want to write out a file with no reads.");
+            }
+        }
 
         // Lists for sequential files, but also used when not sequential
         final List<FastqReader> readers1 = new ArrayList<>();

--- a/src/main/java/picard/sam/FastqToSam.java
+++ b/src/main/java/picard/sam/FastqToSam.java
@@ -337,7 +337,7 @@ public class FastqToSam extends CommandLineProgram {
             if (ALLOW_EMPTY_FASTQ) {
                 LOG.warn("Input FASTQ is empty, will write out SAM/BAM file with no reads.");
             } else {
-                throw new PicardException("Input fastq is empty.  Set ALLOW_EMPTY_FASTQ if you still want to write out a file with no reads.");
+                throw new PicardException("Input fastq is empty. Set ALLOW_EMPTY_FASTQ if you still want to write out a file with no reads.");
             }
         }
 

--- a/src/main/resources/picard/analysis/readLengthDistribution.R
+++ b/src/main/resources/picard/analysis/readLengthDistribution.R
@@ -25,25 +25,25 @@ for (i in 1:length(startFinder))
         }
 }
 
-melted <- tryCatch (
-        {
-        histogram <- read.table(metricsFile, header=T, sep="\t", skip=secondBlankLine)
-        M=max(histogram$READ_LENGTH)
-        histogram=merge(histogram,data.frame(y=seq(0,M)),by.x = "READ_LENGTH",by.y="y",all.y = T)
-        melted=reshape(histogram,idvar="READ_LENGTH", varying = list(2:ncol(histogram)),direction = "long", timevar = "variable", v.names="value",  times=names(histogram)[2:ncol(histogram)],new.row.names = NULL)
-        rownames(melted) <- c()
-        melted[!complete.cases(melted),"value"]=0
-        melted$variable=gsub("_LENGTH_COUNT","",melted$variable)
-        melted
-        },
-  error = function(cond) {
-          if (grepl("no lines available in input", cond$message)) {
-                melted <- data.frame(READ_LENGTH=c(100,100), value=c(0,0), variable=c("PAIRD_TOTAL", "PAIRED_ALIGNED"))
-          } else {
-                stop(cond)
-          }
-        }
-  )
+metrics <- read.table(metricsFile, header=T, nrows=1, sep="\t", skip=firstBlankLine)
+histogram <- read.table(metricsFile, header=T, sep="\t", skip=secondBlankLine)
+
+
+
+# get maximal value in histogram 
+M=max(histogram$READ_LENGTH)
+
+#introduce rows for the missing ones
+histogram=merge(histogram,data.frame(y=seq(0,M)),by.x = "READ_LENGTH",by.y="y",all.y = T)
+
+#melt the histogram
+melted=reshape(histogram,idvar="READ_LENGTH", varying = list(2:ncol(histogram)),direction = "long", timevar = "variable", v.names="value",  times=names(histogram)[2:ncol(histogram)],new.row.names = NULL)
+rownames(melted) <- c()
+#complete the missing values to zero
+melted[!complete.cases(melted),"value"]=0
+
+#remove the trailing "_LENGTH_COUNT" from the name of the variable
+melted$variable=gsub("_LENGTH_COUNT","",melted$variable)
 
 # Then plot as a PDF
 pdf(outputFile)

--- a/src/test/java/picard/analysis/CollectAlignmentSummaryMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectAlignmentSummaryMetricsTest.java
@@ -656,14 +656,15 @@ public class CollectAlignmentSummaryMetricsTest extends CommandLineProgramTest {
     @DataProvider
     Object[][] fileForTestReadLengthHistogram(){
         return new Object[][]{
-                new Object[]{"summary_alignment_stats_test.sam"},
-                new Object[]{"summary_alignment_stats_test2.sam"},
-                new Object[]{"summary_alignment_stats_test3.sam"}
+                {"summary_alignment_stats_test.sam", true},
+                {"summary_alignment_stats_test2.sam", true},
+                {"summary_alignment_stats_test3.sam", true},
+                {"summary_alignment_stats_test_empty.sam", false}
         };
     }
 
     @Test(dataProvider = "fileForTestReadLengthHistogram")
-    public void testReadLengthHistogram(final String fileToUse) throws IOException {
+    public void testReadLengthHistogram(final String fileToUse, final Boolean expectHistogramOut) throws IOException {
         final File input = new File(TEST_DATA_DIR, fileToUse);
         final File outFile = getTempOutputFile("testReadLengthHistogram", ".txt");
 
@@ -676,7 +677,9 @@ public class CollectAlignmentSummaryMetricsTest extends CommandLineProgramTest {
 
         Assert.assertEquals(runPicardCommandLine(argsList.toArray(new String[0])),0);
 
-        Assert.assertTrue(outHist.exists());
+        if (expectHistogramOut) {
+            Assert.assertTrue(outHist.exists());
+        }
     }
 
 

--- a/testdata/picard/sam/AlignmentSummaryMetrics/summary_alignment_stats_test_empty.sam
+++ b/testdata/picard/sam/AlignmentSummaryMetrics/summary_alignment_stats_test_empty.sam
@@ -1,0 +1,11 @@
+@HD	VN:1.0	SO:coordinate
+@SQ	SN:chr1	LN:101	UR:file:testdata/net/sf/picard/sam/merger.fasta	M5:bd01f7e11515bb6beda8f7257902aa67
+@SQ	SN:chr2	LN:101	UR:file:testdata/net/sf/picard/sam/merger.fasta	M5:31c33e2155b3de5e2554b693c475b310
+@SQ	SN:chr3	LN:101	UR:file:testdata/net/sf/picard/sam/merger.fasta	M5:631593c6dd2048ae88dcce2bd505d295
+@SQ	SN:chr4	LN:101	UR:file:testdata/net/sf/picard/sam/merger.fasta	M5:c60cb92f1ee5b78053c92bdbfa19abf1
+@SQ	SN:chr5	LN:101	UR:file:testdata/net/sf/picard/sam/merger.fasta	M5:07ebc213c7611db0eacbb1590c3e9bda
+@SQ	SN:chr6	LN:101	UR:file:testdata/net/sf/picard/sam/merger.fasta	M5:7be2f5e7ee39e60a6c3b5b6a41178c6d
+@SQ	SN:chr7	LN:404	UR:file:testdata/net/sf/picard/sam/merger.fasta	M5:da488fc432cdaf2c20c96da473a7b630
+@SQ	SN:chr8	LN:202	UR:file:testdata/net/sf/picard/sam/merger.fasta	M5:d339678efce576d5546e88b49a487b63
+@RG	ID:0	SM:Hi,Momma!	LB:whatever	PU:me	PL:ILLUMINA
+@PG	ID:samtools	PN:samtools	VN:1.12	CL:samtools view -H -o summary_alignment_stats_test_empty.sam summary_alignment_stats_test.sam


### PR DESCRIPTION
Currently, if input files to the tools have 0 reads, various exceptions are thrown by CollectAlignmentSummaryMetrics and FastqToSam.  This PR adds an option to allow FastqToSam to produce an empty Sam when passed an empty fastq instead of throwing an exception, and does not try to plot readlength distribution in CollectAlignmentSummaryMetrics when there are 0 reads (which currently hits an r error). 

