### PR TITLE
Add piped input tests for RevertSam, MergeBamAlignment

### DIFF
--- a/src/main/java/picard/sam/RevertSam.java
+++ b/src/main/java/picard/sam/RevertSam.java
@@ -269,6 +269,12 @@ public class RevertSam extends CommandLineProgram {
         }
 
         final boolean sanitizing = SANITIZE;
+
+        // Wrap the INPUT.toPath() inside SamInputResource.of() as a workaround for the Illegal Seek error.
+        // For details, see:
+        //   https://github.com/broadinstitute/picard/pull/1974
+        //   https://github.com/samtools/htsjdk/pull/1124
+        //   https://github.com/samtools/htsjdk/issues/1084
         final SamReader in = SamReaderFactory.makeDefault().referenceSequence(referenceSequence.getReferencePath()).validationStringency(VALIDATION_STRINGENCY).open(SamInputResource.of(INPUT.toPath()));
         final SAMFileHeader inHeader = in.getFileHeader();
         ValidationUtil.validateHeaderOverrides(inHeader, SAMPLE_ALIAS, LIBRARY_NAME);

--- a/src/main/java/picard/sam/RevertSam.java
+++ b/src/main/java/picard/sam/RevertSam.java
@@ -269,7 +269,7 @@ public class RevertSam extends CommandLineProgram {
         }
 
         final boolean sanitizing = SANITIZE;
-        final SamReader in = SamReaderFactory.makeDefault().referenceSequence(referenceSequence.getReferencePath()).validationStringency(VALIDATION_STRINGENCY).open(SamInputResource.of(INPUT.toPath())); // tsato: confirm this won't break piped input
+        final SamReader in = SamReaderFactory.makeDefault().referenceSequence(referenceSequence.getReferencePath()).validationStringency(VALIDATION_STRINGENCY).open(SamInputResource.of(INPUT.toPath()));
         final SAMFileHeader inHeader = in.getFileHeader();
         ValidationUtil.validateHeaderOverrides(inHeader, SAMPLE_ALIAS, LIBRARY_NAME);
 

