### PR TITLE
Convert to use the java-library plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 }
 
 plugins {
-    id "java"
+    id "java-library"
     id 'maven-publish'
     id 'signing'
     id 'jacoco'
@@ -60,25 +60,34 @@ def ensureBuildPrerequisites(buildPrerequisitesMessage) {
 ensureBuildPrerequisites(buildPrerequisitesMessage)
 
 final htsjdkVersion = System.getProperty('htsjdk.version', '4.1.0')
+final log4jVersion = System.getProperty('log4j.version', '2.20.0')
+
 dependencies {
-    implementation('com.intel.gkl:gkl:0.8.11') {
+    api 'com.github.samtools:htsjdk:' + htsjdkVersion
+    api 'org.broadinstitute:barclay:5.0.0'
+
+    //log4j api and core used in logging
+    api 'org.apache.logging.log4j:log4j-api:' +log4jVersion
+    implementation 'org.apache.logging.log4j:log4j-core:' + log4jVersion
+
+    //gkl and associated native bindings
+    implementation('com.intel.gkl:gkl:0.8.11'){
         exclude module: 'htsjdk'
     }
     implementation 'org.broadinstitute:gatk-native-bindings:1.0.0' //this should be redundant when GKL is updated past 0.8.11
 
+    //needed for execuing javascript in filter
+    implementation 'org.openjdk.nashorn:nashorn-core:15.4'
+
     implementation 'com.google.guava:guava:32.1.1-jre'
     implementation 'org.apache.commons:commons-math3:3.6.1'
     implementation 'org.apache.commons:commons-collections4:4.4'
-    implementation 'com.github.samtools:htsjdk:' + htsjdkVersion
-    implementation 'org.broadinstitute:barclay:5.0.0'
-    implementation 'org.apache.logging.log4j:log4j-api:2.20.0'
-    implementation 'org.apache.logging.log4j:log4j-core:2.20.0'
-    implementation 'org.openjdk.nashorn:nashorn-core:15.4'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
-    implementation 'com.google.cloud:google-cloud-nio:0.127.0'
-    implementation 'org.broadinstitute:http-nio:1.1.0'
     implementation 'commons-io:commons-io:2.11.0'
 
+    //nio plugin providers for google cloud and http(s)
+    implementation 'com.google.cloud:google-cloud-nio:0.127.0'
+    implementation 'org.broadinstitute:http-nio:1.1.0'
 
     testImplementation 'org.testng:testng:7.7.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -66,10 +66,6 @@ dependencies {
     api 'com.github.samtools:htsjdk:' + htsjdkVersion
     api 'org.broadinstitute:barclay:5.0.0'
 
-    //log4j api and core used in logging
-    api 'org.apache.logging.log4j:log4j-api:' +log4jVersion
-    implementation 'org.apache.logging.log4j:log4j-core:' + log4jVersion
-
     //gkl and associated native bindings
     implementation('com.intel.gkl:gkl:0.8.11'){
         exclude module: 'htsjdk'
@@ -90,6 +86,12 @@ dependencies {
     implementation 'org.broadinstitute:http-nio:1.1.0'
 
     testImplementation 'org.testng:testng:7.7.0'
+
+    constraints {
+        //log4j api and core, specify these so we don't transitively get old vulnerable versions
+        implementation 'org.apache.logging.log4j:log4j-api:' +log4jVersion
+        implementation 'org.apache.logging.log4j:log4j-core:' + log4jVersion
+    }
 }
 
 configurations.configureEach {

--- a/src/main/java/picard/nio/DeleteRecursive.java
+++ b/src/main/java/picard/nio/DeleteRecursive.java
@@ -1,7 +1,7 @@
 package picard.nio;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import htsjdk.samtools.util.Log;
+
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -15,10 +15,10 @@ import java.util.LinkedHashSet;
  *
  * <p>This class is a modification of {@link htsjdk.samtools.util.nio.DeleteOnExitPathHook}
  *
- * This class should be considered an implementation detail of {@link IOUtils#deleteOnExit(Path)} and not used directly.
+ * This class should be considered an implementation detail of {@link GATKIOUtils#deleteOnExit(Path)} and not used directly.
  */
 class DeleteRecursivelyOnExitPathHook {
-    private static final Logger LOG = LogManager.getLogger(DeleteRecursivelyOnExitPathHook.class);
+    private static final Log LOG = Log.getInstance(DeleteRecursivelyOnExitPathHook.class);
     private static LinkedHashSet<Path> paths = new LinkedHashSet<>();
     static {
         Runtime.getRuntime().addShutdownHook(new Thread(DeleteRecursivelyOnExitPathHook::runHooks));
@@ -60,8 +60,8 @@ class DeleteRecursivelyOnExitPathHook {
             try {
                 GATKIOUtils.deleteRecursively(path);
             } catch (final Exception e) {
-                // do nothing if cannot be deleted, because it is a shutdown hook
-                LOG.debug(() -> "Could not recursively delete " + path.toString() + " during JVM shutdown because we encountered the following exception:", e);
+                // do nothing if itcannot be deleted, because it is a shutdown hook
+                LOG.debug(e, "Could not recursively delete ", path.toString(), " during JVM shutdown because we encountered the following exception:");
             }
         }
     }


### PR DESCRIPTION
Use the 'java-library' plugin instead of the 'java' one.  This should improve our dependency resolution for downstream projects.

As part of this change, remove picard dependency on log4j and replace it with a version constraint so that transitive dependencies don't import a vulnerable version.

I don't have any automatic tooling to distinguish api from implementation dependencies so this is a best effort.  We should be ready to change any if we are exposing some that we don't expect.

Addresses the issue brought up in https://github.com/broadinstitute/picard/pull/1919, however we've made the deliberate decision to include the minimum required dependencies instead of marking them all as api.  