### PR TITLE
Switch transitive dependencies from runtime to compile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 }
 
 plugins {
-    id "java"
+    id 'java-library'
     id 'maven-publish'
     id 'signing'
     id 'jacoco'
@@ -61,22 +61,22 @@ ensureBuildPrerequisites(buildPrerequisitesMessage)
 
 final htsjdkVersion = System.getProperty('htsjdk.version', '4.0.2')
 dependencies {
-    implementation('com.intel.gkl:gkl:0.8.11') {
+    api('com.intel.gkl:gkl:0.8.11') {
         exclude module: 'htsjdk'
     }
-    implementation 'org.broadinstitute:gatk-native-bindings:1.0.0' //this should be redundant when GKL is updated past 0.8.11
+    api 'org.broadinstitute:gatk-native-bindings:1.0.0' //this should be redundant when GKL is updated past 0.8.11
 
-    implementation 'com.google.guava:guava:32.1.1-jre'
-    implementation 'org.apache.commons:commons-math3:3.6.1'
-    implementation 'org.apache.commons:commons-collections4:4.4'
-    implementation 'com.github.samtools:htsjdk:' + htsjdkVersion
-    implementation 'org.broadinstitute:barclay:5.0.0'
-    implementation 'org.apache.logging.log4j:log4j-api:2.20.0'
-    implementation 'org.apache.logging.log4j:log4j-core:2.20.0'
-    implementation 'org.openjdk.nashorn:nashorn-core:15.4'
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
-    implementation 'com.google.cloud:google-cloud-nio:0.127.0'
-    implementation 'commons-io:commons-io:2.11.0'
+    api 'com.google.guava:guava:32.1.1-jre'
+    api 'org.apache.commons:commons-math3:3.6.1'
+    api 'org.apache.commons:commons-collections4:4.4'
+    api 'com.github.samtools:htsjdk:' + htsjdkVersion
+    api 'org.broadinstitute:barclay:5.0.0'
+    api 'org.apache.logging.log4j:log4j-api:2.20.0'
+    api 'org.apache.logging.log4j:log4j-core:2.20.0'
+    api 'org.openjdk.nashorn:nashorn-core:15.4'
+    api 'org.apache.commons:commons-lang3:3.12.0'
+    api 'com.google.cloud:google-cloud-nio:0.127.0'
+    api 'commons-io:commons-io:2.11.0'
 
     testImplementation 'org.testng:testng:7.7.0'
 }


### PR DESCRIPTION
### Description

In the POM file generated for Picard, dependencies are all listed as `runtime`. However, if one wants to use Picard as a library, they end up having to explicitly include Picard's dependencies instead of them being implicitly added to the downstream project.

This changes the generated POM file, switching dependencies from `runtime` to `compile`.

* For the old POM using `runtime`, see:
https://repo1.maven.org/maven2/com/github/broadinstitute/picard/3.1.1/picard-3.1.1.pom
* Gradle docs on `runtime` vs. `compile`: https://docs.gradle.org/8.4/userguide/java_library_plugin.html
* Maven docs on Dependency Scope options: https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#dependency-scope

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on github actions

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

