### PR TITLE
fix: documentation errors in HsMetrics

### DIFF
--- a/src/main/java/picard/analysis/directed/HsMetrics.java
+++ b/src/main/java/picard/analysis/directed/HsMetrics.java
@@ -38,8 +38,8 @@ import picard.util.help.HelpConstants;
  *     <li>Metrics that are intended for evaluating the performance of the wet-lab assay that generated the data.
  *     This group includes metrics like the number of bases mapping on/off/near baits, %selected, fold 80 base
  *     penalty, hs library size and the hs penalty metrics. These metrics are calculated prior to some of the
- *     filters are applied (e.g. low mapping quality reads, low base quality bases and bases overlapping in the middle
- *     of paired-end reads are all counted).
+ *     filters are applied (e.g. duplicate reads, low mapping quality reads, low base quality bases and bases
+ *     overlapping in the middle of paired-end reads are all counted).
  *     </li>
  *     <li>Metrics for assessing target coverage as a proxy for how well the data is likely to perform in downstream
  *     applications like variant calling. This group includes metrics like mean target coverage, the percentage of bases
@@ -82,10 +82,11 @@ public class HsMetrics extends PanelMetricsBase {
     /** The mean coverage of all baits in the experiment. */
     public double MEAN_BAIT_COVERAGE;
 
-    /** The number of aligned, de-duped, on-bait bases out of the PF bases available. */
+    /** The fraction of aligned, on-bait bases out of the PF bases available.
+     * (NOTE: This uses duplicate reads for both numerator and denominator) */
     public double PCT_USABLE_BASES_ON_BAIT;
 
-    /** The number of aligned, de-duped, on-target bases out of all of the PF bases available. */
+    /** The fraction of aligned, de-duped, on-target bases out of all the PF bases available. */
     public double PCT_USABLE_BASES_ON_TARGET;
 
     /** The fold by which the baited region has been amplified above genomic background. */


### PR DESCRIPTION
closes: #1996

The documentation in HsMetrics class was inaccurate regarding the filtering of reads that go into the PCT_USABLE_BASES_ON_BAIT. It now correctly reflects the fact that the reads/bases that go into this calculation are _not_ unique, i.e. duplicate reads are counted.

### Description

_Give your PR a **concise** yet **descriptive** title_
_Please explain the changes you made here._
_Explain the **motivation** for making this change. What existing problem does the pull request solve?_
_Mention any issues fixed, addressed or otherwise related to this pull request, including issue numbers or hard links for issues in other repos._
_You can delete these instructions once you have written your PR description._

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on github actions

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

