### PR TITLE
Prevent MBA from re-sorting input on error if the input is a pipe

### DIFF
--- a/src/main/java/picard/sam/AbstractAlignmentMerger.java
+++ b/src/main/java/picard/sam/AbstractAlignmentMerger.java
@@ -40,6 +40,7 @@ import htsjdk.samtools.util.CigarUtil;
 import picard.PicardException;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.*;
 
 /**
@@ -106,7 +107,8 @@ public abstract class AbstractAlignmentMerger {
     private UnmappingReadStrategy unmappingReadsStrategy = UnmappingReadStrategy.DO_NOT_CHANGE;
     private boolean addPGTagToReads = true;
 
-
+    protected final boolean inputIsRegularFile;
+    
     private final SamRecordFilter alignmentFilter = new SamRecordFilter() {
         public boolean filterOut(final SAMRecord record) {
             return ignoreAlignment(record);
@@ -284,6 +286,8 @@ public abstract class AbstractAlignmentMerger {
         IOUtil.assertFileIsReadable(referenceFasta);
 
         this.unmappedBamFile = unmappedBamFile;
+        this.inputIsRegularFile = unmappedBamFile.isFile();
+        
         this.targetBamFile = targetBamFile;
         this.referenceFasta = referenceFasta;
 

--- a/src/main/java/picard/sam/SamAlignmentMerger.java
+++ b/src/main/java/picard/sam/SamAlignmentMerger.java
@@ -180,6 +180,10 @@ public class SamAlignmentMerger extends AbstractAlignmentMerger {
         try {
             super.mergeAlignment(referenceFasta);
         } catch (final IllegalStateException ise) {
+            if (!this.inputIsRegularFile) {
+                log.error("Input is not regular file, cannot sort and restart. Please queryname sort the input prior to piping it in.");
+                throw ise;
+            }
             log.warn("Exception merging bam alignment - attempting to sort aligned reads and try again: ", ise.getMessage());
             forceSort = true;
             resetRefSeqFileWalker();


### PR DESCRIPTION
MergeBamAlignment will attempt to resort the input when it encounters non-queryname-sorted input. This happens (for example) when processing SRA samples since they are usually re-named sequentially (1,2,3,4...) but samtool-sort will use "natural" sorting while htsjdk expected lexicographic sorting. both call their sort order "queryname".

In the typical use of MBA the input is _piped_ into it from the output of the aligner (e.g bwa mem) and so sorting the file means sorting the _rest_ of the file as the first reads are lost. This also means that the input doesn't have a dictionary (since it's been consumed already) and so eventually the program breaks with a "mismatching dictionary" error. 

This has been plagueing the forums without a good answer for years:
* https://www.biostars.org/p/423722/
* https://bioinformatics.stackexchange.com/questions/21457/mergebamalignment-error
* https://gatk.broadinstitute.org/hc/en-us/community/posts/8653662288283-MergeBamAlignment-error-Do-not-use-this-function-to-merge-dictionaries-with-different-sequences-in-them-Sequences-must-be-in-the-same-order-as-well

I can try to write a test for this, but wanted to see if it would be accepted first.
