### PR TITLE
Fix deprecated uses of newInstance()

### DIFF
--- a/src/main/java/picard/cmdline/PicardCommandLine.java
+++ b/src/main/java/picard/cmdline/PicardCommandLine.java
@@ -8,6 +8,7 @@ import org.broadinstitute.barclay.argparser.CommandLineProgramGroup;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.argparser.ExperimentalFeature;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -150,12 +151,11 @@ public class PicardCommandLine {
                 printCommandList(classes);
             } else {
                 if (simpleNameToClass.containsKey(args[0])) {
-                    final Class clazz = simpleNameToClass.get(args[0]);
+                    final Class<?> clazz = simpleNameToClass.get(args[0]);
                     try {
-                        return (CommandLineProgram)clazz.newInstance();
-                    } catch (final InstantiationException e) {
-                        throw new RuntimeException(e);
-                    } catch (final IllegalAccessException e) {
+                        return (CommandLineProgram)clazz.getDeclaredConstructor().newInstance();
+                    } catch (final InstantiationException | IllegalAccessException
+                                   | InvocationTargetException | NoSuchMethodException e) {
                         throw new RuntimeException(e);
                     }
                 }
@@ -229,10 +229,9 @@ public class PicardCommandLine {
             CommandLineProgramGroup programGroup = programGroupClassToProgramGroupInstance.get(property.programGroup());
             if (null == programGroup) {
                 try {
-                    programGroup = property.programGroup().newInstance();
-                } catch (final InstantiationException e) {
-                    throw new RuntimeException(e);
-                } catch (final IllegalAccessException e) {
+                    programGroup = property.programGroup().getDeclaredConstructor().newInstance();
+                } catch (final InstantiationException | IllegalAccessException
+                               | NoSuchMethodException | InvocationTargetException e) {
                     throw new RuntimeException(e);
                 }
                 programGroupClassToProgramGroupInstance.put(property.programGroup(), programGroup);

--- a/src/main/java/picard/sam/MergeBamAlignment.java
+++ b/src/main/java/picard/sam/MergeBamAlignment.java
@@ -310,7 +310,7 @@ public class MergeBamAlignment extends CommandLineProgram {
                 "the alignment pair with the largest insert size. If all alignments would be chimeric, it picks the " +
                 "alignments for each end with the best MAPQ. ");
 
-        private final Class<PrimaryAlignmentSelectionStrategy> clazz;
+        private final Class<? extends PrimaryAlignmentSelectionStrategy> clazz;
 
         private final String description;
 
@@ -318,14 +318,14 @@ public class MergeBamAlignment extends CommandLineProgram {
             return description;
         }
 
-        PrimaryAlignmentStrategy(final Class<?> clazz, final String description) {
-            this.clazz = (Class<PrimaryAlignmentSelectionStrategy>) clazz;
+        PrimaryAlignmentStrategy(final Class<? extends PrimaryAlignmentSelectionStrategy> clazz, final String description) {
+            this.clazz = clazz;
             this.description = description;
         }
 
         PrimaryAlignmentSelectionStrategy newInstance() {
             try {
-                return clazz.newInstance();
+                return clazz.getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                 throw new PicardException("Trouble instantiating " + clazz.getName(), e);
             }

--- a/src/test/java/picard/TestDataProviders.java
+++ b/src/test/java/picard/TestDataProviders.java
@@ -44,9 +44,9 @@ public class TestDataProviders {
     // https://github.com/cbeust/testng/blob/master/src/test/java/test/inject/NoInjectionTest.java
     @Test(dataProvider = "DataprovidersThatDontTestThemselves")
     public void testDataProviderswithDP(@NoInjection final Method method, final Class clazz) throws
-            IllegalAccessException, InstantiationException {
+            IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
 
-        Object instance = clazz.newInstance();
+        Object instance = clazz.getDeclaredConstructor().newInstance();
 
         Set<Method> methodSet = new HashSet<>();
         methodSet.addAll(Arrays.asList(clazz.getDeclaredMethods()));

--- a/src/test/java/picard/cmdline/PicardCommandLineTest.java
+++ b/src/test/java/picard/cmdline/PicardCommandLineTest.java
@@ -7,6 +7,8 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
 public class PicardCommandLineTest {
@@ -50,13 +52,13 @@ public class PicardCommandLineTest {
             // Check for missing annotations
             Assert.assertNotNull(clProperties);
             try {
-                final Object commandLineProgram = clazz.newInstance();
+                final Object commandLineProgram = clazz.getDeclaredConstructor().newInstance();
                 try {
                     new CommandLineArgumentParser(commandLineProgram);
                 } catch (CommandLineException.CommandLineParserInternalException e) {
                     throw new RuntimeException("Barclay command line parser internal exception parsing class: " + clazz.getName(), e);
                 }
-            } catch (IllegalAccessException | InstantiationException e) {
+            } catch (IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException e) {
                 throw new RuntimeException("Failure instantiating command line program: " + clazz.getName(), e);
             }
         });

--- a/src/test/java/picard/sam/CramCompatibilityTest.java
+++ b/src/test/java/picard/sam/CramCompatibilityTest.java
@@ -10,6 +10,7 @@ import org.testng.annotations.Test;
 import picard.cmdline.CommandLineProgram;
 
 import java.io.*;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -258,7 +259,12 @@ public class CramCompatibilityTest {
             args.add("REFERENCE_SEQUENCE=" + new File(reference).getAbsolutePath());
         }
 
-        final CommandLineProgram program = (CommandLineProgram) Class.forName(programClassname).newInstance();
+        final CommandLineProgram program;
+        try {
+            program = (CommandLineProgram) Class.forName(programClassname).getDeclaredConstructor().newInstance();
+        } catch (InvocationTargetException | NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
         program.instanceMain(args.toArray(new String[0]));
     }
 


### PR DESCRIPTION
Replace instances of `newInstance()`  which is deprecated with `getDeclaredConstructor().newInstance()` which is the drop in replacement.