### PR TITLE
MarkDuplicates strategy of flow based reads that looks only at the qualities close to the end of the read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ jacoco.data
 .gradle
 build
 *.swp
-
+.vscode
 # OSX file system stuff
 .DS_STORE
 

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -613,7 +613,6 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram imp
                         }
 
                         pairedEnds.score += calcHelper.getReadDuplicateScore(rec, pairedEnds);
-
                         this.pairSort.add(pairedEnds);
                     }
                 }
@@ -808,8 +807,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram imp
         }
     }
 
-    protected boolean areComparableForDuplicates(final ReadEndsForMarkDuplicates lhs, final ReadEndsForMarkDuplicates rhs,
-                                                 final boolean compareRead2, final boolean useBarcodes) {
+    protected boolean areComparableForDuplicates(final ReadEndsForMarkDuplicates lhs, final ReadEndsForMarkDuplicates rhs, final boolean compareRead2, final boolean useBarcodes) {
         boolean areComparable = lhs.libraryId == rhs.libraryId;
 
         if (useBarcodes && areComparable) { // areComparable is useful here to avoid the casts below
@@ -822,7 +820,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram imp
 
         if (areComparable) {
             areComparable = lhs.read1ReferenceIndex == rhs.read1ReferenceIndex &&
-                    lhs.read1Coordinate==rhs.read1Coordinate &&
+                    lhs.read1Coordinate == rhs.read1Coordinate &&
                     lhs.orientation == rhs.orientation;
         }
 

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -613,6 +613,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram imp
                         }
 
                         pairedEnds.score += calcHelper.getReadDuplicateScore(rec, pairedEnds);
+
                         this.pairSort.add(pairedEnds);
                     }
                 }
@@ -807,7 +808,8 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram imp
         }
     }
 
