### PR TITLE
Update http-nio to 1.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ dependencies {
 
     //nio plugin providers for google cloud and http(s)
     implementation 'com.google.cloud:google-cloud-nio:0.127.0'
-    implementation 'org.broadinstitute:http-nio:1.1.0'
+    implementation 'org.broadinstitute:http-nio:1.1.1'
 
     testImplementation 'org.testng:testng:7.7.0'
 


### PR DESCRIPTION
This release fixes several bugs when using HttpPath resolve methods that have been affecting users. In particular, they were causing issues when trying to construct HTTP URIs for companion files such as fasta/bam indices.

