### PR TITLE
Check for non-symbolic alt alleles before left aligning in liftover

### DIFF
--- a/src/main/java/picard/util/LiftoverUtils.java
+++ b/src/main/java/picard/util/LiftoverUtils.java
@@ -187,7 +187,9 @@ public class LiftoverUtils {
     private static boolean isIndelForLiftover(final VariantContext vc) {
         final Allele ref = vc.getReference();
         if (ref.length() != 1) {
-            return true;
+            //need to make sure the only other alleles are not all symbolic or spanning deletion
+            return vc.getAlternateAlleles().stream()
+                    .anyMatch(a -> !a.isSymbolic() && !a.equals(Allele.SPAN_DEL));
         }
 
         return vc.getAlleles().stream()

--- a/src/test/java/picard/util/LiftoverVcfTest.java
+++ b/src/test/java/picard/util/LiftoverVcfTest.java
@@ -381,6 +381,7 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         final Allele RefT = Allele.create("T", true);
         final Allele RefA = Allele.create("A", true);
         final Allele RefAC = Allele.create("AC", true);
+        final Allele RefGT = Allele.create("GT", true);
         final Allele RefC = Allele.create("C", true);
         final Allele RefG = Allele.create("G", true);
 
@@ -615,6 +616,19 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
 
         builder.source("test14").start(start).stop(stop).alleles(CollectionUtil.makeList(RefACGT, A, spanningDeletion));
         result_builder.start(CHAIN_SIZE - stop).stop(CHAIN_SIZE - start).alleles(CollectionUtil.makeList(RefAACG, A, spanningDeletion));
+        genotypeBuilder.alleles(builder.getAlleles());
+        resultGenotypeBuilder.alleles(result_builder.getAlleles());
+        builder.genotypes(genotypeBuilder.make());
+        result_builder.genotypes(resultGenotypeBuilder.make());
+        tests.add(new Object[]{builder.make(), REFERENCE, result_builder.make()});
+
+        // a spanning deletion with a multibase reference (for example a multiallelic mnp which has be split), where the spanning deletion is the only alt
+        // AC, * --> GT, *
+        start = CHAIN_SIZE - 13;
+        stop = start + 1;
+
+        builder.start(start).stop(stop).alleles(CollectionUtil.makeList(RefAC, spanningDeletion));
+        result_builder.start(CHAIN_SIZE - stop + 1).stop(CHAIN_SIZE - start + 1).alleles(CollectionUtil.makeList(RefGT, spanningDeletion));
         genotypeBuilder.alleles(builder.getAlleles());
         resultGenotypeBuilder.alleles(result_builder.getAlleles());
         builder.genotypes(genotypeBuilder.make());


### PR DESCRIPTION
During liftover, if the strand switches for an indel, the indel will be left aligned and trimmed.  However, in determining whether a variant is an indel to be left aligned, any variant with a multi-character REF allele is marked as an indel and left aligned.  The problem is that if all the alt alleles are either symbolic or spanning-deletions, then the left alignment algorithm will left align the variant all the way to the beginning of the contig, where it will set the REF allele to N.

While a variant with a multi-character REF and only symbolic/spanning-del alt seems a bit odd, as far as I can tell it is allowed by the vcf spec, and it can occur fairly naturally in the wild by splitting multiallelics on a vcf which includes spanning deletions.  For example
```
POS   REF        ALT
100    AC         A,*

---> split multiallelics
POS   REF        ALT
100    AC         A
100    AC         *
```

fixes #1899

