### PR TITLE
Fix to CollectSamErrorMetrics getIndelOperator function to check operator type

### DIFF
--- a/src/main/java/picard/sam/SamErrorMetric/ReadBaseStratification.java
+++ b/src/main/java/picard/sam/SamErrorMetric/ReadBaseStratification.java
@@ -1273,8 +1273,8 @@ public class ReadBaseStratification {
             }
 
             if (recordAndOffset.getAlignmentType() == AbstractRecordAndOffset.AlignmentType.Insertion) {
-                // If it doesn't consume bases, skip to the next
-                if (cigarElement.getOperator().consumesReadBases() && readPosition == offset) {
+                // Return only if this is actually an insertion element at the right position
+                if (cigarElement.getOperator() == CigarOperator.I && readPosition == offset) {
                     return cigarElement;
                 }
             }

--- a/src/test/java/picard/sam/SamErrorMetric/CollectSamErrorMetricsTest.java
+++ b/src/test/java/picard/sam/SamErrorMetric/CollectSamErrorMetricsTest.java
@@ -709,5 +709,39 @@ public class CollectSamErrorMetricsTest {
 
         Assert.assertEquals(metric, expectedMetric);
     }
+
+    /**
+     * Test that getIndelElement returns null (rather than a non-insertion CIGAR element)
+     * when called with an offset that doesn't correspond to an actual insertion in the CIGAR.
+     *
+     * This can happen when htsjdk's accumulateIndels has a readBase drift: if an
+     * earlier insertion fails the BQ check, readBase is not advanced, causing subsequent
+     * insertions to be reported at the wrong offset. When getIndelElement is called
+     * with that drifted offset, it should not return a Match element that happens to
+     * be at that position.
+     *
+     * CIGAR: 10M1I1M1I10M — the 1M between the two insertions occupies read position 11.
+     * If called with offset=11 (a drifted offset that lands on the M), getIndelElement
+     * should return null, not the 1M CigarElement.
+     */
+    @Test
+    public void testGetIndelElementRejectsNonInsertionElement() {
+        final SAMRecord record = createRecordFromCigar("10M1I1M1I10M");
+
+        // Create a RecordAndOffset for an insertion at the drifted offset (11),
+        // which actually corresponds to the 1M element, not the 1I.
+        final SamLocusIterator.RecordAndOffset rao =
+                new SamLocusIterator.RecordAndOffset(record, 11,
+                        SamLocusIterator.RecordAndOffset.AlignmentType.Insertion);
+
+        final CigarElement result = ReadBaseStratification.getIndelElement(rao);
+
+        // Before the fix, this returns the 1M element (operator=M, length=1).
+        // After the fix, it should return null since offset 11 is not an insertion.
+        Assert.assertNull(result,
+                "getIndelElement should return null when the offset lands on a " +
+                "non-insertion CIGAR element, but returned operator=" +
+                (result != null ? result.getOperator() : "N/A"));
+    }
 }
 


### PR DESCRIPTION
### Description

The getIndelOperator function in ReadBaseStratifier takes a `RecordAndOffset` and is intended to return either the Insertion or Deletion Cigar element found in that read's cigar at that offset, depending on whether the RecordAndOffset represents an insertion of deletion operation.

It appears to function correctly if and only if passed RecordAndOffsets that are also correct - i.e. correctly identify an insertion or deletion within a read at an accurate offset.  However, when an incorrect offset is given for an insertion (as triggered by [this bug](https://github.com/samtools/htsjdk/pull/1758) in HTSJDK, it will erroneously return any cigar element with an operator that consumes read bases.  

This PR adds a test to highlight that invalid input causes this problem, and ensure that in that case `null` is returned instead of an incorrect cigar element.
----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [ ] All tests passing on github actions

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