--- a/src/test/java/picard/sam/MergeBamAlignmentTest.java
+++ b/src/test/java/picard/sam/MergeBamAlignmentTest.java
@@ -75,8 +75,9 @@ public class MergeBamAlignmentTest extends CommandLineProgramTest {
     private static final File DATA_DIR = new File("testdata/picard/sam");
     private static final File TEST_DATA_DIR = new File(DATA_DIR, "MergeBamAlignment");
 
-    private static final File unmappedBam = new File(DATA_DIR, "unmapped.sam");
+    public static final File unmappedBam = new File(DATA_DIR, "unmapped.sam");
     private static final File alignedBam = new File(DATA_DIR, "aligned.sam");
+    public static final File alignedQuerySortedBam = new File(DATA_DIR, "aligned_query_name_sorted.sam");
     private static final File oneHalfAlignedBam = new File(DATA_DIR, "onehalfaligned.sam");
     private static final File otherHalfAlignedBam = new File(DATA_DIR, "otherhalfaligned.sam");
     private static final File mergingUnmappedBam = new File(TEST_DATA_DIR, "unmapped.sam");
@@ -87,8 +88,8 @@ public class MergeBamAlignmentTest extends CommandLineProgramTest {
     private static final File secondReadAlignedBam_firstHalf = new File(TEST_DATA_DIR, "firsthalf.read2.trimmed.aligned.sam");
     private static final File secondReadAlignedBam_secondHalf = new File(TEST_DATA_DIR, "secondhalf.read2.trimmed.aligned.sam");
     private static final File supplementalReadAlignedBam = new File(TEST_DATA_DIR, "aligned.supplement.sam");
-    private static final File alignedQuerynameSortedBam = new File(DATA_DIR, "aligned_queryname_sorted.sam");
-    private static final File fasta = new File(DATA_DIR, "merger.fasta");
+    public static final File alignedQuerynameSortedBam = new File(DATA_DIR, "aligned_queryname_sorted.sam");
+    public static final File fasta = new File(DATA_DIR, "merger.fasta");
     private static final String bigSequenceName = "chr7"; // The longest sequence in merger.fasta
     private static final File sequenceDict = new File(DATA_DIR, "merger.dict");
     private static final File sequenceDict2 = new File(DATA_DIR, "merger.2.dict");

--- a/src/test/java/picard/sam/MergeBamAlignmentTest.java
+++ b/src/test/java/picard/sam/MergeBamAlignmentTest.java
@@ -77,7 +77,6 @@ public class MergeBamAlignmentTest extends CommandLineProgramTest {
 
     public static final File unmappedBam = new File(DATA_DIR, "unmapped.sam");
     private static final File alignedBam = new File(DATA_DIR, "aligned.sam");
-    public static final File alignedQuerySortedBam = new File(DATA_DIR, "aligned_query_name_sorted.sam");
     private static final File oneHalfAlignedBam = new File(DATA_DIR, "onehalfaligned.sam");
     private static final File otherHalfAlignedBam = new File(DATA_DIR, "otherhalfaligned.sam");
     private static final File mergingUnmappedBam = new File(TEST_DATA_DIR, "unmapped.sam");

--- a/src/test/java/picard/sam/PipedDataTest.java
+++ b/src/test/java/picard/sam/PipedDataTest.java
@@ -49,7 +49,7 @@ public class PipedDataTest {
         final String[] revertSamCommand = {
             "/bin/bash",
             "-c",
-            getViewSamPicardCommand("testdata/picard/sam/test.bam") + // tsato: this has to be a "+", not ",". Best to extract a method "piped input argument builder" or something
+            getViewSamPicardCommand("testdata/picard/sam/test.bam") +
             "| " +
             picardCommandlinePreamble +
             "RevertSam " +

--- a/src/test/java/picard/sam/PipedDataTest.java
+++ b/src/test/java/picard/sam/PipedDataTest.java
@@ -16,7 +16,7 @@ import static picard.sam.MergeBamAlignmentTest.unmappedBam;
 public class PipedDataTest {
     private static final String classPath = "\"" + System.getProperty("java.class.path") + "\" ";
     private static final String picardCommandlinePreamble = "java -classpath " + classPath + "picard.cmdline.PicardCommandLine ";
-    private static final String TEST_BAM = "testdata/picard/sam/test.bam";
+    private static final String testBam = "testdata/picard/sam/test.bam";
 
     /**
      * Creates the command line argument to be used for piped (/dev/stdin) input tests.
@@ -41,7 +41,7 @@ public class PipedDataTest {
         final String[] sortSamCommand = {
                 "/bin/bash",
                 "-c",
-                getViewSamPicardCommand(TEST_BAM) +
+                getViewSamPicardCommand(testBam) +
                 "| " +
                 picardCommandlinePreamble +
                 "SortSam " +
@@ -55,7 +55,7 @@ public class PipedDataTest {
         final String[] revertSamCommand = {
             "/bin/bash",
             "-c",
-            getViewSamPicardCommand(TEST_BAM) +
+            getViewSamPicardCommand(testBam) +
             "| " +
             picardCommandlinePreamble +
             "RevertSam " +

--- a/src/test/java/picard/sam/PipedDataTest.java
+++ b/src/test/java/picard/sam/PipedDataTest.java
@@ -1,18 +1,22 @@
 package picard.sam;
 
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.stream.StreamSupport;
 
 import static picard.sam.MergeBamAlignmentTest.fasta;
 import static picard.sam.MergeBamAlignmentTest.unmappedBam;
 
 public class PipedDataTest {
-    private final String classPath = "\"" + System.getProperty("java.class.path") + "\" ";
-    private final String picardCommandlinePreamble = "java -classpath " + classPath + "picard.cmdline.PicardCommandLine ";
+    private static final String classPath = "\"" + System.getProperty("java.class.path") + "\" ";
+    private static final String picardCommandlinePreamble = "java -classpath " + classPath + "picard.cmdline.PicardCommandLine ";
+    private static final String TEST_BAM = "testdata/picard/sam/test.bam";
 
     /**
      * Creates the command line argument to be used for piped (/dev/stdin) input tests.
@@ -32,63 +36,74 @@ public class PipedDataTest {
     public Object[][] getPipedInputTestData() throws IOException {
         // Note the trailing space in each string block.
         // TODO: port ArgumentBuilder from GATK so this would not be necessary.
+        final File sortSamOutput = File.createTempFile("SortSam_pipe_test", "bam");
+        sortSamOutput.deleteOnExit();
         final String[] sortSamCommand = {
                 "/bin/bash",
                 "-c",
-                getViewSamPicardCommand("testdata/picard/sam/test.bam") +
+                getViewSamPicardCommand(TEST_BAM) +
                 "| " +
                 picardCommandlinePreamble +
                 "SortSam " +
+                "SORT_ORDER=queryname " +
                 "I=/dev/stdin " +
-                "O=/dev/null " +
-                "SORT_ORDER=queryname"
+                "O=" + sortSamOutput.getAbsolutePath()
         };
 
-        final File temp = File.createTempFile("test", "sam");
-        temp.deleteOnExit();
+        final File revertSamOutput = File.createTempFile("RevertSam_pipe_test", "bam");
+        revertSamOutput.deleteOnExit();
         final String[] revertSamCommand = {
             "/bin/bash",
             "-c",
-            getViewSamPicardCommand("testdata/picard/sam/test.bam") +
+            getViewSamPicardCommand(TEST_BAM) +
             "| " +
             picardCommandlinePreamble +
             "RevertSam " +
             "I=/dev/stdin " +
-            "O=/dev/null "
+            "O=" + revertSamOutput.getAbsolutePath()
         };
 
-        // Only test the case where the "alignedBam" argument is /dev/stdin, which is the standard use case (bwa -> mergebamalignment)
-        // Make sure that the input aligned bam is query-name sorted (as it would be if it's piped from bwa)
+
+        // Only test the case where the "alignedBam" argument is /dev/stdin, which is the standard use case (bwa -> MergeBamAlignment).
+        //
+        // Note that the input aligned bam must be query-name sorted (as it would be if it's piped from bwa).
         // MergeBamAlignment fails if the coordinate sorted aligned bam is given, after trying to query-name sort dynamically and failing to find the reference header items,
-        // due seemingly to the fact that the input is /dev/stdin.
+        // seemingly due to the fact that the input is /dev/stdin.
+        final File mergeBamAlignmentOutput = File.createTempFile("MergeBamAlignment_pipe_test", "bam");
+        mergeBamAlignmentOutput.deleteOnExit();
         final String[] mergeBamAlignmentCommand = {
                 "/bin/bash",
                 "-c",
-                getViewSamPicardCommand(MergeBamAlignmentTest.alignedQuerynameSortedBam.getAbsolutePath()) + // here we have to use "+", not ",". Best to extract a method "piped input argument builder" or something
+                getViewSamPicardCommand(MergeBamAlignmentTest.alignedQuerynameSortedBam.getAbsolutePath()) + // here we have to use "+", not ",".
                 "| " +
                 picardCommandlinePreamble +
                 "MergeBamAlignment " +
                 "ALIGNED_BAM=/dev/stdin " +
                 "UNMAPPED=" + unmappedBam + " " +
                 "REFERENCE_SEQUENCE=" + fasta + " " +
-                "OUTPUT=/dev/null "
+                "OUTPUT=" + mergeBamAlignmentOutput.getAbsolutePath()
         };
 
         return new Object[][]{
-                {sortSamCommand},
-                {revertSamCommand},
-                {mergeBamAlignmentCommand}
+                {sortSamCommand, sortSamOutput},
+                {revertSamCommand, revertSamOutput},
+                {mergeBamAlignmentCommand, mergeBamAlignmentOutput}
         };
     }
 
     @Test(dataProvider = "pipedInputTestData")
-    public void testPipedInput(final String[] command) {
+    public void testPipedInput(final String[] command, final File tmpOutput) {
         try {
             ProcessBuilder processBuilder = new ProcessBuilder(command);
             processBuilder.inheritIO();
 
             Process process = processBuilder.start();
             Assert.assertEquals(process.waitFor(), 0);
+
+            final SamReader reader = SamReaderFactory.makeDefault().open(tmpOutput);
+            final long numOutputReads = StreamSupport.stream(reader.spliterator(), false).count();
+            Assert.assertTrue(numOutputReads > 0);
+            Assert.assertTrue(reader.getFileHeader().getReadGroups().size() > 0);
         } catch (Exception e) {
             Assert.fail("Failed to pipe data to picard. The error was: ", e);
         }

--- a/src/test/java/picard/sam/PipedDataTest.java
+++ b/src/test/java/picard/sam/PipedDataTest.java
@@ -1,44 +1,96 @@
 package picard.sam;
 
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import picard.cmdline.CommandLineProgramTest;
+
+import java.io.File;
+import java.io.IOException;
+
+import static picard.sam.MergeBamAlignmentTest.fasta;
+import static picard.sam.MergeBamAlignmentTest.unmappedBam;
 
 public class PipedDataTest {
+    private final String classPath = "\"" + System.getProperty("java.class.path") + "\" ";
+    private final String picardCommandlinePreamble = "java -classpath " + classPath + "picard.cmdline.PicardCommandLine ";
 
-    private String classPath = "\"" + System.getProperty("java.class.path") + "\" ";
+    /**
+     * Creates the command line argument to be used for piped (/dev/stdin) input tests.
+     *
+     * @param inputSAM the path to the input SAM file.
+     * @return commandline for ViewSam.
+     */
+    private String getViewSamPicardCommand(final String inputSAM){
+        return picardCommandlinePreamble +
+                "ViewSam " +
+                "I=" + inputSAM + " " +
+                "ALIGNMENT_STATUS=All " +
+                "PF_STATUS=All ";
+    }
 
-    @Test
-    public void testSortSam() {
-        String[] command = {
+    @DataProvider(name = "pipedInputTestData")
+    public Object[][] getPipedInputTestData() throws IOException {
+        // Note the trailing space in each string block.
+        // TODO: port ArgumentBuilder from GATK so this would not be necessary.
+        final String[] sortSamCommand = {
                 "/bin/bash",
                 "-c",
-                "java -classpath " +
-                        classPath +
-                        "picard.cmdline.PicardCommandLine " +
-                        "ViewSam " +
-                        "I=testdata/picard/sam/test.bam " +
-                        "ALIGNMENT_STATUS=All " +
-                        "PF_STATUS=All " +
-                        "| " +
-                        "java -classpath " +
-                        classPath +
-                        "picard.cmdline.PicardCommandLine " +
-                        "SortSam " +
-                        "I=/dev/stdin " +
-                        "O=/dev/null " +
-                        "SORT_ORDER=queryname"
+                getViewSamPicardCommand("testdata/picard/sam/test.bam") +
+                "| " +
+                picardCommandlinePreamble +
+                "SortSam " +
+                "I=/dev/stdin " +
+                "O=/dev/null " +
+                "SORT_ORDER=queryname"
         };
 
+        final File temp = File.createTempFile("test", "sam");
+        temp.deleteOnExit();
+        final String[] revertSamCommand = {
+            "/bin/bash",
+            "-c",
+            getViewSamPicardCommand("testdata/picard/sam/test.bam") + // tsato: this has to be a "+", not ",". Best to extract a method "piped input argument builder" or something
+            "| " +
+            picardCommandlinePreamble +
+            "RevertSam " +
+            "I=/dev/stdin " +
+            "O=/dev/null "
+        };
+
+        // Only test the case where the "alignedBam" argument is /dev/stdin, which is the standard use case (bwa -> mergebamalignment)
+        // Make sure that the input aligned bam is query-name sorted (as it would be if it's piped from bwa)
+        // MergeBamAlignment fails if the coordinate sorted aligned bam is given, after trying to query-name sort dynamically and failing to find the reference header items,
+        // due seemingly to the fact that the input is /dev/stdin.
+        final String[] mergeBamAlignmentCommand = {
+                "/bin/bash",
+                "-c",
+                getViewSamPicardCommand(MergeBamAlignmentTest.alignedQuerynameSortedBam.getAbsolutePath()) + // here we have to use "+", not ",". Best to extract a method "piped input argument builder" or something
+                "| " +
+                picardCommandlinePreamble +
+                "MergeBamAlignment " +
+                "ALIGNED_BAM=/dev/stdin " +
+                "UNMAPPED=" + unmappedBam + " " +
+                "REFERENCE_SEQUENCE=" + fasta + " " +
+                "OUTPUT=/dev/null "
+        };
+
+        return new Object[][]{
+                {sortSamCommand},
+                {revertSamCommand},
+                {mergeBamAlignmentCommand}
+        };
+    }
+
+    @Test(dataProvider = "pipedInputTestData")
+    public void testPipedInput(final String[] command) {
         try {
             ProcessBuilder processBuilder = new ProcessBuilder(command);
             processBuilder.inheritIO();
 
             Process process = processBuilder.start();
             Assert.assertEquals(process.waitFor(), 0);
-
         } catch (Exception e) {
-            Assert.fail("Failed to pipe data from htsjdk to picard", e);
+            Assert.fail("Failed to pipe data to picard. The error was: ", e);
         }
     }
 }


### PR DESCRIPTION
### Description

When we cloudify a Picard tool, we change the input and output file types from `FILE` to `PicardHtsPath.` This could trigger a "java.io.IOException: Illegal seek" if the input SAM is piped (/dev/stdin). I believe this is related to a known issue (see samtools/htsjdk#1084, samtools/htsjdk#1077). The workaround is to wrap a Path object in `SamInputResource.of()`, which was put in place in samtools/htsjdk#1124. The tests in PR should safeguard us from inadvertently removing the workaround until a more robust fix can be implemented.

The targeted tools are RevertSam and MergeBamAlignment, both of which are used with piped input in warp pipelines. For example, see
https://github.com/broadinstitute/warp/blob/develop/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl
https://github.com/broadinstitute/warp/blob/develop/tasks/broad/Alignment.wdl

To reproduce the bug, change Line 272 of RevertSam from:

```java 
final SamReader in = SamReaderFactory.makeDefault().referenceSequence(referenceSequence.getReferencePath()).validationStringency(VALIDATION_STRINGENCY).open(SamInputResource.of(INPUT.toPath())); ;
```

to 

```java
final SamReader in = SamReaderFactory.makeDefault().referenceSequence(referenceSequence.getReferencePath()).validationStringency(VALIDATION_STRINGENCY).open(INPUT.toPath());
```

That is, remove the wrapper `SamInputResource.of()`.

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on github actions

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests
