### PR TITLE
Mark GENOTYPING_ERROR_RATE as a DeprecatedFeature and remove code ref…

### DIFF
--- a/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
+++ b/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
@@ -33,6 +33,7 @@ import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.DeprecatedFeature;
 import org.broadinstitute.barclay.argparser.Hidden;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import picard.PicardException;
@@ -384,6 +385,7 @@ public class CrosscheckFingerprints extends CommandLineProgram {
             "marking has been overly aggressive and coverage is low.")
     public boolean ALLOW_DUPLICATE_READS = false;
 
+    @DeprecatedFeature(detail = "No longer used in fingerprint checking. Will be removed in a future release.")
     @Argument(doc = "Assumed genotyping error rate that provides a floor on the probability that a genotype comes from " +
             "the expected sample. Must be greater than zero. ")
     public double GENOTYPING_ERROR_RATE = 0.01;
@@ -423,12 +425,6 @@ public class CrosscheckFingerprints extends CommandLineProgram {
 
     @Override
     protected String[] customCommandLineValidation() {
-        if (GENOTYPING_ERROR_RATE <= 0) {
-            return new String[]{"GENOTYPING_ERROR_RATE must be greater than zero. Found " + GENOTYPING_ERROR_RATE};
-        }
-        if (GENOTYPING_ERROR_RATE >= 1) {
-            return new String[]{"GENOTYPING_ERROR_RATE must be strictly less than 1, found " + GENOTYPING_ERROR_RATE};
-        }
         if (SECOND_INPUT == null && INPUT_SAMPLE_MAP != null) {
             return new String[]{"INPUT_SAMPLE_MAP can only be used when also using SECOND_INPUT"};
         }
@@ -900,7 +896,7 @@ public class CrosscheckFingerprints extends CommandLineProgram {
                 final boolean expectedToMatch = EXPECT_ALL_GROUPS_TO_MATCH || lhsMatchId.equals(rhsMatchId);
 
                 final MatchResults results = FingerprintChecker.calculateMatchResults(lhsFingerprints.get(lhsId), rhsFingerprints.get(rhsId),
-                        GENOTYPING_ERROR_RATE, LOSS_OF_HET_RATE, false, CALCULATE_TUMOR_AWARE_RESULTS);
+                        LOSS_OF_HET_RATE, false, CALCULATE_TUMOR_AWARE_RESULTS);
                 final FingerprintResult result = getMatchResults(expectedToMatch, results);
 
                 if (!OUTPUT_ERRORS_ONLY || result == FingerprintResult.INCONCLUSIVE || !result.isExpected()) {
@@ -958,7 +954,7 @@ public class CrosscheckFingerprints extends CommandLineProgram {
             }
 
             final MatchResults results = FingerprintChecker.calculateMatchResults(lhsFP, rhsFP,
-                    GENOTYPING_ERROR_RATE, LOSS_OF_HET_RATE, false, CALCULATE_TUMOR_AWARE_RESULTS);
+                    LOSS_OF_HET_RATE, false, CALCULATE_TUMOR_AWARE_RESULTS);
             final CrosscheckMetric.FingerprintResult result = getMatchResults(true, results);
 
             if (!OUTPUT_ERRORS_ONLY || !result.isExpected()) {

--- a/src/main/java/picard/fingerprint/FingerprintChecker.java
+++ b/src/main/java/picard/fingerprint/FingerprintChecker.java
@@ -774,7 +774,7 @@ public class FingerprintChecker {
 
                 final FingerprintResults results = new FingerprintResults(p, null, specificSample);
                 for (final Fingerprint expectedFp : expectedFingerprints) {
-                    final MatchResults result = calculateMatchResults(combinedFp, expectedFp, 0, pLossofHet);
+                    final MatchResults result = calculateMatchResults(combinedFp, expectedFp, pLossofHet);
                     results.addResults(result);
                 }
 
@@ -784,7 +784,7 @@ public class FingerprintChecker {
                 for (final FingerprintIdDetails rg : fingerprintsByReadGroup.keySet()) {
                     final FingerprintResults results = new FingerprintResults(p, rg.platformUnit, rg.sample);
                     for (final Fingerprint expectedFp : expectedFingerprints) {
-                        final MatchResults result = calculateMatchResults(fingerprintsByReadGroup.get(rg), expectedFp, 0, pLossofHet);
+                        final MatchResults result = calculateMatchResults(fingerprintsByReadGroup.get(rg), expectedFp, pLossofHet);
                         results.addResults(result);
                     }
 
@@ -831,7 +831,7 @@ public class FingerprintChecker {
             for (final String sample : observedFingerprintsBySample.keySet()) {
                 final FingerprintResults results = new FingerprintResults(p, null, sample);
                 for (final Fingerprint expectedFp : expectedFingerprints) {
-                    final MatchResults result = calculateMatchResults(observedFingerprintsBySample.get(sample), expectedFp, 0, pLossofHet);
+                    final MatchResults result = calculateMatchResults(observedFingerprintsBySample.get(sample), expectedFp, pLossofHet);
                     results.addResults(result);
                 }
                 resultsList.add(results);
@@ -840,8 +840,8 @@ public class FingerprintChecker {
         return resultsList;
     }
 
-    public static MatchResults calculateMatchResults(final Fingerprint observedFp, final Fingerprint expectedFp, final double minPExpected, final double pLoH) {
-        return calculateMatchResults(observedFp, expectedFp, minPExpected, pLoH, true, true);
+    public static MatchResults calculateMatchResults(final Fingerprint observedFp, final Fingerprint expectedFp, final double pLoH) {
+        return calculateMatchResults(observedFp, expectedFp, pLoH, true, true);
 
     }
 
@@ -856,7 +856,7 @@ public class FingerprintChecker {
      * In the cases where the most likely genotypes from the two fingerprints do not match the
      * lExpectedSample is Max(actualpExpectedSample, minPExpected).
      */
-    public static MatchResults calculateMatchResults(final Fingerprint observedFp, final Fingerprint expectedFp, final double minPExpected, final double pLoH, final boolean calculateLocusInfo, final boolean calculateTumorAwareLod) {
+    public static MatchResults calculateMatchResults(final Fingerprint observedFp, final Fingerprint expectedFp, final double pLoH, final boolean calculateLocusInfo, final boolean calculateTumorAwareLod) {
         final List<LocusResult> locusResults = calculateLocusInfo ? new ArrayList<>() : null;
 
         double llNoSwapModel = 0;
@@ -934,7 +934,7 @@ public class FingerprintChecker {
      * as the observedFp and the genotype data as the expectedFp in order to get the best output.
      */
     public static MatchResults calculateMatchResults(final Fingerprint observedFp, final Fingerprint expectedFp) {
-        return calculateMatchResults(observedFp, expectedFp, 0, 0);
+        return calculateMatchResults(observedFp, expectedFp, 0);
     }
 
     public void setReferenceFasta(final File referenceFasta) {

--- a/src/test/java/picard/fingerprint/FingerprintCheckerTest.java
+++ b/src/test/java/picard/fingerprint/FingerprintCheckerTest.java
@@ -80,7 +80,7 @@ public class FingerprintCheckerTest {
         fpObserved.add(hpHomRef);
 
         // get match results using pLOD
-        final MatchResults mr = FingerprintChecker.calculateMatchResults(fpObserved, fpExpected, 0.01, pLoH);
+        final MatchResults mr = FingerprintChecker.calculateMatchResults(fpObserved, fpExpected, pLoH);
 
         // make sure that it's more likely to be the same sample, if the observed is "tumor" and the expected is "normal"
         Assert.assertTrue(mr.getLodTN() > mr.getLOD());


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/picard/issues/1865. If anyone has a better suggestion for the `DeprecatedFeature` detail message please let me know.