### PR TITLE
FastqToSam stdin fix for #915

### DIFF
--- a/src/main/java/picard/nio/PicardHtsPath.java
+++ b/src/main/java/picard/nio/PicardHtsPath.java
@@ -24,10 +24,6 @@
 
 package picard.nio;
 
-import htsjdk.io.HtsPath;
-import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.RuntimeIOException;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -37,6 +33,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
+import htsjdk.io.HtsPath;
+import htsjdk.io.IOPath;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.RuntimeIOException;
 
 /**
  * A Subclass of {@link HtsPath} with conversion to {@link Path} making use of {@link IOUtil}
@@ -86,21 +87,6 @@ public class PicardHtsPath extends HtsPath {
     }
 
     /**
-     * Test if the URI of this object is something other than a regular file, directory, or
-     * symbolic link.
-     * 
-     * @return {@code true} if it's a device, socket or named pipe
-     * @throws RuntimeException if an I/O error occurs when creating the file system
-     */
-    public boolean isOther() {
-        try {
-            return Files.readAttributes(IOUtil.getPath(super.getURIString()), BasicFileAttributes.class).isOther();
-        } catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
-    }
-
-    /**
      * Resolve the URI of this object to a {@link Path} object.
      *
      * @return the resulting {@link Path}
@@ -124,6 +110,24 @@ public class PicardHtsPath extends HtsPath {
         Objects.requireNonNull(path);
         return new PicardHtsPath(new HtsPath(path.toUri().toString()));
     }
+
+    /**
+     * Test if {@code ioPath} is something other than a regular file, directory, or symbolic link.
+     * 
+     * @return {@code true} if it's a device, named pipe, htsget API URL, etc.
+     * @throws RuntimeException if an I/O error occurs when creating the file system
+     */
+    public static boolean isOther(final IOPath ioPath) {
+        if(ioPath.isPath()) {
+            try {
+                return Files.readAttributes(ioPath.toPath(), BasicFileAttributes.class).isOther();
+            } catch (IOException e) {
+                throw new RuntimeIOException(e);
+            }
+        } else {
+            return true;
+        }
+    }    
 
     /**
      * Create a {@link List<Path>} from {@link PicardHtsPath}s

--- a/src/main/java/picard/nio/PicardHtsPath.java
+++ b/src/main/java/picard/nio/PicardHtsPath.java
@@ -30,7 +30,9 @@ import htsjdk.samtools.util.RuntimeIOException;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -81,6 +83,21 @@ public class PicardHtsPath extends HtsPath {
     public static List<PicardHtsPath> fromPaths(Collection<String> paths) {
         Objects.requireNonNull(paths);
         return paths.stream().map(PicardHtsPath::new).collect(Collectors.toList());
+    }
+
+    /**
+     * Test if the URI of this object is something other than a regular file, directory, or
+     * symbolic link.
+     * 
+     * @return {@code true} if it's a device, socket or named pipe
+     * @throws RuntimeException if an I/O error occurs when creating the file system
+     */
+    public boolean isOther() {
+        try {
+            return Files.readAttributes(IOUtil.getPath(super.getURIString()), BasicFileAttributes.class).isOther();
+        } catch (IOException e) {
+            throw new RuntimeIOException(e);
+        }
     }
 
     /**

--- a/src/main/java/picard/sam/FastqToSam.java
+++ b/src/main/java/picard/sam/FastqToSam.java
@@ -82,7 +82,7 @@ import java.util.List;
  * </p>
  * <p>
  *     By default, this tool will try to guess the base quality score encoding. However you can indicate it explicitly
- *     using the <code>QUALITY_FORMAT</code> argument.
+ *     using the <code>QUALITY_FORMAT</code> argument, and must do so if input is not from a regular file.
  * </p>
  * <h3>Output</h3>
  * A single unaligned BAM or SAM file. By default, the records are sorted by query (read) name.
@@ -132,7 +132,7 @@ public class FastqToSam extends CommandLineProgram {
         "<p>Alternatively, for larger inputs you can provide a collection of FASTQ files indexed by their name " +
         "(see USE_SEQUENCIAL_FASTQ for details below).</p>" +
         "<p>By default, this tool will try to guess the base quality score encoding. However you can indicate it explicitly " +
-        "using the QUALITY_FORMAT argument.</p>" +
+        "using the QUALITY_FORMAT argument, and must do so if input is not from a regular file.</p>" +
         "<h3>Output</h3>" +
         "<p>A single unaligned BAM or SAM file. By default, the records are sorted by query (read) name.</p>" +
         "<h3>Usage examples</h3>" +
@@ -176,7 +176,8 @@ public class FastqToSam extends CommandLineProgram {
 
     @Argument(shortName="V", doc="A value describing how the quality values are encoded in the input FASTQ file.  " +
             "Either Solexa (phred scaling + 66), Illumina (phred scaling + 64) or Standard (phred scaling + 33).  " +
-            "If this value is not specified, the quality format will be detected automatically.", optional = true)
+            "If input is from a regular file and this value is not specified, the quality format will be detected automatically. " +
+            "If input is from STDIN or a named pipe, this value is required.", optional = true)
     public FastqQualityFormat QUALITY_FORMAT;
 
     @Argument(doc="Output BAM/SAM/CRAM file. ", shortName=StandardOptionDefinitions.OUTPUT_SHORT_NAME)

--- a/src/test/java/picard/sam/FastqToSamTest.java
+++ b/src/test/java/picard/sam/FastqToSamTest.java
@@ -36,8 +36,10 @@ import org.testng.annotations.Test;
 import picard.cmdline.CommandLineProgramTest;
 import picard.PicardException;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -47,6 +49,8 @@ import java.util.List;
  */
 public class FastqToSamTest extends CommandLineProgramTest {
     private static final File TEST_DATA_DIR = new File("testdata/picard/sam/fastq2bam");
+    private static final String CLASSPATH = "\"" + System.getProperty("java.class.path") + "\" ";
+
 
     public String getCommandLineProgramName() {
         return FastqToSam.class.getSimpleName();
@@ -175,6 +179,67 @@ public class FastqToSamTest extends CommandLineProgramTest {
     public void testEmptyFastqAllowed() throws IOException {
         final File emptyFastq = File.createTempFile("empty", ".fastq");
         convertFile(emptyFastq, null, FastqQualityFormat.Illumina, false, false, true);
+    }
+
+    @Test
+    public void testStreamInputWithoutQuality() throws IOException {
+        ByteArrayOutputStream stderrStream = new ByteArrayOutputStream();
+        PrintStream newStderr = new PrintStream(stderrStream);
+        PrintStream oldStderr = System.err;
+        System.setErr(newStderr);
+
+        final File tmpFile = File.createTempFile("empty", ".sam");
+
+        final String[] args = {
+                "FASTQ=/dev/stdin",
+                "SAMPLE_NAME=sample001",
+                "OUTPUT=" + tmpFile
+        };
+
+        Assert.assertEquals(runPicardCommandLine(args), 1);
+        System.setErr(oldStderr);
+        Assert.assertTrue(stderrStream.toString().endsWith("QUALITY_FORMAT must be specified when input is not a regular file\n"));
+    }
+
+    @Test
+    public void testStreamInput() throws IOException {
+        final File output = newTempSamFile("stdin");
+        String[] command = {
+                "/bin/bash",
+                "-c",
+                "echo -ne '" +
+                "@ERR194147.10008417/1\\n" +
+                "ATTTAATTAAGAAAATGTAAACTAAATGACAGTAGACAGACAAGTATGCCTTTGC\\n" +
+                "+\\n" +
+                "???????????????????????????????????????????????????????\\n'" +
+                "|" +
+                "java -classpath " +
+                        CLASSPATH +
+                        "picard.cmdline.PicardCommandLine " +
+                        "FastqToSam " +
+                        "-FASTQ /dev/stdin " +
+                        "-QUALITY_FORMAT Standard " +
+                        "-SAMPLE_NAME sample001 " +
+                        "-OUTPUT " + output 
+        };
+
+        try {
+            ProcessBuilder processBuilder = new ProcessBuilder(command);
+            processBuilder.inheritIO();
+            Process process = processBuilder.start();
+            Assert.assertEquals(process.waitFor(), 0);
+        } catch (Exception e) {
+            Assert.fail("Failed to pipe data from stdin to FastqToSam", e);
+        }
+        final SamReader samReader = SamReaderFactory.makeDefault().open(output);
+        final SAMRecordIterator iterator = samReader.iterator();
+        int actualCount = 0;
+        while (iterator.hasNext()) {
+            iterator.next();
+            actualCount++;
+        }
+        samReader.close();
+        Assert.assertEquals(actualCount, 1);
     }
 
     private File convertFile(final String filename, final FastqQualityFormat version) throws IOException {

--- a/src/test/java/picard/sam/FastqToSamTest.java
+++ b/src/test/java/picard/sam/FastqToSamTest.java
@@ -198,7 +198,7 @@ public class FastqToSamTest extends CommandLineProgramTest {
         } finally {
             System.setErr(oldStderr);
         }
-        Assert.assertTrue(stderrStream.toString().endsWith("QUALITY_FORMAT must be specified when FASTQ is not a regular file\n"));
+        Assert.assertTrue(stderrStream.toString().endsWith("QUALITY_FORMAT must be specified when either of FASTQ or FASTQ2 is not a regular file\n"));
     }
 
     @Test


### PR DESCRIPTION
### Description

Allow `FastqToSam` to take input from stdin or a named pipe.

* If input is not a regular file, don't autodetect the quality format, and use the same opened reader throughout.
* If input is not a regular file and `QUALITY_FORMAT` is not specified, that's an argument validation error.

Addresses #915

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on github actions

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

