### PR TITLE
FLOW_* parameters must be accompanied by FLOW_MODE

### DIFF
--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -27,9 +27,7 @@ package picard.sam.markduplicates;
 import htsjdk.samtools.*;
 import htsjdk.samtools.DuplicateScoringStrategy.ScoringStrategy;
 import htsjdk.samtools.util.*;
-import org.broadinstitute.barclay.argparser.Argument;
-import org.broadinstitute.barclay.argparser.ArgumentCollection;
-import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.*;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import picard.PicardException;
 import picard.cmdline.programgroups.ReadDataManipulationProgramGroup;
@@ -263,6 +261,8 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram imp
         // use flow based calculation helper?
         if ( flowBasedArguments.FLOW_MODE ) {
             calcHelper = new MarkDuplicatesForFlowHelper(this);
+        } else {
+            ensureNoFlowParametersSpecified();
         }
 
         reportMemoryStats("Start of doWork");
@@ -448,6 +448,19 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram imp
         finalizeAndWriteMetrics(libraryIdGenerator, getMetricsFile(), METRICS_FILE);
 
         return 0;
+    }
+
+    // make sure no FLOW__ parameter was set (except for FLOW_MODE)
+    private void ensureNoFlowParametersSpecified() {
+        if ( getCommandLineParser() instanceof CommandLineArgumentParser ) {
+            final CommandLineArgumentParser parser = (CommandLineArgumentParser)getCommandLineParser();
+            for (NamedArgumentDefinition def : parser.getNamedArgumentDefinitions()) {
+                final String name = def.getLongName();
+                if (name != "FLOW_MODE" && name.startsWith("FLOW_") && def.getHasBeenSet()) {
+                    throw new PicardException(name + " specified, but no FLOW_MODE");
+                }
+            }
+        }
     }
 
     /**

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelperTest.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelperTest.java
@@ -299,7 +299,16 @@ public class MarkDuplicatesForFlowHelperTest {
     }
 
     @Test(dataProvider = "forFlowDataProvider")
-    public void testForFlowMDCall(final DuplicateScoringStrategy.ScoringStrategy scoringStrategy, final TestRecordInfo[] recInfos, final String[] params, TesterModifier modifier) {
+    public void testForFlowMDCall_WithFlowMode(final DuplicateScoringStrategy.ScoringStrategy scoringStrategy, final TestRecordInfo[] recInfos, final String[] params, TesterModifier modifier) {
+        testForFlowMDCall(scoringStrategy, recInfos, params, modifier, true);
+    }
+
+    @Test(dataProvider = "forFlowDataProvider")
+    public void testForFlowMDCall_WithoutFlowMode(final DuplicateScoringStrategy.ScoringStrategy scoringStrategy, final TestRecordInfo[] recInfos, final String[] params, TesterModifier modifier) {
+        testForFlowMDCall(scoringStrategy, recInfos, params, modifier, false);
+    }
+
+    private void testForFlowMDCall(final DuplicateScoringStrategy.ScoringStrategy scoringStrategy, final TestRecordInfo[] recInfos, final String[] params, TesterModifier modifier, final boolean withFlowMode) {
 
         // get tester, build records
         final AbstractMarkDuplicatesCommandLineProgramTester tester =
@@ -328,7 +337,9 @@ public class MarkDuplicatesForFlowHelperTest {
         }
 
         // add parames, set flow order
-        tester.addArg("FLOW_MODE=true");
+        if ( withFlowMode ) {
+            tester.addArg("FLOW_MODE=true");
+        }
         for ( final String param : params ) {
             tester.addArg(param);
         }
@@ -339,8 +350,12 @@ public class MarkDuplicatesForFlowHelperTest {
             modifier.modify(tester);
         }
 
-        // run test
-        tester.runTest();
+        // run test. tests without flow mode should fail
+        if ( withFlowMode ) {
+            tester.runTest();
+        } else {
+            Assert.assertThrows(() -> tester.runTest());
+        }
     }
 
     @DataProvider(name ="getFlowSumOfBaseQualitiesDataProvider")


### PR DESCRIPTION
This is an additional PR to close issue 1959. As requested, The code base now checks for the presence of FLOW_MODE if any other FLOW_ parameter is specified. A test has also been added.