### PR TITLE
Fix UMI-aware duplicate set tagging

### DIFF
--- a/src/main/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigar.java
+++ b/src/main/java/picard/sam/markduplicates/SimpleMarkDuplicatesWithMateCigar.java
@@ -46,6 +46,7 @@ import picard.sam.markduplicates.util.ReadEnds;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -122,18 +123,40 @@ public class SimpleMarkDuplicatesWithMateCigar extends MarkDuplicates {
         final ProgressLogger progress = new ProgressLogger(log, (int) 1e6, "Read");
 
         int numDuplicates = 0;
+        int outputRecordIndex = 0;
         
         libraryIdGenerator = new LibraryIdGenerator(headerAndIterator.header);
         
         for (final DuplicateSet duplicateSet : new IterableAdapter<>(iterator)) {
             final SAMRecord representative = duplicateSet.getRepresentative();
+            final List<SAMRecord> records = duplicateSet.getRecords();
             final boolean doOpticalDuplicateTracking = (this.READ_NAME_REGEX != null) &&
                     isPairedAndBothMapped(representative) &&
                     representative.getFirstOfPairFlag();
             final Set<String> duplicateReadEndsSeen = new HashSet<>();
             
             final List<ReadEnds> duplicateReadEnds = new ArrayList<>();
-            for (final SAMRecord record : duplicateSet.getRecords()) {
+            int representativeRecordIndex = -1;
+            int duplicateSetSize = 0;
+            if (TAG_DUPLICATE_SET_MEMBERS) {
+                int indexWithinSet = outputRecordIndex;
+                final Map<String, Integer> firstRecordIndexByReadName = new HashMap<>();
+                final Set<String> readNamesInDuplicateSet = new HashSet<>();
+                for (final SAMRecord record : records) {
+                    if (this.REMOVE_DUPLICATES && record.getDuplicateReadFlag()) {
+                        continue;
+                    }
+                    if (!record.isSecondaryOrSupplementary() && !record.getReadUnmappedFlag()) {
+                        readNamesInDuplicateSet.add(record.getReadName());
+                        firstRecordIndexByReadName.putIfAbsent(record.getReadName(), indexWithinSet);
+                    }
+                    indexWithinSet++;
+                }
+                duplicateSetSize = readNamesInDuplicateSet.size();
+                representativeRecordIndex = firstRecordIndexByReadName.getOrDefault(representative.getReadName(), -1);
+            }
+
+            for (final SAMRecord record : records) {
 
                 // get the metrics for the library of this read (creating a new one if needed)
                 final String library = LibraryIdGenerator.getLibraryName(header, record);
@@ -192,11 +215,16 @@ public class SimpleMarkDuplicatesWithMateCigar extends MarkDuplicates {
                 }
 
                 if (!this.REMOVE_DUPLICATES || !record.getDuplicateReadFlag()) {
+                    if (TAG_DUPLICATE_SET_MEMBERS && duplicateSetSize > 1 && !record.isSecondaryOrSupplementary() && !record.getReadUnmappedFlag()) {
+                        record.setAttribute(DUPLICATE_SET_INDEX_TAG, representativeRecordIndex);
+                        record.setAttribute(DUPLICATE_SET_SIZE_TAG, duplicateSetSize);
+                    }
                     if (PROGRAM_RECORD_ID != null) {
                         record.setAttribute(SAMTag.PG.name(), chainedPgIds.get(record.getStringAttribute(SAMTag.PG.name())));
                     }
                     out.addAlignment(record);
                     progress.record(record);
+                    outputRecordIndex++;
                 }
             }
 

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTest.java
@@ -176,6 +176,42 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
         tester.setExpectedAssignedUmis(assignedUmi).runTest();
     }
 
+    @Test
+    public void testTagDuplicateSetMembers() {
+        final UmiAwareMarkDuplicatesWithMateCigarTester tester = getTester(false);
+        tester.addArg("TAG_DUPLICATE_SET_MEMBERS=true");
+        tester.addArg("MOLECULAR_IDENTIFIER_TAG=MI");
+        tester.setExpectedOpticalDuplicate(1);
+        final String representativeReadName = "RUNID:1:1:16020:13352";
+        final String duplicateReadName = "RUNID:1:1:15993:13361";
+
+        tester.addMatePairWithUmi("A", representativeReadName, 0, 0, 20, 20, false, false, false, false,
+                "45M", "45M", false, true, false, false, false, 10, "AAAA", "AAAA");
+        tester.expectedRepresentativeReadMap.put(representativeReadName, null);
+        tester.expectedSetSizeMap.put(representativeReadName, 2);
+
+        tester.addMatePairWithUmi("A", duplicateReadName, 0, 0, 20, 20, false, false, true, true,
+                "44M1S", "44M1S", false, true, false, false, false, 10, "AAAA", "AAAA");
+        tester.expectedRepresentativeReadMap.put(duplicateReadName, null);
+        tester.expectedSetSizeMap.put(duplicateReadName, 2);
+
+        tester.runTest();
+    }
+
+    @Test
+    public void testDoesNotTagSingletonDuplicateSets() {
+        final UmiAwareMarkDuplicatesWithMateCigarTester tester = getTester(false);
+        tester.addArg("TAG_DUPLICATE_SET_MEMBERS=true");
+
+        final String readName = "RUNID:1:1:16020:13352";
+        tester.addMatePairWithUmi("A", readName, 0, 0, 20, 20, false, false, false, false,
+                "45M", "45M", false, true, false, false, false, 10, "AAAA", "AAAA");
+        tester.expectedRepresentativeReadMap.put(readName, null);
+        tester.expectedSetSizeMap.put(readName, null);
+
+        tester.runTest();
+    }
+
     @Test(dataProvider = "testBadUmiSetsDataProvider", expectedExceptions = {IllegalArgumentException.class, PicardException.class})
     public void testBadUmis(List<String> umis, List<String> assignedUmi, final List<Boolean> isDuplicate, final int editDistanceToJoin) {
         UmiAwareMarkDuplicatesWithMateCigarTester tester = getTester(false);
@@ -503,4 +539,3 @@ public class UmiAwareMarkDuplicatesWithMateCigarTest extends SimpleMarkDuplicate
         tester.runTest();
     }
 }
-

--- a/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
+++ b/src/test/java/picard/sam/markduplicates/UmiAwareMarkDuplicatesWithMateCigarTester.java
@@ -36,7 +36,9 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This class is an extension of AbstractMarkDuplicatesCommandLineProgramTester used to test
@@ -50,6 +52,9 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
     private List<String> expectedAssignedUmis;
     private UmiMetrics expectedMetrics;
     private File umiMetricsFile = new File(getOutputDir(), "umi_metrics.txt");
+    final Map<String, String> expectedRepresentativeReadMap = new HashMap<>();
+    final Map<String, Integer> readIndexMap = new HashMap<>();
+    final Map<String, Integer> expectedSetSizeMap = new HashMap<>();
 
     // This tag is only used for testing, it indicates what we expect to see in the inferred UMI tag.
     private final String expectedUmiTag = "RE";
@@ -196,6 +201,31 @@ public class UmiAwareMarkDuplicatesWithMateCigarTester extends AbstractMarkDupli
     void testRecordHook(final SAMRecord record) {
         if (expectedAssignedUmis != null) {
             Assert.assertEquals(getAssignedUmi(record.getStringAttribute("MI")), record.getAttribute(expectedUmiTag));
+        }
+        if (expectedRepresentativeReadMap.containsKey(record.getReadName())) {
+            if (expectedRepresentativeReadMap.get(record.getReadName()) == null) {
+                if (expectedSetSizeMap.get(record.getReadName()) == null) {
+                    Assert.assertNull(record.getAttribute("DI"));
+                } else {
+                    Assert.assertNotNull(record.getAttribute("DI"));
+                }
+            } else {
+                Assert.assertEquals(record.getAttribute("DI"), readIndexMap.get(expectedRepresentativeReadMap.get(record.getReadName())));
+            }
+            Assert.assertEquals(record.getAttribute("DS"), expectedSetSizeMap.get(record.getReadName()));
+        }
+    }
+
+    @Override
+    void updateExpectationsHook() {
+        try (final SamReader reader = SamReaderFactory.makeDefault().referenceSequence(fastaFiles.get(samRecordSetBuilder.getHeader())).open(getOutput())) {
+            int indexInFile = 0;
+            for (final SAMRecord record : reader) {
+                readIndexMap.putIfAbsent(record.getReadName(), indexInFile);
+                indexInFile++;
+            }
+        } catch (final IOException ex) {
+            Assert.fail("Problem updating read file indices", ex);
         }
     }
 


### PR DESCRIPTION
### Description

This change fixes `UmiAwareMarkDuplicatesWithMateCigar` so that `TAG_DUPLICATE_SET_MEMBERS=true` now behaves like `MarkDuplicates`: records in true duplicate sets get `DI` and `DS` tags, and singleton sets are not tagged. The implementation was added in the `SimpleMarkDuplicatesWithMateCigar` path that the UMI-aware tool actually uses, and regression coverage was added for both positive tagging and singleton suppression.

The motivation was a real behavior gap in Picard. `UmiAwareMarkDuplicatesWithMateCigar` inherited the `TAG_DUPLICATE_SET_MEMBERS` argument from MarkDuplicates, but it did not execute the code path that writes `DI`/`DS`, so users could enable the flag and still get no duplicate-set-member tags in output. This pull request fixes that inconsistency and aligns UMI-aware duplicate tagging semantics with the existing `MarkDuplicates` behavior.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [X] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [x] All tests passing on github actions

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

