### PR TITLE
make MergeVcfs (more) deterministic

### DIFF
--- a/src/main/java/picard/vcf/MergeVcfs.java
+++ b/src/main/java/picard/vcf/MergeVcfs.java
@@ -52,6 +52,7 @@ import picard.nio.PicardHtsPath;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.sql.Array;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -170,7 +171,7 @@ public class MergeVcfs extends CommandLineProgram {
         final List<Path> inputPaths = INPUT.stream().map(PicardHtsPath::toPath).collect(Collectors.toList());
         final List<Path> unrolledPaths = IOUtil.unrollPaths(inputPaths, FileExtensions.VCF_LIST.toArray(new String[]{}));
         final Collection<CloseableIterator<VariantContext>> iteratorCollection = new ArrayList<>(unrolledPaths.size());
-        final Collection<VCFHeader> headers = new HashSet<>(unrolledPaths.size());
+        final Collection<VCFHeader> headers = new ArrayList<>(unrolledPaths.size());
         VariantContextComparator variantContextComparator = null;
         SAMSequenceDictionary sequenceDictionary = null;
 

--- a/src/main/java/picard/vcf/MergeVcfs.java
+++ b/src/main/java/picard/vcf/MergeVcfs.java
@@ -52,10 +52,8 @@ import picard.nio.PicardHtsPath;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.sql.Array;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 


### PR DESCRIPTION
MergeVcfs currently stores input headers in a HashSet, so that the order they are passed to be merged is non-deterministic, which can lead to the resulting merged header being non-deterministic.  This PR changes that so that (hopefully) the results of MergeVcf are always the same.