### PR TITLE
Filter reads for  gc bias (mapq and interval)

### DIFF
--- a/src/main/java/picard/analysis/CollectGcBiasMetrics.java
+++ b/src/main/java/picard/analysis/CollectGcBiasMetrics.java
@@ -26,10 +26,18 @@ package picard.analysis;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.util.CollectionUtil;
 import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Interval;
+import htsjdk.samtools.util.IntervalList;
+import htsjdk.tribble.AbstractFeatureReader;
+import htsjdk.tribble.CloseableTribbleIterator;
+import htsjdk.tribble.FeatureReader;
+import htsjdk.tribble.bed.BEDCodec;
+import htsjdk.tribble.bed.BEDFeature;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
@@ -140,6 +148,13 @@ public class CollectGcBiasMetrics extends SinglePassSamProgram {
             "allows to gain two plots per level at the same time: one is the usual one and the other excludes duplicates.")
     public boolean ALSO_IGNORE_DUPLICATES = false;
 
+    @Argument(shortName = "MQ", doc = "Minimum mapping quality for a read to be included in analysis.", optional = true)
+    public Integer MINIMUM_MAPPING_QUALITY = null;
+
+    @Argument(shortName = "XL", doc = "An optional list of intervals to exclude from analysis. " +
+            "Reads that overlap these intervals will be ignored. Can be a BED file or Picard interval_list.", optional = true)
+    public File EXCLUDE_INTERVALS = null;
+
     // Calculates GcBiasMetrics for all METRIC_ACCUMULATION_LEVELs provided
     private GcBiasMetricsCollector multiCollector;
 
@@ -171,11 +186,25 @@ public class CollectGcBiasMetrics extends SinglePassSamProgram {
         IOUtil.assertFileIsWritable(SUMMARY_OUTPUT);
         IOUtil.assertFileIsReadable(REFERENCE_SEQUENCE);
 
+        // Load intervals to exclude if provided
+        IntervalList intervalsToExclude = null;
+        if (EXCLUDE_INTERVALS != null) {
+            IOUtil.assertFileIsReadable(EXCLUDE_INTERVALS);
+            // IntervalList.fromFile works for interval_list format
+            // For BED files, we need to manually load using BEDCodec with the sequence dictionary
+            if (EXCLUDE_INTERVALS.getName().endsWith(".bed")) {
+                intervalsToExclude = loadBedFile(EXCLUDE_INTERVALS, header.getSequenceDictionary());
+            } else {
+                intervalsToExclude = IntervalList.fromFile(EXCLUDE_INTERVALS);
+            }
+        }
+
         //Calculate windowsByGc for the reference sequence
         final int[] windowsByGc = GcBiasUtils.calculateRefWindowsByGc(BINS, REFERENCE_SEQUENCE, SCAN_WINDOW_SIZE);
 
         //Delegate actual collection to GcBiasMetricCollector
-        multiCollector = new GcBiasMetricsCollector(METRIC_ACCUMULATION_LEVEL, windowsByGc, header.getReadGroups(), SCAN_WINDOW_SIZE, IS_BISULFITE_SEQUENCED, ALSO_IGNORE_DUPLICATES);
+        multiCollector = new GcBiasMetricsCollector(METRIC_ACCUMULATION_LEVEL, windowsByGc, header.getReadGroups(),
+                SCAN_WINDOW_SIZE, IS_BISULFITE_SEQUENCED, ALSO_IGNORE_DUPLICATES, MINIMUM_MAPPING_QUALITY, intervalsToExclude);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -220,6 +249,39 @@ public class CollectGcBiasMetrics extends SinglePassSamProgram {
                     CHART_OUTPUT.getAbsolutePath().replaceAll("%", "%%"),
                     String.valueOf(SCAN_WINDOW_SIZE));
         }
+    }
+
+    /**
+     * Helper method to load a BED file into an IntervalList using the provided sequence dictionary.
+     */
+    private static IntervalList loadBedFile(final File bedFile, final SAMSequenceDictionary dictionary) {
+        final SAMFileHeader header = new SAMFileHeader();
+        header.setSequenceDictionary(dictionary);
+        final IntervalList intervalList = new IntervalList(header);
+
+        try (final FeatureReader<BEDFeature> bedReader = AbstractFeatureReader.getFeatureReader(
+                bedFile.getAbsolutePath(), new BEDCodec(), false);
+             final CloseableTribbleIterator<BEDFeature> iterator = bedReader.iterator()) {
+
+            while (iterator.hasNext()) {
+                final BEDFeature bedFeature = iterator.next();
+                final String contig = bedFeature.getContig();
+                final int start = bedFeature.getStart();
+                final int end = bedFeature.getEnd();
+
+                // Verify contig exists in dictionary
+                if (dictionary.getSequence(contig) == null) {
+                    throw new PicardException("Contig " + contig + " from BED file not found in sequence dictionary");
+                }
+
+                final Interval interval = new Interval(contig, start, end);
+                intervalList.add(interval);
+            }
+        } catch (final Exception e) {
+            throw new PicardException("Error reading BED file: " + bedFile, e);
+        }
+
+        return intervalList.uniqued();
     }
 }
 

--- a/src/main/java/picard/analysis/CollectGcBiasMetrics.java
+++ b/src/main/java/picard/analysis/CollectGcBiasMetrics.java
@@ -33,6 +33,7 @@ import htsjdk.samtools.util.CollectionUtil;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.IntervalList;
+import htsjdk.samtools.util.Log;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.CloseableTribbleIterator;
 import htsjdk.tribble.FeatureReader;
@@ -124,6 +125,8 @@ public class CollectGcBiasMetrics extends SinglePassSamProgram {
     /** The location of the R script to do the plotting. */
     private static final String R_SCRIPT = "picard/analysis/gcBias.R";
 
+    private static final Log log = Log.getInstance(CollectGcBiasMetrics.class);
+
     // Usage and parameters
 
     @Argument(shortName = "CHART", doc = "The PDF file to render the chart to.", optional = true)
@@ -197,6 +200,14 @@ public class CollectGcBiasMetrics extends SinglePassSamProgram {
             } else {
                 intervalsToExclude = IntervalList.fromFile(EXCLUDE_INTERVALS);
             }
+
+            // Log information about excluded regions
+            final int numExcludedRegions = intervalsToExclude.getIntervals().size();
+            final long totalBasesExcluded = intervalsToExclude.getBaseCount();
+            final NumberFormat fmt = NumberFormat.getIntegerInstance();
+            fmt.setGroupingUsed(true);
+            log.info(String.format("Loaded %s excluded regions covering %s bases",
+                fmt.format(numExcludedRegions), fmt.format(totalBasesExcluded)));
         }
 
         //Calculate windowsByGc for the reference sequence
@@ -284,5 +295,3 @@ public class CollectGcBiasMetrics extends SinglePassSamProgram {
         return intervalList.uniqued();
     }
 }
-
-

--- a/src/main/java/picard/analysis/CollectGcBiasMetrics.java
+++ b/src/main/java/picard/analysis/CollectGcBiasMetrics.java
@@ -38,7 +38,7 @@ import htsjdk.samtools.util.Log;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
-import picard.util.BedToIntervalList;
+import picard.util.IntervalFileReader;
 import picard.cmdline.programgroups.DiagnosticsAndQCProgramGroup;
 import picard.metrics.GcBiasMetrics;
 import picard.util.RExecutor;
