### PR TITLE
Fix for order flipping in SortingCollection used for MarkDuplicates

### DIFF
--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -1035,10 +1035,10 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram imp
             // access to the index-in-file of the records (e.g. SPARK implmentations)
 
             if (compareDifference == 0) {
-                compareDifference = (int) (lhs.read1IndexInFile - rhs.read1IndexInFile);
+                compareDifference = Long.compare(lhs.read1IndexInFile, rhs.read1IndexInFile);
             }
             if (compareDifference == 0) {
-                compareDifference = (int) (lhs.read2IndexInFile - rhs.read2IndexInFile);
+                compareDifference = Long.compare(lhs.read2IndexInFile, rhs.read2IndexInFile);
             }
 
             return compareDifference;


### PR DESCRIPTION
### Description

When number of reads in input file is over max value of signed int, the comparator for SortingCollection may return a value with sign opposite to the intended because the comparator calculates difference between two long numbers then down-casts into signed int.

_compareDifference = (int) (lhs.read1IndexInFile - rhs.read1IndexInFile);_

This comparison acts as a tie-score-breaker, so affects best read election among duplicate reads with same score.

Furthermore, because of this, same input file may result in different duplicate read set if run with different Java memory configuration - such as Xmx - which determines number of temp file chunks created by SortingCollection.
It is because order of element insertion into TreeSet which is internally used by SortingCollection for merging temp files varies by the number of temp files and the insertion order affects final order of duplicate reads.

I chose a high-depth sample with reads over 2,200,000,000, query-name sorted it in order to compare with Spark implementation and checked below cases using that sample.

- Picard MarkDuplicates vs Picard Markduplicates with different Xmx --> **DIFFERENT**
- Picard MarkDuplicates vs GATK MarkDuplicatesSpark --> **DIFFERENT**
- GATK MarkDuplicatesSpark vs Picard MarkDuplicates with this fix --> **IDENTICAL**

Please let me know if something missed or I'm missing something.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on github actions

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

