### PR TITLE
Refactor code around cloud support

### DIFF
--- a/src/main/java/picard/cmdline/CommandLineProgram.java
+++ b/src/main/java/picard/cmdline/CommandLineProgram.java
@@ -25,6 +25,7 @@ package picard.cmdline;
 
 import com.intel.gkl.compression.IntelDeflaterFactory;
 import com.intel.gkl.compression.IntelInflaterFactory;
+import htsjdk.io.IOPath;
 import htsjdk.samtools.Defaults;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMFileWriterFactory;
@@ -341,7 +342,7 @@ public abstract class CommandLineProgram {
         // object created by this code path won't be valid - but we still have to set it here in case
         // the tool tries to access REFERENCE_SEQUENCE directly (such tools will subsequently fail given
         // a non-local file anyway, but this prevents them from immediately throwing an NPE).
-        final PicardHtsPath refHtsPath = referenceSequence.getHtsPath();
+        final IOPath refHtsPath = referenceSequence.getHtsPath();
         REFERENCE_SEQUENCE = ReferenceArgumentCollection.getFileSafe(refHtsPath, Log.getInstance(this.getClass()));
 
         // The TMP_DIR setting section below was moved from instanceMain() to here due to timing issues

--- a/src/main/java/picard/cmdline/argumentcollections/ReferenceArgumentCollection.java
+++ b/src/main/java/picard/cmdline/argumentcollections/ReferenceArgumentCollection.java
@@ -27,6 +27,7 @@ package picard.cmdline.argumentcollections;
 import java.io.File;
 import java.nio.file.Path;
 
+import htsjdk.io.IOPath;
 import htsjdk.samtools.util.Log;
 import picard.nio.PicardBucketUtils;
 import picard.nio.PicardHtsPath;
@@ -61,7 +62,7 @@ public interface ReferenceArgumentCollection {
      *
      * @return The reference provided by the user, if any, or the default, if any, as a PicardHtsPath. May be null.
      */
-    default PicardHtsPath getHtsPath(){
+    default IOPath getHtsPath(){
         return getReferenceFile() == null ? null : new PicardHtsPath(getReferenceFile());
     }
 
@@ -74,7 +75,7 @@ public interface ReferenceArgumentCollection {
      * the value returned by calls to getReferenceFile to not get an NPE, and to fail gracefully downstream
      * with an error message that includes the reference file specifier.
      */
-    static File getFileSafe(final PicardHtsPath picardPath, final Log log) {
+    static File getFileSafe(final IOPath picardPath, final Log log) {
         if (picardPath == null) {
             return null;
         } else if (picardPath.getScheme().equals(PicardBucketUtils.FILE_SCHEME)) {

--- a/src/main/java/picard/nio/PicardBucketUtils.java
+++ b/src/main/java/picard/nio/PicardBucketUtils.java
@@ -1,15 +1,11 @@
 package picard.nio;
 
-import com.google.cloud.storage.contrib.nio.CloudStorageFileSystem;
-import com.google.cloud.storage.contrib.nio.CloudStoragePath;
-import htsjdk.io.HtsPath;
 import htsjdk.io.IOPath;
 import htsjdk.samtools.util.FileExtensions;
 import htsjdk.utils.ValidationUtils;
 import picard.PicardException;
 
 import java.util.UUID;
-
 
 /**
  * Derived from BucketUtils.java in GATK
@@ -143,6 +139,9 @@ public class PicardBucketUtils {
     }
 
     /**
+     * As of August 2024, we only support Google Cloud.
+     * Will add other filesystems (e.g. Azure, AWS) when ready.
+     *
      * @return whether the cloud filesystem is currently supported by Picard.
      */
     public static boolean isSupportedCloudFilesystem(final IOPath path){

--- a/src/main/java/picard/nio/PicardBucketUtils.java
+++ b/src/main/java/picard/nio/PicardBucketUtils.java
@@ -2,14 +2,12 @@ package picard.nio;
 
 import com.google.cloud.storage.contrib.nio.CloudStorageFileSystem;
 import com.google.cloud.storage.contrib.nio.CloudStoragePath;
+import htsjdk.io.HtsPath;
 import htsjdk.io.IOPath;
 import htsjdk.samtools.util.FileExtensions;
 import htsjdk.utils.ValidationUtils;
+import picard.PicardException;
 
-import java.io.File;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.UUID;
 
 
@@ -20,11 +18,12 @@ public class PicardBucketUtils {
     public static final String GOOGLE_CLOUD_STORAGE_FILESYSTEM_SCHEME = "gs";
     public static final String HTTP_FILESYSTEM_PROVIDER_SCHEME = "http";
     public static final String HTTPS_FILESYSTEM_PROVIDER_SCHEME = "https";
-    public static final String HDFS_SCHEME = "hdfs";
     public static final String FILE_SCHEME = "file";
 
     // This Picard test staging bucket has a TTL of 180 days (DeleteAction with Age = 180)
-    public static final String GCLOUD_PICARD_STAGING_DIRECTORY = "gs://hellbender-test-logs/staging/picard/";
+    public static final String GCLOUD_PICARD_STAGING_DIRECTORY_STR = "gs://hellbender-test-logs/staging/picard/";
+    public static final PicardHtsPath GCLOUD_PICARD_STAGING_DIRECTORY = new PicardHtsPath(GCLOUD_PICARD_STAGING_DIRECTORY_STR);
+
 
     // slashes omitted since hdfs paths seem to only have 1 slash which would be weirder to include than no slashes
     private PicardBucketUtils(){} //private so that no one will instantiate this class
@@ -41,59 +40,43 @@ public class PicardBucketUtils {
      * @return a new temporary path of the form [directory]/[prefix][random chars][.extension]
      *
      */
-    public static PicardHtsPath getTempFilePath(final String directory, String prefix, final String extension){
+    public static IOPath getTempFilePath(final IOPath directory, String prefix, final String extension){
         ValidationUtils.validateArg(extension.startsWith("."), "The new extension must start with a period '.'");
         final String defaultPrefix = "tmp";
 
         if (directory == null){
+            // If directory = null, we are creating a local temp file.
             // File#createTempFile requires that the prefix be at least 3 characters long
             prefix = prefix.length() >= 3 ? prefix : defaultPrefix;
             return new PicardHtsPath(PicardIOUtils.createTempFile(prefix, extension));
-        }
-
-        if (isGcsUrl(directory) || isHadoopUrl(directory)){
-            final PicardHtsPath path = PicardHtsPath.fromPath(randomRemotePath(directory, prefix, extension));
-            PicardIOUtils.deleteOnExit(path.toPath());
-            // Mark auxiliary files to be deleted
-            PicardIOUtils.deleteOnExit(PicardHtsPath.replaceExtension(path, FileExtensions.TRIBBLE_INDEX, true).toPath());
-            PicardIOUtils.deleteOnExit(PicardHtsPath.replaceExtension(path, FileExtensions.TABIX_INDEX, true).toPath());
-            PicardIOUtils.deleteOnExit(PicardHtsPath.replaceExtension(path, FileExtensions.BAI_INDEX, true).toPath()); // e.g. file.bam.bai
-            PicardIOUtils.deleteOnExit(PicardHtsPath.replaceExtension(path, FileExtensions.BAI_INDEX, false).toPath()); // e.g. file.bai
-            PicardIOUtils.deleteOnExit(PicardHtsPath.replaceExtension(path, ".md5", true).toPath());
-            return path;
-        } else {
+        } else if (PicardBucketUtils.isLocalPath(directory)) {
             // Assume the (non-null) directory points to a directory on a local filesystem
             prefix = prefix.length() >= 3 ? prefix : defaultPrefix;
-            return new PicardHtsPath(PicardIOUtils.createTempFileInDirectory(prefix, extension, new File(directory)));
+            return new PicardHtsPath(PicardIOUtils.createTempFileInDirectory(prefix, extension, directory.toPath().toFile()));
+        } else {
+            if (isSupportedCloudFilesystem(directory)) {
+                final IOPath path = randomRemotePath(directory, prefix, extension);
+                PicardIOUtils.deleteOnExit(path.toPath());
+                // Mark auxiliary files to be deleted
+                PicardIOUtils.deleteOnExit(PicardHtsPath.replaceExtension(path, FileExtensions.TRIBBLE_INDEX, true).toPath());
+                PicardIOUtils.deleteOnExit(PicardHtsPath.replaceExtension(path, FileExtensions.TABIX_INDEX, true).toPath());
+                PicardIOUtils.deleteOnExit(PicardHtsPath.replaceExtension(path, FileExtensions.BAI_INDEX, true).toPath()); // e.g. file.bam.bai
+                PicardIOUtils.deleteOnExit(PicardHtsPath.replaceExtension(path, FileExtensions.BAI_INDEX, false).toPath()); // e.g. file.bai
+                PicardIOUtils.deleteOnExit(PicardHtsPath.replaceExtension(path, ".md5", true).toPath());
+                return path;
+            } else {
+                throw new PicardException("Unsupported cloud filesystem: " + directory.getURIString());
+            }
         }
-    }
-
-    /**
-     * This overload of getTempFilePath takes the directory of type PicardHtsPath instead of String.
-     *
-     * @see #getTempFilePath(String, String, String)
-     *
-     */
-    public static PicardHtsPath getTempFilePath(final IOPath directory, String prefix, final String extension){
-        return getTempFilePath(directory.getURIString(), prefix, extension);
-    }
-
-    /**
-     * Calls getTempFilePath with the empty string as the prefix.
-     *
-     * @see #getTempFilePath(String, String, String)
-     */
-    public static PicardHtsPath getTempFilePath(String directory, String extension){
-        return getTempFilePath(directory, "", extension);
     }
 
     /**
      * Creates a temporary file in a local directory.
      *
-     * @see #getTempFilePath(String, String, String)
+     * @see #getTempFilePath(IOPath, String, String)
      */
-    public static PicardHtsPath getLocalTempFilePath(final String prefix, final String extension){
-        return getTempFilePath((String) null, prefix, extension);
+    public static IOPath getLocalTempFilePath(final String prefix, final String extension){
+        return getTempFilePath(null, prefix, extension);
     }
 
     /**
@@ -110,10 +93,10 @@ public class PicardBucketUtils {
      * @param relativePath The relative location for the new "directory" under the harcoded staging bucket with a TTL set e.g. "test/RevertSam/".
      * @return A PicardHtsPath object to a randomly generated "directory" e.g. "gs://hellbender-test-logs/staging/picard/test/RevertSam/{randomly-generated-string}/"
      */
-    public static PicardHtsPath getRandomGCSDirectory(final String relativePath){
+    public static IOPath getRandomGCSDirectory(final String relativePath){
         ValidationUtils.validateArg(relativePath.endsWith("/"), "relativePath must end in backslash '/': " + relativePath);
 
-        return PicardHtsPath.fromPath(PicardBucketUtils.randomRemotePath(GCLOUD_PICARD_STAGING_DIRECTORY + relativePath, "", "/"));
+        return PicardBucketUtils.randomRemotePath(PicardHtsPath.resolve(GCLOUD_PICARD_STAGING_DIRECTORY, relativePath), "", "/");
     }
 
     /**
@@ -123,37 +106,12 @@ public class PicardBucketUtils {
      * @param prefix The beginning of the file name
      * @param suffix The end of the file name, e.g. ".tmp"
      */
-    public static Path randomRemotePath(String stagingLocation, String prefix, String suffix) {
+    public static IOPath randomRemotePath(final IOPath stagingLocation, final String prefix, final String suffix) {
         if (isGcsUrl(stagingLocation)) {
-            return getPathOnGcs(stagingLocation).resolve(prefix + UUID.randomUUID() + suffix);
-        } else if (isHadoopUrl(stagingLocation)) {
-            return Paths.get(stagingLocation, prefix + UUID.randomUUID() + suffix);
+            return PicardHtsPath.resolve(stagingLocation, prefix + UUID.randomUUID() + suffix);
         } else {
             throw new IllegalArgumentException("Staging location is not remote: " + stagingLocation);
         }
-    }
-
-    /**
-     * String -> Path. This *should* not be necessary (use Paths.get(URI.create(...)) instead) , but it currently is
-     * on Spark because using the fat, shaded jar breaks the registration of the GCS FilesystemProvider.
-     * To transform other types of string URLs into Paths, use IOUtils.getPath instead.
-     */
-    private static CloudStoragePath getPathOnGcs(String gcsUrl) {
-        // use a split limit of -1 to preserve empty split tokens, especially trailing slashes on directory names
-        final String[] split = gcsUrl.split("/", -1);
-        final String BUCKET = split[2];
-        final String pathWithoutBucket = String.join("/", Arrays.copyOfRange(split, 3, split.length));
-        return CloudStorageFileSystem.forBucket(BUCKET).getPath(pathWithoutBucket);
-    }
-
-    /**
-     *
-     * @param path path to inspect
-     * @return true if this path represents a gcs location
-     */
-    private static boolean isGcsUrl(final String path) {
-        GATKUtils.nonNull(path);
-        return path.startsWith(GOOGLE_CLOUD_STORAGE_FILESYSTEM_SCHEME + "://");
     }
 
     /**
@@ -168,34 +126,28 @@ public class PicardBucketUtils {
     }
 
     /**
-     * @param pathSpec specifier to inspect
-     * @return true if this {@code GATKPath} represents a remote storage system which may benefit from prefetching (gcs or http(s))
+     * @param path specifier to inspect
+     * @return true if this {@code IOPath} represents a remote storage system which may benefit from prefetching (gcs or http(s))
      */
-    public static boolean isEligibleForPrefetching(final IOPath pathSpec) {
-        GATKUtils.nonNull(pathSpec);
-        return isEligibleForPrefetching(pathSpec.getScheme());
-    }
-
-    /**
-     * @param path path to inspect
-     * @return true if this {@code Path} represents a remote storage system which may benefit from prefetching (gcs or http(s))
-     */
-    public static boolean isEligibleForPrefetching(final Path path) {
+    public static boolean isEligibleForPrefetching(final IOPath path) {
         GATKUtils.nonNull(path);
-        return isEligibleForPrefetching(path.toUri().getScheme());
-    }
-
-    private static boolean isEligibleForPrefetching(final String scheme){
+        final String scheme = path.getScheme();
         return scheme != null
                 && (scheme.equals(GOOGLE_CLOUD_STORAGE_FILESYSTEM_SCHEME)
                 || scheme.equals(HTTP_FILESYSTEM_PROVIDER_SCHEME)
                 || scheme.equals(HTTPS_FILESYSTEM_PROVIDER_SCHEME));
     }
 
+    public static boolean isLocalPath(final IOPath path){
+        return path.getScheme().equals(FILE_SCHEME);
+    }
+
     /**
-     * Returns true if the given path is a HDFS (Hadoop filesystem) URL.
+     * @return whether the cloud filesystem is currently supported by Picard.
      */
-    private static boolean isHadoopUrl(String path) {
-        return path.startsWith(HDFS_SCHEME + "://");
+    public static boolean isSupportedCloudFilesystem(final IOPath path){
+        ValidationUtils.validateArg(! isLocalPath(path), "isSupportedCloudFilesystem should be called on a cloud path but was given: " +
+                path.getURIString());
+        return isGcsUrl(path);
     }
 }

--- a/src/main/java/picard/nio/PicardHtsPath.java
+++ b/src/main/java/picard/nio/PicardHtsPath.java
@@ -182,7 +182,7 @@ public class PicardHtsPath extends HtsPath {
     /**
      * Wrapper for Path.resolve()
      */
-    public static PicardHtsPath resolve(final PicardHtsPath absPath, final String relativePath){
+    public static PicardHtsPath resolve(final IOPath absPath, final String relativePath){
         return PicardHtsPath.fromPath(absPath.toPath().resolve(relativePath));
     }
 }

--- a/src/test/java/picard/cmdline/CommandLineProgramTest.java
+++ b/src/test/java/picard/cmdline/CommandLineProgramTest.java
@@ -24,19 +24,19 @@ public abstract class CommandLineProgramTest {
     public static final File CHR_M_DICT = new File(REFERENCE_TEST_DIR,"chrM.reference.dict");
 
     // These are the hg19 references with chromosome names "1" (rather than "chr1")
-    public static final PicardHtsPath HG19_CHR2021_GCLOUD = new PicardHtsPath(GCloudTestUtils.getTestInputPath() + "picard/references/human_g1k_v37.20.21.fasta");
+    public static final PicardHtsPath HG19_CHR2021_GCLOUD = PicardHtsPath.resolve(GCloudTestUtils.getTestInputPath(), "picard/references/human_g1k_v37.20.21.fasta");
     public static final PicardHtsPath HG19_CHR2021 = new PicardHtsPath("testdata/picard/reference/human_g1k_v37.20.21.fasta.gz");
 
-    public static final PicardHtsPath NA12878_MINI_GCLOUD = new PicardHtsPath(GCloudTestUtils.getTestInputPath() + "picard/bam/CEUTrio.HiSeq.WGS.b37.NA12878.20.21_n100.bam");
-    public static final PicardHtsPath NA12878_MINI_CRAM_GCLOUD = new PicardHtsPath(GCloudTestUtils.getTestInputPath() + "picard/bam/CEUTrio.HiSeq.WGS.b37.NA12878.20.21_n100.cram");
-    public static final PicardHtsPath NA12878_MEDIUM_GCLOUD = new PicardHtsPath(GCloudTestUtils.getTestInputPath() + "picard/bam/CEUTrio.HiSeq.WGS.b37.NA12878.20.21_n10000.bam");
-    public static final PicardHtsPath NA12878_MEDIUM_CRAM_GCLOUD = new PicardHtsPath(GCloudTestUtils.getTestInputPath() + "picard/bam/CEUTrio.HiSeq.WGS.b37.NA12878.20.21_n10000.cram");
+    public static final PicardHtsPath NA12878_MINI_GCLOUD = PicardHtsPath.resolve(GCloudTestUtils.getTestInputPath(), "picard/bam/CEUTrio.HiSeq.WGS.b37.NA12878.20.21_n100.bam");
+    public static final PicardHtsPath NA12878_MINI_CRAM_GCLOUD = PicardHtsPath.resolve(GCloudTestUtils.getTestInputPath(), "picard/bam/CEUTrio.HiSeq.WGS.b37.NA12878.20.21_n100.cram");
+    public static final PicardHtsPath NA12878_MEDIUM_GCLOUD = PicardHtsPath.resolve(GCloudTestUtils.getTestInputPath(), "picard/bam/CEUTrio.HiSeq.WGS.b37.NA12878.20.21_n10000.bam");
+    public static final PicardHtsPath NA12878_MEDIUM_CRAM_GCLOUD = PicardHtsPath.resolve(GCloudTestUtils.getTestInputPath(), "picard/bam/CEUTrio.HiSeq.WGS.b37.NA12878.20.21_n10000.cram");
 
     // A per-test-class directory that will be deleted after the tests are complete.
     private File tempOutputDir;
 
     /**
-     * returns an directory designated for output which will be deleted after the test class is tested
+     * returns a directory designated for output which will be deleted after the test class is tested
      */
     public File getTempOutputDir() {
         if (tempOutputDir == null) {

--- a/src/test/java/picard/cmdline/CommandLineProgramTest.java
+++ b/src/test/java/picard/cmdline/CommandLineProgramTest.java
@@ -1,5 +1,6 @@
 package picard.cmdline;
 
+import htsjdk.io.IOPath;
 import org.apache.commons.io.FileUtils;
 import org.testng.annotations.AfterClass;
 import picard.PicardException;
@@ -24,13 +25,13 @@ public abstract class CommandLineProgramTest {
     public static final File CHR_M_DICT = new File(REFERENCE_TEST_DIR,"chrM.reference.dict");
 
     // These are the hg19 references with chromosome names "1" (rather than "chr1")
-    public static final PicardHtsPath HG19_CHR2021_GCLOUD = PicardHtsPath.resolve(GCloudTestUtils.getTestInputPath(), "picard/references/human_g1k_v37.20.21.fasta");
-    public static final PicardHtsPath HG19_CHR2021 = new PicardHtsPath("testdata/picard/reference/human_g1k_v37.20.21.fasta.gz");
+    public static final IOPath HG19_CHR2021_GCLOUD = PicardHtsPath.resolve(GCloudTestUtils.getTestInputPath(), "picard/references/human_g1k_v37.20.21.fasta");
+    public static final IOPath HG19_CHR2021 = new PicardHtsPath("testdata/picard/reference/human_g1k_v37.20.21.fasta.gz");
 
-    public static final PicardHtsPath NA12878_MINI_GCLOUD = PicardHtsPath.resolve(GCloudTestUtils.getTestInputPath(), "picard/bam/CEUTrio.HiSeq.WGS.b37.NA12878.20.21_n100.bam");
-    public static final PicardHtsPath NA12878_MINI_CRAM_GCLOUD = PicardHtsPath.resolve(GCloudTestUtils.getTestInputPath(), "picard/bam/CEUTrio.HiSeq.WGS.b37.NA12878.20.21_n100.cram");
-    public static final PicardHtsPath NA12878_MEDIUM_GCLOUD = PicardHtsPath.resolve(GCloudTestUtils.getTestInputPath(), "picard/bam/CEUTrio.HiSeq.WGS.b37.NA12878.20.21_n10000.bam");
-    public static final PicardHtsPath NA12878_MEDIUM_CRAM_GCLOUD = PicardHtsPath.resolve(GCloudTestUtils.getTestInputPath(), "picard/bam/CEUTrio.HiSeq.WGS.b37.NA12878.20.21_n10000.cram");
+    public static final IOPath NA12878_MINI_GCLOUD = PicardHtsPath.resolve(GCloudTestUtils.getTestInputPath(), "picard/bam/CEUTrio.HiSeq.WGS.b37.NA12878.20.21_n100.bam");
+    public static final IOPath NA12878_MINI_CRAM_GCLOUD = PicardHtsPath.resolve(GCloudTestUtils.getTestInputPath(), "picard/bam/CEUTrio.HiSeq.WGS.b37.NA12878.20.21_n100.cram");
+    public static final IOPath NA12878_MEDIUM_GCLOUD = PicardHtsPath.resolve(GCloudTestUtils.getTestInputPath(), "picard/bam/CEUTrio.HiSeq.WGS.b37.NA12878.20.21_n10000.bam");
+    public static final IOPath NA12878_MEDIUM_CRAM_GCLOUD = PicardHtsPath.resolve(GCloudTestUtils.getTestInputPath(), "picard/bam/CEUTrio.HiSeq.WGS.b37.NA12878.20.21_n10000.cram");
 
     // A per-test-class directory that will be deleted after the tests are complete.
     private File tempOutputDir;

--- a/src/test/java/picard/nio/PicardBucketUtilsTest.java
+++ b/src/test/java/picard/nio/PicardBucketUtilsTest.java
@@ -1,15 +1,10 @@
 package picard.nio;
 
-import htsjdk.io.HtsPath;
 import htsjdk.io.IOPath;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import picard.util.GCloudTestUtils;
-
-import java.net.URI;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 public class PicardBucketUtilsTest {
 
@@ -38,9 +33,9 @@ public class PicardBucketUtilsTest {
     @DataProvider
     public Object[][] getVariousPathsForPrefetching(){
         return new Object[][]{
-                {new HtsPath("file:///local/file"), false},
-                {new HtsPath("gs://abucket/bucket"), true},
-                {new HtsPath("gs://abucket_with_underscores"), true},
+                {new PicardHtsPath("file:///local/file"), false},
+                {new PicardHtsPath("gs://abucket/bucket"), true},
+                {new PicardHtsPath("gs://abucket_with_underscores"), true},
         };
     }
 

--- a/src/test/java/picard/nio/PicardBucketUtilsTest.java
+++ b/src/test/java/picard/nio/PicardBucketUtilsTest.java
@@ -1,5 +1,7 @@
 package picard.nio;
 
+import htsjdk.io.HtsPath;
+import htsjdk.io.IOPath;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -23,32 +25,28 @@ public class PicardBucketUtilsTest {
 
     // Check that the extension scheme is consistent for cloud and local files
     @Test(dataProvider = "testGetTempFilePathDataProvider", groups = "cloud")
-    public void testGetTempFilePath(final String directory, final String prefix, final String extension){
-        PicardHtsPath path = PicardBucketUtils.getTempFilePath(directory, prefix, extension);
+    public void testGetTempFilePath(final IOPath directory, final String prefix, final String extension){
+        final IOPath path = PicardBucketUtils.getTempFilePath(directory, prefix, extension);
         Assert.assertTrue(path.hasExtension(extension));
         if (directory != null){
-            Assert.assertTrue(path.getURIString().startsWith(directory));
-        }
-
-        if (directory == null){
-            Assert.assertEquals(path.getScheme(), "file");
+            Assert.assertTrue(path.getURIString().startsWith(directory.getURIString()));
+        } else {
+            Assert.assertEquals(path.getScheme(), PicardBucketUtils.FILE_SCHEME);
         }
     }
 
     @DataProvider
     public Object[][] getVariousPathsForPrefetching(){
         return new Object[][]{
-                {"file:///local/file", false},
-                {"gs://abucket/bucket", true},
-                {"gs://abucket_with_underscores", true},
+                {new HtsPath("file:///local/file"), false},
+                {new HtsPath("gs://abucket/bucket"), true},
+                {new HtsPath("gs://abucket_with_underscores"), true},
         };
     }
 
     @Test(groups="bucket", dataProvider = "getVariousPathsForPrefetching")
-    public void testIsEligibleForPrefetching(String path, boolean isPrefetchable){
-        final URI uri = URI.create(path);
-        final Path uriPath = Paths.get(uri);
-        Assert.assertEquals(PicardBucketUtils.isEligibleForPrefetching(uriPath), isPrefetchable);
+    public void testIsEligibleForPrefetching(final IOPath path, boolean isPrefetchable){
+        Assert.assertEquals(PicardBucketUtils.isEligibleForPrefetching(path), isPrefetchable);
     }
 
 }

--- a/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
+++ b/src/test/java/picard/sam/CreateSequenceDictionaryTest.java
@@ -23,6 +23,7 @@
  */
 package picard.sam;
 
+import htsjdk.io.IOPath;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.variant.utils.SAMSequenceDictionaryExtractor;
@@ -289,7 +290,7 @@ public class CreateSequenceDictionaryTest extends CommandLineProgramTest {
     final PicardHtsPath HG19_MINI = PicardHtsPath.resolve(GCloudTestUtils.TEST_INPUTS_DEFAULT_GCLOUD, "picard/references/hg19mini.fasta");
     final PicardHtsPath HG19_MINI_LOCAL = new PicardHtsPath("testdata/picard/reference/hg19mini.fasta");
 
-    final PicardHtsPath CLOUD_OUTPUT_DIR = PicardHtsPath.resolve(GCloudTestUtils.TEST_STAGING_DEFAULT_GCLOUD, "picard/");
+    final PicardHtsPath CLOUD_OUTPUT_DIR = PicardHtsPath.resolve(GCloudTestUtils.TEST_STAGING_DEFAULT_GCLOUD, "picard/CreateSequenceDictionary/");
 
     @DataProvider
     public Object[][] cloudTestData() {
@@ -302,7 +303,7 @@ public class CreateSequenceDictionaryTest extends CommandLineProgramTest {
 
     @Test(groups = "cloud", dataProvider = "cloudTestData")
     public void testCloud(final PicardHtsPath inputReference) {
-        final PicardHtsPath output = PicardBucketUtils.getTempFilePath(CLOUD_OUTPUT_DIR.getURIString() + "test", ".dict");
+        final IOPath output = PicardBucketUtils.getTempFilePath(CLOUD_OUTPUT_DIR, "", ".dict");
 
         final String[] argv = {
                 "REFERENCE=" + inputReference.getURI(),
@@ -310,7 +311,7 @@ public class CreateSequenceDictionaryTest extends CommandLineProgramTest {
         };
 
         // This is the "original" dictionary that lives in gs://hellbender/test/resources/
-        final PicardHtsPath expectedOutputPath = PicardHtsPath.resolve(GCloudTestUtils.TEST_INPUTS_DEFAULT_GCLOUD, "hg19mini.dict");
+        final IOPath expectedOutputPath = PicardHtsPath.resolve(GCloudTestUtils.TEST_INPUTS_DEFAULT_GCLOUD, "hg19mini.dict");
         Assert.assertEquals(runPicardCommandLine(argv), 0);
         final SAMSequenceDictionary expectedDictionary = SAMSequenceDictionaryExtractor.extractDictionary(expectedOutputPath.toPath());
         final SAMSequenceDictionary actualDictionary = SAMSequenceDictionaryExtractor.extractDictionary(output.toPath());

--- a/src/test/java/picard/sam/RevertSamTest.java
+++ b/src/test/java/picard/sam/RevertSamTest.java
@@ -618,7 +618,7 @@ public class RevertSamTest extends CommandLineProgramTest {
                 // Output by read group using the output map, write output bams in the cloud
                 {NA12878_MEDIUM_GCLOUD, null, OUTPUT_BY_READ_GROUP, DEFAULT_CLOUD_TEST_OUTPUT_DIR, null },
                 // Output by read group using the local output map, write output bams in the cloud
-                {NA12878_MEDIUM_GCLOUD, null, OUTPUT_BY_READ_GROUP, new PicardHtsPath(REVERT_SAM_LOCAL_TEST_DATA_DIR), null }, // tsato: relative local dir...just wrap it in PicardHtsPath to see what happens
+                {NA12878_MEDIUM_GCLOUD, null, OUTPUT_BY_READ_GROUP, new PicardHtsPath(REVERT_SAM_LOCAL_TEST_DATA_DIR), null },
                 // Cram input, output a CRAM for each read group
                 {NA12878_MEDIUM_CRAM_GCLOUD, null, OUTPUT_BY_READ_GROUP, DEFAULT_CLOUD_TEST_OUTPUT_DIR, HG19_CHR2021 },
                 // Cram input in the cloud, single cloud cram output

--- a/src/test/java/picard/util/GCloudTestUtils.java
+++ b/src/test/java/picard/util/GCloudTestUtils.java
@@ -1,5 +1,6 @@
 package picard.util;
 
+import htsjdk.io.IOPath;
 import picard.nio.PicardHtsPath;
 
 public final class GCloudTestUtils {
@@ -48,8 +49,8 @@ public final class GCloudTestUtils {
      *
      * @return PICARD_TEST_STAGING env. var if defined, or {@value #TEST_STAGING_DEFAULT.getURIString()}
      */
-    public static String getTestStaging() {
-        return getSystemProperty("PICARD_TEST_STAGING", TEST_STAGING_DEFAULT_GCLOUD.getURIString());
+    public static IOPath getTestStaging() {
+        return new PicardHtsPath(getSystemProperty("PICARD_TEST_STAGING", TEST_STAGING_DEFAULT_GCLOUD.getURIString()));
     }
 
     /**
@@ -58,8 +59,8 @@ public final class GCloudTestUtils {
      *
      * @return PICARD_TEST_INPUTS env. var if defined or {@value #TEST_INPUTS_DEFAULT.getURIString()}.
      */
-    public static String getTestInputPath() {
-        return getSystemProperty("PICARD_TEST_INPUTS", TEST_INPUTS_DEFAULT_GCLOUD.getURIString());
+    public static IOPath getTestInputPath() {
+        return new PicardHtsPath(getSystemProperty("PICARD_TEST_INPUTS", TEST_INPUTS_DEFAULT_GCLOUD.getURIString()));
     }
 
 }

--- a/src/test/java/picard/util/GCloudTestUtilsUnitTest.java
+++ b/src/test/java/picard/util/GCloudTestUtilsUnitTest.java
@@ -22,7 +22,7 @@ public class GCloudTestUtilsUnitTest {
 
     @Test(groups = "bucket")
     public void testUpload() throws IOException {
-        final Path uploadDir = Files.createTempDirectory(IOUtil.getPath(GCloudTestUtils.getTestStaging()), "picardTest");
+        final Path uploadDir = Files.createTempDirectory(GCloudTestUtils.getTestStaging().toPath(), "picardTest");
         final Path txtUpload = uploadDir.resolve("tmp.txt");
         try {
             Assert.assertFalse(Files.exists(txtUpload));

--- a/src/test/java/picard/util/IntervalListToolsTest.java
+++ b/src/test/java/picard/util/IntervalListToolsTest.java
@@ -23,6 +23,7 @@
  */
 package picard.util;
 
+import htsjdk.io.IOPath;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.IntervalList;
@@ -59,8 +60,8 @@ import java.util.stream.Stream;
 
 public class IntervalListToolsTest extends CommandLineProgramTest {
     private static final String TEST_DATA_DIR = "testdata/picard/util/";
-    private static final String CLOUD_DATA_DIR = GCloudTestUtils.getTestInputPath() + "picard/intervals/";
-    private static final String CLOUD_OUTPUT_DIR = GCloudTestUtils.getTestStaging() + "picard/";
+    private static final IOPath CLOUD_DATA_DIR = PicardHtsPath.resolve(GCloudTestUtils.getTestInputPath(), "picard/intervals/");
+    private static final IOPath CLOUD_OUTPUT_DIR = PicardHtsPath.resolve(GCloudTestUtils.getTestStaging(), "picard/");
     private final Path scatterable = Paths.get(TEST_DATA_DIR, "scatterable.interval_list");
     private final PicardHtsPath scatterableCloud = new PicardHtsPath(CLOUD_DATA_DIR + "scatterable.interval_list");
     private final Path scatterableStdin = Paths.get(TEST_DATA_DIR, "scatterable_stdin");
@@ -242,9 +243,8 @@ public class IntervalListToolsTest extends CommandLineProgramTest {
 
     private IntervalList tester(final IntervalListTools.Action action, final boolean invert, final boolean unique,
                                 final boolean dontMergeAbutting, final Path input1, final Path input2, final boolean cloudOutput) {
-        final String outputDirFullName = cloudOutput ? CLOUD_OUTPUT_DIR : null;
         final String prefix = "IntervalListTools";
-        final PicardHtsPath output = PicardBucketUtils.getTempFilePath(outputDirFullName, prefix, INTERVAL_LIST_EXTENSION);
+        final IOPath output = PicardBucketUtils.getTempFilePath(cloudOutput ? CLOUD_OUTPUT_DIR : null, prefix, INTERVAL_LIST_EXTENSION);
         final List<String> args = buildStandardTesterArguments(action, invert, unique, dontMergeAbutting, input1, input2);
         args.add("OUTPUT=" + output);
         Assert.assertEquals(runPicardCommandLine(args), 0);
@@ -263,9 +263,8 @@ public class IntervalListToolsTest extends CommandLineProgramTest {
     private long testerCountOutput(IntervalListTools.Action action, IntervalListTools.Output outputValue, boolean invert,
                                    boolean unique, boolean dontMergeAbutting, Path input1, Path input2,
                                    final boolean cloudOutput) throws IOException {
-        final String outputDirFullName = cloudOutput ? CLOUD_OUTPUT_DIR : null;
         final String prefix = "IntervalListTools";
-        final PicardHtsPath countOutput = PicardBucketUtils.getTempFilePath(outputDirFullName, prefix, ".txt");
+        final IOPath countOutput = PicardBucketUtils.getTempFilePath(cloudOutput ? CLOUD_OUTPUT_DIR : null, prefix, ".txt");
 
         final List<String> args = buildStandardTesterArguments(action, invert, unique, dontMergeAbutting, input1, input2);
         args.add("OUTPUT_VALUE=" + outputValue);


### PR DESCRIPTION
### Description

As requested by @cmnbroad. The changes include: 

- Replace the String input type with IOPath type where appropriate (Rule: if a the String variable is a legal path to a file/directory, convert to PicardHTSPath as soon as possible. And the method argument for such an object should be IOPath.)  
- Remove all the legacy methods copied from GATK in PicardBucketUtils that takes String where it should take IOPath.
- Replace PicardHtsPath type with the interface IOPath where appropriate (makes clear which methods can and should be moved to htsjdk).
- Remove Hadoop support, which is a remnant of code ported from GATK.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on github actions

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

