### PR TITLE
Fix #1081. Make --USE_SEQUENTIAL_FASTQS help message more user friendly

### DIFF
--- a/src/main/java/picard/sam/FastqToSam.java
+++ b/src/main/java/picard/sam/FastqToSam.java
@@ -161,7 +161,7 @@ public class FastqToSam extends CommandLineProgram {
     @Argument(shortName="F2", doc="Input fastq file (optionally gzipped) for the second read of paired end data.", optional=true)
     public PicardHtsPath FASTQ2;
 
-    @Argument(doc="Use sequential fastq files with the suffix <prefix>_###.fastq[.qz]." +
+    @Argument(doc="Use sequential fastq files with the suffix <prefix>_###.fastq[.gz]." +
             " The files should be named:\n" +
             "    <prefix>_001.<extension>, <prefix>_002.<extension>, ..., <prefix>_XYZ.<extension>\n" +
             "Use the *first* file for the --FASTQ argument, e.g., --FASTQ <prefix>_001.<extension>.\n" +

--- a/src/main/java/picard/sam/FastqToSam.java
+++ b/src/main/java/picard/sam/FastqToSam.java
@@ -161,17 +161,17 @@ public class FastqToSam extends CommandLineProgram {
     @Argument(shortName="F2", doc="Input fastq file (optionally gzipped) for the second read of paired end data.", optional=true)
     public PicardHtsPath FASTQ2;
 
-    @Argument(doc="Use sequential fastq files with the suffix <prefix>_###.fastq or <prefix>_###.fastq.gz." +
-            "The files should be named:\n" +
+    @Argument(doc="Use sequential fastq files with the suffix <prefix>_###.fastq[.qz]." +
+            " The files should be named:\n" +
             "    <prefix>_001.<extension>, <prefix>_002.<extension>, ..., <prefix>_XYZ.<extension>\n" +
-            " The base files should be:\n" +
-            "    <prefix>_001.<extension>\n" +
-            " An example would be:\n" +
+            "Use the *first* file for the --FASTQ argument, e.g., --FASTQ <prefix>_001.<extension>.\n" +
+            "If paired end, use the *first* read2 file for the --FASTQ2 argument, e.g., <R2_prefix>_001.<extension>.\n" + 
+            "Example: combine and convert 4 single end fastqs with filenames:\n" +
             "    RUNNAME_S8_L005_R1_001.fastq\n" +
             "    RUNNAME_S8_L005_R1_002.fastq\n" +
             "    RUNNAME_S8_L005_R1_003.fastq\n" +
             "    RUNNAME_S8_L005_R1_004.fastq\n" +
-            "RUNNAME_S8_L005_R1_001.fastq should be provided as FASTQ.", optional=true)
+            "Run command with --FASTQ RUNNAME_S8_L005_R1_001.fastq --USE_SEQUENTIAL_FASTQS true", optional=true)
     public boolean USE_SEQUENTIAL_FASTQS = false;
 
     @Argument(shortName="V", doc="A value describing how the quality values are encoded in the input FASTQ file.  " +


### PR DESCRIPTION
 - Issue #1081 raised that help message for FastqToSam.java's --USE_SEQUENTIAL_FASTQS was not very intuititive.  When I used this tool for the first time today, I also found the documentation confusing.  Therefore, I made a PR.

 - Updated help message with more explicit usage (specific text on how to use the option and example commands).


### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality (not applicable; only documentation changed)
- [X] Edited the README / documentation (if applicable)
- [X] All tests passing on github actions

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

