### PR TITLE
Enable IntelInflater

### DIFF
--- a/src/main/java/picard/cmdline/CommandLineProgram.java
+++ b/src/main/java/picard/cmdline/CommandLineProgram.java
@@ -218,7 +218,6 @@ public abstract class CommandLineProgram {
         this.defaultHeaders.add(new StringHeader("Started on: " + startDate));
 
         Log.setGlobalLogLevel(VERBOSITY);
-        SamReaderFactory.setDefaultValidationStringency(VALIDATION_STRINGENCY);
 
         // Set the compression level everywhere we can think of
         BlockCompressedOutputStream.setDefaultCompressionLevel(COMPRESSION_LEVEL);
@@ -256,6 +255,10 @@ public abstract class CommandLineProgram {
         if (!USE_JDK_INFLATER) {
             BlockGunzipper.setDefaultInflaterFactory(new IntelInflaterFactory());
         }
+
+        // This has to happen after the inflater factory is set because it causes a reinitialization of the static
+        // default reader factory.  At least until https://github.com/samtools/htsjdk/issues/1666 is resolved
+        SamReaderFactory.setDefaultValidationStringency(VALIDATION_STRINGENCY);
 
         if (!QUIET) {
             System.err.println("[" + new Date() + "] " + commandLine);

--- a/src/test/java/picard/IntelInflaterDeflaterLoadTest.java
+++ b/src/test/java/picard/IntelInflaterDeflaterLoadTest.java
@@ -1,11 +1,23 @@
 package picard;
 
 import com.intel.gkl.compression.IntelDeflater;
+import com.intel.gkl.compression.IntelDeflaterFactory;
 import com.intel.gkl.compression.IntelInflater;
+import com.intel.gkl.compression.IntelInflaterFactory;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.util.zip.DeflaterFactory;
+import htsjdk.samtools.util.zip.InflaterFactory;
 import org.apache.commons.lang3.SystemUtils;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
+import picard.cmdline.CommandLineProgram;
+import picard.cmdline.programgroups.OtherProgramGroup;
+import picard.cmdline.programgroups.Testing;
+
+import java.lang.reflect.Field;
 
 /**
  * Test that the Intel Inflater and Deflater can be loaded successfully.
@@ -25,6 +37,20 @@ public class IntelInflaterDeflaterLoadTest {
                 "Intel shared library was not loaded. This could be due to a configuration error, or your system might not support it.");
     }
 
+    @Test
+    public void testIntelInflaterIsUsed(){
+        final InflaterDeflaterTester cmd = new InflaterDeflaterTester();
+        cmd.instanceMain(new String[]{});
+        Assert.assertEquals(cmd.inflaterFactory.getClass(), IntelInflaterFactory.class);
+    }
+
+    @Test
+    public void testDeflaterIsUsed(){
+        final InflaterDeflaterTester cmd = new InflaterDeflaterTester();
+        cmd.instanceMain(new String[]{});
+        Assert.assertEquals(cmd.deflaterFactory.getClass(), IntelDeflaterFactory.class);
+    }
+
     private void checkIntelSupported(final String componentName) {
         if (!SystemUtils.IS_OS_LINUX && !SystemUtils.IS_OS_MAC) {
             throw new SkipException(componentName + " is not available on this platform");
@@ -32,6 +58,37 @@ public class IntelInflaterDeflaterLoadTest {
 
         if (SystemUtils.OS_ARCH != null && SystemUtils.OS_ARCH.equals("ppc64le")) {
             throw new SkipException(componentName + " is not available for this architecture");
+        }
+    }
+
+
+    @CommandLineProgramProperties(summary = "test program for checking if the intel optimized inflater/deflater are active",
+            oneLineSummary = "test program please ignore",
+            programGroup = Testing.class,
+            omitFromCommandLine = true)
+    public static class InflaterDeflaterTester extends CommandLineProgram {
+        public InflaterFactory inflaterFactory;
+        public DeflaterFactory deflaterFactory;
+
+        @Override
+        protected int doWork() {
+            final SamReaderFactory samReaderFactory = SamReaderFactory.makeDefault();
+            inflaterFactory = getFieldValue(samReaderFactory, "inflaterFactory", InflaterFactory.class);
+
+            final SAMFileWriterFactory samFileWriterFactory = new SAMFileWriterFactory();
+            deflaterFactory = getFieldValue(samFileWriterFactory, "deflaterFactory", DeflaterFactory.class);
+
+            return 0;
+        }
+
+        private <T,R> R getFieldValue(final T obj,final String fieldName,  Class<R> clazz) {
+            try {
+                final Field deflaterFactoryField = obj.getClass().getDeclaredField(fieldName);
+                deflaterFactoryField.setAccessible(true);
+                return clazz.cast(deflaterFactoryField.get(obj));
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes a long standing bug where we were accidentally not using the intel inflator when decompressing even when it was requested.  Includes a horrible test using brittle reflection.