### PR TITLE
Properly plumbs the CREATE_INDEX logic in FilterVcf.

### DIFF
--- a/src/main/java/picard/vcf/filter/FilterVcf.java
+++ b/src/main/java/picard/vcf/filter/FilterVcf.java
@@ -28,6 +28,7 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.util.*;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.filter.JavascriptVariantFilter;
+import htsjdk.variant.variantcontext.writer.Options;
 import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 import htsjdk.variant.vcf.*;
@@ -121,6 +122,12 @@ public class FilterVcf extends CommandLineProgram {
             // If the user is writing to a .bcf or .vcf, VariantContextBuilderWriter requires a Sequence Dictionary.  Make sure that the
             // Input VCF has one.
             final VariantContextWriterBuilder variantContextWriterBuilder = new VariantContextWriterBuilder();
+            
+            if (!CREATE_INDEX){
+                variantContextWriterBuilder.clearIndexCreator();
+                variantContextWriterBuilder.unsetOption(Options.INDEX_ON_THE_FLY);
+            }
+            
             if (isVcfOrBcf(OUTPUT)) {
                 final SAMSequenceDictionary sequenceDictionary = header.getSequenceDictionary();
                 if (sequenceDictionary == null) {

--- a/src/test/java/picard/vcf/filter/TestFilterVcf.java
+++ b/src/test/java/picard/vcf/filter/TestFilterVcf.java
@@ -36,6 +36,7 @@ import picard.vcf.VcfTestUtils;
 
 import java.io.File;
 import java.io.PrintWriter;
+import java.nio.file.Files;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -234,6 +235,36 @@ public class TestFilterVcf {
 
         filterer.doWork();
     }
+
+    @DataProvider(name = "trueFalse")
+    private Object[][] trueFalse() {
+        return new Object[][]{{true}, {false}};
+    }
+
+    /**
+     * Tests that attempting to create no index works
+     */
+    @Test(dataProvider = "trueFalse")
+    public void testFilteringWithoutIndexing(boolean createIndex) throws Exception {
+        final File out = File.createTempFile("filterVcfTest.", ".vcf");
+        out.deleteOnExit();
+        final File out_idx = new File(out.getPath() + ".idx");
+        out_idx.deleteOnExit();
+
+        final FilterVcf filterer = new FilterVcf();
+        filterer.CREATE_INDEX = createIndex;
+        filterer.INPUT = INPUT;
+        filterer.OUTPUT = out;
+        filterer.MIN_AB = 0;
+        filterer.MIN_DP = 18;
+        filterer.MIN_GQ = 0;
+        filterer.MAX_FS = Double.MAX_VALUE;
+
+        filterer.doWork();
+
+         Assert.assertEquals(out_idx.exists(), createIndex);
+    }
+
 
     /**
      * Consumes a VCF and returns a ListMap where each they keys are the IDs of filtered out sites and the values are the set of filters.


### PR DESCRIPTION
FilterVcf's CREATE_INDEX doesn't actually affect the attempt to create an index. It defaults to `true` but when set as `false` it still attempts to create an index. This means that when setting the output to `/dev/stdout` the program fails with an error:

> Exception in thread "main" htsjdk.samtools.util.RuntimeIOException: Unable to close index for java.io.BufferedOutputStream@4d0402b

This PR fixes this, and adds tests to verify that an index is indeed created according to the value of the `CREATE_INDEX` argument. I've also verifiesd that these tests fail without the other changes in the PR.


