### PR TITLE
A few fixes to crosscheckfingerprints

### DIFF
--- a/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
+++ b/src/main/java/picard/fingerprint/CrosscheckFingerprints.java
@@ -900,7 +900,6 @@ public class CrosscheckFingerprints extends CommandLineProgram {
                         LOSS_OF_HET_RATE, false, CALCULATE_TUMOR_AWARE_RESULTS);
                 final FingerprintResult result = getMatchResults(expectedToMatch, results);
 
-
                 if (!OUTPUT_ERRORS_ONLY || result == FingerprintResult.INCONCLUSIVE || !result.isExpected()) {
                     metrics.add(getMatchDetails(result, results, lhsId, rhsId, type));
                 }

--- a/src/main/java/picard/fingerprint/Fingerprint.java
+++ b/src/main/java/picard/fingerprint/Fingerprint.java
@@ -136,7 +136,7 @@ public class Fingerprint extends TreeMap<HaplotypeBlock, HaplotypeProbabilities>
                             final FingerprintIdDetails finalId;
                             if (entryList.size() == 1) {
                                 finalId = entryList.get(0).getKey();
-                            } else {;;;;
+                            } else {
                                 finalId = new FingerprintIdDetails();
                                 entryList.forEach(id -> finalId.merge(id.getKey()));
                             }

--- a/src/main/java/picard/fingerprint/Fingerprint.java
+++ b/src/main/java/picard/fingerprint/Fingerprint.java
@@ -136,7 +136,7 @@ public class Fingerprint extends TreeMap<HaplotypeBlock, HaplotypeProbabilities>
                             final FingerprintIdDetails finalId;
                             if (entryList.size() == 1) {
                                 finalId = entryList.get(0).getKey();
-                            } else {
+                            } else {;;;;
                                 finalId = new FingerprintIdDetails();
                                 entryList.forEach(id -> finalId.merge(id.getKey()));
                             }

--- a/src/main/java/picard/fingerprint/FingerprintChecker.java
+++ b/src/main/java/picard/fingerprint/FingerprintChecker.java
@@ -79,7 +79,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Major class that coordinates the activities involved in comparing genetic fingerprint

--- a/src/main/java/picard/fingerprint/FingerprintChecker.java
+++ b/src/main/java/picard/fingerprint/FingerprintChecker.java
@@ -79,6 +79,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Major class that coordinates the activities involved in comparing genetic fingerprint
@@ -340,7 +341,13 @@ public class FingerprintChecker {
         return loadFingerprintsFromVariantContexts(() ->
                         snps.stream().map(snp -> {
                             try {
-                                return reader.query(snp.getChrom(), snp.getPos(), snp.getPos()).next();
+                                final List<VariantContext> ctxs = reader.query(snp.getChrom(), snp.getPos(), snp.getPos()).toList();
+                                for (final VariantContext ctx : ctxs) {
+                                    if (AlleleSubsettingUtils.subsetVCToMatchSnp(ctx, snp) != null) {
+                                        return ctx;
+                                    }
+                                }
+                                return null;
                             } catch (NoSuchElementException e) {
                                 return null;
                             }

--- a/src/test/java/picard/fingerprint/CrosscheckFingerprintsTest.java
+++ b/src/test/java/picard/fingerprint/CrosscheckFingerprintsTest.java
@@ -1088,7 +1088,15 @@ public class CrosscheckFingerprintsTest extends CommandLineProgramTest {
             second_input.forEach(f -> args.add("INPUT=" + f));
             doTest(args.toArray(new String[0]), metrics, exptectRetVal, expectedNMetrics, dataType, expectAllMatch);
         }
+
+        //add OUTPUT_ERRORS_ONLY
+        args.add("OUTPUT_ERRORS_ONLY=true");
+        final CrosscheckFingerprints crossChecker = new CrosscheckFingerprints();
+        Assert.assertEquals(crossChecker.instanceMain(args.toArray(new String[0])), exptectRetVal);
+
     }
+
+    @Test
 
     private void doTest(final String[] args, final File metrics, final int expectedRetVal, final int expectedNMetrics, final CrosscheckMetric.DataType expectedType) throws IOException {
         doTest(args, metrics, expectedRetVal, expectedNMetrics, expectedType, false);

--- a/src/test/java/picard/fingerprint/CrosscheckFingerprintsTest.java
+++ b/src/test/java/picard/fingerprint/CrosscheckFingerprintsTest.java
@@ -1096,8 +1096,6 @@ public class CrosscheckFingerprintsTest extends CommandLineProgramTest {
 
     }
 
-    @Test
-
     private void doTest(final String[] args, final File metrics, final int expectedRetVal, final int expectedNMetrics, final CrosscheckMetric.DataType expectedType) throws IOException {
         doTest(args, metrics, expectedRetVal, expectedNMetrics, expectedType, false);
     }

--- a/src/test/java/picard/fingerprint/FingerprintCheckerTest.java
+++ b/src/test/java/picard/fingerprint/FingerprintCheckerTest.java
@@ -556,4 +556,19 @@ public class FingerprintCheckerTest {
 
         VcfTestUtils.assertVcfFilesAreEqual(vcfOutput, vcfExpected);
     }
+
+    @Test void testFingerprintWithDupe() {
+        final File haplotype_db = new File(TEST_DATA_DIR, "Homo_sapiens_assembly19.haplotype_database.subset.txt");
+        final HaplotypeMap map = new HaplotypeMap(haplotype_db);
+        final File vcf = new File(TEST_DATA_DIR, "NA12891.multiple_per_site.vcf");
+        final File vcf_index = new File(TEST_DATA_DIR, "NA12891.multiple_per_site.vcf.idx");
+        final VCFFileReader vcf_reader = new VCFFileReader(vcf.toPath(), vcf_index.toPath());
+
+        final FingerprintChecker checker = new FingerprintChecker(map);
+
+        final Map<String, Fingerprint> fingerprintMap = checker.loadFingerprintsFromQueriableReader(vcf_reader, null, null);
+
+        Assert.assertEquals(fingerprintMap.get("NA12891").size(), 5);
+
+    }
 }


### PR DESCRIPTION
This PR fixes a few edges in crosscheckfingerprints

1) If a vcf includes multiple records at the same location overlapping a fingerprinting snp, will now find the unfiltered record that matches the fingerprinting snp, instead of skipping if the first record is not an unfiltered match

2) If OUTPUT_ERRORS_ONLY is true, will no longer return `EXIT_CODE_WHEN_NO_VALID_CHECKS` if all checks are as expected

2) If OUTPUT_ERRORS_ONLY is true, will no longer hit an NPE if result is INCONCLUSIVE

