### PR TITLE
Add molecular position stratification to CollectSamErrorMetrics

### DIFF
--- a/src/main/java/picard/sam/SamErrorMetric/ReadBaseStratification.java
+++ b/src/main/java/picard/sam/SamErrorMetric/ReadBaseStratification.java
@@ -77,8 +77,8 @@ public class ReadBaseStratification {
     /**
      * defaults to 2500
      **/
-    public static void setLocationBinSize(int locationBinSize) { 
-       LOCATION_BIN_SIZE = locationBinSize; 
+    public static void setLocationBinSize(int locationBinSize) {
+        LOCATION_BIN_SIZE = locationBinSize;
     }
 
     /* ******* general-use classes, for defining and creating new stratifiers ***********/
@@ -116,6 +116,7 @@ public class ReadBaseStratification {
         public Integer stratify(RecordAndOffset recordAndOffset, SAMLocusAndReference locusInfo) {
             return stratify(recordAndOffset.getRecord());
         }
+
         //Static ReadNameParser so that cache of read names/ PhysicalLocations is shared between all PositionBasedStratifiers
         static final ReadNameParser readNameParser = new ReadNameParser();
 
@@ -576,9 +577,10 @@ public class ReadBaseStratification {
 
         /**
          * Returns the number of bases associated with I and D CIGAR elements.
+         *
          * @param samRecord The read to investigate
          * @return The number of bases associated with I and D CIGAR elements, or null if the evaluation of either
-         *         operation caused an error
+         * operation caused an error
          */
         @Override
         public Integer stratify(final SAMRecord samRecord) {
@@ -751,6 +753,11 @@ public class ReadBaseStratification {
     public static final RecordAndOffsetStratifier<Integer> baseCycleStratifier = wrapStaticFunction(ReadBaseStratification::stratifyCycle, "cycle");
 
     /**
+     * Get the one-based molecular position of the base, taking the distance to the ends into account
+     */
+    public static final RecordAndOffsetStratifier<Integer> baseMolecularPosStratifier = wrapStaticFunction(ReadBaseStratification::stratifyMolecularPosition, "molecular_pos");
+
+    /**
      * Stratifies into the read-pairs estimated insert-length, as long as it isn't larger than 10x the length of the read
      */
     public static final RecordAndOffsetStratifier<Integer> insertLengthStratifier = wrapStaticReadFunction(ReadBaseStratification::stratifyInsertLength, "insert_length");
@@ -839,6 +846,7 @@ public class ReadBaseStratification {
         READ_GROUP(() -> readgroupStratifier, "The read-group id of the read."),
         CYCLE(() -> baseCycleStratifier, "The machine cycle during which the base was read."),
         BINNED_CYCLE(() -> binnedReadCycleStratifier, "The binned machine cycle. Similar to CYCLE, but binned into 5 evenly spaced ranges across the size of the read.  This stratifier may produce confusing results when used on datasets with variable sized reads."),
+        MOLECULAR_POS(() -> baseMolecularPosStratifier, "The molecular position of the base was read (distance from the end of the molecule)."),
         SOFT_CLIPS(() -> softClipsLengthStratifier, "The number of softclipped bases the read has."),
         INSERT_LENGTH(() -> insertLengthStratifier, "The insert-size they came from (taken from the TLEN field.)"),
         BASE_QUALITY(() -> baseQualityStratifier, "The base quality."),
@@ -884,6 +892,10 @@ public class ReadBaseStratification {
                 return null;
             }
             return sam.getFirstOfPairFlag() ? ReadOrdinality.FIRST : ReadOrdinality.SECOND;
+        }
+
+        public boolean isFirst() {
+            return this.equals(FIRST);
         }
     }
 
@@ -1067,8 +1079,9 @@ public class ReadBaseStratification {
 
     /**
      * Returns the number of bases associated with a specific cigar operator within a read
+     *
      * @param samRecord The read to investigate
-     * @param operator The operator that the counted bases should be associated with
+     * @param operator  The operator that the counted bases should be associated with
      */
     private static Integer stratifyCigarOperatorsInRead(final SAMRecord samRecord, final CigarOperator operator) {
         try {
@@ -1122,6 +1135,29 @@ public class ReadBaseStratification {
 
         return retval;
     }
+
+
+    /**
+     * Get the one-based position of the base relative to the ends of the molecule.
+     * <p>
+     * Take the minimum of cycle and insertlength - cycle + 1, if the smaller is the latter,
+     * negate its value. If you are on read 2, also negate the value. The idea is that overlapping
+     * bases should get the same molecular position, and that for read 1 it should be "natural".
+     *
+     * @param recordAndOffset the read and offset in question
+     * @return the molecular position
+     */
+    private static Integer stratifyMolecularPosition(final RecordAndOffset recordAndOffset) {
+        final int cycle = stratifyCycle(recordAndOffset);
+        final int insertSize = stratifyInsertLength(recordAndOffset.getRecord());
+        final int cycleFromEnd = insertSize - cycle + 1;
+        final ReadOrdinality ordinality = ReadOrdinality.of(recordAndOffset.getRecord());
+        
+        if (ordinality == null) return null;
+
+        return (cycle < cycleFromEnd ? cycle : -cycleFromEnd) * (ordinality.isFirst() ? 1 : -1);
+    }
+
 
     private static Integer stratifyHomopolymerLength(final RecordAndOffset recordAndOffset, final SAMLocusAndReference locusInfo) {
 
@@ -1277,8 +1313,7 @@ public class ReadBaseStratification {
                 if (cigarElement.getOperator().consumesReadBases() && readPosition == offset) {
                     return cigarElement;
                 }
-            }
-            else if (recordAndOffset.getAlignmentType() == AbstractRecordAndOffset.AlignmentType.Deletion) {
+            } else if (recordAndOffset.getAlignmentType() == AbstractRecordAndOffset.AlignmentType.Deletion) {
                 if (readPosition == offset + 1) {
                     return cigarElement;
                 }

--- a/src/main/java/picard/sam/SamErrorMetric/ReadBaseStratification.java
+++ b/src/main/java/picard/sam/SamErrorMetric/ReadBaseStratification.java
@@ -846,7 +846,9 @@ public class ReadBaseStratification {
         READ_GROUP(() -> readgroupStratifier, "The read-group id of the read."),
         CYCLE(() -> baseCycleStratifier, "The machine cycle during which the base was read."),
         BINNED_CYCLE(() -> binnedReadCycleStratifier, "The binned machine cycle. Similar to CYCLE, but binned into 5 evenly spaced ranges across the size of the read.  This stratifier may produce confusing results when used on datasets with variable sized reads."),
-        INSERT_END_DISTANCE(() -> baseInsertEndDistanceStratifier, "Distance from the nearest insert end for FR read pairs. Negative if closer to read 2's 3' end. Overlapping bases get matching values. Ignores non-FR orientations, unpaired, or chimeric reads."),
+        INSERT_END_DISTANCE(() -> baseInsertEndDistanceStratifier, "Distance from the nearest insert end for FR read pairs. " +
+                "Negative if closer to read 2's 3' end, e.g., 150x2 reads with 100bp overlap will have values (R1) 51, .., 100, -100, .., -51 for the overlapping region. " +
+                "Overlapping bases get matching values. As it is designed for use with OVERLAPPING_ERROR, values in non-overlapping region are unspecified. Ignores non-FR orientations, unpaired, or chimeric reads."),
         SOFT_CLIPS(() -> softClipsLengthStratifier, "The number of softclipped bases the read has."),
         INSERT_LENGTH(() -> insertLengthStratifier, "The insert-size they came from (taken from the TLEN field.)"),
         BASE_QUALITY(() -> baseQualityStratifier, "The base quality."),

--- a/src/main/java/picard/sam/SamErrorMetric/ReadBaseStratification.java
+++ b/src/main/java/picard/sam/SamErrorMetric/ReadBaseStratification.java
@@ -753,9 +753,9 @@ public class ReadBaseStratification {
     public static final RecordAndOffsetStratifier<Integer> baseCycleStratifier = wrapStaticFunction(ReadBaseStratification::stratifyCycle, "cycle");
 
     /**
-     * Get the one-based molecular position of the base, taking the distance to the ends into account
+     * Get the one-based distance from the nearest end of the insert, taking both reads into account
      */
-    public static final RecordAndOffsetStratifier<Integer> baseMolecularPosStratifier = wrapStaticFunction(ReadBaseStratification::stratifyMolecularPosition, "molecular_pos");
+    public static final RecordAndOffsetStratifier<Integer> baseInsertEndDistanceStratifier = wrapStaticFunction(ReadBaseStratification::stratifyInsertEndDistance, "insert_end_distance");
 
     /**
      * Stratifies into the read-pairs estimated insert-length, as long as it isn't larger than 10x the length of the read
@@ -846,7 +846,7 @@ public class ReadBaseStratification {
         READ_GROUP(() -> readgroupStratifier, "The read-group id of the read."),
         CYCLE(() -> baseCycleStratifier, "The machine cycle during which the base was read."),
         BINNED_CYCLE(() -> binnedReadCycleStratifier, "The binned machine cycle. Similar to CYCLE, but binned into 5 evenly spaced ranges across the size of the read.  This stratifier may produce confusing results when used on datasets with variable sized reads."),
-        MOLECULAR_POS(() -> baseMolecularPosStratifier, "The molecular position of the read-base (distance from the end of the molecule, negative if closer to read 2's 3' end)."),
+        INSERT_END_DISTANCE(() -> baseInsertEndDistanceStratifier, "The distance from the nearest end of the insert (positive if closer to read 1's 5' end, negative if closer to read 2's 3' end). Overlapping bases from paired reads get the same absolute value."),
         SOFT_CLIPS(() -> softClipsLengthStratifier, "The number of softclipped bases the read has."),
         INSERT_LENGTH(() -> insertLengthStratifier, "The insert-size they came from (taken from the TLEN field.)"),
         BASE_QUALITY(() -> baseQualityStratifier, "The base quality."),
@@ -1138,33 +1138,31 @@ public class ReadBaseStratification {
 
 
     /**
-     * Get the one-based position of the base relative to the ends of the molecule.
+     * Get the one-based distance from the nearest end of the insert.
      * <p>
-     * Positive values indicate bases closer to the 5' end of the molecule (WRT 
-     * strand read by read1),
-     * negative values indicate bases closer to the 3' end (WRT same). The absolute value
+     * Positive values indicate bases closer to the 5' end of the insert (as read by read 1),
+     * negative values indicate bases closer to the 3' end. The absolute value
      * is the distance from the nearer end. Overlapping bases from read pairs
-     * should therefore get the _same_ molecular position value. . 
+     * should therefore get the same absolute distance value.
      * <p>
      * Example with insert size = 10 and read length = 6:
      * <pre>
-     * Molecule positions:    1    2    3    4    5    6    7    8    9   10
+     * Insert positions:      1    2    3    4    5    6    7    8    9   10
      * Read 1 (fwd):         ────────────────────────────>>
      *   cycle:               1    2    3    4    5    6
-     *   mol_pos:             1    2    3    4    5   -5
-     * R                    ────────────────────────────>>
-     *      *   
+     *   insert_end_dist:     1    2    3    4    5   -5
+     *
      * Read 2 (rev):                           <<─────────────────────────────
      *   cycle:                                   6    5    4    3    2    1
-     *   mol_pos:                                 5   -5   -4   -3   -2   -1
-     *                                         <<─────────────────────────────
-     * Overlapping bases at positions 5 and 6 have matching mol_pos (5 and -5).
+     *   insert_end_dist:                         5   -5   -4   -3   -2   -1
+     *
+     * Overlapping bases at positions 5 and 6 have matching insert_end_dist (5 and -5).
      * </pre>
      *
      * @param recordAndOffset the read and offset in question
-     * @return the molecular position
+     * @return the distance from the nearest insert end
      */
-    private static Integer stratifyMolecularPosition(final RecordAndOffset recordAndOffset) {
+    private static Integer stratifyInsertEndDistance(final RecordAndOffset recordAndOffset) {
         final SAMRecord rec = recordAndOffset.getRecord();
         final ReadOrdinality ordinality = ReadOrdinality.of(rec);
 

--- a/src/main/java/picard/sam/SamErrorMetric/ReadBaseStratification.java
+++ b/src/main/java/picard/sam/SamErrorMetric/ReadBaseStratification.java
@@ -846,7 +846,7 @@ public class ReadBaseStratification {
         READ_GROUP(() -> readgroupStratifier, "The read-group id of the read."),
         CYCLE(() -> baseCycleStratifier, "The machine cycle during which the base was read."),
         BINNED_CYCLE(() -> binnedReadCycleStratifier, "The binned machine cycle. Similar to CYCLE, but binned into 5 evenly spaced ranges across the size of the read.  This stratifier may produce confusing results when used on datasets with variable sized reads."),
-        INSERT_END_DISTANCE(() -> baseInsertEndDistanceStratifier, "The distance from the nearest end of the insert (positive if closer to read 1's 5' end, negative if closer to read 2's 3' end). Overlapping bases from paired reads get the same absolute value."),
+        INSERT_END_DISTANCE(() -> baseInsertEndDistanceStratifier, "Distance from the nearest insert end for FR read pairs. Negative if closer to read 2's 3' end. Overlapping bases get matching values. Ignores non-FR orientations, unpaired, or chimeric reads."),
         SOFT_CLIPS(() -> softClipsLengthStratifier, "The number of softclipped bases the read has."),
         INSERT_LENGTH(() -> insertLengthStratifier, "The insert-size they came from (taken from the TLEN field.)"),
         BASE_QUALITY(() -> baseQualityStratifier, "The base quality."),

--- a/src/main/java/picard/sam/SamErrorMetric/ReadBaseStratification.java
+++ b/src/main/java/picard/sam/SamErrorMetric/ReadBaseStratification.java
@@ -846,7 +846,7 @@ public class ReadBaseStratification {
         READ_GROUP(() -> readgroupStratifier, "The read-group id of the read."),
         CYCLE(() -> baseCycleStratifier, "The machine cycle during which the base was read."),
         BINNED_CYCLE(() -> binnedReadCycleStratifier, "The binned machine cycle. Similar to CYCLE, but binned into 5 evenly spaced ranges across the size of the read.  This stratifier may produce confusing results when used on datasets with variable sized reads."),
-        MOLECULAR_POS(() -> baseMolecularPosStratifier, "The molecular position of the base was read (distance from the end of the molecule)."),
+        MOLECULAR_POS(() -> baseMolecularPosStratifier, "The molecular position of the read-base (distance from the end of the molecule, negative if closer to read 2's 3' end)."),
         SOFT_CLIPS(() -> softClipsLengthStratifier, "The number of softclipped bases the read has."),
         INSERT_LENGTH(() -> insertLengthStratifier, "The insert-size they came from (taken from the TLEN field.)"),
         BASE_QUALITY(() -> baseQualityStratifier, "The base quality."),
@@ -1140,22 +1140,49 @@ public class ReadBaseStratification {
     /**
      * Get the one-based position of the base relative to the ends of the molecule.
      * <p>
-     * Take the minimum of cycle and insertlength - cycle + 1, if the smaller is the latter,
-     * negate its value. If you are on read 2, also negate the value. The idea is that overlapping
-     * bases should get the same molecular position, and that for read 1 it should be "natural".
+     * Positive values indicate bases closer to the 5' end of the molecule (WRT 
+     * strand read by read1),
+     * negative values indicate bases closer to the 3' end (WRT same). The absolute value
+     * is the distance from the nearer end. Overlapping bases from read pairs
+     * should therefore get the _same_ molecular position value. . 
+     * <p>
+     * Example with insert size = 10 and read length = 6:
+     * <pre>
+     * Molecule positions:    1    2    3    4    5    6    7    8    9   10
+     * Read 1 (fwd):         ────────────────────────────>>
+     *   cycle:               1    2    3    4    5    6
+     *   mol_pos:             1    2    3    4    5   -5
+     * R                    ────────────────────────────>>
+     *      *   
+     * Read 2 (rev):                           <<─────────────────────────────
+     *   cycle:                                   6    5    4    3    2    1
+     *   mol_pos:                                 5   -5   -4   -3   -2   -1
+     *                                         <<─────────────────────────────
+     * Overlapping bases at positions 5 and 6 have matching mol_pos (5 and -5).
+     * </pre>
      *
      * @param recordAndOffset the read and offset in question
      * @return the molecular position
      */
     private static Integer stratifyMolecularPosition(final RecordAndOffset recordAndOffset) {
-        final int cycle = stratifyCycle(recordAndOffset);
-        final int insertSize = stratifyInsertLength(recordAndOffset.getRecord());
-        final int cycleFromEnd = insertSize - cycle + 1;
-        final ReadOrdinality ordinality = ReadOrdinality.of(recordAndOffset.getRecord());
-        
+        final SAMRecord rec = recordAndOffset.getRecord();
+        final ReadOrdinality ordinality = ReadOrdinality.of(rec);
+
+        // Return null for unpaired reads
         if (ordinality == null) return null;
 
-        return (cycle < cycleFromEnd ? cycle : -cycleFromEnd) * (ordinality.isFirst() ? 1 : -1);
+        // Return null if mate is unmapped or on different chromosome (chimeric)
+        if (rec.getMateUnmappedFlag() || !rec.getReferenceIndex().equals(rec.getMateReferenceIndex())) return null;
+
+        // Return null for non-FR orientation (RF, tandem, etc.)
+        if (SamPairUtil.getPairOrientation(rec) != SamPairUtil.PairOrientation.FR) return null;
+
+        final int cycle = stratifyCycle(recordAndOffset);
+        final int insertSize = Math.abs(rec.getInferredInsertSize());
+        final int cycleFromEnd = insertSize - cycle + 1;
+
+        // At the midpoint (cycle == cycleFromEnd), we consider it part of the first half (positive)
+        return (cycle <= cycleFromEnd ? cycle : -cycleFromEnd) * (ordinality.isFirst() ? 1 : -1);
     }
 
 

--- a/src/main/java/picard/sam/SamErrorMetric/ReadBaseStratification.java
+++ b/src/main/java/picard/sam/SamErrorMetric/ReadBaseStratification.java
@@ -848,7 +848,7 @@ public class ReadBaseStratification {
         BINNED_CYCLE(() -> binnedReadCycleStratifier, "The binned machine cycle. Similar to CYCLE, but binned into 5 evenly spaced ranges across the size of the read.  This stratifier may produce confusing results when used on datasets with variable sized reads."),
         INSERT_END_DISTANCE(() -> baseInsertEndDistanceStratifier, "Distance from the nearest insert end for FR read pairs. " +
                 "Negative if closer to read 2's 3' end, e.g., 150x2 reads with 100bp overlap will have values (R1) 51, .., 100, -100, .., -51 for the overlapping region. " +
-                "Overlapping bases get matching values. As it is designed for use with OVERLAPPING_ERROR, value in non-overlapping region is unspecified, and non-FR orientations, unpaired, and chimeric reads are ignored."),
+                "Overlapping bases get matching values. As it is designed for use with OVERLAPPING_ERROR, value in non-overlapping region is unspecified, and non-FR orientations, unpaired, chimeric reads, and reads with TLEN=0 are ignored."),
         SOFT_CLIPS(() -> softClipsLengthStratifier, "The number of softclipped bases the read has."),
         INSERT_LENGTH(() -> insertLengthStratifier, "The insert-size they came from (taken from the TLEN field.)"),
         BASE_QUALITY(() -> baseQualityStratifier, "The base quality."),
@@ -1179,6 +1179,10 @@ public class ReadBaseStratification {
 
         final int cycle = stratifyCycle(recordAndOffset);
         final int insertSize = Math.abs(rec.getInferredInsertSize());
+
+        // Return null if insert size is zero (TLEN not set or invalid)
+        if (insertSize == 0) return null;
+
         final int cycleFromEnd = insertSize - cycle + 1;
 
         // At the midpoint (cycle == cycleFromEnd), we consider it part of the first half (positive)

--- a/src/main/java/picard/sam/SamErrorMetric/ReadBaseStratification.java
+++ b/src/main/java/picard/sam/SamErrorMetric/ReadBaseStratification.java
@@ -848,7 +848,7 @@ public class ReadBaseStratification {
         BINNED_CYCLE(() -> binnedReadCycleStratifier, "The binned machine cycle. Similar to CYCLE, but binned into 5 evenly spaced ranges across the size of the read.  This stratifier may produce confusing results when used on datasets with variable sized reads."),
         INSERT_END_DISTANCE(() -> baseInsertEndDistanceStratifier, "Distance from the nearest insert end for FR read pairs. " +
                 "Negative if closer to read 2's 3' end, e.g., 150x2 reads with 100bp overlap will have values (R1) 51, .., 100, -100, .., -51 for the overlapping region. " +
-                "Overlapping bases get matching values. As it is designed for use with OVERLAPPING_ERROR, values in non-overlapping region are unspecified. Ignores non-FR orientations, unpaired, or chimeric reads."),
+                "Overlapping bases get matching values. As it is designed for use with OVERLAPPING_ERROR, value in non-overlapping region is unspecified, and non-FR orientations, unpaired, and chimeric reads are ignored."),
         SOFT_CLIPS(() -> softClipsLengthStratifier, "The number of softclipped bases the read has."),
         INSERT_LENGTH(() -> insertLengthStratifier, "The insert-size they came from (taken from the TLEN field.)"),
         BASE_QUALITY(() -> baseQualityStratifier, "The base quality."),

--- a/src/test/java/picard/sam/SamErrorMetric/ReadBaseStratificationTest.java
+++ b/src/test/java/picard/sam/SamErrorMetric/ReadBaseStratificationTest.java
@@ -554,7 +554,7 @@ public class ReadBaseStratificationTest {
     }
 
     @Test(dataProvider = "molecularPositions")
-    public void testTestMolecularPositionStratifier(int position, boolean read1, int expected_mol_pos) {
+    public void testTestMolecularPositionStratifier(int offset, boolean read1, int expected_mol_pos) {
         final SAMSequenceRecord samSequenceRecord = new SAMSequenceRecord("chr1", 2_000);
         final SAMFileHeader samFileHeader = new SAMFileHeader();
         samFileHeader.addSequence(samSequenceRecord);
@@ -569,8 +569,8 @@ public class ReadBaseStratificationTest {
 
         ReadBaseStratification.RecordAndOffsetStratifier<Integer> stratifier = ReadBaseStratification.baseMolecularPosStratifier;
 
-        SamLocusIterator.RecordAndOffset recordAndOffset = new SamLocusIterator.RecordAndOffset(pair.get(read1 ? 0 : 1), position);
-        SamLocusIterator.LocusInfo locusInfo = new SamLocusIterator.LocusInfo(samSequenceRecord, position + 1);
+        SamLocusIterator.RecordAndOffset recordAndOffset = new SamLocusIterator.RecordAndOffset(pair.get(read1 ? 0 : 1), offset);
+        SamLocusIterator.LocusInfo locusInfo = new SamLocusIterator.LocusInfo(samSequenceRecord, 1);
         SAMLocusAndReference locusAndReference = new SAMLocusAndReference(locusInfo, (byte) 'A');
 
 

--- a/src/test/java/picard/sam/SamErrorMetric/ReadBaseStratificationTest.java
+++ b/src/test/java/picard/sam/SamErrorMetric/ReadBaseStratificationTest.java
@@ -543,24 +543,24 @@ public class ReadBaseStratificationTest {
     }
 
     @DataProvider
-    public Object[][] molecularPositions() {
+    public Object[][] insertEndDistances() {
         // Test setup: read length = 36, insert size = 36 (fully overlapping reads)
         // Read 1: forward strand, Read 2: reverse strand
         return new Object[][] {
                 // Read 1 (forward strand)
-                {0, true, 1},     // cycle=1, cycleFromEnd=36, mol_pos=1
-                {1, true, 2},     // cycle=2, cycleFromEnd=35, mol_pos=2
-                {17, true, 18},   // cycle=18, cycleFromEnd=19, mol_pos=18 (last positive)
-                {18, true, -18},  // cycle=19, cycleFromEnd=18, mol_pos=-18 (first negative)
-                {35, true, -1},   // cycle=36, cycleFromEnd=1, mol_pos=-1
+                {0, true, 1},     // cycle=1, cycleFromEnd=36, insert_end_dist=1
+                {1, true, 2},     // cycle=2, cycleFromEnd=35, insert_end_dist=2
+                {17, true, 18},   // cycle=18, cycleFromEnd=19, insert_end_dist=18 (last positive)
+                {18, true, -18},  // cycle=19, cycleFromEnd=18, insert_end_dist=-18 (first negative)
+                {35, true, -1},   // cycle=36, cycleFromEnd=1, insert_end_dist=-1
                 // Read 2 (reverse strand) - overlapping positions should match Read 1
                 {0, false, 1},    // cycle=36, cycleFromEnd=1, base=-1, *-1=1 (matches R1 offset 0)
                 {35, false, -1},  // cycle=1, cycleFromEnd=36, base=1, *-1=-1 (matches R1 offset 35)
         };
     }
 
-    @Test(dataProvider = "molecularPositions")
-    public void testTestMolecularPositionStratifier(int offset, boolean read1, int expected_mol_pos) {
+    @Test(dataProvider = "insertEndDistances")
+    public void testTestInsertEndDistanceStratifier(int offset, boolean read1, int expected_insert_end_dist) {
         final SAMSequenceRecord samSequenceRecord = new SAMSequenceRecord("chr1", 2_000);
         final SAMFileHeader samFileHeader = new SAMFileHeader();
         samFileHeader.addSequence(samSequenceRecord);
@@ -570,21 +570,21 @@ public class ReadBaseStratificationTest {
 
         SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
         builder.setHeader(samFileHeader);
-        final List<SAMRecord> pair = builder.addPair("test_MolecularPositionStratifier",
+        final List<SAMRecord> pair = builder.addPair("test_InsertEndDistanceStratifier",
                 0, 100, 100, false, false, "36M", "36M", false, true, 30);
 
-        ReadBaseStratification.RecordAndOffsetStratifier<Integer> stratifier = ReadBaseStratification.baseMolecularPosStratifier;
+        ReadBaseStratification.RecordAndOffsetStratifier<Integer> stratifier = ReadBaseStratification.baseInsertEndDistanceStratifier;
 
         SamLocusIterator.RecordAndOffset recordAndOffset = new SamLocusIterator.RecordAndOffset(pair.get(read1 ? 0 : 1), offset);
         SamLocusIterator.LocusInfo locusInfo = new SamLocusIterator.LocusInfo(samSequenceRecord, 1);
         SAMLocusAndReference locusAndReference = new SAMLocusAndReference(locusInfo, (byte) 'A');
 
 
-        Assert.assertEquals(stratifier.stratify(recordAndOffset, locusAndReference), expected_mol_pos);
+        Assert.assertEquals(stratifier.stratify(recordAndOffset, locusAndReference), expected_insert_end_dist);
     }
 
     @DataProvider
-    public Object[][] molecularPositionsRead1Reverse() {
+    public Object[][] insertEndDistancesRead1Reverse() {
         // Test setup: read length = 36, insert size = 36 (fully overlapping reads)
         // Read 1: reverse strand (rightmost), Read 2: forward strand (leftmost)
         // This is still FR orientation: → ←
@@ -598,8 +598,8 @@ public class ReadBaseStratificationTest {
         };
     }
 
-    @Test(dataProvider = "molecularPositionsRead1Reverse")
-    public void testMolecularPositionStratifierRead1Reverse(int offset, boolean read1, int expected_mol_pos) {
+    @Test(dataProvider = "insertEndDistancesRead1Reverse")
+    public void testInsertEndDistanceStratifierRead1Reverse(int offset, boolean read1, int expected_insert_end_dist) {
         final SAMSequenceRecord samSequenceRecord = new SAMSequenceRecord("chr1", 2_000);
         final SAMFileHeader samFileHeader = new SAMFileHeader();
         samFileHeader.addSequence(samSequenceRecord);
@@ -610,20 +610,20 @@ public class ReadBaseStratificationTest {
         builder.setHeader(samFileHeader);
         // Read 2 at position 100 (forward), Read 1 at position 100 (reverse)
         // FR orientation with read 1 on reverse strand
-        final List<SAMRecord> pair = builder.addPair("test_MolecularPositionStratifier_R1rev",
+        final List<SAMRecord> pair = builder.addPair("test_InsertEndDistanceStratifier_R1rev",
                 0, 100, 100, false, false, "36M", "36M", true, false, 30);
 
-        ReadBaseStratification.RecordAndOffsetStratifier<Integer> stratifier = ReadBaseStratification.baseMolecularPosStratifier;
+        ReadBaseStratification.RecordAndOffsetStratifier<Integer> stratifier = ReadBaseStratification.baseInsertEndDistanceStratifier;
 
         SamLocusIterator.RecordAndOffset recordAndOffset = new SamLocusIterator.RecordAndOffset(pair.get(read1 ? 0 : 1), offset);
         SamLocusIterator.LocusInfo locusInfo = new SamLocusIterator.LocusInfo(samSequenceRecord, 1);
         SAMLocusAndReference locusAndReference = new SAMLocusAndReference(locusInfo, (byte) 'A');
 
-        Assert.assertEquals(stratifier.stratify(recordAndOffset, locusAndReference), expected_mol_pos);
+        Assert.assertEquals(stratifier.stratify(recordAndOffset, locusAndReference), expected_insert_end_dist);
     }
 
     @DataProvider
-    public Object[][] molecularPositionsPartialOverlap() {
+    public Object[][] insertEndDistancesPartialOverlap() {
         // Test setup: read length = 36, insert size = 51 (partial overlap)
         // Read 1: forward strand, positions 100-135
         // Read 2: reverse strand, positions 115-150
@@ -634,20 +634,20 @@ public class ReadBaseStratificationTest {
         // Read 1 (fwd):       [R1 ................. R1 ................. R1]
         //                      ─────────────────────────────────────────→
         //   offsets:           0                   15                   35
-        //   mol_pos:           1                   16                  -16
+        //   insert_end_dist:           1                   16                  -16
         //                      ───────────────────────────────────────────────────────────────
         // Read 2 (rev):                           [R2 ................. R2 ................. R2]
         //                                         ←─────────────────────────────────────────
         //   offsets:                               0                   20                   35
-        //   mol_pos:                              16                  -16                   -1
+        //   insert_end_dist:                              16                  -16                   -1
         //                      ───────────────────────────────────────────────────────────────
-        // Overlapping bases at molecule positions 16-36 have matching mol_pos values.
+        // Overlapping bases at molecule positions 16-36 have matching insert_end_dist values.
         return new Object[][] {
                 // Read 1 (forward strand)
-                {0, true, 1},      // cycle=1, cycleFromEnd=51, mol_pos=1
-                {15, true, 16},    // cycle=16, cycleFromEnd=36, mol_pos=16 (start of overlap)
-                {25, true, 26},   // cycle=26, cycleFromEnd=26, mol_pos=-26 (midpoint)
-                {35, true, -16},   // cycle=36, cycleFromEnd=16, mol_pos=-16 (end of R1)
+                {0, true, 1},      // cycle=1, cycleFromEnd=51, insert_end_dist=1
+                {15, true, 16},    // cycle=16, cycleFromEnd=36, insert_end_dist=16 (start of overlap)
+                {25, true, 26},   // cycle=26, cycleFromEnd=26, insert_end_dist=-26 (midpoint)
+                {35, true, -16},   // cycle=36, cycleFromEnd=16, insert_end_dist=-16 (end of R1)
                 // Read 2 (reverse strand)
                 {0, false, 16},    // cycle=36, cycleFromEnd=16, base=-16, *-1=16 (matches R1 offset 15)
                 {20, false, -16},  // cycle=16, cycleFromEnd=36, base=16, *-1=-16 (matches R1 offset 35)
@@ -655,8 +655,8 @@ public class ReadBaseStratificationTest {
         };
     }
 
-    @Test(dataProvider = "molecularPositionsPartialOverlap")
-    public void testMolecularPositionStratifierPartialOverlap(int offset, boolean read1, int expected_mol_pos) {
+    @Test(dataProvider = "insertEndDistancesPartialOverlap")
+    public void testInsertEndDistanceStratifierPartialOverlap(int offset, boolean read1, int expected_insert_end_dist) {
         final SAMSequenceRecord samSequenceRecord = new SAMSequenceRecord("chr1", 2_000);
         final SAMFileHeader samFileHeader = new SAMFileHeader();
         samFileHeader.addSequence(samSequenceRecord);
@@ -666,20 +666,20 @@ public class ReadBaseStratificationTest {
         SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
         builder.setHeader(samFileHeader);
         // Read 1 starts at 100, Read 2 starts at 115, both 36 bases → insert size = 51
-        final List<SAMRecord> pair = builder.addPair("test_MolecularPositionStratifier_partial",
+        final List<SAMRecord> pair = builder.addPair("test_InsertEndDistanceStratifier_partial",
                 0, 100, 115, false, false, "36M", "36M", false, true, 30);
 
-        ReadBaseStratification.RecordAndOffsetStratifier<Integer> stratifier = ReadBaseStratification.baseMolecularPosStratifier;
+        ReadBaseStratification.RecordAndOffsetStratifier<Integer> stratifier = ReadBaseStratification.baseInsertEndDistanceStratifier;
 
         SamLocusIterator.RecordAndOffset recordAndOffset = new SamLocusIterator.RecordAndOffset(pair.get(read1 ? 0 : 1), offset);
         SamLocusIterator.LocusInfo locusInfo = new SamLocusIterator.LocusInfo(samSequenceRecord, 1);
         SAMLocusAndReference locusAndReference = new SAMLocusAndReference(locusInfo, (byte) 'A');
 
-        Assert.assertEquals(stratifier.stratify(recordAndOffset, locusAndReference), expected_mol_pos);
+        Assert.assertEquals(stratifier.stratify(recordAndOffset, locusAndReference), expected_insert_end_dist);
     }
 
     @DataProvider
-    public Object[][] molecularPositionEdgeCases() {
+    public Object[][] insertEndDistanceEdgeCases() {
         // Returns: description, contig1, start1, contig2, start2, unmapped1, unmapped2, cigar1, cigar2, strand1, strand2
         return new Object[][] {
                 // description,      c1, s1,  c2,  s2, unmap1, unmap2, cig1,  cig2,  neg1,  neg2
@@ -691,8 +691,8 @@ public class ReadBaseStratificationTest {
         };
     }
 
-    @Test(dataProvider = "molecularPositionEdgeCases")
-    public void testMolecularPositionStratifierEdgeCases(String description, int contig1, int start1,
+    @Test(dataProvider = "insertEndDistanceEdgeCases")
+    public void testInsertEndDistanceStratifierEdgeCases(String description, int contig1, int start1,
             int contig2, int start2, boolean unmapped1, boolean unmapped2,
             String cigar1, String cigar2, boolean negStrand1, boolean negStrand2) {
         final SAMSequenceRecord chr1 = new SAMSequenceRecord("chr1", 10_000);
@@ -706,7 +706,7 @@ public class ReadBaseStratificationTest {
         SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
         builder.setHeader(samFileHeader);
 
-        ReadBaseStratification.RecordAndOffsetStratifier<Integer> stratifier = ReadBaseStratification.baseMolecularPosStratifier;
+        ReadBaseStratification.RecordAndOffsetStratifier<Integer> stratifier = ReadBaseStratification.baseInsertEndDistanceStratifier;
         SamLocusIterator.LocusInfo locusInfo = new SamLocusIterator.LocusInfo(chr1, 1);
         SAMLocusAndReference locusAndReference = new SAMLocusAndReference(locusInfo, (byte) 'A');
 
@@ -724,7 +724,7 @@ public class ReadBaseStratificationTest {
     }
 
     @Test
-    public void testMolecularPositionStratifierUnpaired() {
+    public void testInsertEndDistanceStratifierUnpaired() {
         final SAMSequenceRecord chr1 = new SAMSequenceRecord("chr1", 10_000);
         final SAMFileHeader samFileHeader = new SAMFileHeader();
         samFileHeader.addSequence(chr1);
@@ -734,7 +734,7 @@ public class ReadBaseStratificationTest {
         SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
         builder.setHeader(samFileHeader);
 
-        ReadBaseStratification.RecordAndOffsetStratifier<Integer> stratifier = ReadBaseStratification.baseMolecularPosStratifier;
+        ReadBaseStratification.RecordAndOffsetStratifier<Integer> stratifier = ReadBaseStratification.baseInsertEndDistanceStratifier;
         SamLocusIterator.LocusInfo locusInfo = new SamLocusIterator.LocusInfo(chr1, 1);
         SAMLocusAndReference locusAndReference = new SAMLocusAndReference(locusInfo, (byte) 'A');
 

--- a/src/test/java/picard/sam/SamErrorMetric/ReadBaseStratificationTest.java
+++ b/src/test/java/picard/sam/SamErrorMetric/ReadBaseStratificationTest.java
@@ -537,9 +537,43 @@ public class ReadBaseStratificationTest {
 
         if (expected == null) {
             Assert.assertNull(ReadBaseStratification.getIndelElement(rao));
-        }
-        else {
+        } else {
             Assert.assertEquals(ReadBaseStratification.getIndelElement(rao).getOperator(), expected);
         }
+    }
+
+    @DataProvider
+    public Object[][] molecularPositions() {
+        return new Object[][] {
+                {0, true, 1},
+                {1, true, 2},
+                {1, true, 2},
+                {36, true, -1},
+                {35, true, -2},
+        };
+    }
+
+    @Test(dataProvider = "molecularPositions")
+    public void testTestMolecularPositionStratifier(int position, boolean read1, int expected_mol_pos) {
+        final SAMSequenceRecord samSequenceRecord = new SAMSequenceRecord("chr1", 2_000);
+        final SAMFileHeader samFileHeader = new SAMFileHeader();
+        samFileHeader.addSequence(samSequenceRecord);
+        final SAMReadGroupRecord readGroupRecord = new SAMReadGroupRecord("rgID");
+        samFileHeader.addReadGroup(readGroupRecord);
+
+
+        SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
+        builder.setHeader(samFileHeader);
+        final List<SAMRecord> pair = builder.addPair("test_MolecularPositionStratifier",
+                0, 100, 100, false, false, "36M", "36M", false, true, 30);
+
+        ReadBaseStratification.RecordAndOffsetStratifier<Integer> stratifier = ReadBaseStratification.baseMolecularPosStratifier;
+
+        SamLocusIterator.RecordAndOffset recordAndOffset = new SamLocusIterator.RecordAndOffset(pair.get(read1 ? 0 : 1), position);
+        SamLocusIterator.LocusInfo locusInfo = new SamLocusIterator.LocusInfo(samSequenceRecord, position + 1);
+        SAMLocusAndReference locusAndReference = new SAMLocusAndReference(locusInfo, (byte) 'A');
+
+
+        Assert.assertEquals(stratifier.stratify(recordAndOffset, locusAndReference), expected_mol_pos);
     }
 }

--- a/src/test/java/picard/sam/SamErrorMetric/ReadBaseStratificationTest.java
+++ b/src/test/java/picard/sam/SamErrorMetric/ReadBaseStratificationTest.java
@@ -544,12 +544,18 @@ public class ReadBaseStratificationTest {
 
     @DataProvider
     public Object[][] molecularPositions() {
+        // Test setup: read length = 36, insert size = 36 (fully overlapping reads)
+        // Read 1: forward strand, Read 2: reverse strand
         return new Object[][] {
-                {0, true, 1},
-                {1, true, 2},
-                {1, true, 2},
-                {36, true, -1},
-                {35, true, -2},
+                // Read 1 (forward strand)
+                {0, true, 1},     // cycle=1, cycleFromEnd=36, mol_pos=1
+                {1, true, 2},     // cycle=2, cycleFromEnd=35, mol_pos=2
+                {17, true, 18},   // cycle=18, cycleFromEnd=19, mol_pos=18 (last positive)
+                {18, true, -18},  // cycle=19, cycleFromEnd=18, mol_pos=-18 (first negative)
+                {35, true, -1},   // cycle=36, cycleFromEnd=1, mol_pos=-1
+                // Read 2 (reverse strand) - overlapping positions should match Read 1
+                {0, false, 1},    // cycle=36, cycleFromEnd=1, base=-1, *-1=1 (matches R1 offset 0)
+                {35, false, -1},  // cycle=1, cycleFromEnd=36, base=1, *-1=-1 (matches R1 offset 35)
         };
     }
 
@@ -575,5 +581,166 @@ public class ReadBaseStratificationTest {
 
 
         Assert.assertEquals(stratifier.stratify(recordAndOffset, locusAndReference), expected_mol_pos);
+    }
+
+    @DataProvider
+    public Object[][] molecularPositionsRead1Reverse() {
+        // Test setup: read length = 36, insert size = 36 (fully overlapping reads)
+        // Read 1: reverse strand (rightmost), Read 2: forward strand (leftmost)
+        // This is still FR orientation: → ←
+        return new Object[][] {
+                // Read 1 (reverse strand) - cycle counts from 3' end of read
+                {0, true, -1},    // cycle=36, cycleFromEnd=1, base=-1, *1=-1 (genomic pos 100)
+                {35, true, 1},    // cycle=1, cycleFromEnd=36, base=1, *1=1 (genomic pos 135)
+                // Read 2 (forward strand) - overlapping positions should match Read 1
+                {0, false, -1},   // cycle=1, cycleFromEnd=36, base=1, *-1=-1 (genomic pos 100, matches R1)
+                {35, false, 1},   // cycle=36, cycleFromEnd=1, base=-1, *-1=1 (genomic pos 135, matches R1)
+        };
+    }
+
+    @Test(dataProvider = "molecularPositionsRead1Reverse")
+    public void testMolecularPositionStratifierRead1Reverse(int offset, boolean read1, int expected_mol_pos) {
+        final SAMSequenceRecord samSequenceRecord = new SAMSequenceRecord("chr1", 2_000);
+        final SAMFileHeader samFileHeader = new SAMFileHeader();
+        samFileHeader.addSequence(samSequenceRecord);
+        final SAMReadGroupRecord readGroupRecord = new SAMReadGroupRecord("rgID");
+        samFileHeader.addReadGroup(readGroupRecord);
+
+        SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
+        builder.setHeader(samFileHeader);
+        // Read 2 at position 100 (forward), Read 1 at position 100 (reverse)
+        // FR orientation with read 1 on reverse strand
+        final List<SAMRecord> pair = builder.addPair("test_MolecularPositionStratifier_R1rev",
+                0, 100, 100, false, false, "36M", "36M", true, false, 30);
+
+        ReadBaseStratification.RecordAndOffsetStratifier<Integer> stratifier = ReadBaseStratification.baseMolecularPosStratifier;
+
+        SamLocusIterator.RecordAndOffset recordAndOffset = new SamLocusIterator.RecordAndOffset(pair.get(read1 ? 0 : 1), offset);
+        SamLocusIterator.LocusInfo locusInfo = new SamLocusIterator.LocusInfo(samSequenceRecord, 1);
+        SAMLocusAndReference locusAndReference = new SAMLocusAndReference(locusInfo, (byte) 'A');
+
+        Assert.assertEquals(stratifier.stratify(recordAndOffset, locusAndReference), expected_mol_pos);
+    }
+
+    @DataProvider
+    public Object[][] molecularPositionsPartialOverlap() {
+        // Test setup: read length = 36, insert size = 51 (partial overlap)
+        // Read 1: forward strand, positions 100-135
+        // Read 2: reverse strand, positions 115-150
+        // Overlap at genomic positions 115-135 (21 bases)
+        //
+        // Molecule positions:  1 ................. 16 ................. 36 ................. 51
+        //                      ───────────────────────────────────────────────────────────────
+        // Read 1 (fwd):       [R1 ................. R1 ................. R1]
+        //                      ─────────────────────────────────────────→
+        //   offsets:           0                   15                   35
+        //   mol_pos:           1                   16                  -16
+        //                      ───────────────────────────────────────────────────────────────
+        // Read 2 (rev):                           [R2 ................. R2 ................. R2]
+        //                                         ←─────────────────────────────────────────
+        //   offsets:                               0                   20                   35
+        //   mol_pos:                              16                  -16                   -1
+        //                      ───────────────────────────────────────────────────────────────
+        // Overlapping bases at molecule positions 16-36 have matching mol_pos values.
+        return new Object[][] {
+                // Read 1 (forward strand)
+                {0, true, 1},      // cycle=1, cycleFromEnd=51, mol_pos=1
+                {15, true, 16},    // cycle=16, cycleFromEnd=36, mol_pos=16 (start of overlap)
+                {25, true, 26},   // cycle=26, cycleFromEnd=26, mol_pos=-26 (midpoint)
+                {35, true, -16},   // cycle=36, cycleFromEnd=16, mol_pos=-16 (end of R1)
+                // Read 2 (reverse strand)
+                {0, false, 16},    // cycle=36, cycleFromEnd=16, base=-16, *-1=16 (matches R1 offset 15)
+                {20, false, -16},  // cycle=16, cycleFromEnd=36, base=16, *-1=-16 (matches R1 offset 35)
+                {35, false, -1},   // cycle=1, cycleFromEnd=51, base=1, *-1=-1
+        };
+    }
+
+    @Test(dataProvider = "molecularPositionsPartialOverlap")
+    public void testMolecularPositionStratifierPartialOverlap(int offset, boolean read1, int expected_mol_pos) {
+        final SAMSequenceRecord samSequenceRecord = new SAMSequenceRecord("chr1", 2_000);
+        final SAMFileHeader samFileHeader = new SAMFileHeader();
+        samFileHeader.addSequence(samSequenceRecord);
+        final SAMReadGroupRecord readGroupRecord = new SAMReadGroupRecord("rgID");
+        samFileHeader.addReadGroup(readGroupRecord);
+
+        SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
+        builder.setHeader(samFileHeader);
+        // Read 1 starts at 100, Read 2 starts at 115, both 36 bases → insert size = 51
+        final List<SAMRecord> pair = builder.addPair("test_MolecularPositionStratifier_partial",
+                0, 100, 115, false, false, "36M", "36M", false, true, 30);
+
+        ReadBaseStratification.RecordAndOffsetStratifier<Integer> stratifier = ReadBaseStratification.baseMolecularPosStratifier;
+
+        SamLocusIterator.RecordAndOffset recordAndOffset = new SamLocusIterator.RecordAndOffset(pair.get(read1 ? 0 : 1), offset);
+        SamLocusIterator.LocusInfo locusInfo = new SamLocusIterator.LocusInfo(samSequenceRecord, 1);
+        SAMLocusAndReference locusAndReference = new SAMLocusAndReference(locusInfo, (byte) 'A');
+
+        Assert.assertEquals(stratifier.stratify(recordAndOffset, locusAndReference), expected_mol_pos);
+    }
+
+    @DataProvider
+    public Object[][] molecularPositionEdgeCases() {
+        // Returns: description, contig1, start1, contig2, start2, unmapped1, unmapped2, cigar1, cigar2, strand1, strand2
+        return new Object[][] {
+                // description,      c1, s1,  c2,  s2, unmap1, unmap2, cig1,  cig2,  neg1,  neg2
+                {"mateUnmapped",      0, 100,   0,   0,  false,   true, "36M",  null, false, false},
+                {"chimeric",          0, 100,   1, 100,  false,  false, "36M", "36M", false,  true},
+                {"outie",             0,  50,   0, 100,  false,  false, "36M", "36M",  true, false},
+                {"tandemFF",          0, 100,   0, 150,  false,  false, "36M", "36M", false, false},
+                {"tandemRR",          0, 100,   0, 150,  false,  false, "36M", "36M",  true,  true},
+        };
+    }
+
+    @Test(dataProvider = "molecularPositionEdgeCases")
+    public void testMolecularPositionStratifierEdgeCases(String description, int contig1, int start1,
+            int contig2, int start2, boolean unmapped1, boolean unmapped2,
+            String cigar1, String cigar2, boolean negStrand1, boolean negStrand2) {
+        final SAMSequenceRecord chr1 = new SAMSequenceRecord("chr1", 10_000);
+        final SAMSequenceRecord chr2 = new SAMSequenceRecord("chr2", 10_000);
+        final SAMFileHeader samFileHeader = new SAMFileHeader();
+        samFileHeader.addSequence(chr1);
+        samFileHeader.addSequence(chr2);
+        final SAMReadGroupRecord readGroupRecord = new SAMReadGroupRecord("rgID");
+        samFileHeader.addReadGroup(readGroupRecord);
+
+        SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
+        builder.setHeader(samFileHeader);
+
+        ReadBaseStratification.RecordAndOffsetStratifier<Integer> stratifier = ReadBaseStratification.baseMolecularPosStratifier;
+        SamLocusIterator.LocusInfo locusInfo = new SamLocusIterator.LocusInfo(chr1, 1);
+        SAMLocusAndReference locusAndReference = new SAMLocusAndReference(locusInfo, (byte) 'A');
+
+        final List<SAMRecord> pair = builder.addPair(description,
+                contig1, start1, start2, unmapped1, unmapped2, cigar1, cigar2, negStrand1, negStrand2, 30);
+
+        // For chimeric, fix the reference indices
+        if (contig2 != contig1) {
+            pair.get(1).setReferenceIndex(contig2);
+            pair.get(0).setMateReferenceIndex(contig2);
+        }
+
+        SamLocusIterator.RecordAndOffset rao = new SamLocusIterator.RecordAndOffset(pair.get(0), 0);
+        Assert.assertNull(stratifier.stratify(rao, locusAndReference), description + " should return null");
+    }
+
+    @Test
+    public void testMolecularPositionStratifierUnpaired() {
+        final SAMSequenceRecord chr1 = new SAMSequenceRecord("chr1", 10_000);
+        final SAMFileHeader samFileHeader = new SAMFileHeader();
+        samFileHeader.addSequence(chr1);
+        final SAMReadGroupRecord readGroupRecord = new SAMReadGroupRecord("rgID");
+        samFileHeader.addReadGroup(readGroupRecord);
+
+        SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
+        builder.setHeader(samFileHeader);
+
+        ReadBaseStratification.RecordAndOffsetStratifier<Integer> stratifier = ReadBaseStratification.baseMolecularPosStratifier;
+        SamLocusIterator.LocusInfo locusInfo = new SamLocusIterator.LocusInfo(chr1, 1);
+        SAMLocusAndReference locusAndReference = new SAMLocusAndReference(locusInfo, (byte) 'A');
+
+        // Unpaired read
+        final SAMRecord unpaired = builder.addFrag("unpaired", 0, 100, false, false, "36M", null, 30);
+        SamLocusIterator.RecordAndOffset unpairedRao = new SamLocusIterator.RecordAndOffset(unpaired, 0);
+        Assert.assertNull(stratifier.stratify(unpairedRao, locusAndReference), "Unpaired read should return null");
     }
 }

--- a/src/test/java/picard/sam/SamErrorMetric/ReadBaseStratificationTest.java
+++ b/src/test/java/picard/sam/SamErrorMetric/ReadBaseStratificationTest.java
@@ -722,6 +722,31 @@ public class ReadBaseStratificationTest {
     }
 
     @Test
+    public void testInsertEndDistanceStratifierZeroInsertSize() {
+        final SAMSequenceRecord chr1 = new SAMSequenceRecord("chr1", 10_000);
+        final SAMFileHeader samFileHeader = new SAMFileHeader();
+        samFileHeader.addSequence(chr1);
+        final SAMReadGroupRecord readGroupRecord = new SAMReadGroupRecord("rgID");
+        samFileHeader.addReadGroup(readGroupRecord);
+
+        SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
+        builder.setHeader(samFileHeader);
+
+        ReadBaseStratification.RecordAndOffsetStratifier<Integer> stratifier = ReadBaseStratification.baseInsertEndDistanceStratifier;
+        SamLocusIterator.LocusInfo locusInfo = new SamLocusIterator.LocusInfo(chr1, 1);
+        SAMLocusAndReference locusAndReference = new SAMLocusAndReference(locusInfo, (byte) 'A');
+
+        // Create a normal FR pair, then set TLEN to 0 to simulate missing insert size
+        final List<SAMRecord> pair = builder.addPair("zeroInsertSize",
+                0, 100, 115, false, false, "36M", "36M", false, true, 30);
+        pair.get(0).setInferredInsertSize(0);
+        pair.get(1).setInferredInsertSize(0);
+
+        SamLocusIterator.RecordAndOffset rao = new SamLocusIterator.RecordAndOffset(pair.get(0), 0);
+        Assert.assertNull(stratifier.stratify(rao, locusAndReference), "Zero insert size should return null");
+    }
+
+    @Test
     public void testInsertEndDistanceStratifierUnpaired() {
         final SAMSequenceRecord chr1 = new SAMSequenceRecord("chr1", 10_000);
         final SAMFileHeader samFileHeader = new SAMFileHeader();

--- a/src/test/java/picard/sam/SamErrorMetric/ReadBaseStratificationTest.java
+++ b/src/test/java/picard/sam/SamErrorMetric/ReadBaseStratificationTest.java
@@ -566,8 +566,7 @@ public class ReadBaseStratificationTest {
         samFileHeader.addSequence(samSequenceRecord);
         final SAMReadGroupRecord readGroupRecord = new SAMReadGroupRecord("rgID");
         samFileHeader.addReadGroup(readGroupRecord);
-
-
+        
         SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
         builder.setHeader(samFileHeader);
         final List<SAMRecord> pair = builder.addPair("test_InsertEndDistanceStratifier",
@@ -578,8 +577,7 @@ public class ReadBaseStratificationTest {
         SamLocusIterator.RecordAndOffset recordAndOffset = new SamLocusIterator.RecordAndOffset(pair.get(read1 ? 0 : 1), offset);
         SamLocusIterator.LocusInfo locusInfo = new SamLocusIterator.LocusInfo(samSequenceRecord, 1);
         SAMLocusAndReference locusAndReference = new SAMLocusAndReference(locusInfo, (byte) 'A');
-
-
+        
         Assert.assertEquals(stratifier.stratify(recordAndOffset, locusAndReference), expected_insert_end_dist);
     }
 


### PR DESCRIPTION
### Description                                                                                                        
   - Adds a new "molecular position" stratification for ReadBaseStratification                                                                                                                                       
   - Unlike cycle position, this stratification provides consistent answers for overlapping bases from paired reads                                                                                                  
   - Includes tests for the new stratification                                                                                                                                                   
                                                                                                                                                                                                                     
----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [ ] All tests passing on github actions

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