-    protected boolean areComparableForDuplicates(final ReadEndsForMarkDuplicates lhs, final ReadEndsForMarkDuplicates rhs, final boolean compareRead2, final boolean useBarcodes) {
+    protected boolean areComparableForDuplicates(final ReadEndsForMarkDuplicates lhs, final ReadEndsForMarkDuplicates rhs,
+                                                 final boolean compareRead2, final boolean useBarcodes) {
         boolean areComparable = lhs.libraryId == rhs.libraryId;
 
         if (useBarcodes && areComparable) { // areComparable is useful here to avoid the casts below
@@ -820,7 +822,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram imp
 
         if (areComparable) {
             areComparable = lhs.read1ReferenceIndex == rhs.read1ReferenceIndex &&
-                    lhs.read1Coordinate == rhs.read1Coordinate &&
+                    lhs.read1Coordinate==rhs.read1Coordinate &&
                     lhs.orientation == rhs.orientation;
         }
 

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowArgumentCollection.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowArgumentCollection.java
@@ -4,12 +4,21 @@ import org.broadinstitute.barclay.argparser.Argument;
 
 public class MarkDuplicatesForFlowArgumentCollection {
 
+    public enum FLOW_DUPLICATE_SELECTION_STRATEGY {
+        FLOW_QUALITY_SUM_STRATEGY,
+        FLOW_END_QUALITY_STRATEGY
+    }
     @Argument(doc = "enable parameters and behavior specific to flow based reads.", optional = true)
     public boolean FLOW_MODE = false;
 
     @Argument(doc = "Use specific quality summing strategy for flow based reads. The strategy ensures that the same " +
             "(and correct) quality value is used for all bases of the same homopolymer.", optional = true)
-    public boolean FLOW_QUALITY_SUM_STRATEGY = false;
+    public FLOW_DUPLICATE_SELECTION_STRATEGY FLOW_DUP_STRATEGY = FLOW_DUPLICATE_SELECTION_STRATEGY.FLOW_QUALITY_SUM_STRATEGY;
+
+    @Argument(doc = "Selects the flow-based read with the best quality around the ends " +
+            "useful in cases of high duplication rate and one wants to ensure that the selected read is consistent in " +
+            "start and end positions with the majority.", optional = true)
+    public boolean FLOW_END_QUALITY_STRATEGY = false;
 
     @Argument(doc = "Make the end location of single end read be significant when considering duplicates, " +
             "in addition to the start location, which is always significant (i.e. require single-ended reads to start and" +

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowArgumentCollection.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowArgumentCollection.java
@@ -15,11 +15,6 @@ public class MarkDuplicatesForFlowArgumentCollection {
             "(and correct) quality value is used for all bases of the same homopolymer.", optional = true)
     public FLOW_DUPLICATE_SELECTION_STRATEGY FLOW_DUP_STRATEGY = FLOW_DUPLICATE_SELECTION_STRATEGY.FLOW_QUALITY_SUM_STRATEGY;
 
-    @Argument(doc = "Selects the flow-based read with the best quality around the ends " +
-            "useful in cases of high duplication rate and one wants to ensure that the selected read is consistent in " +
-            "start and end positions with the majority.", optional = true)
-    public boolean FLOW_END_QUALITY_STRATEGY = false;
-
     @Argument(doc = "Make the end location of single end read be significant when considering duplicates, " +
             "in addition to the start location, which is always significant (i.e. require single-ended reads to start and" +
             "end on the same position to be considered duplicate) " +

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowArgumentCollection.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowArgumentCollection.java
@@ -26,6 +26,11 @@ public class MarkDuplicatesForFlowArgumentCollection {
             "(for this argument, \"read end\" means 3' end)", optional = true)
     public int UNPAIRED_END_UNCERTAINTY = 0;
 
+    @Argument(doc = "Maximal difference of the read start position that counted as equal. Useful for flow based " +
+            "reads where the end position might vary due to sequencing errors. " +
+            "(for this argument, \"read start\" means 5' end in the direction of sequencing)", optional = true)
+    public int UNPAIRED_START_UNCERTAINTY = 0;
+
     @Argument(doc = "Skip first N flows, starting from the read's start, when considering duplicates. Useful for flow based reads where sometimes there " +
             "is noise in the first flows " +
             "(for this argument, \"read start\" means 5' end).", optional = true)

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowArgumentCollection.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowArgumentCollection.java
@@ -11,8 +11,10 @@ public class MarkDuplicatesForFlowArgumentCollection {
     @Argument(doc = "enable parameters and behavior specific to flow based reads.", optional = true)
     public boolean FLOW_MODE = false;
 
-    @Argument(doc = "Use specific quality summing strategy for flow based reads. The strategy ensures that the same " +
-            "(and correct) quality value is used for all bases of the same homopolymer.", optional = true)
+    @Argument(doc = "Use specific quality summing strategy for flow based reads. Two strategies are available: " + 
+          "FLOW_QUALITY_SUM_STRATEG: The selects the read with the best total homopolymer quality." + 
+            " FLOW_END_QUALITY_STRATEGY: The strategy selects the read with the best homopolymer quality close to the end (10 bases) of the read. " +
+            " The latter strategy is recommended for samples with high duplication rate ", optional = true)
     public FLOW_DUPLICATE_SELECTION_STRATEGY FLOW_DUP_STRATEGY = FLOW_DUPLICATE_SELECTION_STRATEGY.FLOW_QUALITY_SUM_STRATEGY;
 
     @Argument(doc = "Make the end location of single end read be significant when considering duplicates, " +

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelper.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelper.java
@@ -298,10 +298,10 @@ public class MarkDuplicatesForFlowHelper implements MarkDuplicatesHelper {
      * A quality summing scoring strategy used for flow based reads.
      *
      * We look at the bases of the reads that are close to the ends of the fragment
-     * and calculate the minimal quality
+     * and calculate the minimal quality of the homopolymers
      *
      * @param rec - SAMRecord to get a score for
-     * @param threshold - threshold above which effective quality is included
+     * @param dist - Distance fro the end end
      * @return - calculated score (see method description)
      */
     static protected int getFlowSumOfBaseQualitiesNearEnds(final SAMRecord rec, int dist) {

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelper.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelper.java
@@ -236,8 +236,8 @@ public class MarkDuplicatesForFlowHelper implements MarkDuplicatesHelper {
         final byte[]  bases = rec.getReadBases();
 
         // create iteration range and direction
-        final int startingOffset = !rec.getReadNegativeStrandFlag() ? 0 : bases.length;
-        final int endOffset = !rec.getReadNegativeStrandFlag() ? bases.length : 0;
+        final int startingOffset = !rec.getReadNegativeStrandFlag() ? 0 : bases.length - 1;
+        final int endOffset = !rec.getReadNegativeStrandFlag() ? bases.length : -1;
         final int  iterIncr = !rec.getReadNegativeStrandFlag() ? 1 : -1;
 
         // loop on bases, extract qual related to homopolymer from start of homopolymer

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelper.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelper.java
@@ -334,7 +334,7 @@ public class MarkDuplicatesForFlowHelper implements MarkDuplicatesHelper {
             }
         }
 
-        for ( int i = bases.length-1 ; (i > bases.length - 1 - dist) || ( insideHpol ) ; i ++ ) {
+        for ( int i = bases.length-1 ; (i > bases.length - 1 - dist) || ( insideHpol ) ; i -- ) {
             final byte base = bases[i];
             if ( (i == 0) || ( base != bases[i - 1] )) {
                 insideHpol = false;

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelper.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelper.java
@@ -323,7 +323,7 @@ public class MarkDuplicatesForFlowHelper implements MarkDuplicatesHelper {
 
         for ( int i = 0 ; (i < dist) || ( insideHpol ) ; i ++ ) {
             final byte base = bases[i];
-            if ( (i == bases.length) || ( base != bases[i+1] )) {
+            if ( (i == bases.length - 1) || ( base != bases[i+1] )) {
                 insideHpol = false;
             } else {
                 insideHpol = true;

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelper.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelper.java
@@ -294,6 +294,62 @@ public class MarkDuplicatesForFlowHelper implements MarkDuplicatesHelper {
         return score;
     }
 
+    /**
+     * A quality summing scoring strategy used for flow based reads.
+     *
+     * We look at the bases of the reads that are close to the ends of the fragment
+     * and calculate the minimal quality
+     *
+     * @param rec - SAMRecord to get a score for
+     * @param threshold - threshold above which effective quality is included
+     * @return - calculated score (see method description)
+     */
+    static protected int getFlowSumOfBaseQualitiesNearEnds(final SAMRecord rec, int dist) {
+        int score = 100;
+
+        // access qualities and bases
+        final byte[] quals = rec.getBaseQualities();
+        final byte[]  bases = rec.getReadBases();
+
+
+
+        // loop on bases, extract qual related to homopolymer from start of homopolymer
+        byte lastBase = 0;
+        byte effectiveQual = 0;
+        boolean insideHpol = false;
+        if (dist > bases.length){
+            dist = bases.length;
+        }
+
+        for ( int i = 0 ; (i < dist) || ( insideHpol ) ; i ++ ) {
+            final byte base = bases[i];
+            if ( (i == bases.length) || ( base != bases[i+1] )) {
+                insideHpol = false;
+            } else {
+                insideHpol = true;
+            }
+
+            if ( quals[i] < score) {
+                score = quals[i];
+            }
+        }
+
+        for ( int i = bases.length-1 ; (i > bases.length - 1 - dist) || ( insideHpol ) ; i ++ ) {
+            final byte base = bases[i];
+            if ( (i == 0) || ( base != bases[i - 1] )) {
+                insideHpol = false;
+            } else {
+                insideHpol = true;
+            }
+
+            if ( quals[i] < score) {
+                score = quals[i];
+            }
+        }
+        return score;
+    }
+
+
     private short computeFlowDuplicateScore(final SAMRecord rec, final int end) {
 
         if ( end == END_INSIGNIFICANT_VALUE)
@@ -303,8 +359,8 @@ public class MarkDuplicatesForFlowHelper implements MarkDuplicatesHelper {
         if ( storedScore == null ) {
             short score = 0;
 
-            score += (short) Math.min(getFlowSumOfBaseQualities(rec, md.flowBasedArguments.FLOW_EFFECTIVE_QUALITY_THRESHOLD), Short.MAX_VALUE / 2);
-
+//            score += (short) Math.min(getFlowSumOfBaseQualities(rec, md.flowBasedArguments.FLOW_EFFECTIVE_QUALITY_THRESHOLD), Short.MAX_VALUE / 2);
+            score += (short) Math.min(getFlowSumOfBaseQualitiesNearEnds(rec, 10), Short.MAX_VALUE / 2);
             score += rec.getReadFailsVendorQualityCheckFlag() ? (short) (Short.MIN_VALUE / 2) : 0;
             storedScore = score;
             rec.setTransientAttribute(ATTR_DUPLICATE_SCORE, storedScore);

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelper.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelper.java
@@ -192,10 +192,8 @@ public class MarkDuplicatesForFlowHelper implements MarkDuplicatesHelper {
      */
     @Override
     public short getReadDuplicateScore(final SAMRecord rec, final ReadEndsForMarkDuplicates pairedEnds) {
-        if (md.flowBasedArguments.FLOW_DUP_STRATEGY == MarkDuplicatesForFlowArgumentCollection.FLOW_DUPLICATE_SELECTION_STRATEGY.FLOW_QUALITY_SUM_STRATEGY ) {
+        if (md.flowBasedArguments.FLOW_MODE){
             return computeFlowDuplicateScore(rec, pairedEnds.read2Coordinate);
-        } else if (md.flowBasedArguments.FLOW_DUP_STRATEGY == MarkDuplicatesForFlowArgumentCollection.FLOW_DUPLICATE_SELECTION_STRATEGY.FLOW_END_QUALITY_STRATEGY ){
-            return computeFlowEndDuplicateScore(rec, pairedEnds.read2Coordinate);
         } else {
             return md.getReadDuplicateScore(rec, pairedEnds);
         }

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelper.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelper.java
@@ -197,7 +197,7 @@ public class MarkDuplicatesForFlowHelper implements MarkDuplicatesHelper {
         }
     }
 
-    //This method is identical to areComparableForDuplicates but allow working with readStartUncertainty
+    //This method is identical to MarkDuplicates.areComparableForDuplicates but allows working with readStartUncertainty
     protected boolean areComparableForDuplicates(final ReadEndsForMarkDuplicates lhs, final ReadEndsForMarkDuplicates rhs,
                                                  final boolean compareRead2, final boolean useBarcodes) {
         boolean areComparable = lhs.libraryId == rhs.libraryId;

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelper.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelper.java
@@ -180,9 +180,7 @@ public class MarkDuplicatesForFlowHelper implements MarkDuplicatesHelper {
         }
 
         // adjust score
-        if ( md.flowBasedArguments.FLOW_DUP_STRATEGY == MarkDuplicatesForFlowArgumentCollection.FLOW_DUPLICATE_SELECTION_STRATEGY.FLOW_QUALITY_SUM_STRATEGY ) {
-            ends.score = computeFlowDuplicateScore(rec, ends.read2Coordinate);
-        }
+        ends.score = computeFlowDuplicateScore(rec, ends.read2Coordinate);
 
         return ends;
     }

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelperTest.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelperTest.java
@@ -202,8 +202,8 @@ public class MarkDuplicatesForFlowHelperTest {
                 {
                         DuplicateScoringStrategy.ScoringStrategy.SUM_OF_BASE_QUALITIES,
                         new TestRecordInfo[] {
-                                new TestRecordInfo(76, 12,"76M", false, "AAAC", null),
-                                new TestRecordInfo(76, 12, "76M", true, "AACC", null)
+                                new TestRecordInfo(76, 12,"76M", true, "AAAC", null),
+                                new TestRecordInfo(76, 12, "76M", false, "AACC", null)
                         },
                         new String[] { "FLOW_DUP_STRATEGY=FLOW_END_QUALITY_STRATEGY" },
                         new TesterModifier() {

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelperTest.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelperTest.java
@@ -198,6 +198,25 @@ public class MarkDuplicatesForFlowHelperTest {
                             }
                         }
                 },
+                // testFLOW_END_QUALITY_STRATEGY: flow (homopolymer based) minumum
+                {
+                        DuplicateScoringStrategy.ScoringStrategy.SUM_OF_BASE_QUALITIES,
+                        new TestRecordInfo[] {
+                                new TestRecordInfo(76, 12,"76M", false, "AAAC", null),
+                                new TestRecordInfo(76, 12, "76M", true, "AACC", null)
+                        },
+                        new String[] { "FLOW_DUP_STRATEGY=FLOW_END_QUALITY_STRATEGY" },
+                        new TesterModifier() {
+                            @Override
+                            public void modify(final AbstractMarkDuplicatesCommandLineProgramTester tester) {
+                                final SAMRecord[] records = tester.getSamRecordSetBuilder().getRecords().toArray(new SAMRecord[0]);
+                                records[0].setAttribute("tp", new int[76]);
+                                records[1].setAttribute("tp", new int[76]);
+                                records[0].getBaseQualities()[1] = 25; // dip inside AAA
+                                records[1].getBaseQualities()[30] = 10;
+                            }
+                        }
+                },
 
                 // testUNPAIRED_END_UNCERTAINTY: End location is significant and uncertain, end sorted
                 {
@@ -208,6 +227,17 @@ public class MarkDuplicatesForFlowHelperTest {
                                 new TestRecordInfo(94, 12, null, false, null, null)
                         },
                         new String[] { "USE_END_IN_UNPAIRED_READS=true", "UNPAIRED_END_UNCERTAINTY=10" }, null
+                },
+
+                // testUNPAIRED_START_UNCERTAINTY: End location is significant and uncertain, end sorted
+                {
+                        null,
+                        new TestRecordInfo[] {
+                                new TestRecordInfo(74, 12, null, false, null, null),
+                                new TestRecordInfo(64, 22, null, true, null, null),
+                                new TestRecordInfo(54, 32, null, true, null, null)
+                        },
+                        new String[] { "USE_END_IN_UNPAIRED_READS=true", "UNPAIRED_START_UNCERTAINTY=10" }, null
                 },
 
                 // testUNPAIRED_END_UNCERTAINTY: End location is significant and uncertain, end not sorted


### PR DESCRIPTION
### Description
1. We found that when the duplication rate is very high, we sometimes also get variability at the start position (although usually it is more precise than the end position). In this version we added a parameter that also allows for an uncertainty in the read start position to be counted as duplicate. We introduced a parameter `UNPAIRED_START_UNCERTAINTY` in flow mode. 
2. When duplication rate is very high for large cluster of reads when all reads (start,end) are (A,B) we will sometimes get read with (start,end) at (A-1,B). In the default configuration, we will select the read with the best quality sum over all the reads. However, we found that if it is desirable to select read that starts and ends on (A,B) it is better to only look at the qualities close to the end. We thus introduced a new strategy: `FLOW_END_QUALITY_STRATEGY`. 
----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on github actions

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

