### PR TITLE
AlignmentSummaryMetrics - Improve and harmonize PCT_CHIMERAS description

### DIFF
--- a/src/main/java/picard/analysis/AlignmentSummaryMetrics.java
+++ b/src/main/java/picard/analysis/AlignmentSummaryMetrics.java
@@ -201,10 +201,10 @@ public class AlignmentSummaryMetrics extends MultilevelMetrics {
     public double STRAND_BALANCE;
 
     /**
-     * The fraction of reads with a mapping quality (MAPQ) ≥ 20 that are identified as chimeric by and any of the 
+     * The fraction of read pairs with a mapping quality (MAPQ) ≥ 20 that are identified as chimeric by and any of the 
      * following criteria: (1) the insert size exceeds the maximum insert size (by default 100 kb), (2) the two 
      * ends of a read pair map to different contigs, (3) the paired-end orientation deviates from the expected 
-     * orientation, or (4) the read contains an SA (supplementary alignment) tag indicating a chimeric alignment.
+     * orientation, or (4) either read in the pair contains an SA (supplementary alignment) tag indicating a chimeric alignment.
      */
     public double PCT_CHIMERAS;
 

--- a/src/main/java/picard/analysis/AlignmentSummaryMetrics.java
+++ b/src/main/java/picard/analysis/AlignmentSummaryMetrics.java
@@ -201,8 +201,10 @@ public class AlignmentSummaryMetrics extends MultilevelMetrics {
     public double STRAND_BALANCE;
 
     /**
-     * The fraction of reads that map outside of a maximum insert size (usually 100kb) or that have
-     * the two ends mapping to different chromosomes.
+     * The fraction of reads with a mapping quality (MAPQ) ≥ 20 that are identified as chimeric by and any of the 
+     * following criteria: (1) the insert size exceeds the maximum insert size (by default 100 kb), (2) the two 
+     * ends of a read pair map to different contigs, (3) the paired-end orientation deviates from the expected 
+     * orientation, or (4) the read contains an SA (supplementary alignment) tag indicating a chimeric alignment.
      */
     public double PCT_CHIMERAS;
 

--- a/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
+++ b/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
@@ -70,12 +70,12 @@ import java.util.Set;
  * </ul>
  * Metrics are written for the first read of a pair, the second read, and combined for the pair.
  *
- * Chimeric reads are identified when the mapping quality (MAPQ) is ≥ 20 and any of the following criteria are met:
+ * Read pairs with a mapping quality (MAPQ) is ≥ 20 are classified as chimeric if any of the following criteria are met:
  * <ul>
  * <li>the insert size is larger than MAX_INSERT_SIZE</li>
  * <li>the ends of a pair map to different contigs</li>
  * <li>the paired end orientation is different that the expected orientation</li>
- * <li>the read contains an SA tag (chimeric alignment)</li>
+ * <li>either read in the pair contains an SA tag (chimeric alignment)</li>
  * </ul>
  *
  * @author Doug Voet (dvoet at broadinstitute dot org)

--- a/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
+++ b/src/main/java/picard/analysis/CollectAlignmentSummaryMetrics.java
@@ -70,7 +70,7 @@ import java.util.Set;
  * </ul>
  * Metrics are written for the first read of a pair, the second read, and combined for the pair.
  *
- * Chimeras are identified if any of the of following criteria are met:
+ * Chimeric reads are identified when the mapping quality (MAPQ) is ≥ 20 and any of the following criteria are met:
  * <ul>
  * <li>the insert size is larger than MAX_INSERT_SIZE</li>
  * <li>the ends of a pair map to different contigs</li>


### PR DESCRIPTION
### Description

fix #2009

As outlined in the above issue the docs for the PCT_CHIMERA metric could be more accurate and also harmonized as the metrics is described differently in two places. 

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [ ] All tests passing on github actions

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

