### PR TITLE
switches from short to int for tile number 

### DIFF
--- a/src/main/java/picard/sam/PositionBasedDownsampleSam.java
+++ b/src/main/java/picard/sam/PositionBasedDownsampleSam.java
@@ -202,13 +202,13 @@ public class PositionBasedDownsampleSam extends CommandLineProgram {
        look per-readgroup, but at this point I'm making the assumptions that I need to downsample a
        sample where all the readgroups came from the same type of flowcell. */
 
-    CollectionUtil.DefaultingMap.Factory<Coord, Short> defaultingMapFactory = aShort -> new Coord();
+    CollectionUtil.DefaultingMap.Factory<Coord, Integer> defaultingMapFactory = anInt -> new Coord();
 
-    final private Map<Short, Coord> tileCoord = new CollectionUtil.DefaultingMap<>(defaultingMapFactory, true);
+    final private Map<Integer, Coord> tileCoord = new CollectionUtil.DefaultingMap<>(defaultingMapFactory, true);
 
 
-    final Map<Short, Histogram<Short>> xPositions = new HashMap<>();
-    final Map<Short, Histogram<Short>> yPositions = new HashMap<>();
+    final Map<Integer, Histogram<Integer>> xPositions = new HashMap<>();
+    final Map<Integer, Histogram<Integer>> yPositions = new HashMap<>();
 
     @Override
     protected String[] customCommandLineValidation() {

--- a/src/main/java/picard/sam/markduplicates/EstimateLibraryComplexity.java
+++ b/src/main/java/picard/sam/markduplicates/EstimateLibraryComplexity.java
@@ -285,7 +285,7 @@ public class EstimateLibraryComplexity extends AbstractOpticalDuplicateFinderCom
         public void encode(final PairedReadSequence val) {
             try {
                 this.out.writeShort(val.readGroup);
-                this.out.writeShort(val.tile);
+                this.out.writeInt(val.tile);
                 this.out.writeInt(val.x);
                 this.out.writeInt(val.y);
                 this.out.writeInt(val.read1.length);
@@ -306,7 +306,7 @@ public class EstimateLibraryComplexity extends AbstractOpticalDuplicateFinderCom
                     return null;
                 }
 
-                val.tile = this.in.readShort();
+                val.tile = this.in.readInt();
                 val.x = this.in.readInt();
                 val.y = this.in.readInt();
 

--- a/src/main/java/picard/sam/markduplicates/util/OpticalDuplicateFinder.java
+++ b/src/main/java/picard/sam/markduplicates/util/OpticalDuplicateFinder.java
@@ -211,7 +211,7 @@ public class OpticalDuplicateFinder extends ReadNameParser implements Serializab
             log.debug("Building adjacency graph for duplicate group");
         }
 
-        final Map<Integer, List<Integer>> tileRGmap = new HashMap<>();
+        final Map<List<Integer>, List<Integer>> tileRGmap = new HashMap<>();
 
         int keeperIndex = -1;
         for (int i = 0; i < list.size(); i++) {
@@ -220,7 +220,7 @@ public class OpticalDuplicateFinder extends ReadNameParser implements Serializab
                 keeperIndex = i;
             }
             if (currentLoc.hasLocation()) {
-                final int key = ((int) currentLoc.getReadGroup() << 16) + currentLoc.getTile();
+                final List<Integer> key = Arrays.asList((int) currentLoc.getReadGroup(), currentLoc.getTile());
 
                 if (tileRGmap.containsKey(key)) {
                     tileRGmap.get(key).add(i);

--- a/src/main/java/picard/sam/util/PhysicalLocation.java
+++ b/src/main/java/picard/sam/util/PhysicalLocation.java
@@ -14,9 +14,9 @@ public interface PhysicalLocation extends Serializable {
 
     public void setReadGroup(short rg);
 
-    public short getTile();
+    public int getTile();
 
-    public void setTile(short tile);
+    public void setTile(int tile);
 
     public int getX();
 

--- a/src/main/java/picard/sam/util/PhysicalLocationInt.java
+++ b/src/main/java/picard/sam/util/PhysicalLocationInt.java
@@ -11,16 +11,16 @@ import picard.PicardException;
  */
 public class PhysicalLocationInt implements PhysicalLocation {
 
-    public short tile = -1;
+    public int tile = -1;
     public int x = -1, y = -1;
 
     public short getReadGroup() { throw new PicardException("Not Implemented"); }
 
     public void setReadGroup(final short readGroup) { throw new PicardException("Not Implemented"); }
 
-    public short getTile() { return tile; }
+    public int getTile() { return tile; }
 
-    public void setTile(final short tile) { this.tile = tile; }
+    public void setTile(final int tile) { this.tile = tile; }
 
     public int getX() { return x; }
 

--- a/src/main/java/picard/sam/util/ReadNameParser.java
+++ b/src/main/java/picard/sam/util/ReadNameParser.java
@@ -95,7 +95,7 @@ public class ReadNameParser implements Serializable {
                     }
                     return false;
                 }
-                loc.setTile((short) tmpLocationFields[0]);
+                loc.setTile(tmpLocationFields[0]);
                 loc.setX(tmpLocationFields[1]);
                 loc.setY(tmpLocationFields[2]);
                 return true;
@@ -107,7 +107,7 @@ public class ReadNameParser implements Serializable {
 
                 final Matcher m = this.readNamePattern.matcher(readName);
                 if (m.matches()) {
-                    loc.setTile((short) Integer.parseInt(m.group(1)));
+                    loc.setTile(Integer.parseInt(m.group(1)));
                     loc.setX(Integer.parseInt(m.group(2)));
                     loc.setY(Integer.parseInt(m.group(3)));
                     return true;


### PR DESCRIPTION

### Description
This avoids overflow on instruments with many tiles. semi-related to #2034 (overflow for x/y positions) 
It changes which duplicate is selected as the representative duplicate in some situations.
The overflow is not very elegant, but I'm not sure it's worth the change to existing workflows.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on github actions

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

