### PR TITLE
Reject piped input (/dev/stdin) for BedToIntervalList

### DIFF
--- a/src/main/java/picard/util/BedToIntervalList.java
+++ b/src/main/java/picard/util/BedToIntervalList.java
@@ -24,6 +24,7 @@ import picard.PicardException;
 import picard.cmdline.CommandLineProgram;
 import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.programgroups.IntervalsManipulationProgramGroup;
+import picard.nio.PicardHtsPath;
 
 import java.io.File;
 import java.io.IOException;
@@ -120,6 +121,11 @@ public class BedToIntervalList extends CommandLineProgram {
         IOUtil.assertFileIsReadable(INPUT);
         IOUtil.assertFileIsReadable(SEQUENCE_DICTIONARY);
         IOUtil.assertFileIsWritable(OUTPUT);
+
+        if(PicardHtsPath.isOther(new PicardHtsPath(INPUT))) {
+            throw new IllegalArgumentException("BedToIntervalList cannot read from /dev/stdin.");
+        }
+
         try {
             // create a new header that we will assign the dictionary provided by the SAMSequenceDictionaryExtractor to.
             final SAMFileHeader header = new SAMFileHeader();

--- a/src/main/java/picard/util/BedToIntervalList.java
+++ b/src/main/java/picard/util/BedToIntervalList.java
@@ -119,7 +119,7 @@ public class BedToIntervalList extends CommandLineProgram {
     protected int doWork() {
         IOUtil.assertFileIsReadable(INPUT);
         if(INPUT.getPath().equals("/dev/stdin")) {
-            throw new IllegalArgumentException("BedToIntervalList cannot read from /dev/stdin.");
+            throw new IllegalArgumentException("BedToIntervalList does not support reading from standard input - a file must be provided.");
         }
 
         IOUtil.assertFileIsReadable(SEQUENCE_DICTIONARY);

--- a/src/main/java/picard/util/BedToIntervalList.java
+++ b/src/main/java/picard/util/BedToIntervalList.java
@@ -24,7 +24,6 @@ import picard.PicardException;
 import picard.cmdline.CommandLineProgram;
 import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.programgroups.IntervalsManipulationProgramGroup;
-import picard.nio.PicardHtsPath;
 
 import java.io.File;
 import java.io.IOException;
@@ -119,12 +118,12 @@ public class BedToIntervalList extends CommandLineProgram {
     @Override
     protected int doWork() {
         IOUtil.assertFileIsReadable(INPUT);
-        IOUtil.assertFileIsReadable(SEQUENCE_DICTIONARY);
-        IOUtil.assertFileIsWritable(OUTPUT);
-
-        if(PicardHtsPath.isOther(new PicardHtsPath(INPUT))) {
+        if(INPUT.getPath().equals("/dev/stdin")) {
             throw new IllegalArgumentException("BedToIntervalList cannot read from /dev/stdin.");
         }
+
+        IOUtil.assertFileIsReadable(SEQUENCE_DICTIONARY);
+        IOUtil.assertFileIsWritable(OUTPUT);
 
         try {
             // create a new header that we will assign the dictionary provided by the SAMSequenceDictionaryExtractor to.

--- a/src/test/java/picard/util/BedToIntervalListTest.java
+++ b/src/test/java/picard/util/BedToIntervalListTest.java
@@ -61,6 +61,18 @@ public class BedToIntervalListTest {
         doTest(inputBed, "header.sam", false);
     }
 
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testRejectStdin() throws IOException {
+        final BedToIntervalList program = new BedToIntervalList();
+        final File outputFile  = File.createTempFile("bed_to_interval_list_test.", ".interval_list");
+        outputFile.deleteOnExit();
+        program.OUTPUT = outputFile;
+        program.SEQUENCE_DICTIONARY = new File(TEST_DATA_DIR, "header.sam");
+        program.UNIQUE = true;
+        program.INPUT = new File("/dev/stdin");
+        program.doWork();
+    }
+
     @DataProvider
     public Object[][] testBedToIntervalListDataProvider() {
         return new Object[][]{


### PR DESCRIPTION


As the title states, reject piped input (/dev/stdin) for BedToIntervalList since it cannot process such input.