### PR TITLE
Change test values to doubles and add epsilon in CollectHsMetricsTest

### DIFF
--- a/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
+++ b/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
@@ -250,9 +250,7 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
 
         // epsilons added due to an issue when running tests on debian,
         // https://github.com/broadinstitute/picard/issues/1987
-        // not sure if they're necessary, but they're harmless
-        Assert.assertEquals(highCoverageMetrics.MEAN_TARGET_COVERAGE, 100000.0, 1.E-4);  // epsilons added due to an isue when running tests on debian, not sure if they're absolutely necessary but they should
-        // be harmless
+        Assert.assertEquals(highCoverageMetrics.MEAN_TARGET_COVERAGE, 100000.0, 1.E-4);
         Assert.assertEquals(highCoverageMetrics.MEDIAN_TARGET_COVERAGE, 100000.0, 1.E-4);
         Assert.assertEquals(highCoverageMetrics.FOLD_80_BASE_PENALTY, 1.0, 1.E-4);
     }

--- a/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
+++ b/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
@@ -247,9 +247,14 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
 
         IOUtil.deleteDirectoryTree(dir);
         // actual coverage should not be impacted by coverage_cap
-        Assert.assertEquals(highCoverageMetrics.MEAN_TARGET_COVERAGE, 100000);
-        Assert.assertEquals(highCoverageMetrics.MEDIAN_TARGET_COVERAGE, 100000);
-        Assert.assertEquals(highCoverageMetrics.FOLD_80_BASE_PENALTY, 1);
+
+        // epsilons added due to an issue when running tests on debian,
+        // https://github.com/broadinstitute/picard/issues/1987
+        // not sure if they're necessary, but they're harmless
+        Assert.assertEquals(highCoverageMetrics.MEAN_TARGET_COVERAGE, 100000.0, 1.E-4);  // epsilons added due to an isue when running tests on debian, not sure if they're absolutely necessary but they should
+        // be harmless
+        Assert.assertEquals(highCoverageMetrics.MEDIAN_TARGET_COVERAGE, 100000.0, 1.E-4);
+        Assert.assertEquals(highCoverageMetrics.FOLD_80_BASE_PENALTY, 1.0, 1.E-4);
     }
 
 

--- a/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
+++ b/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
@@ -248,11 +248,9 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
         IOUtil.deleteDirectoryTree(dir);
         // actual coverage should not be impacted by coverage_cap
 
-        // epsilons added due to an issue when running tests on debian,
-        // https://github.com/broadinstitute/picard/issues/1987
-        Assert.assertEquals(highCoverageMetrics.MEAN_TARGET_COVERAGE, 100000.0, 1.E-4);
-        Assert.assertEquals(highCoverageMetrics.MEDIAN_TARGET_COVERAGE, 100000.0, 1.E-4);
-        Assert.assertEquals(highCoverageMetrics.FOLD_80_BASE_PENALTY, 1.0, 1.E-4);
+        Assert.assertEquals(highCoverageMetrics.MEAN_TARGET_COVERAGE, 100000.0);
+        Assert.assertEquals(highCoverageMetrics.MEDIAN_TARGET_COVERAGE, 100000.0);
+        Assert.assertEquals(highCoverageMetrics.FOLD_80_BASE_PENALTY, 1.0);
     }
 
 


### PR DESCRIPTION
* fix for https://github.com/broadinstitute/picard/issues/1987
* This should fix an issue when running tests on debian systems

@pgrt I added your patch + I changed the numbers it's comparing against to doubles.  I suspect that might  be sufficient to fix the issue but I'm not sure exactly why it's happening on your systems so I kept your epsilons too.  