### PR TITLE
Update Dockerfile and build_push_docker.sh

### DIFF
--- a/build_push_docker.sh
+++ b/build_push_docker.sh
@@ -20,6 +20,6 @@ read -p "Is this really what you want to do? " -n 1 -r
 echo    # (optional) move to a new line
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-    docker build -t ${PICARD_CLOUD_TAG} --build-arg build_command=cloudJar --build-arg jar_name=picardcloud.jar .
+    docker build -t ${PICARD_CLOUD_TAG} --build-arg release=true .
     docker push ${PICARD_CLOUD_TAG}
 fi


### PR DESCRIPTION
Removing the cloud jar broke the `Dockerfile` and `build_push_docker.sh` 
* Rewrote the docker file to use staged builds
    this reduces the build size from about 1.7gb to about 650mb
* Properly set the build version so it's not listed as a 'snapshot'