### PR TITLE
Fix crash on PF_READS == 0 for AlignmentSummaryMetricsCollector

### DIFF
--- a/src/main/java/picard/analysis/AlignmentSummaryMetricsCollector.java
+++ b/src/main/java/picard/analysis/AlignmentSummaryMetricsCollector.java
@@ -261,7 +261,7 @@ public class AlignmentSummaryMetricsCollector extends SAMRecordAndReferenceMulti
         @Override
         public void finish() {
             //summarize read data
-            if (metrics.TOTAL_READS > 0) {
+            if (metrics.TOTAL_READS > 0 && metrics.PF_READS > 0) {
                 metrics.PCT_PF_READS = (double) metrics.PF_READS / (double) metrics.TOTAL_READS;
                 metrics.PCT_ADAPTER = adapterReads / (double) metrics.PF_READS;
                 metrics.MEAN_READ_LENGTH = readLengthHistogram.getMean();

--- a/src/main/java/picard/analysis/AlignmentSummaryMetricsCollector.java
+++ b/src/main/java/picard/analysis/AlignmentSummaryMetricsCollector.java
@@ -40,6 +40,7 @@ import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.util.CoordMath;
 import htsjdk.samtools.util.Histogram;
 import htsjdk.samtools.util.SequenceUtil;
+import picard.PicardException;
 import picard.metrics.PerUnitMetricCollector;
 import picard.metrics.SAMRecordAndReference;
 import picard.metrics.SAMRecordAndReferenceMultiLevelCollector;
@@ -298,6 +299,8 @@ public class AlignmentSummaryMetricsCollector extends SAMRecordAndReferenceMulti
 
                     metrics.PF_HQ_MEDIAN_MISMATCHES = hqMismatchHistogram.getMedian();
                 }
+            } else {
+                throw new PicardException("Input file contains no PF_READS.");
             }
         }
 

--- a/src/main/java/picard/analysis/AlignmentSummaryMetricsCollector.java
+++ b/src/main/java/picard/analysis/AlignmentSummaryMetricsCollector.java
@@ -261,7 +261,7 @@ public class AlignmentSummaryMetricsCollector extends SAMRecordAndReferenceMulti
         @Override
         public void finish() {
             //summarize read data
-            if (metrics.TOTAL_READS > 0 && metrics.PF_READS > 0) {
+            if (metrics.PF_READS > 0) {
                 metrics.PCT_PF_READS = (double) metrics.PF_READS / (double) metrics.TOTAL_READS;
                 metrics.PCT_ADAPTER = adapterReads / (double) metrics.PF_READS;
                 metrics.MEAN_READ_LENGTH = readLengthHistogram.getMean();

--- a/src/main/java/picard/analysis/AlignmentSummaryMetricsCollector.java
+++ b/src/main/java/picard/analysis/AlignmentSummaryMetricsCollector.java
@@ -40,6 +40,7 @@ import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.util.CoordMath;
 import htsjdk.samtools.util.Histogram;
 import htsjdk.samtools.util.SequenceUtil;
+import picard.PicardException;
 import picard.metrics.PerUnitMetricCollector;
 import picard.metrics.SAMRecordAndReference;
 import picard.metrics.SAMRecordAndReferenceMultiLevelCollector;
@@ -297,6 +298,10 @@ public class AlignmentSummaryMetricsCollector extends SAMRecordAndReferenceMulti
                     metrics.AVG_POS_3PRIME_SOFTCLIP_LENGTH = MathUtil.divide(num3PrimeSoftClippedBases, (double) numReadsWith3PrimeSoftClips);
 
                     metrics.PF_HQ_MEDIAN_MISMATCHES = hqMismatchHistogram.getMedian();
+                }
+            } else {
+                if (metrics.TOTAL_READS > 0) {
+                    throw new PicardException("Input file contains no PF_READS.");
                 }
             }
         }

--- a/src/main/java/picard/analysis/AlignmentSummaryMetricsCollector.java
+++ b/src/main/java/picard/analysis/AlignmentSummaryMetricsCollector.java
@@ -40,7 +40,6 @@ import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.util.CoordMath;
 import htsjdk.samtools.util.Histogram;
 import htsjdk.samtools.util.SequenceUtil;
-import picard.PicardException;
 import picard.metrics.PerUnitMetricCollector;
 import picard.metrics.SAMRecordAndReference;
 import picard.metrics.SAMRecordAndReferenceMultiLevelCollector;
@@ -299,8 +298,6 @@ public class AlignmentSummaryMetricsCollector extends SAMRecordAndReferenceMulti
 
                     metrics.PF_HQ_MEDIAN_MISMATCHES = hqMismatchHistogram.getMedian();
                 }
-            } else {
-                throw new PicardException("Input file contains no PF_READS.");
             }
         }
 

