### PR TITLE
protect collect rnaseqmetrics from pair orientation assert

### DIFF
--- a/src/main/java/picard/analysis/ChimeraUtil.java
+++ b/src/main/java/picard/analysis/ChimeraUtil.java
@@ -75,7 +75,6 @@ public class ChimeraUtil {
     }
 
     private static boolean matchesExpectedOrientations(final SAMRecord rec, final Set<PairOrientation> expectedOrientations) {
-        return rec.getReferenceName().equals(rec.getMateReferenceName()) && 
-                expectedOrientations.contains(SamPairUtil.getPairOrientation(rec)) && rec.getAttribute(SAMTag.SA.toString()) == null;
+        return expectedOrientations.contains(SamPairUtil.getPairOrientation(rec)) && rec.getAttribute(SAMTag.SA.toString()) == null;
     }
 }

--- a/src/main/java/picard/analysis/directed/InsertSizeMetricsCollector.java
+++ b/src/main/java/picard/analysis/directed/InsertSizeMetricsCollector.java
@@ -56,9 +56,7 @@ public class InsertSizeMetricsCollector extends MultiLevelCollector<InsertSizeMe
     @Override
     protected InsertSizeCollectorArgs makeArg(SAMRecord samRecord, ReferenceSequence refSeq) {
         final int insertSize = Math.abs(samRecord.getInferredInsertSize());
-        final SamPairUtil.PairOrientation orientation = 
-                samRecord.getReferenceName().equals(samRecord.getMateReferenceName()) ?
-                        SamPairUtil.getPairOrientation(samRecord) : null;
+        final SamPairUtil.PairOrientation orientation = SamPairUtil.getPairOrientation(samRecord);
 
         return new InsertSizeCollectorArgs(insertSize, orientation);
     }
@@ -77,7 +75,8 @@ public class InsertSizeMetricsCollector extends MultiLevelCollector<InsertSizeMe
                 record.getFirstOfPairFlag() ||
                 record.isSecondaryOrSupplementary() ||
                 (record.getDuplicateReadFlag() && !this.includeDuplicates) ||
-                record.getInferredInsertSize() == 0) {
+                record.getInferredInsertSize() == 0 ||
+                !record.getReferenceName().equals(record.getMateReferenceName())) {
             return;
         }
 

--- a/src/test/java/picard/analysis/CollectInsertSizeMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectInsertSizeMetricsTest.java
@@ -349,6 +349,25 @@ public class CollectInsertSizeMetricsTest extends CommandLineProgramTest {
         };
         Assert.assertEquals(runPicardCommandLine(args), 0);
         Assert.assertTrue(pdf.exists());
+    }   
+    
+    @Test
+    public void testWithChimera() throws IOException {
+        final File input = new File(TEST_DATA_DIR + "/InsertSizeMetrics","test_chimeras.sam");
+        final File outfile   = File.createTempFile("test_with_chimeras", ".insert_size_metrics");
+        final File pdf = File.createTempFile("test_with_chimeras", ".pdf");
+        pdf.deleteOnExit();
+
+        final String[] args = new String[] {
+            "INPUT="  + input.getAbsolutePath(),
+            "OUTPUT=" + outfile.getAbsolutePath(),
+            "Histogram_FILE=" + pdf.getAbsolutePath(),
+            "LEVEL=SAMPLE",
+            "LEVEL=LIBRARY",
+            "LEVEL=READ_GROUP"
+        };
+        Assert.assertEquals(runPicardCommandLine(args), 0);
+        Assert.assertTrue(pdf.exists());
     }
 
     @Test

--- a/src/test/java/picard/analysis/CollectRnaSeqMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectRnaSeqMetricsTest.java
@@ -47,6 +47,8 @@ public class CollectRnaSeqMetricsTest extends CommandLineProgramTest {
         return CollectRnaSeqMetrics.class.getSimpleName();
     }
 
