### PR TITLE
typo correction "Didn't recognized" -> "Didn't recognize"

### DIFF
--- a/src/main/java/picard/illumina/parser/readers/FilterFileReader.java
+++ b/src/main/java/picard/illumina/parser/readers/FilterFileReader.java
@@ -100,7 +100,7 @@ public class FilterFileReader implements Iterator<Boolean> {
         } else {
             String hexVal = Integer.toHexString(value);
             hexVal = (hexVal.length() < 2 ? "0x0" : "0x") + hexVal;
-            throw new PicardException("Didn't recognized PF Byte (" + hexVal + ")" + " for element (" + currentCluster + ") in file(" + bbIterator.getFile().getAbsolutePath() + ")");
+            throw new PicardException("Didn't recognize PF Byte (" + hexVal + ")" + " for element (" + currentCluster + ") in file(" + bbIterator.getFile().getAbsolutePath() + ")");
         }
     }
 


### PR DESCRIPTION
### Description

This corrects a typo encountered while working with a sequencing run containing a corrupt cluster filter file.
`FilterFileReader.java`:
"Didn't recogniz**ed** PF Byte" -> "Didn't recognize PF Byte"

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on github actions

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

