### PR TITLE
Fold80 Bug Fix

### DIFF
--- a/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
+++ b/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
@@ -126,6 +126,10 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
     // give it the bin label "coverage_or_base_quality" to make clear that in the metrics file the coverage and base quality histograms share the same bin column on the left
     private final Histogram<Integer> highQualityDepthHistogram = new Histogram<>("coverage_or_base_quality", "high_quality_coverage_count");
 
+    // histogram of depths. does not include bases with quality less than MINIMUM_BASE_QUALITY (default 20) or bases with zero coverage.
+    // we use this for the calculation of the FOLD_80_BASE_PENALTY metric
+    private final Histogram<Integer> highQualityFilteredDepthHistogram = new Histogram<>("coverage_or_base_quality", "high_quality_non_zero_coverage_count");
+
     // histogram of base qualities. includes all but quality 2 bases. we use this histogram to calculate theoretical het sensitivity.
     private final Histogram<Integer> unfilteredDepthHistogram = new Histogram<>("coverage_or_base_quality", "unfiltered_coverage_count");
 
@@ -708,6 +712,7 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
         private void calculateTargetCoverageMetrics() {
 
             LongStream.range(0, hqMaxDepth).forEach(i -> highQualityDepthHistogram.increment((int) i, 0));
+            LongStream.range(1, hqMaxDepth).forEach(i -> highQualityFilteredDepthHistogram.increment((int) i, 0));
 
             int zeroCoverageTargets = 0;
 
@@ -738,7 +743,9 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
                     totalCoverage += depth;
                     highQualityDepthHistogram.increment(depth, 1);
                     minDepth = Math.min(minDepth, depth);
-
+                    if (depth > 0) {
+                        highQualityFilteredDepthHistogram.increment(depth, 1);
+                    }
                     // Add to the "how many target bases at at-least X" calculations.
                     for (int i = 0; i < targetBasesDepth.length; i++) {
                         if (depth >= targetBasesDepth[i]) targetBases[i]++;
@@ -750,8 +757,8 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
             if (targetBases[0] !=  highQualityCoverageByTarget.keySet().stream().mapToInt(Interval::length).sum()) {
                 throw new PicardException("the number of target bases with at least 0x coverage does not equal the number of target bases");
             }
-
-            metrics.MEAN_TARGET_COVERAGE = (double) totalCoverage / metrics.TARGET_TERRITORY;
+            
+            metrics.MEAN_TARGET_COVERAGE = highQualityDepthHistogram.getMean();
             metrics.MEDIAN_TARGET_COVERAGE = highQualityDepthHistogram.getMedian();
             metrics.MAX_TARGET_COVERAGE = hqMaxDepth;
             // Use Math.min() to account for edge case where highQualityCoverageByTarget is empty (minDepth=Long.MAX_VALUE)
@@ -759,7 +766,7 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
 
             // compute the coverage value such that 80% of target bases have better coverage than it i.e. 20th percentile
             // this roughly measures how much we must sequence extra such that 80% of target bases have coverage at least as deep as the current mean coverage
-            metrics.FOLD_80_BASE_PENALTY = metrics.MEAN_TARGET_COVERAGE / highQualityDepthHistogram.getPercentile(0.2);
+            metrics.FOLD_80_BASE_PENALTY = highQualityFilteredDepthHistogram.getMean() / highQualityFilteredDepthHistogram.getPercentile(0.2);
             metrics.ZERO_CVG_TARGETS_PCT = zeroCoverageTargets / (double) allTargets.getIntervals().size();
 
             // Store the "how many bases at at-least X" calculations.


### PR DESCRIPTION
### Description

Added `highQualityDepthHistogramNonZero` as a histogram variable to [WgsMetrics.java ](https://github.com/broadinstitute/picard/blob/d8d87c971f8ecee959ab79087e8672366f9ee2dc/src/main/java/picard/analysis/WgsMetrics.java)and [CollectTargetMetrics.java](https://github.com/broadinstitute/picard/blob/master/src/main/java/picard/analysis/directed/TargetMetricsCollector.java).`highQualityDepthHistogramNonZero` is identical to `highQualityDepthHistogram`, but gets rid of its '0 coverage' bin. `highQualityDepthHistogramNonZero` is then used in the place of the `highQualityDepthHistogram` for the calculation of the `FOLD_80_BASE_PENALTY` metric. The motivation for making this change is to have these metrics accurately calculate the `FOLD_80_BASE_PENALTY` metric accord to its definition: "The fold over-coverage necessary to raise 80% of bases in "non-zero-cvg" targets to the mean coverage level in those targets."

This change fixes the issue brought up in the following [Picard Bug Report](https://github.com/broadinstitute/picard/issues/1971).



----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on github actions

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