+    private static final File TEST_DATA_DIR = new File("testdata/picard/sam/RnaSeqMetrics");
+
     @Test
     public void testBasic() throws Exception {
         final String sequence = "chr1";
@@ -546,6 +548,27 @@ public class CollectRnaSeqMetricsTest extends CommandLineProgramTest {
         Assert.assertEquals(metrics.MEDIAN_3PRIME_BIAS, expected_3prime);
         Assert.assertEquals(metrics.MEDIAN_5PRIME_TO_3PRIME_BIAS, expected_ratio);
     }
+
+
+    @Test
+    public void testWithChimera() throws Exception {
+        final File input = new File(TEST_DATA_DIR,"test_chimeras.sam");
+        final File outfile   = File.createTempFile("test_with_chimeras", ".rna_seq_metrics");
+        outfile.deleteOnExit();
+        final String sequence = "chr1";
+        final String ignoredSequence = "chrM";
+        
+        final String[] args = new String[] {
+                "INPUT="  + input.getAbsolutePath(),
+                "REF_FLAT=" + getRefFlatFile(sequence).getAbsolutePath(),
+                "OUTPUT=" + outfile.getAbsolutePath(),
+                "IGNORE_SEQUENCE=" + ignoredSequence,
+                "STRAND_SPECIFICITY=SECOND_READ_TRANSCRIPTION_STRAND"
+        };
+        Assert.assertEquals(runPicardCommandLine(args), 0);
+        Assert.assertTrue(outfile.exists());
+    }
+    
 
     @Test
     public void testPctRibosomalBases() throws Exception {

--- a/testdata/picard/sam/InsertSizeMetrics/test_chimeras.sam
+++ b/testdata/picard/sam/InsertSizeMetrics/test_chimeras.sam
@@ -1,0 +1,22 @@
+@HD	VN:1.0	SO:coordinate
+@SQ	SN:chr1	LN:101
+@SQ	SN:chr2	LN:101
+@SQ	SN:chr3	LN:101
+@SQ	SN:chr4	LN:101
+@SQ	SN:chr5	LN:101
+@SQ	SN:chr6	LN:101
+@SQ	SN:chr7	LN:202
+@SQ	SN:chr8	LN:202
+@RG	ID:0	SM:Hi,Momma!	LB:whatever	PU:me	PL:ILLUMINA
+SL-XAV:1:1:0:764#0/1	113	chr1	1	255	6M	chr1	10	10	TTCATG	&/,&-.	OT:Z:left pointing
+SL-XAV:1:1:0:764#0/1	177	chr1	10	255	6M	chr1	1	10	TTCATG	&/,&-.	OT:Z:normal
+SL-XAV:1:1:0:800#0/1	81	chr2	1	255	6M	chr2	10	10	TTCATG	&/,&-.	OT:Z:outtie
+SL-XAV:1:1:0:800#0/1	161	chr2	10	255	6M	chr2	1	10	TTCATG	&/,&-.	OT:Z:outtie
+SL-XAV:1:1:0:877#0/1	97	chr3	1	255	6M	chr4	10	10	TTCATG	&/,&-.	OT:Z:chimeric
+SL-XAV:1:1:0:877#0/1	145	chr4	10	255	6M	chr3	1	10	TTCATG	&/,&-.	OT:Z:chimeric
+SL-XAV:1:1:0:940#0/1	97	chr5	1	255	6M	chr5	10	10	TTCATG	&/,&-.	OT:Z:normal
+SL-XAV:1:1:0:940#0/1	145	chr5	10	255	6M	chr5	1	10	TTCATG	&/,&-.	OT:Z:normal
+SL-XAV:1:1:0:999#0/1	97	chr6	1	255	6M	chr5	10	60	TTCATG	&/,&-.	OT:Z:chimeric
+SL-XAV:1:1:0:999#0/1	145	chr6	60	255	6M	chr5	1	60	TTCATG	&/,&-.	OT:Z:chimeric
+SL-XAV:1:1:0:430#0/1	97	chr7	1	255	6M	chr5	10	10	TTCATG	&/,&-.	OT:Z:hasSa SA:Z:gotSA
+SL-XAV:1:1:0:430#0/1	145	chr7	10	255	6M	chr5	1	10	TTCATG	&/,&-.	OT:Z:normal

--- a/testdata/picard/sam/RnaSeqMetrics/test_chimeras.sam
+++ b/testdata/picard/sam/RnaSeqMetrics/test_chimeras.sam
@@ -1,0 +1,10 @@
+@HD	VN:1.0	SO:coordinate
+@SQ	SN:chr1	LN:101
+@SQ	SN:chrM	LN:101
+@RG	ID:0	SM:Hi,Momma!	LB:whatever	PU:me	PL:ILLUMINA
+SL-XAV:1:1:0:764#0/1	113	chr1	1	255	6M	chr1	10	10	TTCATG	&/,&-.
+SL-XAV:1:1:0:764#0/1	177	chr1	10	255	6M	chr1	1	10	TTCATG	&/,&-.
+SL-XAV:1:1:0:800#0/1	81	chr1	1	255	6M	chrM	10	10	TTCATG	&/,&-.
+SL-XAV:1:1:0:800#0/1	161	chrM	10	255	6M	chr1	1	10	TTCATG	&/,&-.
+SL-XAV:1:1:0:1800#0/1	81	chr1	50	255	6M	chrM	10	10	TTCATG	&/,&-.
+SL-XAV:1:1:0:1800#0/1	161	chrM	10	255	6M	chr1	50	10	TTCATG	&/,&-.


### PR DESCRIPTION
### Description

[fixes](https://github.com/broadinstitute/picard/commit/773aae04c1c75578d47463793c4cce12c989b16b) https://github.com/broadinstitute/picard/issues/2026 

Protect code from calling getPairOrientation() when references of read and mate are not equal (as that now throws an exception)

- Also added similar protection to CollectInsertSizeMetrics

- Tests added.


