### PR TITLE
LiftoverVcf - Use indexed FASTA access in LiftoverVcf for faster reference loading

### DIFF
--- a/src/main/java/picard/vcf/LiftoverVcf.java
+++ b/src/main/java/picard/vcf/LiftoverVcf.java
@@ -29,6 +29,7 @@ import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.ValidationStringency;
 import htsjdk.samtools.liftover.LiftOver;
 import htsjdk.samtools.reference.ReferenceSequence;
+import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
 import htsjdk.samtools.reference.ReferenceSequenceFileWalker;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.CollectionUtil;
@@ -323,7 +324,10 @@ public class LiftoverVcf extends CommandLineProgram {
         final VCFFileReader in = new VCFFileReader(INPUT, false);
 
         log.info("Loading up the target reference genome.");
-        final ReferenceSequenceFileWalker walker = new ReferenceSequenceFileWalker(REFERENCE_SEQUENCE);
+        // Prefer indexed FASTA access (.fai) for faster reference loading (see htsjdk#269).
+        final ReferenceSequenceFileWalker walker = new ReferenceSequenceFileWalker(
+            ReferenceSequenceFileFactory.getReferenceSequenceFile(REFERENCE_SEQUENCE, true, true)
+        );
         final Map<String, ReferenceSequence> refSeqs = new HashMap<>();
         // check if sequence dictionary exists
         if (walker.getSequenceDictionary() == null) {


### PR DESCRIPTION
### Why

The default `ReferenceSequenceFileWalker` uses `prefereIndexed=false` (see https://github.com/samtools/htsjdk/issues/269)


### How 

Use `ReferenceSequenceFileFactory` with `preferIndexed=true` to leverage the `.fai` index when loading the reference genome. This enables direct seeking to chromosome offsets rather than  sequential file scanning, resulting in at least 4x faster reference loading.

  This especially helps when running on:

  - Slower storage like HDDs, network mounts, or cloud environments
  - Automated pipelines where the tool is invoked repeatedly

  Falls back to non-indexed reader if `.fai` is unavailable, maintaining full backward
  compatibility.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
(NOTE: no new tests needed really as this is more of a htsjdk thing than picard - existing tests already cover everything properly -  i can technically add a test with fai and without, but it will test htsjdk more than this tool...)
- [ ] Edited the README / documentation (if applicable)
- [x] All tests passing on github actions

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

