### PR TITLE
Fix tests broken under i) upcoming htsjdk 5, and ii) on non-x86 architectures.

### DIFF
--- a/src/main/java/picard/sam/ViewSam.java
+++ b/src/main/java/picard/sam/ViewSam.java
@@ -183,7 +183,13 @@ public class ViewSam extends CommandLineProgram {
 
                     if (this.PF_STATUS == PfStatus.PF && rec.getReadFailsVendorQualityCheckFlag()) continue;
                     if (this.PF_STATUS == PfStatus.NonPF && !rec.getReadFailsVendorQualityCheckFlag()) continue;
-                    writer.write(rec.getSAMString());
+                    // htsjdk 5.0 dropped the trailing newline from SAMRecord.getSAMString(); add one
+                    // ourselves when missing so this code works with both pre- and post-5.0 htsjdk.
+                    final String samString = rec.getSAMString();
+                    writer.write(samString);
+                    if (samString.isEmpty() || samString.charAt(samString.length() - 1) != '\n') {
+                        writer.write("\n");
+                    }
                 }
             }
             writer.flush();

--- a/src/test/java/picard/IntelInflaterDeflaterLoadTest.java
+++ b/src/test/java/picard/IntelInflaterDeflaterLoadTest.java
@@ -56,8 +56,11 @@ public class IntelInflaterDeflaterLoadTest {
             throw new SkipException(componentName + " is not available on this platform");
         }
 
-        if (SystemUtils.OS_ARCH != null && SystemUtils.OS_ARCH.equals("ppc64le")) {
-            throw new SkipException(componentName + " is not available for this architecture");
+        // Intel GKL only ships native libraries for x86_64. Skip on any other CPU architecture
+        // (e.g. ppc64le, aarch64/Apple Silicon).
+        final String arch = SystemUtils.OS_ARCH;
+        if (arch != null && !arch.equals("x86_64") && !arch.equals("amd64")) {
+            throw new SkipException(componentName + " is not available for architecture " + arch);
         }
     }
 


### PR DESCRIPTION
IntelInflaterDeflaterLoadTest's checkIntelSupported() only skipped ppc64le, so the two tests that actually load the Intel native library failed on aarch64 (e.g. Apple Silicon). Generalize the arch check to skip on anything that isn't x86_64/amd64.  (These fail on master).

ViewSam streamed records by writing rec.getSAMString() back-to-back, relying on the trailing '\n' that older htsjdk included in that string. htsjdk 5.0 intentionally drops that newline, so adjacent records were being concatenated on a single line, producing malformed SAM. This broke ViewSamTest.testIntervals and the three PipedDataTest cases (which pipe ViewSam | {SortSam, RevertSam, MergeBamAlignment}). Fix by appending '\n' only when the returned string doesn't already end with one, so the code works against both pre- and post-5.0 htsjdk releases.

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [ ] All tests passing on github actions

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

