### PR TITLE
Update outdated links to HaplotypeMap file format

### DIFF
--- a/src/main/java/picard/fingerprint/CalculateFingerprintMetrics.java
+++ b/src/main/java/picard/fingerprint/CalculateFingerprintMetrics.java
@@ -99,7 +99,7 @@ public class CalculateFingerprintMetrics extends CommandLineProgram {
     public File OUTPUT;
 
     @Argument(shortName = "H", doc = "The file lists a set of SNPs, optionally arranged in high-LD blocks, to be used for fingerprinting. See " +
-            "https://software.broadinstitute.org/gatk/documentation/article?id=9526 for details.")
+            "https://gatk.broadinstitute.org/hc/en-us/articles/360035531672-Haplotype-map-format for details.")
     public File HAPLOTYPE_MAP;
 
     @Argument(doc = "Specificies which data-type should be used as the basic unit. Fingerprints from readgroups can " +

--- a/src/main/java/picard/fingerprint/CheckFingerprint.java
+++ b/src/main/java/picard/fingerprint/CheckFingerprint.java
@@ -196,7 +196,7 @@ public class CheckFingerprint extends CommandLineProgram {
     public String EXPECTED_SAMPLE_ALIAS;
 
     @Argument(shortName = "H", doc = "The file lists a set of SNPs, optionally arranged in high-LD blocks, to be used for fingerprinting. See " +
-            "https://software.broadinstitute.org/gatk/documentation/article?id=9526 for details.")
+            "https://gatk.broadinstitute.org/hc/en-us/articles/360035531672-Haplotype-map-format for details.")
     public File HAPLOTYPE_MAP;
 
     @Argument(shortName = "LOD", doc = "When counting haplotypes checked and matching, count only haplotypes " +

--- a/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
+++ b/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
@@ -353,7 +353,7 @@ public class CrosscheckFingerprints extends CommandLineProgram {
     public File MATRIX_OUTPUT = null;
 
     @Argument(shortName = "H", doc = "The file lists a set of SNPs, optionally arranged in high-LD blocks, to be used for fingerprinting. See " +
-            "https://software.broadinstitute.org/gatk/documentation/article?id=9526 for details.")
+            "https://gatk.broadinstitute.org/hc/en-us/articles/360035531672-Haplotype-map-format for details.")
     public File HAPLOTYPE_MAP;
 
     @Argument(shortName = "LOD",

--- a/src/main/java/picard/fingerprint/ExtractFingerprint.java
+++ b/src/main/java/picard/fingerprint/ExtractFingerprint.java
@@ -59,7 +59,7 @@ public class ExtractFingerprint extends CommandLineProgram {
     public File OUTPUT;
 
     @Argument(shortName = "H", doc = "A file of haplotype information. The file lists a set of SNPs, optionally arranged in high-LD blocks, to be used for fingerprinting. See " +
-            "https://software.broadinstitute.org/gatk/documentation/article?id=9526 for details.")
+            "https://gatk.broadinstitute.org/hc/en-us/articles/360035531672-Haplotype-map-format for details.")
     public File HAPLOTYPE_MAP;
 
     @Argument(shortName = "C", doc = "A value of estimated contamination in the input. A non-zero value will cause the program to provide a better estimate of the fingerprint in the presence of contaminating reads",

--- a/src/main/java/picard/fingerprint/IdentifyContaminant.java
+++ b/src/main/java/picard/fingerprint/IdentifyContaminant.java
@@ -55,7 +55,7 @@ public class IdentifyContaminant extends CommandLineProgram {
     public File OUTPUT;
 
     @Argument(shortName = "H", doc = "A file of haplotype information. The file lists a set of SNPs, optionally arranged in high-LD blocks, to be used for fingerprinting. See " +
-            "https://software.broadinstitute.org/gatk/documentation/article?id=9526 for details.")
+            "https://gatk.broadinstitute.org/hc/en-us/articles/360035531672-Haplotype-map-format for details.")
     public File HAPLOTYPE_MAP;
 
     @Argument(shortName = "C", doc = "A value of estimated contamination in the input. ", minValue = 0D, maxValue = 1D)


### PR DESCRIPTION
The link to the HaplotypeMap format was dead, now it's not.