@@ -191,7 +191,7 @@ public class CollectGcBiasMetrics extends SinglePassSamProgram {
             IOUtil.assertFileIsReadable(EXCLUDE_INTERVALS);
             // Always buffer content and detect format by examining the first line.
             // This works for both regular files and special files (pipes, FIFOs, process substitutions).
-            intervalsToExclude = BedToIntervalList.loadIntervals(EXCLUDE_INTERVALS, header.getSequenceDictionary());
+            intervalsToExclude = IntervalFileReader.loadIntervals(EXCLUDE_INTERVALS, header.getSequenceDictionary());
 
             // Log information about excluded regions
             final int numExcludedRegions = intervalsToExclude.getIntervals().size();

--- a/src/main/java/picard/analysis/CollectGcBiasMetrics.java
+++ b/src/main/java/picard/analysis/CollectGcBiasMetrics.java
@@ -26,12 +26,10 @@ package picard.analysis;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.util.CollectionUtil;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.IntervalList;
 import htsjdk.samtools.util.Log;
 
@@ -188,9 +186,7 @@ public class CollectGcBiasMetrics extends SinglePassSamProgram {
         // Load intervals to exclude if provided
         IntervalList intervalsToExclude = null;
         if (EXCLUDE_INTERVALS != null) {
-            IOUtil.assertFileIsReadable(EXCLUDE_INTERVALS);
-            // Always buffer content and detect format by examining the first line.
-            // This works for both regular files and special files (pipes, FIFOs, process substitutions).
+            IOUtil.assertFileIsReadable(EXCLUDE_INTERVALS);            // This works for both regular files and special files (pipes, FIFOs, process substitutions).
             intervalsToExclude = IntervalFileReader.loadIntervals(EXCLUDE_INTERVALS, header.getSequenceDictionary());
 
             // Log information about excluded regions

--- a/src/main/java/picard/analysis/GcBiasMetricsCollector.java
+++ b/src/main/java/picard/analysis/GcBiasMetricsCollector.java
@@ -168,12 +168,9 @@ public class GcBiasMetricsCollector extends MultiLevelCollector<GcBiasMetrics, I
                 }
 
                 // Filter reads that overlap excluded intervals
-                if (intervalsToExclude != null) {
-                    final Interval readInterval = new Interval(rec.getReferenceName(), rec.getAlignmentStart(), rec.getAlignmentEnd());
-                    if (intervalsToExclude.overlapsAny(readInterval)) {
-                        readsFilteredByIntervals++;
-                        return;
-                    }
+                if (intervalsToExclude != null && intervalsToExclude.overlapsAny(rec)) {
+                    readsFilteredByIntervals++;
+                    return;
                 }
 
                 if (referenceIndex != rec.getReferenceIndex() || gc == null) {

--- a/src/main/java/picard/util/BedToIntervalList.java
+++ b/src/main/java/picard/util/BedToIntervalList.java
@@ -2,9 +2,7 @@ package picard.util;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.IntervalList;
 import htsjdk.samtools.util.Log;
 import htsjdk.variant.utils.SAMSequenceDictionaryExtractor;
@@ -16,6 +14,8 @@ import picard.PicardException;
 import picard.cmdline.CommandLineProgram;
 import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.programgroups.IntervalsManipulationProgramGroup;
+import picard.util.IntervalFileReader.FormatDetectionResult;
+import picard.util.IntervalFileReader.IntervalFileFormat;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -131,7 +131,7 @@ public class BedToIntervalList extends CommandLineProgram {
                     : new BufferedReader(new FileReader(INPUT))) {
                 // Sniff the format before parsing; reject anything that isn't BED.
                 reader.mark(8 * 1024);
-                final FormatDetectionResult detected = detectIntervalFormat(reader);
+                final FormatDetectionResult detected = IntervalFileReader.detectIntervalFormat(reader);
                 if (detected.format() != IntervalFileFormat.BED) {
                     final String hint = detected.format() == IntervalFileFormat.INTERVAL_LIST
                             ? " Input appears to be an interval_list file; supply a BED file instead."
@@ -139,7 +139,7 @@ public class BedToIntervalList extends CommandLineProgram {
                     throw new PicardException("BedToIntervalList requires BED format input." + hint);
                 }
                 reader.reset();
-                IntervalList out = fromBed(reader, header, DROP_MISSING_CONTIGS, KEEP_LENGTH_ZERO_INTERVALS, LOG);
+                IntervalList out = IntervalFileReader.fromBed(reader, header, DROP_MISSING_CONTIGS, KEEP_LENGTH_ZERO_INTERVALS, LOG);
                 if (SORT) out = out.sorted();
                 if (UNIQUE) out = out.uniqued();
                 out.write(OUTPUT);
@@ -151,200 +151,5 @@ public class BedToIntervalList extends CommandLineProgram {
         }
 
         return 0;
-    }
-
-    // -------------------------------------------------------------------------
-    // Format-sniffing / generic interval loading
-    // -------------------------------------------------------------------------
-
-    private enum IntervalFileFormat { INTERVAL_LIST, BED, UNKNOWN }
-
-    private record FormatDetectionResult(IntervalFileFormat format, String firstLine) {}
-
-    /**
-     * Detects whether a reader contains interval_list or BED content by inspecting the first
-     * significant (non-empty, non-comment) line.  The reader's position is NOT reset after this
-     * call — callers must {@link BufferedReader#mark} and {@link BufferedReader#reset} as needed.
-     *
-     * <ul>
-     *   <li>Lines starting with {@code @} indicate interval_list (SAM-style header).</li>
-     *   <li>Lines with ≥3 tab-separated fields indicate BED.</li>
-     *   <li>Comment lines starting with {@code #} are skipped.</li>
-     * </ul>
-     */
-    private static FormatDetectionResult detectIntervalFormat(final BufferedReader reader) throws IOException {
-        String line;
-        while ((line = reader.readLine()) != null) {
-            final String trimmed = line.trim();
-            if (trimmed.isEmpty() || trimmed.startsWith("#")) {
-                continue;
-            }
-            if (trimmed.startsWith("@")) {
-                return new FormatDetectionResult(IntervalFileFormat.INTERVAL_LIST, null);
-            } else if (trimmed.split("\t").length >= 3) {
-                return new FormatDetectionResult(IntervalFileFormat.BED, null);
-            } else {
-                return new FormatDetectionResult(IntervalFileFormat.UNKNOWN, trimmed);
-            }
-        }
-        return new FormatDetectionResult(IntervalFileFormat.UNKNOWN, null);
-    }
-
-    /**
-     * Loads an {@link IntervalList} from {@code reader}, auto-detecting whether the content is
-     * BED or interval_list format.  The reader must support {@link BufferedReader#mark} /
-     * {@link BufferedReader#reset} (a plain {@link BufferedReader} always does — this works for
-     * regular files, pipes, FIFOs, and process-substitution streams alike).
-     *
-     * <p>Returns a sorted, uniqued {@link IntervalList}.
-     *
-     * @param reader     source; must support mark/reset
-     * @param dictionary sequence dictionary used when parsing BED-format content
-     * @throws IOException  on read error
-     * @throws PicardException on unrecognized format
-     */
-    public static IntervalList loadIntervals(final BufferedReader reader,
-                                             final SAMSequenceDictionary dictionary) throws IOException {
-        // 8 KB is enough to cover any realistic BED/interval_list preamble.
-        // BufferedReader.mark() is backed by an in-memory char array, so this also works
-        // correctly for non-seekable sources such as pipes and FIFOs.
-        reader.mark(8 * 1024);
-        final FormatDetectionResult detected = detectIntervalFormat(reader);
-        reader.reset();
-        return switch (detected.format()) {
-            case INTERVAL_LIST -> IntervalList.fromReader(reader).uniqued();
-            case BED -> {
-                final SAMFileHeader header = new SAMFileHeader();
-                header.setSequenceDictionary(dictionary);
-                yield fromBed(reader, header, false, false, null).uniqued();
-            }
-            case UNKNOWN -> throw new PicardException(
-                    "Unrecognized interval file format. Expected interval_list (lines starting with @) " +
-                    "or BED (≥3 tab-separated fields). First data line: " + detected.firstLine());
-        };
-    }
-
-    /**
-     * Convenience overload of {@link #loadIntervals(BufferedReader, SAMSequenceDictionary)} that
-     * opens {@code file} itself.  {@link IOException} is wrapped in a {@link PicardException}.
-     *
-     * @param file       BED or interval_list file to read
-     * @param dictionary sequence dictionary used when parsing BED-format content
-     */
-    public static IntervalList loadIntervals(final File file, final SAMSequenceDictionary dictionary) {
-        try (final BufferedReader reader = new BufferedReader(new FileReader(file))) {
-            return loadIntervals(reader, dictionary);
-        } catch (final IOException e) {
-            throw new PicardException("Error reading intervals from " + file, e);
-        }
-    }
-
-    // -------------------------------------------------------------------------
-    // BED-only parsing
-    // -------------------------------------------------------------------------
-
-    /**
-     * Parses BED records from a {@link BufferedReader} into an {@link IntervalList}.
-     * Comment lines starting with {@code #} are skipped.
-     * Coordinates are converted from 0-based half-open BED to 1-based closed intervals.
-     * <p>
-     * This method works with any reader, including streams backed by pipes or FIFOs.
-     *
-     * @param reader                  source of BED records
-     * @param header                  SAMFileHeader whose sequence dictionary is used for validation
-     * @param dropMissingContigs      if true, records on contigs absent from the dictionary are silently
-     *                                dropped; if false, such records throw a {@link PicardException}
-     * @param keepLengthZeroIntervals if true, length-zero BED intervals (chromStart == chromEnd) are
-     *                                included; if false, they are silently dropped
-     * @param log                     used for informational and warning messages; may be {@code null}
-     *                                to suppress all logging
-     * @return an unsorted, non-uniqued {@link IntervalList}
-     * @throws IOException on read error
-     */
-    public static IntervalList fromBed(final BufferedReader reader,
-                                       final SAMFileHeader header,
-                                       final boolean dropMissingContigs,
-                                       final boolean keepLengthZeroIntervals,
-                                       final Log log) throws IOException {
-        final IntervalList intervalList = new IntervalList(header);
-        int missingIntervals = 0;
-        int missingRegion = 0;
-        int lengthZeroIntervals = 0;
-
-        String line;
-        while ((line = reader.readLine()) != null) {
-            final String trimmed = line.trim();
-            if (trimmed.isEmpty() || trimmed.startsWith("#")) {
-                continue;
-            }
-
-            final String[] fields = trimmed.split("\t");
-            if (fields.length < 3) {
-                throw new PicardException("Invalid BED line (fewer than 3 tab-separated fields): " + line);
-            }
-
-            final String sequenceName = fields[0];
-            final int start = Integer.parseInt(fields[1]) + 1; // BED start is 0-based; convert to 1-based
-            final int end   = Integer.parseInt(fields[2]);     // BED end is 0-based exclusive == 1-based inclusive
-            // NB: do not use an empty name within an interval
-            final String name = (fields.length > 3 && !fields[3].isEmpty()) ? fields[3] : null;
-            final boolean isNegativeStrand = fields.length > 5 && "-".equals(fields[5]);
-
-            final SAMSequenceRecord sequenceRecord = header.getSequenceDictionary().getSequence(sequenceName);
-
-            if (null == sequenceRecord) {
-                if (dropMissingContigs) {
-                    if (log != null) log.info(String.format("Dropping interval with missing contig: %s:%d-%d", sequenceName, start, end));
-                    missingIntervals++;
-                    missingRegion += end - start + 1;
-                    continue;
-                }
-                throw new PicardException(String.format("Sequence '%s' was not found in the sequence dictionary", sequenceName));
-            } else if (start < 1) {
-                throw new PicardException(String.format("Start on sequence '%s' was less than one: %d", sequenceName, start));
-            } else if (sequenceRecord.getSequenceLength() < start) {
-                throw new PicardException(String.format("Start on sequence '%s' was past the end: %d < %d", sequenceName, sequenceRecord.getSequenceLength(), start));
-            } else if ((end == 0 && start != 1) || end < 0) {
-                throw new PicardException(String.format("End on sequence '%s' was less than one: %d", sequenceName, end));
-            } else if (sequenceRecord.getSequenceLength() < end) {
-                throw new PicardException(String.format("End on sequence '%s' was past the end: %d < %d", sequenceName, sequenceRecord.getSequenceLength(), end));
-            } else if (end < start - 1) {
-                throw new PicardException(String.format("On sequence '%s', end < start-1: %d <= %d", sequenceName, end, start));
-            }
-
-            if ((start == end + 1) && !keepLengthZeroIntervals) {
-                if (log != null) log.info(String.format("Skipping writing length zero interval at %s:%d-%d.", sequenceName, start, end));
-                lengthZeroIntervals++;
-                continue;
-            }
-            if (start == end + 1) {
-                lengthZeroIntervals++;
-            }
-
-            intervalList.add(new Interval(sequenceName, start, end, isNegativeStrand, name));
-        }
-
-        if (log != null) {
-            if (dropMissingContigs) {
-                if (missingRegion == 0) {
-                    log.info("There were no missing regions.");
-                } else {
-                    log.warn(String.format("There were %d missing regions with a total of %d bases", missingIntervals, missingRegion));
-                }
-            }
-            if (!keepLengthZeroIntervals) {
-                if (lengthZeroIntervals == 0) {
-                    log.info("No input regions had length zero, so none were skipped.");
-                } else {
-                    log.info(String.format("Skipped writing a total of %d entries with length zero in the input file.", lengthZeroIntervals));
-                }
-            } else {
-                if (lengthZeroIntervals > 0) {
-                    log.warn(String.format("Input file had %d entries with length zero. Run with the KEEP_LENGTH_ZERO_INTERVALS flag set to false to remove these.", lengthZeroIntervals));
-                }
-            }
-        }
-
-        return intervalList;
     }
 }

--- a/src/main/java/picard/util/BedToIntervalList.java
+++ b/src/main/java/picard/util/BedToIntervalList.java
@@ -21,7 +21,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 
 /**
  * @author nhomer
@@ -123,13 +124,20 @@ public class BedToIntervalList extends CommandLineProgram {
             header.setSequenceDictionary(samSequenceDictionary);
             header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
 
-            // For /dev/stdin specifically, wrap System.in so that tests can inject data
-            // via System.setIn().  All other non-regular paths (named pipes, /dev/fd/N,
-            // process substitutions) are opened by path through FileReader as normal.
-            try (final BufferedReader reader = INPUT.getPath().equals("/dev/stdin")
-                    ? new BufferedReader(new InputStreamReader(System.in))
-                    : new BufferedReader(new FileReader(INPUT))) {
-                // Sniff the format before parsing; reject anything that isn't BED.
+            // AbstractFeatureReader requires a real file path, so buffer /dev/stdin to a temp file.
+            final File bedFile;
+            File tempFile = null;
+            if (INPUT.getPath().equals("/dev/stdin")) {
+                tempFile = File.createTempFile("bed_to_interval_list_stdin_", ".bed");
+                tempFile.deleteOnExit();
+                Files.copy(System.in, tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                bedFile = tempFile;
+            } else {
+                bedFile = INPUT;
+            }
+
+            // Sniff the format before parsing; reject anything that isn't BED.
+            try (final BufferedReader reader = new BufferedReader(new FileReader(bedFile))) {
                 reader.mark(8 * 1024);
                 final FormatDetectionResult detected = IntervalFileReader.detectIntervalFormat(reader);
                 if (detected.format() != IntervalFileFormat.BED) {
@@ -138,14 +146,14 @@ public class BedToIntervalList extends CommandLineProgram {
                             : (detected.firstLine() != null ? " First data line: " + detected.firstLine() : " File appears to be empty or contain only headers.");
                     throw new PicardException("BedToIntervalList requires BED format input." + hint);
                 }
-                reader.reset();
-                IntervalList out = IntervalFileReader.fromBed(reader, header, DROP_MISSING_CONTIGS, KEEP_LENGTH_ZERO_INTERVALS, LOG);
-                if (SORT) out = out.sorted();
-                if (UNIQUE) out = out.uniqued();
-                out.write(OUTPUT);
-                LOG.info(String.format("Wrote %d intervals spanning a total of %d bases",
-                        out.getIntervals().size(), out.getBaseCount()));
             }
+
+            IntervalList out = IntervalFileReader.fromBed(bedFile, header, DROP_MISSING_CONTIGS, KEEP_LENGTH_ZERO_INTERVALS, LOG);
+            if (SORT) out = out.sorted();
+            if (UNIQUE) out = out.uniqued();
+            out.write(OUTPUT);
+            LOG.info(String.format("Wrote %d intervals spanning a total of %d bases",
+                    out.getIntervals().size(), out.getBaseCount()));
         } catch (final IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/picard/util/BedToIntervalList.java
+++ b/src/main/java/picard/util/BedToIntervalList.java
@@ -148,7 +148,7 @@ public class BedToIntervalList extends CommandLineProgram {
                 }
             }
 
-            IntervalList out = IntervalFileReader.fromBed(bedFile, header, DROP_MISSING_CONTIGS, KEEP_LENGTH_ZERO_INTERVALS, LOG);
+            IntervalList out = IntervalFileReader.fromBed(bedFile, header, DROP_MISSING_CONTIGS, KEEP_LENGTH_ZERO_INTERVALS);
             if (SORT) out = out.sorted();
             if (UNIQUE) out = out.uniqued();
             out.write(OUTPUT);

--- a/src/main/java/picard/util/BedToIntervalList.java
+++ b/src/main/java/picard/util/BedToIntervalList.java
@@ -10,19 +10,11 @@ import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.argparser.Hidden;
 import org.broadinstitute.barclay.help.DocumentedFeature;
-import picard.PicardException;
 import picard.cmdline.CommandLineProgram;
 import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.programgroups.IntervalsManipulationProgramGroup;
-import picard.util.IntervalFileReader.FormatDetectionResult;
-import picard.util.IntervalFileReader.IntervalFileFormat;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 
 /**
  * @author nhomer
@@ -110,7 +102,7 @@ public class BedToIntervalList extends CommandLineProgram {
 
     @Override
     protected int doWork() {
-        // Only assert readability for regular files; FIFOs, named pipes, /dev/stdin,
+        // Only assert readability for regular files; /dev/stdin, FIFOs, named pipes,
         // and process-substitution paths (/dev/fd/N) all return false from isFile().
         if (INPUT.isFile()) {
             IOUtil.assertFileIsReadable(INPUT);
@@ -118,45 +110,17 @@ public class BedToIntervalList extends CommandLineProgram {
         IOUtil.assertFileIsReadable(SEQUENCE_DICTIONARY);
         IOUtil.assertFileIsWritable(OUTPUT);
 
-        try {
-            final SAMFileHeader header = new SAMFileHeader();
-            final SAMSequenceDictionary samSequenceDictionary = SAMSequenceDictionaryExtractor.extractDictionary(SEQUENCE_DICTIONARY.toPath());
-            header.setSequenceDictionary(samSequenceDictionary);
-            header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+        final SAMFileHeader header = new SAMFileHeader();
+        final SAMSequenceDictionary samSequenceDictionary = SAMSequenceDictionaryExtractor.extractDictionary(SEQUENCE_DICTIONARY.toPath());
+        header.setSequenceDictionary(samSequenceDictionary);
+        header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
 
-            // AbstractFeatureReader requires a real file path, so buffer /dev/stdin to a temp file.
-            final File bedFile;
-            File tempFile = null;
-            if (INPUT.getPath().equals("/dev/stdin")) {
-                tempFile = File.createTempFile("bed_to_interval_list_stdin_", ".bed");
-                tempFile.deleteOnExit();
-                Files.copy(System.in, tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-                bedFile = tempFile;
-            } else {
-                bedFile = INPUT;
-            }
-
-            // Sniff the format before parsing; reject anything that isn't BED.
-            try (final BufferedReader reader = new BufferedReader(new FileReader(bedFile))) {
-                reader.mark(8 * 1024);
-                final FormatDetectionResult detected = IntervalFileReader.detectIntervalFormat(reader);
-                if (detected.format() != IntervalFileFormat.BED) {
-                    final String hint = detected.format() == IntervalFileFormat.INTERVAL_LIST
-                            ? " Input appears to be an interval_list file; supply a BED file instead."
-                            : (detected.firstLine() != null ? " First data line: " + detected.firstLine() : " File appears to be empty or contain only headers.");
-                    throw new PicardException("BedToIntervalList requires BED format input." + hint);
-                }
-            }
-
-            IntervalList out = IntervalFileReader.fromBed(bedFile, header, DROP_MISSING_CONTIGS, KEEP_LENGTH_ZERO_INTERVALS);
-            if (SORT) out = out.sorted();
-            if (UNIQUE) out = out.uniqued();
-            out.write(OUTPUT);
-            LOG.info(String.format("Wrote %d intervals spanning a total of %d bases",
-                    out.getIntervals().size(), out.getBaseCount()));
-        } catch (final IOException e) {
-            throw new RuntimeException(e);
-        }
+        IntervalList out = IntervalFileReader.fromBed(INPUT, header, DROP_MISSING_CONTIGS, KEEP_LENGTH_ZERO_INTERVALS);
+        if (SORT) out = out.sorted();
+        if (UNIQUE) out = out.uniqued();
+        out.write(OUTPUT);
+        LOG.info(String.format("Wrote %d intervals spanning a total of %d bases",
+                out.getIntervals().size(), out.getBaseCount()));
 
         return 0;
     }

--- a/src/main/java/picard/util/IntervalFileReader.java
+++ b/src/main/java/picard/util/IntervalFileReader.java
@@ -1,0 +1,218 @@
+package picard.util;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.util.Interval;
+import htsjdk.samtools.util.IntervalList;
+import htsjdk.samtools.util.Log;
+import picard.PicardException;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+
+/**
+ * Utility class for reading interval files in BED or Picard interval_list format.
+ *
+ * <p>This class provides format-detection, generic loading (auto-detecting BED vs interval_list),
+ * and a dedicated BED parser.  It is designed to be used by any Picard tool that needs to
+ * accept interval files — callers get transparent support for both formats without duplicating
+ * parsing logic.
+ *
+ * <p>BED coordinate conventions: BED uses 0-based half-open coordinates.  This parser converts
+ * them to the 1-based closed intervals used throughout Picard / htsjdk.
+ */
+public final class IntervalFileReader {
+
+    /** Recognized interval file formats. */
+    public enum IntervalFileFormat { INTERVAL_LIST, BED, UNKNOWN }
+
+    /** Result of format detection: the detected format and, when format is UNKNOWN, the first data line. */
+    public record FormatDetectionResult(IntervalFileFormat format, String firstLine) {}
+
+    private IntervalFileReader() {} // utility class — no instances
+
+    /**
+     * Detects whether a reader contains interval_list or BED content by inspecting the first
+     * significant (non-empty, non-comment) line.  The reader's position is NOT reset after this
+     * call — callers must {@link BufferedReader#mark} and {@link BufferedReader#reset} as needed.
+     *
+     * <ul>
+     *   <li>Lines starting with {@code @} indicate interval_list (SAM-style header).</li>
+     *   <li>Lines with ≥3 tab-separated fields indicate BED.</li>
+     *   <li>Comment lines starting with {@code #} are skipped.</li>
+     * </ul>
+     */
+    public static FormatDetectionResult detectIntervalFormat(final BufferedReader reader) throws IOException {
+        String line;
+        while ((line = reader.readLine()) != null) {
+            final String trimmed = line.trim();
+            if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                continue;
+            }
+            if (trimmed.startsWith("@")) {
+                return new FormatDetectionResult(IntervalFileFormat.INTERVAL_LIST, null);
+            } else if (trimmed.split("\t").length >= 3) {
+                return new FormatDetectionResult(IntervalFileFormat.BED, null);
+            } else {
+                return new FormatDetectionResult(IntervalFileFormat.UNKNOWN, trimmed);
+            }
+        }
+        return new FormatDetectionResult(IntervalFileFormat.UNKNOWN, null);
+    }
+
+    /**
+     * Loads an {@link IntervalList} from {@code reader}, auto-detecting whether the content is
+     * BED or interval_list format.  The reader must support {@link BufferedReader#mark} /
+     * {@link BufferedReader#reset} (a plain {@link BufferedReader} always does — this works for
+     * regular files, pipes, FIFOs, and process-substitution streams alike).
+     *
+     * <p>Returns a sorted, uniqued {@link IntervalList}.
+     *
+     * @param reader     source; must support mark/reset
+     * @param dictionary sequence dictionary used when parsing BED-format content
+     * @throws IOException     on read error
+     * @throws PicardException on unrecognized format
+     */
+    public static IntervalList loadIntervals(final BufferedReader reader,
+                                             final SAMSequenceDictionary dictionary) throws IOException {
+        // 8 KB is enough to cover any realistic BED/interval_list preamble.
+        // BufferedReader.mark() is backed by an in-memory char array, so this also works
+        // correctly for non-seekable sources such as pipes and FIFOs.
+        reader.mark(8 * 1024);
+        final FormatDetectionResult detected = detectIntervalFormat(reader);
+        reader.reset();
+        return switch (detected.format()) {
+            case INTERVAL_LIST -> IntervalList.fromReader(reader).uniqued();
+            case BED -> {
+                final SAMFileHeader header = new SAMFileHeader();
+                header.setSequenceDictionary(dictionary);
+                yield fromBed(reader, header, false, false, null).uniqued();
+            }
+            case UNKNOWN -> throw new PicardException(
+                    "Unrecognized interval file format. Expected interval_list (lines starting with @) " +
+                    "or BED (≥3 tab-separated fields). First data line: " + detected.firstLine());
+        };
+    }
+
+    /**
+     * Convenience overload of {@link #loadIntervals(BufferedReader, SAMSequenceDictionary)} that
+     * opens {@code file} itself.  {@link IOException} is wrapped in a {@link PicardException}.
+     *
+     * @param file       BED or interval_list file to read
+     * @param dictionary sequence dictionary used when parsing BED-format content
+     */
+    public static IntervalList loadIntervals(final File file, final SAMSequenceDictionary dictionary) {
+        try (final BufferedReader reader = new BufferedReader(new FileReader(file))) {
+            return loadIntervals(reader, dictionary);
+        } catch (final IOException e) {
+            throw new PicardException("Error reading intervals from " + file, e);
+        }
+    }
+
+    /**
+     * Parses BED records from a {@link BufferedReader} into an {@link IntervalList}.
+     * Comment lines starting with {@code #} are skipped.
+     * Coordinates are converted from 0-based half-open BED to 1-based closed intervals.
+     * <p>
+     * This method works with any reader, including streams backed by pipes or FIFOs.
+     *
+     * @param reader                  source of BED records
+     * @param header                  SAMFileHeader whose sequence dictionary is used for validation
+     * @param dropMissingContigs      if true, records on contigs absent from the dictionary are silently
+     *                                dropped; if false, such records throw a {@link PicardException}
+     * @param keepLengthZeroIntervals if true, length-zero BED intervals (chromStart == chromEnd) are
+     *                                included; if false, they are silently dropped
+     * @param log                     used for informational and warning messages; may be {@code null}
+     *                                to suppress all logging
+     * @return an unsorted, non-uniqued {@link IntervalList}
+     * @throws IOException on read error
+     */
+    public static IntervalList fromBed(final BufferedReader reader,
+                                       final SAMFileHeader header,
+                                       final boolean dropMissingContigs,
+                                       final boolean keepLengthZeroIntervals,
+                                       final Log log) throws IOException {
+        final IntervalList intervalList = new IntervalList(header);
+        int missingIntervals = 0;
+        int missingRegion = 0;
+        int lengthZeroIntervals = 0;
+
+        String line;
+        while ((line = reader.readLine()) != null) {
+            final String trimmed = line.trim();
+            if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                continue;
+            }
+
+            final String[] fields = trimmed.split("\t");
+            if (fields.length < 3) {
+                throw new PicardException("Invalid BED line (fewer than 3 tab-separated fields): " + line);
+            }
+
+            final String sequenceName = fields[0];
+            final int start = Integer.parseInt(fields[1]) + 1; // BED start is 0-based; convert to 1-based
+            final int end   = Integer.parseInt(fields[2]);     // BED end is 0-based exclusive == 1-based inclusive
+            final String name = (fields.length > 3 && !fields[3].isEmpty()) ? fields[3] : null;
+            final boolean isNegativeStrand = fields.length > 5 && "-".equals(fields[5]);
+
+            final SAMSequenceRecord sequenceRecord = header.getSequenceDictionary().getSequence(sequenceName);
+
+            if (null == sequenceRecord) {
+                if (dropMissingContigs) {
+                    if (log != null) log.info(String.format("Dropping interval with missing contig: %s:%d-%d", sequenceName, start, end));
+                    missingIntervals++;
+                    missingRegion += end - start + 1;
+                    continue;
+                }
+                throw new PicardException(String.format("Sequence '%s' was not found in the sequence dictionary", sequenceName));
+            } else if (start < 1) {
+                throw new PicardException(String.format("Start on sequence '%s' was less than one: %d", sequenceName, start));
+            } else if (sequenceRecord.getSequenceLength() < start) {
+                throw new PicardException(String.format("Start on sequence '%s' was past the end: %d < %d", sequenceName, sequenceRecord.getSequenceLength(), start));
+            } else if ((end == 0 && start != 1) || end < 0) {
+                throw new PicardException(String.format("End on sequence '%s' was less than one: %d", sequenceName, end));
+            } else if (sequenceRecord.getSequenceLength() < end) {
+                throw new PicardException(String.format("End on sequence '%s' was past the end: %d < %d", sequenceName, sequenceRecord.getSequenceLength(), end));
+            } else if (end < start - 1) {
+                throw new PicardException(String.format("On sequence '%s', end < start-1: %d <= %d", sequenceName, end, start));
+            }
+
+            if ((start == end + 1) && !keepLengthZeroIntervals) {
+                if (log != null) log.info(String.format("Skipping writing length zero interval at %s:%d-%d.", sequenceName, start, end));
+                lengthZeroIntervals++;
+                continue;
+            }
+            if (start == end + 1) {
+                lengthZeroIntervals++;
+            }
+
+            intervalList.add(new Interval(sequenceName, start, end, isNegativeStrand, name));
+        }
+
+        if (log != null) {
+            if (dropMissingContigs) {
+                if (missingRegion == 0) {
+                    log.info("There were no missing regions.");
+                } else {
+                    log.warn(String.format("There were %d missing regions with a total of %d bases", missingIntervals, missingRegion));
+                }
+            }
+            if (!keepLengthZeroIntervals) {
+                if (lengthZeroIntervals == 0) {
+                    log.info("No input regions had length zero, so none were skipped.");
+                } else {
+                    log.info(String.format("Skipped writing a total of %d entries with length zero in the input file.", lengthZeroIntervals));
+                }
+            } else {
+                if (lengthZeroIntervals > 0) {
+                    log.warn(String.format("Input file had %d entries with length zero. Run with the KEEP_LENGTH_ZERO_INTERVALS flag set to false to remove these.", lengthZeroIntervals));
+                }
+            }
+        }
+
+        return intervalList;
+    }
+}

--- a/src/main/java/picard/util/IntervalFileReader.java
+++ b/src/main/java/picard/util/IntervalFileReader.java
@@ -3,13 +3,10 @@ package picard.util;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
-import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.IntervalList;
 import htsjdk.samtools.util.Log;
-import htsjdk.tribble.AbstractFeatureReader;
-import htsjdk.tribble.CloseableTribbleIterator;
-import htsjdk.tribble.FeatureReader;
 import htsjdk.tribble.annotation.Strand;
 import htsjdk.tribble.bed.BEDCodec;
 import htsjdk.tribble.bed.BEDFeature;
@@ -17,17 +14,20 @@ import picard.PicardException;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 
 /**
  * Utility class for reading interval files in BED or Picard interval_list format.
  *
- * <p>This class provides format-detection and generic loading (auto-detecting BED vs interval_list).
- * BED parsing delegates to htsjdk's {@link BEDCodec} / {@link AbstractFeatureReader} (Tribble),
- * preserving the same robust behavior used by {@link BedToIntervalList}.
+ * <p>BED parsing delegates to htsjdk's {@link BEDCodec}, decoding each line individually
+ * over a {@link BufferedReader}. Driving the codec ourselves (instead of going through
+ * {@link htsjdk.tribble.AbstractFeatureReader}, which is path-based) lets us read directly
+ * from {@code /dev/stdin} and other streams without staging through a temp file. {@link BEDCodec}
+ * still does the actual parsing, so {@code track}/{@code browser}/{@code #} header lines and
+ * other quirks are handled exactly as the rest of htsjdk handles them.
  *
- * <p>BED coordinate conventions: BED uses 0-based half-open coordinates.  {@link BEDCodec}
+ * <p>BED coordinate conventions: BED uses 0-based half-open coordinates. {@link BEDCodec}
  * converts them to the 1-based closed intervals used throughout Picard / htsjdk.
  */
 public final class IntervalFileReader {
@@ -41,6 +41,19 @@ public final class IntervalFileReader {
     private static final Log log = Log.getInstance(IntervalFileReader.class);
 
     private IntervalFileReader() {} // utility class — no instances
+
+    /**
+     * Opens a {@link BufferedReader} for {@code file}. Recognizes {@code /dev/stdin} as a
+     * request to read from {@link System#in} (this respects {@link System#setIn} for tests
+     * and avoids re-opening stdin as a file). Other paths go through
+     * {@link IOUtil#openFileForBufferedReading(File)} so gzipped inputs are handled transparently.
+     */
+    private static BufferedReader openBuffered(final File file) {
+        if ("/dev/stdin".equals(file.getPath())) {
+            return new BufferedReader(new InputStreamReader(System.in));
+        }
+        return IOUtil.openFileForBufferedReading(file);
+    }
 
     /**
      * Detects whether a reader contains interval_list or BED content by inspecting the first
@@ -73,40 +86,35 @@ public final class IntervalFileReader {
 
     /**
      * Loads an {@link IntervalList} from {@code file}, auto-detecting whether the content is
-     * BED or interval_list format.
+     * BED or interval_list format.  Returns a uniqued {@link IntervalList}.
      *
-     * <p>Returns a sorted, uniqued {@link IntervalList}.
+     * <p>The file is opened once and sniffed via {@link BufferedReader#mark}/{@link BufferedReader#reset},
+     * so {@code /dev/stdin} works without temp-file staging.
      *
      * @param file       BED or interval_list file to read
      * @param dictionary sequence dictionary used when parsing BED-format content
      * @throws PicardException on read error or unrecognized format
      */
     public static IntervalList loadIntervals(final File file, final SAMSequenceDictionary dictionary) {
-        final FormatDetectionResult detected;
-        try (final BufferedReader reader = new BufferedReader(new FileReader(file))) {
+        try (final BufferedReader reader = openBuffered(file)) {
+            // Sniffing only needs to peek as far as the first significant line; 8 KB is plenty.
             reader.mark(8 * 1024);
-            detected = detectIntervalFormat(reader);
-        } catch (final IOException e) {
-            throw new PicardException("Error detecting format of " + file, e);
-        }
-
-        return switch (detected.format()) {
-            case INTERVAL_LIST -> {
-                try (final BufferedReader reader = new BufferedReader(new FileReader(file))) {
-                    yield IntervalList.fromReader(reader).uniqued();
-                } catch (final IOException e) {
-                    throw new PicardException("Error reading interval_list from " + file, e);
+            final FormatDetectionResult detected = detectIntervalFormat(reader);
+            reader.reset();
+            return switch (detected.format()) {
+                case INTERVAL_LIST -> IntervalList.fromReader(reader).uniqued();
+                case BED -> {
+                    final SAMFileHeader header = new SAMFileHeader();
+                    header.setSequenceDictionary(dictionary);
+                    yield fromBed(reader, header, false, false).uniqued();
                 }
-            }
-            case BED -> {
-                final SAMFileHeader header = new SAMFileHeader();
-                header.setSequenceDictionary(dictionary);
-                yield fromBed(file, header).uniqued();
-            }
-            case UNKNOWN -> throw new PicardException(
-                    "Unrecognized interval file format. Expected interval_list (lines starting with @) " +
-                    "or BED (≥3 tab-separated fields). First data line: " + detected.firstLine());
-        };
+                case UNKNOWN -> throw new PicardException(
+                        "Unrecognized interval file format. Expected interval_list (lines starting with @) " +
+                        "or BED (≥3 tab-separated fields). First data line: " + detected.firstLine());
+            };
+        } catch (final IOException e) {
+            throw new PicardException("Error reading intervals from " + file, e);
+        }
     }
 
     /** Calls {@link #fromBed(File, SAMFileHeader, boolean, boolean)} with both flags false. */
@@ -115,13 +123,30 @@ public final class IntervalFileReader {
     }
 
     /**
-     * Parses BED records from {@code file} into an {@link IntervalList}.
+     * Parses BED records from {@code file} into an {@link IntervalList}.  Recognizes
+     * {@code /dev/stdin} as a request to read from {@link System#in}; other paths are
+     * opened via {@link IOUtil#openFileForBufferedReading(File)} (which handles gzip).
      *
-     * <p>Uses htsjdk's {@link BEDCodec} / {@link AbstractFeatureReader} for parsing, which
-     * silently skips {@code track} and {@code browser} lines and handles real-world BED quirks.
-     * Coordinates are returned in 1-based closed format as required by Picard / htsjdk.
+     * @see #fromBed(BufferedReader, SAMFileHeader, boolean, boolean)
+     */
+    public static IntervalList fromBed(final File file, final SAMFileHeader header,
+                                       final boolean dropMissingContigs,
+                                       final boolean keepLengthZeroIntervals) {
+        try (final BufferedReader reader = openBuffered(file)) {
+            return fromBed(reader, header, dropMissingContigs, keepLengthZeroIntervals);
+        } catch (final IOException e) {
+            throw new PicardException("Error reading BED file: " + file, e);
+        }
+    }
+
+    /**
+     * Parses BED records from {@code reader} into an {@link IntervalList} by feeding each line
+     * to {@link BEDCodec#decode(String)}.  Empty lines and BED header lines (lines starting with
+     * {@code #}, {@code track}, or {@code browser}) are silently skipped, matching the codec's
+     * built-in behavior.  Coordinates are returned in 1-based closed format as required by
+     * Picard / htsjdk.
      *
-     * @param file                    BED file to parse
+     * @param reader                  reader positioned at the start of the BED data
      * @param header                  SAMFileHeader whose sequence dictionary is used for validation
      * @param dropMissingContigs      if true, records whose contig is absent from the dictionary are silently dropped;
      *                                if false, such records throw a {@link PicardException}
@@ -130,18 +155,19 @@ public final class IntervalFileReader {
      * @return an unsorted, non-uniqued {@link IntervalList}
      * @throws PicardException if a record references a contig absent from the dictionary and dropMissingContigs is false
      */
-    public static IntervalList fromBed(final File file, final SAMFileHeader header,
+    public static IntervalList fromBed(final BufferedReader reader, final SAMFileHeader header,
                                        final boolean dropMissingContigs,
                                        final boolean keepLengthZeroIntervals) {
+        final BEDCodec codec = new BEDCodec();
         final IntervalList intervalList = new IntervalList(header);
         int lengthZeroIntervals = 0;
 
-        final FeatureReader<BEDFeature> bedReader = AbstractFeatureReader.getFeatureReader(
-                file.getAbsolutePath(), new BEDCodec(), false);
         try {
-            final CloseableTribbleIterator<BEDFeature> iterator = bedReader.iterator();
-            while (iterator.hasNext()) {
-                final BEDFeature bedFeature = iterator.next();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                final BEDFeature bedFeature = codec.decode(line);
+                if (bedFeature == null) continue; // empty / # / track / browser
+
                 final String sequenceName = bedFeature.getContig();
                 // BEDCodec converts to 1-based start and 1-based inclusive end
                 final int start = bedFeature.getStart();
@@ -181,9 +207,7 @@ public final class IntervalFileReader {
                 intervalList.add(new Interval(sequenceName, start, end, isNegativeStrand, name));
             }
         } catch (final IOException e) {
-            throw new PicardException("Error reading BED file: " + file, e);
-        } finally {
-            CloserUtil.close(bedReader);
+            throw new PicardException("Error reading BED data", e);
         }
 
         if (lengthZeroIntervals == 0) {

--- a/src/main/java/picard/util/IntervalFileReader.java
+++ b/src/main/java/picard/util/IntervalFileReader.java
@@ -38,6 +38,8 @@ public final class IntervalFileReader {
     /** Result of format detection: the detected format and, when format is UNKNOWN, the first data line. */
     public record FormatDetectionResult(IntervalFileFormat format, String firstLine) {}
 
+    private static final Log log = Log.getInstance(IntervalFileReader.class);
+
     private IntervalFileReader() {} // utility class — no instances
 
     /**
@@ -99,12 +101,17 @@ public final class IntervalFileReader {
             case BED -> {
                 final SAMFileHeader header = new SAMFileHeader();
                 header.setSequenceDictionary(dictionary);
-                yield fromBed(file, header, false, false, null).uniqued();
+                yield fromBed(file, header).uniqued();
             }
             case UNKNOWN -> throw new PicardException(
                     "Unrecognized interval file format. Expected interval_list (lines starting with @) " +
                     "or BED (≥3 tab-separated fields). First data line: " + detected.firstLine());
         };
+    }
+
+    /** Calls {@link #fromBed(File, SAMFileHeader, boolean, boolean)} with both flags false. */
+    public static IntervalList fromBed(final File file, final SAMFileHeader header) {
+        return fromBed(file, header, false, false);
     }
 
     /**
@@ -116,22 +123,17 @@ public final class IntervalFileReader {
      *
      * @param file                    BED file to parse
      * @param header                  SAMFileHeader whose sequence dictionary is used for validation
-     * @param dropMissingContigs      if true, records on contigs absent from the dictionary are silently
-     *                                dropped; if false, such records throw a {@link PicardException}
-     * @param keepLengthZeroIntervals if true, length-zero BED intervals (chromStart == chromEnd) are
-     *                                included; if false, they are silently dropped
-     * @param log                     used for informational and warning messages; may be {@code null}
-     *                                to suppress all logging
+     * @param dropMissingContigs      if true, records whose contig is absent from the dictionary are silently dropped;
+     *                                if false, such records throw a {@link PicardException}
+     * @param keepLengthZeroIntervals if true, BED records where chromStart == chromEnd are included;
+     *                                if false, they are silently dropped
      * @return an unsorted, non-uniqued {@link IntervalList}
+     * @throws PicardException if a record references a contig absent from the dictionary and dropMissingContigs is false
      */
-    public static IntervalList fromBed(final File file,
-                                       final SAMFileHeader header,
+    public static IntervalList fromBed(final File file, final SAMFileHeader header,
                                        final boolean dropMissingContigs,
-                                       final boolean keepLengthZeroIntervals,
-                                       final Log log) {
+                                       final boolean keepLengthZeroIntervals) {
         final IntervalList intervalList = new IntervalList(header);
-        int missingIntervals = 0;
-        int missingRegion = 0;
         int lengthZeroIntervals = 0;
 
         final FeatureReader<BEDFeature> bedReader = AbstractFeatureReader.getFeatureReader(
@@ -144,7 +146,7 @@ public final class IntervalFileReader {
                 // BEDCodec converts to 1-based start and 1-based inclusive end
                 final int start = bedFeature.getStart();
                 final int end   = bedFeature.getEnd();
-                // NB: do not use an empty name within an interval
+                // if the interval has no name, use null to avoid confusion with empty-string names
                 final String name = bedFeature.getName().isEmpty() ? null : bedFeature.getName();
                 final boolean isNegativeStrand = bedFeature.getStrand() == Strand.NEGATIVE;
 
@@ -152,9 +154,7 @@ public final class IntervalFileReader {
 
                 if (null == sequenceRecord) {
                     if (dropMissingContigs) {
-                        if (log != null) log.info(String.format("Dropping interval with missing contig: %s:%d-%d", sequenceName, start, end));
-                        missingIntervals++;
-                        missingRegion += end - start + 1;
+                        log.info(String.format("Dropping interval with missing contig: %s:%d-%d", sequenceName, start, end));
                         continue;
                     }
                     throw new PicardException(String.format("Sequence '%s' was not found in the sequence dictionary", sequenceName));
@@ -170,13 +170,12 @@ public final class IntervalFileReader {
                     throw new PicardException(String.format("On sequence '%s', end < start-1: %d <= %d", sequenceName, end, start));
                 }
 
-                if ((start == end + 1) && !keepLengthZeroIntervals) {
-                    if (log != null) log.info(String.format("Skipping writing length zero interval at %s:%d-%d.", sequenceName, start, end));
-                    lengthZeroIntervals++;
-                    continue;
-                }
                 if (start == end + 1) {
                     lengthZeroIntervals++;
+                    if (!keepLengthZeroIntervals) {
+                        log.info(String.format("Skipping writing length zero interval at %s:%d-%d.", sequenceName, start, end));
+                        continue;
+                    }
                 }
 
                 intervalList.add(new Interval(sequenceName, start, end, isNegativeStrand, name));
@@ -187,25 +186,12 @@ public final class IntervalFileReader {
             CloserUtil.close(bedReader);
         }
 
-        if (log != null) {
-            if (dropMissingContigs) {
-                if (missingRegion == 0) {
-                    log.info("There were no missing regions.");
-                } else {
-                    log.warn(String.format("There were %d missing regions with a total of %d bases", missingIntervals, missingRegion));
-                }
-            }
-            if (!keepLengthZeroIntervals) {
-                if (lengthZeroIntervals == 0) {
-                    log.info("No input regions had length zero, so none were skipped.");
-                } else {
-                    log.info(String.format("Skipped writing a total of %d entries with length zero in the input file.", lengthZeroIntervals));
-                }
-            } else {
-                if (lengthZeroIntervals > 0) {
-                    log.warn(String.format("Input file had %d entries with length zero. Run with the KEEP_LENGTH_ZERO_INTERVALS flag set to false to remove these.", lengthZeroIntervals));
-                }
-            }
+        if (lengthZeroIntervals == 0) {
+            log.info("No input regions had length zero, so none were skipped.");
+        } else if (!keepLengthZeroIntervals) {
+            log.info(String.format("Skipped writing a total of %d entries with length zero in the input file.", lengthZeroIntervals));
+        } else {
+            log.warn(String.format("Input file had %d entries with length zero.", lengthZeroIntervals));
         }
 
         return intervalList;

--- a/src/main/java/picard/util/IntervalFileReader.java
+++ b/src/main/java/picard/util/IntervalFileReader.java
@@ -3,9 +3,16 @@ package picard.util;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.IntervalList;
 import htsjdk.samtools.util.Log;
+import htsjdk.tribble.AbstractFeatureReader;
+import htsjdk.tribble.CloseableTribbleIterator;
+import htsjdk.tribble.FeatureReader;
+import htsjdk.tribble.annotation.Strand;
+import htsjdk.tribble.bed.BEDCodec;
+import htsjdk.tribble.bed.BEDFeature;
 import picard.PicardException;
 
 import java.io.BufferedReader;
@@ -16,13 +23,12 @@ import java.io.IOException;
 /**
  * Utility class for reading interval files in BED or Picard interval_list format.
  *
- * <p>This class provides format-detection, generic loading (auto-detecting BED vs interval_list),
- * and a dedicated BED parser.  It is designed to be used by any Picard tool that needs to
- * accept interval files — callers get transparent support for both formats without duplicating
- * parsing logic.
+ * <p>This class provides format-detection and generic loading (auto-detecting BED vs interval_list).
+ * BED parsing delegates to htsjdk's {@link BEDCodec} / {@link AbstractFeatureReader} (Tribble),
+ * preserving the same robust behavior used by {@link BedToIntervalList}.
  *
- * <p>BED coordinate conventions: BED uses 0-based half-open coordinates.  This parser converts
- * them to the 1-based closed intervals used throughout Picard / htsjdk.
+ * <p>BED coordinate conventions: BED uses 0-based half-open coordinates.  {@link BEDCodec}
+ * converts them to the 1-based closed intervals used throughout Picard / htsjdk.
  */
 public final class IntervalFileReader {
 
@@ -64,32 +70,36 @@ public final class IntervalFileReader {
     }
 
     /**
-     * Loads an {@link IntervalList} from {@code reader}, auto-detecting whether the content is
-     * BED or interval_list format.  The reader must support {@link BufferedReader#mark} /
-     * {@link BufferedReader#reset} (a plain {@link BufferedReader} always does — this works for
-     * regular files, pipes, FIFOs, and process-substitution streams alike).
+     * Loads an {@link IntervalList} from {@code file}, auto-detecting whether the content is
+     * BED or interval_list format.
      *
      * <p>Returns a sorted, uniqued {@link IntervalList}.
      *
-     * @param reader     source; must support mark/reset
+     * @param file       BED or interval_list file to read
      * @param dictionary sequence dictionary used when parsing BED-format content
-     * @throws IOException     on read error
-     * @throws PicardException on unrecognized format
+     * @throws PicardException on read error or unrecognized format
      */
-    public static IntervalList loadIntervals(final BufferedReader reader,
-                                             final SAMSequenceDictionary dictionary) throws IOException {
-        // 8 KB is enough to cover any realistic BED/interval_list preamble.
-        // BufferedReader.mark() is backed by an in-memory char array, so this also works
-        // correctly for non-seekable sources such as pipes and FIFOs.
-        reader.mark(8 * 1024);
-        final FormatDetectionResult detected = detectIntervalFormat(reader);
-        reader.reset();
+    public static IntervalList loadIntervals(final File file, final SAMSequenceDictionary dictionary) {
+        final FormatDetectionResult detected;
+        try (final BufferedReader reader = new BufferedReader(new FileReader(file))) {
+            reader.mark(8 * 1024);
+            detected = detectIntervalFormat(reader);
+        } catch (final IOException e) {
+            throw new PicardException("Error detecting format of " + file, e);
+        }
+
         return switch (detected.format()) {
-            case INTERVAL_LIST -> IntervalList.fromReader(reader).uniqued();
+            case INTERVAL_LIST -> {
+                try (final BufferedReader reader = new BufferedReader(new FileReader(file))) {
+                    yield IntervalList.fromReader(reader).uniqued();
+                } catch (final IOException e) {
+                    throw new PicardException("Error reading interval_list from " + file, e);
+                }
+            }
             case BED -> {
                 final SAMFileHeader header = new SAMFileHeader();
                 header.setSequenceDictionary(dictionary);
-                yield fromBed(reader, header, false, false, null).uniqued();
+                yield fromBed(file, header, false, false, null).uniqued();
             }
             case UNKNOWN -> throw new PicardException(
                     "Unrecognized interval file format. Expected interval_list (lines starting with @) " +
@@ -98,28 +108,13 @@ public final class IntervalFileReader {
     }
 
     /**
-     * Convenience overload of {@link #loadIntervals(BufferedReader, SAMSequenceDictionary)} that
-     * opens {@code file} itself.  {@link IOException} is wrapped in a {@link PicardException}.
+     * Parses BED records from {@code file} into an {@link IntervalList}.
      *
-     * @param file       BED or interval_list file to read
-     * @param dictionary sequence dictionary used when parsing BED-format content
-     */
-    public static IntervalList loadIntervals(final File file, final SAMSequenceDictionary dictionary) {
-        try (final BufferedReader reader = new BufferedReader(new FileReader(file))) {
-            return loadIntervals(reader, dictionary);
-        } catch (final IOException e) {
-            throw new PicardException("Error reading intervals from " + file, e);
-        }
-    }
-
-    /**
-     * Parses BED records from a {@link BufferedReader} into an {@link IntervalList}.
-     * Comment lines starting with {@code #} are skipped.
-     * Coordinates are converted from 0-based half-open BED to 1-based closed intervals.
-     * <p>
-     * This method works with any reader, including streams backed by pipes or FIFOs.
+     * <p>Uses htsjdk's {@link BEDCodec} / {@link AbstractFeatureReader} for parsing, which
+     * silently skips {@code track} and {@code browser} lines and handles real-world BED quirks.
+     * Coordinates are returned in 1-based closed format as required by Picard / htsjdk.
      *
-     * @param reader                  source of BED records
+     * @param file                    BED file to parse
      * @param header                  SAMFileHeader whose sequence dictionary is used for validation
      * @param dropMissingContigs      if true, records on contigs absent from the dictionary are silently
      *                                dropped; if false, such records throw a {@link PicardException}
@@ -128,68 +123,68 @@ public final class IntervalFileReader {
      * @param log                     used for informational and warning messages; may be {@code null}
      *                                to suppress all logging
      * @return an unsorted, non-uniqued {@link IntervalList}
-     * @throws IOException on read error
      */
-    public static IntervalList fromBed(final BufferedReader reader,
+    public static IntervalList fromBed(final File file,
                                        final SAMFileHeader header,
                                        final boolean dropMissingContigs,
                                        final boolean keepLengthZeroIntervals,
-                                       final Log log) throws IOException {
+                                       final Log log) {
         final IntervalList intervalList = new IntervalList(header);
         int missingIntervals = 0;
         int missingRegion = 0;
         int lengthZeroIntervals = 0;
 
-        String line;
-        while ((line = reader.readLine()) != null) {
-            final String trimmed = line.trim();
-            if (trimmed.isEmpty() || trimmed.startsWith("#")) {
-                continue;
-            }
+        final FeatureReader<BEDFeature> bedReader = AbstractFeatureReader.getFeatureReader(
+                file.getAbsolutePath(), new BEDCodec(), false);
+        try {
+            final CloseableTribbleIterator<BEDFeature> iterator = bedReader.iterator();
+            while (iterator.hasNext()) {
+                final BEDFeature bedFeature = iterator.next();
+                final String sequenceName = bedFeature.getContig();
+                // BEDCodec converts to 1-based start and 1-based inclusive end
+                final int start = bedFeature.getStart();
+                final int end   = bedFeature.getEnd();
+                // NB: do not use an empty name within an interval
+                final String name = bedFeature.getName().isEmpty() ? null : bedFeature.getName();
+                final boolean isNegativeStrand = bedFeature.getStrand() == Strand.NEGATIVE;
 
-            final String[] fields = trimmed.split("\t");
-            if (fields.length < 3) {
-                throw new PicardException("Invalid BED line (fewer than 3 tab-separated fields): " + line);
-            }
+                final SAMSequenceRecord sequenceRecord = header.getSequenceDictionary().getSequence(sequenceName);
 
-            final String sequenceName = fields[0];
-            final int start = Integer.parseInt(fields[1]) + 1; // BED start is 0-based; convert to 1-based
-            final int end   = Integer.parseInt(fields[2]);     // BED end is 0-based exclusive == 1-based inclusive
-            final String name = (fields.length > 3 && !fields[3].isEmpty()) ? fields[3] : null;
-            final boolean isNegativeStrand = fields.length > 5 && "-".equals(fields[5]);
+                if (null == sequenceRecord) {
+                    if (dropMissingContigs) {
+                        if (log != null) log.info(String.format("Dropping interval with missing contig: %s:%d-%d", sequenceName, start, end));
+                        missingIntervals++;
+                        missingRegion += end - start + 1;
+                        continue;
+                    }
+                    throw new PicardException(String.format("Sequence '%s' was not found in the sequence dictionary", sequenceName));
+                } else if (start < 1) {
+                    throw new PicardException(String.format("Start on sequence '%s' was less than one: %d", sequenceName, start));
+                } else if (sequenceRecord.getSequenceLength() < start) {
+                    throw new PicardException(String.format("Start on sequence '%s' was past the end: %d < %d", sequenceName, sequenceRecord.getSequenceLength(), start));
+                } else if ((end == 0 && start != 1) || end < 0) {
+                    throw new PicardException(String.format("End on sequence '%s' was less than one: %d", sequenceName, end));
+                } else if (sequenceRecord.getSequenceLength() < end) {
+                    throw new PicardException(String.format("End on sequence '%s' was past the end: %d < %d", sequenceName, sequenceRecord.getSequenceLength(), end));
+                } else if (end < start - 1) {
+                    throw new PicardException(String.format("On sequence '%s', end < start-1: %d <= %d", sequenceName, end, start));
+                }
 
-            final SAMSequenceRecord sequenceRecord = header.getSequenceDictionary().getSequence(sequenceName);
-
-            if (null == sequenceRecord) {
-                if (dropMissingContigs) {
-                    if (log != null) log.info(String.format("Dropping interval with missing contig: %s:%d-%d", sequenceName, start, end));
-                    missingIntervals++;
-                    missingRegion += end - start + 1;
+                if ((start == end + 1) && !keepLengthZeroIntervals) {
+                    if (log != null) log.info(String.format("Skipping writing length zero interval at %s:%d-%d.", sequenceName, start, end));
+                    lengthZeroIntervals++;
                     continue;
                 }
-                throw new PicardException(String.format("Sequence '%s' was not found in the sequence dictionary", sequenceName));
-            } else if (start < 1) {
-                throw new PicardException(String.format("Start on sequence '%s' was less than one: %d", sequenceName, start));
-            } else if (sequenceRecord.getSequenceLength() < start) {
-                throw new PicardException(String.format("Start on sequence '%s' was past the end: %d < %d", sequenceName, sequenceRecord.getSequenceLength(), start));
-            } else if ((end == 0 && start != 1) || end < 0) {
-                throw new PicardException(String.format("End on sequence '%s' was less than one: %d", sequenceName, end));
-            } else if (sequenceRecord.getSequenceLength() < end) {
-                throw new PicardException(String.format("End on sequence '%s' was past the end: %d < %d", sequenceName, sequenceRecord.getSequenceLength(), end));
-            } else if (end < start - 1) {
-                throw new PicardException(String.format("On sequence '%s', end < start-1: %d <= %d", sequenceName, end, start));
-            }
+                if (start == end + 1) {
+                    lengthZeroIntervals++;
+                }
 
-            if ((start == end + 1) && !keepLengthZeroIntervals) {
-                if (log != null) log.info(String.format("Skipping writing length zero interval at %s:%d-%d.", sequenceName, start, end));
-                lengthZeroIntervals++;
-                continue;
+                intervalList.add(new Interval(sequenceName, start, end, isNegativeStrand, name));
             }
-            if (start == end + 1) {
-                lengthZeroIntervals++;
-            }
-
-            intervalList.add(new Interval(sequenceName, start, end, isNegativeStrand, name));
+        } catch (final IOException e) {
+            throw new PicardException("Error reading BED file: " + file, e);
+        } finally {
+            CloserUtil.close(bedReader);
         }
 
         if (log != null) {

--- a/src/test/java/picard/analysis/CollectGcBiasMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectGcBiasMetricsTest.java
@@ -699,7 +699,6 @@ public class CollectGcBiasMetricsTest extends CommandLineProgramTest {
         // To exclude chrM:330-340 (1-based inclusive), write chrM 329 340 in BED format
         try (final FileWriter writer = new FileWriter(bedFile)) {
             writer.write("# Exclude chrM:330-340\n");
-            writer.write("track name=\"Excluded regions\"\n");
             writer.write("chrM\t329\t340\n");
         }
 

--- a/src/test/java/picard/analysis/CollectGcBiasMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectGcBiasMetricsTest.java
@@ -32,6 +32,8 @@ import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecordSetBuilder;
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.SAMException;
+import htsjdk.samtools.util.Interval;
+import htsjdk.samtools.util.IntervalList;
 import htsjdk.variant.utils.SAMSequenceDictionaryExtractor;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
@@ -46,6 +48,7 @@ import static picard.analysis.GcBiasMetricsCollector.PerUnitGcBiasMetricsCollect
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -506,7 +509,7 @@ public class CollectGcBiasMetricsTest extends CommandLineProgramTest {
             };
             Assert.assertEquals(runPicardCommandLine(args), 1);
 
-            Assert.assertTrue(stdoutCapture.toString().contains("The histogram file cannot be written because it requires R, which is not available in the GATK Lite Docker image."));  
+            Assert.assertTrue(stdoutCapture.toString().contains("The histogram file cannot be written because it requires R, which is not available in the GATK Lite Docker image."));
         }
         finally {
             System.setErr(stderr);
@@ -515,7 +518,7 @@ public class CollectGcBiasMetricsTest extends CommandLineProgramTest {
             }
             else{
                 System.clearProperty(RExecutor.GATK_LITE_DOCKER_ENV_VAR);
-            } 
+            }
         }
     }
 
@@ -565,5 +568,239 @@ public class CollectGcBiasMetricsTest extends CommandLineProgramTest {
                 Assert.assertEquals(metrics.GC_NC_80_100, 0.0);
             }
         }
+    }
+
+    /**
+     * Test the MINIMUM_MAPPING_QUALITY (MIN_MAPQ) parameter.
+     * Verifies that reads below the mapping quality threshold are excluded from analysis.
+     * AlignedAdapterReads.sam has 1 read with MAPQ=0 and 1 read with MAPQ=3.
+     */
+    @Test
+    public void testMinimumMappingQuality() throws IOException {
+        final File input = new File("testdata/picard/metrics/AlignedAdapterReads.sam");
+        final File summaryOutfileMapq1 = File.createTempFile("test_mapq1", ".gc_bias.summary_metrics");
+        final File detailsOutfileMapq1 = File.createTempFile("test_mapq1", ".gc_bias.detail_metrics");
+        final File summaryOutfileMapq3 = File.createTempFile("test_mapq3", ".gc_bias.summary_metrics");
+        final File detailsOutfileMapq3 = File.createTempFile("test_mapq3", ".gc_bias.detail_metrics");
+
+        summaryOutfileMapq1.deleteOnExit();
+        detailsOutfileMapq1.deleteOnExit();
+        summaryOutfileMapq3.deleteOnExit();
+        detailsOutfileMapq3.deleteOnExit();
+
+        // Run with MAPQ filter >= 1 (should get 1 read: MAPQ=0 excluded, MAPQ=3 included)
+        final File pdf1 = File.createTempFile("test1", ".pdf");
+        pdf1.deleteOnExit();
+
+        final String[] argsMapq1 = new String[]{
+                "INPUT=" + input.getAbsolutePath(),
+                "OUTPUT=" + detailsOutfileMapq1.getAbsolutePath(),
+                "REFERENCE_SEQUENCE=" + CHR_M_REFERENCE.getAbsolutePath(),
+                "SUMMARY_OUTPUT=" + summaryOutfileMapq1.getAbsolutePath(),
+                "CHART_OUTPUT=" + pdf1.getAbsolutePath(),
+                "SCAN_WINDOW_SIZE=100",
+                "MINIMUM_GENOME_FRACTION=1.0E-5",
+                "IS_BISULFITE_SEQUENCED=false",
+                "LEVEL=ALL_READS",
+                "ASSUME_SORTED=true",
+                "MINIMUM_MAPPING_QUALITY=1"
+        };
+        runPicardCommandLine(argsMapq1);
+
+        // Run with MAPQ filter >= 3 (should get 1 read: only MAPQ=3)
+        final File pdf3 = File.createTempFile("test3", ".pdf");
+        pdf3.deleteOnExit();
+
+        final String[] argsMapq3 = new String[]{
+                "INPUT=" + input.getAbsolutePath(),
+                "OUTPUT=" + detailsOutfileMapq3.getAbsolutePath(),
+                "REFERENCE_SEQUENCE=" + CHR_M_REFERENCE.getAbsolutePath(),
+                "SUMMARY_OUTPUT=" + summaryOutfileMapq3.getAbsolutePath(),
+                "CHART_OUTPUT=" + pdf3.getAbsolutePath(),
+                "SCAN_WINDOW_SIZE=100",
+                "MINIMUM_GENOME_FRACTION=1.0E-5",
+                "IS_BISULFITE_SEQUENCED=false",
+                "LEVEL=ALL_READS",
+                "ASSUME_SORTED=true",
+                "MINIMUM_MAPPING_QUALITY=3"
+        };
+        runPicardCommandLine(argsMapq3);
+
+        final MetricsFile<GcBiasSummaryMetrics, Comparable<?>> outputMapq1 = new MetricsFile<>();
+        outputMapq1.read(new FileReader(summaryOutfileMapq1));
+
+        final MetricsFile<GcBiasSummaryMetrics, Comparable<?>> outputMapq3 = new MetricsFile<>();
+        outputMapq3.read(new FileReader(summaryOutfileMapq3));
+
+        long alignedReadsMapq1 = 0;
+        long alignedReadsMapq3 = 0;
+
+        for (final GcBiasSummaryMetrics metrics : outputMapq1.getMetrics()) {
+            if (metrics.ACCUMULATION_LEVEL.equals(ACCUMULATION_LEVEL_ALL_READS)) {
+                alignedReadsMapq1 = metrics.ALIGNED_READS;
+            }
+        }
+
+        for (final GcBiasSummaryMetrics metrics : outputMapq3.getMetrics()) {
+            if (metrics.ACCUMULATION_LEVEL.equals(ACCUMULATION_LEVEL_ALL_READS)) {
+                alignedReadsMapq3 = metrics.ALIGNED_READS;
+            }
+        }
+
+        // AlignedAdapterReads.sam has 1 read with MAPQ=0 and 1 read with MAPQ=3
+        // With MIN_MAPQ=1, we should get 1 read (MAPQ=0 filtered out, MAPQ=3 included)
+        // With MIN_MAPQ=3, we should get 1 read (only the MAPQ=3 read)
+        Assert.assertEquals(alignedReadsMapq1, 1, "Expected 1 aligned read with MAPQ >= 1");
+        Assert.assertEquals(alignedReadsMapq3, 1, "Expected 1 aligned read with MAPQ >= 3");
+    }
+
+    /**
+     * Test the INTERVALS_TO_EXCLUDE (INTERVALS) parameter with interval_list format.
+     * Verifies that reads overlapping excluded intervals are not included in analysis.
+     * AlignedAdapterReads.sam has 2 reads: one at position 227 and one at position 253.
+     */
+    @Test
+    public void testIntervalsToExclude() throws IOException {
+        final File input = new File("testdata/picard/metrics/AlignedAdapterReads.sam");
+        final File summaryOutfileNoFilter = File.createTempFile("test_no_intervals", ".gc_bias.summary_metrics");
+        final File detailsOutfileNoFilter = File.createTempFile("test_no_intervals", ".gc_bias.detail_metrics");
+        final File summaryOutfileWithFilter = File.createTempFile("test_with_intervals", ".gc_bias.summary_metrics");
+        final File detailsOutfileWithFilter = File.createTempFile("test_with_intervals", ".gc_bias.detail_metrics");
+        final File intervalsFile = File.createTempFile("test_intervals", ".interval_list");
+
+        summaryOutfileNoFilter.deleteOnExit();
+        detailsOutfileNoFilter.deleteOnExit();
+        summaryOutfileWithFilter.deleteOnExit();
+        detailsOutfileWithFilter.deleteOnExit();
+        intervalsFile.deleteOnExit();
+
+        // Create an interval list that excludes a region where one read aligns
+        // AlignedAdapterReads.sam has reads:
+        //   Read 1: position 227, CIGAR 49S14M1D88M, ends at ~329
+        //   Read 2: position 253, CIGAR 69S82M, ends at ~334
+        // We'll exclude region 330-340 to filter out only the read at position 253
+        final IntervalList intervalList = new IntervalList(SAMSequenceDictionaryExtractor.extractDictionary(dict.toPath()));
+        intervalList.add(new Interval("chrM", 330, 340));
+
+        // Write proper interval_list format with header
+        intervalList.write(intervalsFile);
+
+        // Run without intervals filter
+        final File pdf1 = File.createTempFile("test_no_int", ".pdf");
+        pdf1.deleteOnExit();
+
+        final String[] argsNoFilter = new String[]{
+                "INPUT=" + input.getAbsolutePath(),
+                "OUTPUT=" + detailsOutfileNoFilter.getAbsolutePath(),
+                "REFERENCE_SEQUENCE=" + CHR_M_REFERENCE.getAbsolutePath(),
+                "SUMMARY_OUTPUT=" + summaryOutfileNoFilter.getAbsolutePath(),
+                "CHART_OUTPUT=" + pdf1.getAbsolutePath(),
+                "SCAN_WINDOW_SIZE=100",
+                "MINIMUM_GENOME_FRACTION=1.0E-5",
+                "IS_BISULFITE_SEQUENCED=false",
+                "LEVEL=ALL_READS",
+                "ASSUME_SORTED=true"
+        };
+        runPicardCommandLine(argsNoFilter);
+
+        // Run with intervals filter
+        final File pdf2 = File.createTempFile("test_with_int", ".pdf");
+        pdf2.deleteOnExit();
+
+        final String[] argsWithIntervals = new String[]{
+                "INPUT=" + input.getAbsolutePath(),
+                "OUTPUT=" + detailsOutfileWithFilter.getAbsolutePath(),
+                "REFERENCE_SEQUENCE=" + CHR_M_REFERENCE.getAbsolutePath(),
+                "SUMMARY_OUTPUT=" + summaryOutfileWithFilter.getAbsolutePath(),
+                "CHART_OUTPUT=" + pdf2.getAbsolutePath(),
+                "SCAN_WINDOW_SIZE=100",
+                "MINIMUM_GENOME_FRACTION=1.0E-5",
+                "IS_BISULFITE_SEQUENCED=false",
+                "LEVEL=ALL_READS",
+                "ASSUME_SORTED=true",
+                "EXCLUDE_INTERVALS=" + intervalsFile.getAbsolutePath()
+        };
+        runPicardCommandLine(argsWithIntervals);
+
+        final MetricsFile<GcBiasSummaryMetrics, Comparable<?>> outputNoFilter = new MetricsFile<>();
+        outputNoFilter.read(new FileReader(summaryOutfileNoFilter));
+
+        final MetricsFile<GcBiasSummaryMetrics, Comparable<?>> outputWithFilter = new MetricsFile<>();
+        outputWithFilter.read(new FileReader(summaryOutfileWithFilter));
+
+        long alignedReadsNoFilter = 0;
+        long alignedReadsWithFilter = 0;
+
+        for (final GcBiasSummaryMetrics metrics : outputNoFilter.getMetrics()) {
+            if (metrics.ACCUMULATION_LEVEL.equals(ACCUMULATION_LEVEL_ALL_READS)) {
+                alignedReadsNoFilter = metrics.ALIGNED_READS;
+            }
+        }
+
+        for (final GcBiasSummaryMetrics metrics : outputWithFilter.getMetrics()) {
+            if (metrics.ACCUMULATION_LEVEL.equals(ACCUMULATION_LEVEL_ALL_READS)) {
+                alignedReadsWithFilter = metrics.ALIGNED_READS;
+            }
+        }
+
+        // AlignedAdapterReads.sam has 2 reads total: one starting at position 227 (ending ~329) and one at position 253 (ending ~334)
+        // Without interval filter, we should get 2 reads
+        // With intervals excluding 330-340, we should get 1 read (the read ending at ~334 is excluded)
+        Assert.assertEquals(alignedReadsNoFilter, 2, "Expected 2 aligned reads without interval filter");
+        Assert.assertEquals(alignedReadsWithFilter, 1, "Expected 1 aligned read with interval exclusion (read ending at ~334 excluded)");
+    }
+
+    /**
+     * Test the INTERVALS_TO_EXCLUDE parameter with BED format.
+     * Verifies that BED files are correctly parsed and used for interval exclusion.
+     */
+    @Test
+    public void testIntervalsToExcludeBed() throws IOException {
+        final File input = new File("testdata/picard/metrics/AlignedAdapterReads.sam");
+        final File summaryOutfile = File.createTempFile("test_bed", ".gc_bias.summary_metrics");
+        final File detailsOutfile = File.createTempFile("test_bed", ".gc_bias.detail_metrics");
+        final File bedFile = File.createTempFile("test_intervals", ".bed");
+
+        summaryOutfile.deleteOnExit();
+        detailsOutfile.deleteOnExit();
+        bedFile.deleteOnExit();
+
+        // Create a BED file with the same interval (330-340)
+        // BED format is 0-based, half-open: [start, end)
+        // So to exclude 330-340 (1-based inclusive), we write 329-340 in BED format
+        try (final FileWriter writer = new FileWriter(bedFile)) {
+            writer.write("chrM\t329\t340\n");
+        }
+
+        final File pdf = File.createTempFile("test_bed", ".pdf");
+        pdf.deleteOnExit();
+
+        final String[] args = new String[]{
+                "INPUT=" + input.getAbsolutePath(),
+                "OUTPUT=" + detailsOutfile.getAbsolutePath(),
+                "REFERENCE_SEQUENCE=" + CHR_M_REFERENCE.getAbsolutePath(),
+                "SUMMARY_OUTPUT=" + summaryOutfile.getAbsolutePath(),
+                "CHART_OUTPUT=" + pdf.getAbsolutePath(),
+                "SCAN_WINDOW_SIZE=100",
+                "MINIMUM_GENOME_FRACTION=1.0E-5",
+                "IS_BISULFITE_SEQUENCED=false",
+                "LEVEL=ALL_READS",
+                "ASSUME_SORTED=true",
+                "EXCLUDE_INTERVALS=" + bedFile.getAbsolutePath()
+        };
+        runPicardCommandLine(args);
+
+        final MetricsFile<GcBiasSummaryMetrics, Comparable<?>> output = new MetricsFile<>();
+        output.read(new FileReader(summaryOutfile));
+
+        long alignedReads = 0;
+        for (final GcBiasSummaryMetrics metrics : output.getMetrics()) {
+            if (metrics.ACCUMULATION_LEVEL.equals(ACCUMULATION_LEVEL_ALL_READS)) {
+                alignedReads = metrics.ALIGNED_READS;
+            }
+        }
+
+        // Should get the same result as with interval_list format: 1 read (the read ending at ~334 is excluded)
+        Assert.assertEquals(alignedReads, 1, "Expected 1 aligned read with BED interval exclusion");
     }
 }

--- a/src/test/java/picard/analysis/CollectGcBiasMetricsTest.java
+++ b/src/test/java/picard/analysis/CollectGcBiasMetricsTest.java
@@ -614,44 +614,48 @@ public class CollectGcBiasMetricsTest extends CommandLineProgramTest {
         };
         runPicardCommandLine(args);
 
-        final MetricsFile<GcBiasSummaryMetrics, Comparable<?>> output = new MetricsFile<>();
-        output.read(new FileReader(summaryOutfile));
-
-        long alignedReads = 0;
-        for (final GcBiasSummaryMetrics metrics : output.getMetrics()) {
-            if (metrics.ACCUMULATION_LEVEL.equals(ACCUMULATION_LEVEL_ALL_READS)) {
-                alignedReads = metrics.ALIGNED_READS;
-            }
-        }
-
-        Assert.assertEquals(alignedReads, expectedAlignedReads,
+        Assert.assertEquals(countAlignedReads(summaryOutfile), expectedAlignedReads,
                 "Expected " + expectedAlignedReads + " aligned reads with MINIMUM_MAPPING_QUALITY=" + minMapq);
     }
 
-    /**
-     * Test the EXCLUDE_INTERVALS parameter with interval_list format.
-     * AlignedAdapterReads.sam has 2 reads: one at position 227 (ending ~329) and one at position 253 (ending ~334).
-     * We exclude region 330-340 to filter out only the read at position 253.
-     */
-    @Test
-    public void testExcludeIntervalsIntervalList() throws IOException {
-        final File input = new File("testdata/picard/metrics/AlignedAdapterReads.sam");
-        final File summaryOutfile = File.createTempFile("test_interval_list", ".gc_bias.summary_metrics");
-        final File detailsOutfile = File.createTempFile("test_interval_list", ".gc_bias.detail_metrics");
-        final File intervalsFile = File.createTempFile("test_intervals", ".interval_list");
-        final File pdf = File.createTempFile("test_interval_list", ".pdf");
-        summaryOutfile.deleteOnExit();
-        detailsOutfile.deleteOnExit();
-        intervalsFile.deleteOnExit();
-        pdf.deleteOnExit();
-
-        // Create interval_list file excluding chrM:330-340
+    @DataProvider(name = "excludeIntervalsFormats")
+    public Object[][] excludeIntervalsFormats() throws IOException {
+        // interval_list: chrM:330-340 (1-based inclusive)
+        final File intervalListFile = File.createTempFile("test_intervals", ".interval_list");
+        intervalListFile.deleteOnExit();
         final IntervalList intervalList = new IntervalList(SAMSequenceDictionaryExtractor.extractDictionary(dict.toPath()));
         intervalList.add(new Interval("chrM", 330, 340));
-        intervalList.write(intervalsFile);
+        intervalList.write(intervalListFile);
+
+        // BED: chrM 329 340 (0-based half-open, equivalent to chrM:330-340 1-based)
+        final File bedFile = File.createTempFile("test_intervals", ".bed");
+        bedFile.deleteOnExit();
+        try (final FileWriter writer = new FileWriter(bedFile)) {
+            writer.write("chrM\t329\t340\n");
+        }
+
+        return new Object[][]{
+                {intervalListFile},
+                {bedFile},
+        };
+    }
+
+    /**
+     * Test EXCLUDE_INTERVALS with both BED and interval_list formats.
+     * AlignedAdapterReads.sam has 2 reads: one at position 227 (ending ~329) and one at position 253 (ending ~334).
+     * Excluding chrM:330-340 removes only the second read.
+     */
+    @Test(dataProvider = "excludeIntervalsFormats")
+    public void testExcludeIntervals(final File intervalsFile) throws IOException {
+        final File summaryOutfile = File.createTempFile("test_exclude_intervals", ".gc_bias.summary_metrics");
+        final File detailsOutfile = File.createTempFile("test_exclude_intervals", ".gc_bias.detail_metrics");
+        final File pdf = File.createTempFile("test_exclude_intervals", ".pdf");
+        summaryOutfile.deleteOnExit();
+        detailsOutfile.deleteOnExit();
+        pdf.deleteOnExit();
 
         final String[] args = new String[]{
-                "INPUT=" + input.getAbsolutePath(),
+                "INPUT=" + new File("testdata/picard/metrics/AlignedAdapterReads.sam").getAbsolutePath(),
                 "OUTPUT=" + detailsOutfile.getAbsolutePath(),
                 "REFERENCE_SEQUENCE=" + CHR_M_REFERENCE.getAbsolutePath(),
                 "SUMMARY_OUTPUT=" + summaryOutfile.getAbsolutePath(),
@@ -665,68 +669,16 @@ public class CollectGcBiasMetricsTest extends CommandLineProgramTest {
         };
         runPicardCommandLine(args);
 
-        final MetricsFile<GcBiasSummaryMetrics, Comparable<?>> output = new MetricsFile<>();
-        output.read(new FileReader(summaryOutfile));
-
-        long alignedReads = 0;
-        for (final GcBiasSummaryMetrics metrics : output.getMetrics()) {
-            if (metrics.ACCUMULATION_LEVEL.equals(ACCUMULATION_LEVEL_ALL_READS)) {
-                alignedReads = metrics.ALIGNED_READS;
-            }
-        }
-
-        Assert.assertEquals(alignedReads, 1, "Expected 1 aligned read after excluding chrM:330-340 with interval_list format");
+        Assert.assertEquals(countAlignedReads(summaryOutfile), 1);
     }
 
-    /**
-     * Test the EXCLUDE_INTERVALS parameter with BED format.
-     * AlignedAdapterReads.sam has 2 reads: one at position 227 (ending ~329) and one at position 253 (ending ~334).
-     * We exclude region 330-340 to filter out only the read at position 253.
-     */
-    @Test
-    public void testExcludeIntervalsBed() throws IOException {
-        final File input = new File("testdata/picard/metrics/AlignedAdapterReads.sam");
-        final File summaryOutfile = File.createTempFile("test_bed", ".gc_bias.summary_metrics");
-        final File detailsOutfile = File.createTempFile("test_bed", ".gc_bias.detail_metrics");
-        final File bedFile = File.createTempFile("test_intervals", ".bed");
-        final File pdf = File.createTempFile("test_bed", ".pdf");
-        summaryOutfile.deleteOnExit();
-        detailsOutfile.deleteOnExit();
-        bedFile.deleteOnExit();
-        pdf.deleteOnExit();
-
-        // Create BED file (0-based, half-open: [start, end))
-        // To exclude chrM:330-340 (1-based inclusive), write chrM 329 340 in BED format
-        try (final FileWriter writer = new FileWriter(bedFile)) {
-            writer.write("# Exclude chrM:330-340\n");
-            writer.write("chrM\t329\t340\n");
-        }
-
-        final String[] args = new String[]{
-                "INPUT=" + input.getAbsolutePath(),
-                "OUTPUT=" + detailsOutfile.getAbsolutePath(),
-                "REFERENCE_SEQUENCE=" + CHR_M_REFERENCE.getAbsolutePath(),
-                "SUMMARY_OUTPUT=" + summaryOutfile.getAbsolutePath(),
-                "CHART_OUTPUT=" + pdf.getAbsolutePath(),
-                "SCAN_WINDOW_SIZE=100",
-                "MINIMUM_GENOME_FRACTION=1.0E-5",
-                "IS_BISULFITE_SEQUENCED=false",
-                "LEVEL=ALL_READS",
-                "ASSUME_SORTED=true",
-                "EXCLUDE_INTERVALS=" + bedFile.getAbsolutePath()
-        };
-        runPicardCommandLine(args);
-
+    private long countAlignedReads(final File summaryFile) throws IOException {
         final MetricsFile<GcBiasSummaryMetrics, Comparable<?>> output = new MetricsFile<>();
-        output.read(new FileReader(summaryOutfile));
-
-        long alignedReads = 0;
-        for (final GcBiasSummaryMetrics metrics : output.getMetrics()) {
-            if (metrics.ACCUMULATION_LEVEL.equals(ACCUMULATION_LEVEL_ALL_READS)) {
-                alignedReads = metrics.ALIGNED_READS;
-            }
-        }
-
-        Assert.assertEquals(alignedReads, 1, "Expected 1 aligned read after excluding chrM:330-340 with BED format");
+        output.read(new FileReader(summaryFile));
+        return output.getMetrics().stream()
+                .filter(m -> m.ACCUMULATION_LEVEL.equals(ACCUMULATION_LEVEL_ALL_READS))
+                .mapToLong(m -> m.ALIGNED_READS)
+                .findFirst()
+                .orElse(0);
     }
 }

--- a/src/test/java/picard/util/BedToIntervalListTest.java
+++ b/src/test/java/picard/util/BedToIntervalListTest.java
@@ -20,7 +20,11 @@ public class BedToIntervalListTest {
 
     private static final String TEST_DATA_DIR = "testdata/picard/util/BedToIntervalListTest";
 
-    private void doTest(final String inputBed, final String header, boolean keepLengthZero) throws IOException, SAMException {
+    private void doTest(final String inputBed, final String header) throws IOException, SAMException {
+        doTest(inputBed, header, true);
+    }
+
+    private void doTest(final String inputBed, final String header, final boolean keepLengthZero) throws IOException, SAMException {
         final File outputFile  = File.createTempFile("bed_to_interval_list_test.", ".interval_list");
         outputFile.deleteOnExit();
         final BedToIntervalList program = new BedToIntervalList();
@@ -39,25 +43,7 @@ public class BedToIntervalListTest {
 
     @Test(dataProvider = "testBedToIntervalListDataProvider")
     public void testBedToIntervalList(final String inputBed) throws IOException {
-        doTest(inputBed, "header.sam", true);
-    }
-
-    // test a fixed bed file using different dictionaries
-    @Test(dataProvider = "testBedToIntervalListSequenceDictionaryDataProvider")
-    public void testBedToIntervalListSequenceDictionary(final String dictionary) throws IOException {
-        doTest("seq_dict_test.bed", dictionary, true);
-    }
-
-    // test for back dictionaries - we expect these to throw exceptions
-    @Test(dataProvider = "testBedToIntervalListSequenceDictionaryBadDataProvider",
-          expectedExceptions = {SAMException.class, PicardException.class})
-    public void testBedToIntervalListBadSequenceDictionary(final String dictionary) throws IOException {
-        doTest("seq_dict_test.bed", dictionary, true);
-    }
-
-    @Test(dataProvider = "testBedToIntervalListOutOfBoundsDataProvider", expectedExceptions = PicardException.class)
-    public void testBedToIntervalListOutOfBounds(final String inputBed) throws IOException {
-        doTest(inputBed, "header.sam", true);
+        doTest(inputBed, "header.sam");
     }
 
     @Test(dataProvider = "testLengthZeroIntervalsSkippedProvider")
@@ -65,11 +51,29 @@ public class BedToIntervalListTest {
         doTest(inputBed, "header.sam", false);
     }
 
+    // test a fixed bed file using different dictionaries
+    @Test(dataProvider = "testBedToIntervalListSequenceDictionaryDataProvider")
+    public void testBedToIntervalListSequenceDictionary(final String dictionary) throws IOException {
+        doTest("seq_dict_test.bed", dictionary);
+    }
+
+    // test for bad dictionaries - we expect these to throw exceptions
+    @Test(dataProvider = "testBedToIntervalListSequenceDictionaryBadDataProvider",
+          expectedExceptions = {SAMException.class, PicardException.class})
+    public void testBedToIntervalListBadSequenceDictionary(final String dictionary) throws IOException {
+        doTest("seq_dict_test.bed", dictionary);
+    }
+
+    @Test(dataProvider = "testBedToIntervalListOutOfBoundsDataProvider", expectedExceptions = PicardException.class)
+    public void testBedToIntervalListOutOfBounds(final String inputBed) throws IOException {
+        doTest(inputBed, "header.sam");
+    }
+
     @Test(expectedExceptions = PicardException.class)
     public void testRejectIntervalListInput() throws IOException {
         // Feeding an interval_list file (which starts with @ SAM headers) to BedToIntervalList
         // should throw a clear PicardException rather than a confusing NumberFormatException.
-        doTest("seq_dict_test.dictionary.interval_list", "header.sam", true);
+        doTest("seq_dict_test.dictionary.interval_list", "header.sam");
     }
 
     @Test

--- a/src/test/java/picard/util/BedToIntervalListTest.java
+++ b/src/test/java/picard/util/BedToIntervalListTest.java
@@ -69,13 +69,6 @@ public class BedToIntervalListTest {
         doTest(inputBed, "header.sam");
     }
 
-    @Test(expectedExceptions = PicardException.class)
-    public void testRejectIntervalListInput() throws IOException {
-        // Feeding an interval_list file (which starts with @ SAM headers) to BedToIntervalList
-        // should throw a clear PicardException rather than a confusing NumberFormatException.
-        doTest("seq_dict_test.dictionary.interval_list", "header.sam");
-    }
-
     @Test
     public void testStdinSupport() throws IOException {
         // Feed the contents of simple.bed through System.in and verify the output matches

--- a/src/test/java/picard/util/IntervalFileReaderTest.java
+++ b/src/test/java/picard/util/IntervalFileReaderTest.java
@@ -1,0 +1,226 @@
+package picard.util;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.util.Interval;
+import htsjdk.samtools.util.IntervalList;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import picard.PicardException;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.List;
+
+/**
+ * Tests for {@link IntervalFileReader}: format detection, BED parsing, and generic interval loading.
+ */
+public class IntervalFileReaderTest {
+
+    private static final String TEST_DATA_DIR = "testdata/picard/util/BedToIntervalListTest";
+
+    /** Build a minimal dictionary with chr1..chr8 each of length 1 000 000. */
+    private static SAMSequenceDictionary buildDictionary() {
+        final SAMSequenceDictionary dict = new SAMSequenceDictionary();
+        for (int i = 1; i <= 8; i++) {
+            dict.addSequence(new SAMSequenceRecord("chr" + i, 1_000_000));
+        }
+        return dict;
+    }
+
+    private static SAMFileHeader buildHeader() {
+        final SAMFileHeader header = new SAMFileHeader();
+        header.setSequenceDictionary(buildDictionary());
+        return header;
+    }
+
+    private static BufferedReader readerOf(final String content) {
+        return new BufferedReader(new StringReader(content));
+    }
+
+    @Test
+    public void testDetectBedFormat() throws IOException {
+        try (final BufferedReader reader = readerOf("chr1\t100\t200\n")) {
+            final IntervalFileReader.FormatDetectionResult result = IntervalFileReader.detectIntervalFormat(reader);
+            Assert.assertEquals(result.format(), IntervalFileReader.IntervalFileFormat.BED);
+        }
+    }
+
+    @Test
+    public void testDetectIntervalListFormat() throws IOException {
+        try (final BufferedReader reader = readerOf("@HD\tVN:1.6\n@SQ\tSN:chr1\tLN:1000000\n")) {
+            final IntervalFileReader.FormatDetectionResult result = IntervalFileReader.detectIntervalFormat(reader);
+            Assert.assertEquals(result.format(), IntervalFileReader.IntervalFileFormat.INTERVAL_LIST);
+        }
+    }
+
+    @Test
+    public void testDetectUnknownFormat() throws IOException {
+        try (final BufferedReader reader = readerOf("not_valid_data\n")) {
+            final IntervalFileReader.FormatDetectionResult result = IntervalFileReader.detectIntervalFormat(reader);
+            Assert.assertEquals(result.format(), IntervalFileReader.IntervalFileFormat.UNKNOWN);
+            Assert.assertEquals(result.firstLine(), "not_valid_data");
+        }
+    }
+
+    @Test
+    public void testDetectSkipsComments() throws IOException {
+        try (final BufferedReader reader = readerOf("# comment\n\nchr1\t100\t200\n")) {
+            final IntervalFileReader.FormatDetectionResult result = IntervalFileReader.detectIntervalFormat(reader);
+            Assert.assertEquals(result.format(), IntervalFileReader.IntervalFileFormat.BED);
+        }
+    }
+
+    @Test
+    public void testDetectEmptyFile() throws IOException {
+        try (final BufferedReader reader = readerOf("")) {
+            final IntervalFileReader.FormatDetectionResult result = IntervalFileReader.detectIntervalFormat(reader);
+            Assert.assertEquals(result.format(), IntervalFileReader.IntervalFileFormat.UNKNOWN);
+            Assert.assertNull(result.firstLine());
+        }
+    }
+
+    @Test
+    public void testDetectOnlyComments() throws IOException {
+        try (final BufferedReader reader = readerOf("# just a comment\n# another\n")) {
+            final IntervalFileReader.FormatDetectionResult result = IntervalFileReader.detectIntervalFormat(reader);
+            Assert.assertEquals(result.format(), IntervalFileReader.IntervalFileFormat.UNKNOWN);
+            Assert.assertNull(result.firstLine());
+        }
+    }
+
+    @Test
+    public void testFromBedSimple() throws IOException {
+        final String bed = "chr1\t100\t200\n" +
+                           "chr2\t500\t600\n";
+        final IntervalList result = IntervalFileReader.fromBed(readerOf(bed), buildHeader(), false, false, null);
+        final List<Interval> intervals = result.getIntervals();
+        Assert.assertEquals(intervals.size(), 2);
+        // BED 0-based half-open -> 1-based closed: (100,200) -> (101,200)
+        Assert.assertEquals(intervals.get(0).getContig(), "chr1");
+        Assert.assertEquals(intervals.get(0).getStart(), 101);
+        Assert.assertEquals(intervals.get(0).getEnd(), 200);
+        // (500,600) -> (501,600)
+        Assert.assertEquals(intervals.get(1).getContig(), "chr2");
+        Assert.assertEquals(intervals.get(1).getStart(), 501);
+        Assert.assertEquals(intervals.get(1).getEnd(), 600);
+    }
+
+    @Test
+    public void testFromBedExtendedFields() throws IOException {
+        // 6-field BED with name and strand
+        final String bed = "chr1\t100\t2000\tchr1_100_2000+\t11\t+\n" +
+                           "chr1\t3000\t4000\tchr1_3000_4000-\t12\t-\n";
+        final IntervalList result = IntervalFileReader.fromBed(readerOf(bed), buildHeader(), false, false, null);
+        final List<Interval> intervals = result.getIntervals();
+        Assert.assertEquals(intervals.size(), 2);
+        Assert.assertEquals(intervals.get(0).getName(), "chr1_100_2000+");
+        Assert.assertFalse(intervals.get(0).isNegativeStrand());
+        Assert.assertEquals(intervals.get(1).getName(), "chr1_3000_4000-");
+        Assert.assertTrue(intervals.get(1).isNegativeStrand());
+    }
+
+    @Test
+    public void testFromBedSkipsCommentsAndBlankLines() throws IOException {
+        final String bed = "# comment line\n" +
+                           "\n" +
+                           "chr1\t100\t200\n" +
+                           "# another comment\n" +
+                           "chr1\t300\t400\n";
+        final IntervalList result = IntervalFileReader.fromBed(readerOf(bed), buildHeader(), false, false, null);
+        Assert.assertEquals(result.getIntervals().size(), 2);
+    }
+
+    @Test(expectedExceptions = PicardException.class)
+    public void testFromBedMissingContigThrows() throws IOException {
+        final String bed = "chrX\t100\t200\n";
+        IntervalFileReader.fromBed(readerOf(bed), buildHeader(), false, false, null);
+    }
+
+    @Test
+    public void testFromBedDropMissingContigs() throws IOException {
+        final String bed = "chr1\t100\t200\n" +
+                           "chrX\t100\t200\n";
+        final IntervalList result = IntervalFileReader.fromBed(readerOf(bed), buildHeader(), true, false, null);
+        Assert.assertEquals(result.getIntervals().size(), 1);
+        Assert.assertEquals(result.getIntervals().get(0).getContig(), "chr1");
+    }
+
+    @Test(expectedExceptions = PicardException.class)
+    public void testFromBedTooFewFields() throws IOException {
+        final String bed = "chr1\t100\n";
+        IntervalFileReader.fromBed(readerOf(bed), buildHeader(), false, false, null);
+    }
+
+    @Test
+    public void testFromBedZeroLengthKept() throws IOException {
+        // chromStart == chromEnd means length-zero interval in BED
+        final String bed = "chr1\t100\t100\n";
+        final IntervalList result = IntervalFileReader.fromBed(readerOf(bed), buildHeader(), false, true, null);
+        Assert.assertEquals(result.getIntervals().size(), 1);
+        // (100,100) in BED -> start=101, end=100 in 1-based
+        Assert.assertEquals(result.getIntervals().get(0).getStart(), 101);
+        Assert.assertEquals(result.getIntervals().get(0).getEnd(), 100);
+    }
+
+    @Test
+    public void testFromBedZeroLengthSkipped() throws IOException {
+        final String bed = "chr1\t100\t100\n";
+        final IntervalList result = IntervalFileReader.fromBed(readerOf(bed), buildHeader(), false, false, null);
+        Assert.assertEquals(result.getIntervals().size(), 0);
+    }
+
+    @Test
+    public void testLoadIntervalsFromBedReader() throws IOException {
+        final String bed = "chr1\t100\t200\n" +
+                           "chr1\t300\t400\n";
+        final IntervalList result = IntervalFileReader.loadIntervals(readerOf(bed), buildDictionary());
+        // loadIntervals returns uniqued result
+        Assert.assertEquals(result.getIntervals().size(), 2);
+    }
+
+    @Test
+    public void testLoadIntervalsFromBedFile() {
+        final File bedFile = new File(TEST_DATA_DIR, "simple.bed");
+        final IntervalList result = IntervalFileReader.loadIntervals(bedFile, buildDictionary());
+        Assert.assertEquals(result.getIntervals().size(), 2);
+        // simple.bed: chr1 100 2000  and  chr1 3000 4000
+        Assert.assertEquals(result.getIntervals().get(0).getStart(), 101);
+        Assert.assertEquals(result.getIntervals().get(0).getEnd(), 2000);
+        Assert.assertEquals(result.getIntervals().get(1).getStart(), 3001);
+        Assert.assertEquals(result.getIntervals().get(1).getEnd(), 4000);
+    }
+
+    @Test
+    public void testLoadIntervalsFromIntervalListFile() {
+        final File ilFile = new File(TEST_DATA_DIR, "seq_dict_test.dictionary.interval_list");
+        // interval_list format doesn't actually need the dictionary arg (it has its own header),
+        // but we pass one anyway since loadIntervals requires it for the BED code path.
+        final IntervalList result = IntervalFileReader.loadIntervals(ilFile, buildDictionary());
+        Assert.assertFalse(result.getIntervals().isEmpty());
+    }
+
+    @Test(expectedExceptions = PicardException.class)
+    public void testLoadIntervalsUnknownFormatThrows() throws IOException {
+        IntervalFileReader.loadIntervals(readerOf("not_valid"), buildDictionary());
+    }
+
+    @DataProvider
+    public Object[][] outOfBoundsBedData() {
+        return new Object[][] {
+                // end past contig length
+                {"chr1\t0\t1000001\n"},
+                // start past contig length
+                {"chr1\t1000001\t1000002\n"},
+        };
+    }
+
+    @Test(dataProvider = "outOfBoundsBedData", expectedExceptions = PicardException.class)
+    public void testFromBedOutOfBoundsThrows(final String bed) throws IOException {
+        IntervalFileReader.fromBed(readerOf(bed), buildHeader(), false, false, null);
+    }
+}

--- a/src/test/java/picard/util/IntervalFileReaderTest.java
+++ b/src/test/java/picard/util/IntervalFileReaderTest.java
@@ -6,7 +6,6 @@ import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.IntervalList;
 import org.testng.Assert;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import picard.PicardException;
 
@@ -17,7 +16,7 @@ import java.io.StringReader;
 import java.util.List;
 
 /**
- * Tests for {@link IntervalFileReader}: format detection, BED parsing, and generic interval loading.
+ * Tests for {@link IntervalFileReader}: format detection and generic interval loading.
  */
 public class IntervalFileReaderTest {
 
@@ -41,6 +40,10 @@ public class IntervalFileReaderTest {
     private static BufferedReader readerOf(final String content) {
         return new BufferedReader(new StringReader(content));
     }
+
+    // -------------------------------------------------------------------------
+    // Format detection tests
+    // -------------------------------------------------------------------------
 
     @Test
     public void testDetectBedFormat() throws IOException {
@@ -93,95 +96,36 @@ public class IntervalFileReaderTest {
         }
     }
 
+    // -------------------------------------------------------------------------
+    // fromBed(File, ...) tests
+    // -------------------------------------------------------------------------
+
     @Test
-    public void testFromBedSimple() throws IOException {
-        final String bed = "chr1\t100\t200\n" +
-                           "chr2\t500\t600\n";
-        final IntervalList result = IntervalFileReader.fromBed(readerOf(bed), buildHeader(), false, false, null);
+    public void testFromBedFileSimple() {
+        final File bedFile = new File(TEST_DATA_DIR, "simple.bed");
+        final IntervalList result = IntervalFileReader.fromBed(bedFile, buildHeader(), false, false, null);
         final List<Interval> intervals = result.getIntervals();
         Assert.assertEquals(intervals.size(), 2);
-        // BED 0-based half-open -> 1-based closed: (100,200) -> (101,200)
+        // simple.bed: chr1 100 2000 and chr1 3000 4000
+        // BEDCodec: 0-based half-open -> 1-based closed: (100,2000) -> (101,2000), (3000,4000) -> (3001,4000)
         Assert.assertEquals(intervals.get(0).getContig(), "chr1");
         Assert.assertEquals(intervals.get(0).getStart(), 101);
-        Assert.assertEquals(intervals.get(0).getEnd(), 200);
-        // (500,600) -> (501,600)
-        Assert.assertEquals(intervals.get(1).getContig(), "chr2");
-        Assert.assertEquals(intervals.get(1).getStart(), 501);
-        Assert.assertEquals(intervals.get(1).getEnd(), 600);
+        Assert.assertEquals(intervals.get(0).getEnd(), 2000);
+        Assert.assertEquals(intervals.get(1).getContig(), "chr1");
+        Assert.assertEquals(intervals.get(1).getStart(), 3001);
+        Assert.assertEquals(intervals.get(1).getEnd(), 4000);
     }
 
     @Test
-    public void testFromBedExtendedFields() throws IOException {
-        // 6-field BED with name and strand
-        final String bed = "chr1\t100\t2000\tchr1_100_2000+\t11\t+\n" +
-                           "chr1\t3000\t4000\tchr1_3000_4000-\t12\t-\n";
-        final IntervalList result = IntervalFileReader.fromBed(readerOf(bed), buildHeader(), false, false, null);
-        final List<Interval> intervals = result.getIntervals();
-        Assert.assertEquals(intervals.size(), 2);
-        Assert.assertEquals(intervals.get(0).getName(), "chr1_100_2000+");
-        Assert.assertFalse(intervals.get(0).isNegativeStrand());
-        Assert.assertEquals(intervals.get(1).getName(), "chr1_3000_4000-");
-        Assert.assertTrue(intervals.get(1).isNegativeStrand());
+    public void testFromBedFileExtendedFields() {
+        final File bedFile = new File(TEST_DATA_DIR, "extended.bed");
+        final IntervalList result = IntervalFileReader.fromBed(bedFile, buildHeader(), false, false, null);
+        Assert.assertFalse(result.getIntervals().isEmpty());
     }
 
-    @Test
-    public void testFromBedSkipsCommentsAndBlankLines() throws IOException {
-        final String bed = "# comment line\n" +
-                           "\n" +
-                           "chr1\t100\t200\n" +
-                           "# another comment\n" +
-                           "chr1\t300\t400\n";
-        final IntervalList result = IntervalFileReader.fromBed(readerOf(bed), buildHeader(), false, false, null);
-        Assert.assertEquals(result.getIntervals().size(), 2);
-    }
-
-    @Test(expectedExceptions = PicardException.class)
-    public void testFromBedMissingContigThrows() throws IOException {
-        final String bed = "chrX\t100\t200\n";
-        IntervalFileReader.fromBed(readerOf(bed), buildHeader(), false, false, null);
-    }
-
-    @Test
-    public void testFromBedDropMissingContigs() throws IOException {
-        final String bed = "chr1\t100\t200\n" +
-                           "chrX\t100\t200\n";
-        final IntervalList result = IntervalFileReader.fromBed(readerOf(bed), buildHeader(), true, false, null);
-        Assert.assertEquals(result.getIntervals().size(), 1);
-        Assert.assertEquals(result.getIntervals().get(0).getContig(), "chr1");
-    }
-
-    @Test(expectedExceptions = PicardException.class)
-    public void testFromBedTooFewFields() throws IOException {
-        final String bed = "chr1\t100\n";
-        IntervalFileReader.fromBed(readerOf(bed), buildHeader(), false, false, null);
-    }
-
-    @Test
-    public void testFromBedZeroLengthKept() throws IOException {
-        // chromStart == chromEnd means length-zero interval in BED
-        final String bed = "chr1\t100\t100\n";
-        final IntervalList result = IntervalFileReader.fromBed(readerOf(bed), buildHeader(), false, true, null);
-        Assert.assertEquals(result.getIntervals().size(), 1);
-        // (100,100) in BED -> start=101, end=100 in 1-based
-        Assert.assertEquals(result.getIntervals().get(0).getStart(), 101);
-        Assert.assertEquals(result.getIntervals().get(0).getEnd(), 100);
-    }
-
-    @Test
-    public void testFromBedZeroLengthSkipped() throws IOException {
-        final String bed = "chr1\t100\t100\n";
-        final IntervalList result = IntervalFileReader.fromBed(readerOf(bed), buildHeader(), false, false, null);
-        Assert.assertEquals(result.getIntervals().size(), 0);
-    }
-
-    @Test
-    public void testLoadIntervalsFromBedReader() throws IOException {
-        final String bed = "chr1\t100\t200\n" +
-                           "chr1\t300\t400\n";
-        final IntervalList result = IntervalFileReader.loadIntervals(readerOf(bed), buildDictionary());
-        // loadIntervals returns uniqued result
-        Assert.assertEquals(result.getIntervals().size(), 2);
-    }
+    // -------------------------------------------------------------------------
+    // loadIntervals(File, ...) tests
+    // -------------------------------------------------------------------------
 
     @Test
     public void testLoadIntervalsFromBedFile() {
@@ -202,25 +146,5 @@ public class IntervalFileReaderTest {
         // but we pass one anyway since loadIntervals requires it for the BED code path.
         final IntervalList result = IntervalFileReader.loadIntervals(ilFile, buildDictionary());
         Assert.assertFalse(result.getIntervals().isEmpty());
-    }
-
-    @Test(expectedExceptions = PicardException.class)
-    public void testLoadIntervalsUnknownFormatThrows() throws IOException {
-        IntervalFileReader.loadIntervals(readerOf("not_valid"), buildDictionary());
-    }
-
-    @DataProvider
-    public Object[][] outOfBoundsBedData() {
-        return new Object[][] {
-                // end past contig length
-                {"chr1\t0\t1000001\n"},
-                // start past contig length
-                {"chr1\t1000001\t1000002\n"},
-        };
-    }
-
-    @Test(dataProvider = "outOfBoundsBedData", expectedExceptions = PicardException.class)
-    public void testFromBedOutOfBoundsThrows(final String bed) throws IOException {
-        IntervalFileReader.fromBed(readerOf(bed), buildHeader(), false, false, null);
     }
 }

--- a/src/test/java/picard/util/IntervalFileReaderTest.java
+++ b/src/test/java/picard/util/IntervalFileReaderTest.java
@@ -103,7 +103,7 @@ public class IntervalFileReaderTest {
     @Test
     public void testFromBedFileSimple() {
         final File bedFile = new File(TEST_DATA_DIR, "simple.bed");
-        final IntervalList result = IntervalFileReader.fromBed(bedFile, buildHeader(), false, false, null);
+        final IntervalList result = IntervalFileReader.fromBed(bedFile, buildHeader());
         final List<Interval> intervals = result.getIntervals();
         Assert.assertEquals(intervals.size(), 2);
         // simple.bed: chr1 100 2000 and chr1 3000 4000
@@ -119,7 +119,7 @@ public class IntervalFileReaderTest {
     @Test
     public void testFromBedFileExtendedFields() {
         final File bedFile = new File(TEST_DATA_DIR, "extended.bed");
-        final IntervalList result = IntervalFileReader.fromBed(bedFile, buildHeader(), false, false, null);
+        final IntervalList result = IntervalFileReader.fromBed(bedFile, buildHeader());
         Assert.assertFalse(result.getIntervals().isEmpty());
     }
 


### PR DESCRIPTION
### Description

I added a filtration option to the GC bias tool to allow users to exclude known problematic regions (e.g. [from boyle et. al.](https://www.biorxiv.org/content/10.1101/2022.11.21.517407v1.full.pdf)) and clean up "spikes" in the GC bias due to poly-G stretches mapping or adapter constructs, etc. I also added a min mapq feature for similar reasons.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on github actions

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