--- a/src/test/java/picard/analysis/CollectAlignmentSummaryMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectAlignmentSummaryMetricsTest.java
@@ -768,4 +768,37 @@ public class CollectAlignmentSummaryMetricsTest extends CommandLineProgramTest {
             }
         }
     }
+
+    @Test
+    public void testNoPFReads() throws IOException {
+        final File input = new File(TEST_DATA_DIR, "null.sam");
+        final File outfile = getTempOutputFile("test", ".txt");
+        final String[] args = new String[]{
+                "INPUT=" + input.getAbsolutePath(),
+                "OUTPUT=" + outfile.getAbsolutePath(),
+        };
+        Assert.assertEquals(runPicardCommandLine(args), 0);
+
+        final MetricsFile<AlignmentSummaryMetrics, Comparable<?>> output = new MetricsFile<>();
+        try (FileReader reader = new FileReader(outfile)) {
+            output.read(reader);
+        }
+
+        Assert.assertEquals(output.getMetrics().size(), 1);
+        for (final AlignmentSummaryMetrics metrics : output.getMetrics()) {
+            Assert.assertEquals(metrics.MEAN_READ_LENGTH, 0.0);
+            Assert.assertEquals(metrics.TOTAL_READS, 3);
+            Assert.assertEquals(metrics.PF_READS, 0);
+            Assert.assertEquals(metrics.PF_NOISE_READS, 0);
+            Assert.assertEquals(metrics.PF_HQ_ALIGNED_READS, 0);
+            Assert.assertEquals(metrics.PF_HQ_ALIGNED_Q20_BASES, 0);
+            Assert.assertEquals(metrics.PF_HQ_MEDIAN_MISMATCHES, 0.0);
+            Assert.assertEquals(metrics.PF_READS_ALIGNED, 0);
+            Assert.assertEquals(metrics.PF_READS_IMPROPER_PAIRS, 0);
+            Assert.assertEquals(metrics.PCT_PF_READS_IMPROPER_PAIRS, 0.0);
+            Assert.assertEquals(metrics.PF_ALIGNED_BASES, 0);
+            Assert.assertEquals(metrics.PF_MISMATCH_RATE, 0.0);
+            Assert.assertEquals(metrics.BAD_CYCLES, 0);
+        }
+    }
 }

--- a/src/test/java/picard/analysis/CollectAlignmentSummaryMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectAlignmentSummaryMetricsTest.java
@@ -29,7 +29,6 @@ import htsjdk.samtools.util.Histogram;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import picard.PicardException;
 import picard.cmdline.CommandLineProgramTest;
 import picard.util.TestNGUtil;
 
@@ -770,7 +769,7 @@ public class CollectAlignmentSummaryMetricsTest extends CommandLineProgramTest {
         }
     }
 
-    @Test(expectedExceptions = PicardException.class)
+    @Test
     public void testNoPFReads() throws IOException {
         final File input = new File(TEST_DATA_DIR, "null.sam");
         final File outfile = getTempOutputFile("test", ".txt");

--- a/src/test/java/picard/analysis/CollectAlignmentSummaryMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectAlignmentSummaryMetricsTest.java
@@ -29,6 +29,7 @@ import htsjdk.samtools.util.Histogram;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import picard.PicardException;
 import picard.cmdline.CommandLineProgramTest;
 import picard.util.TestNGUtil;
 
@@ -769,7 +770,7 @@ public class CollectAlignmentSummaryMetricsTest extends CommandLineProgramTest {
         }
     }
 
-    @Test
+    @Test(expectedExceptions = PicardException.class)
     public void testNoPFReads() throws IOException {
         final File input = new File(TEST_DATA_DIR, "null.sam");
         final File outfile = getTempOutputFile("test", ".txt");

--- a/testdata/picard/sam/AlignmentSummaryMetrics/null.sam
+++ b/testdata/picard/sam/AlignmentSummaryMetrics/null.sam
@@ -1,0 +1,5 @@
+@HD	VN:1.6	GO:none	SO:queryname
+@RG	ID:test	SM:test_sample	LB:test_lib	PL:ILLUMINA	PU:my_platform	CN:BI	DT:2023-01-01T00:00:00-0500	DS:description
+aln1	516	*	0	0	*	*	0	0	AGCTACTG	99999999	RG:Z:test
+aln2	516	*	0	0	*	*	0	0	GTCAGTCA	99999999	RG:Z:test
+aln3	516	*	0	0	*	*	0	0	CCTTGGAA	99999999	RG:Z:test


### PR DESCRIPTION
### Description
----
Create a (mostly) empty metrics file instead of giving a stacktrace if no reads pass Illumina filters.

Related to the following issue: https://github.com/broadinstitute/picard/issues/1862
----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on github actions

#### Review
- [x] Final thumbs-up from reviewer
- [x] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

