### PR TITLE
LiftoverVcf: log live reject rate alongside ProgressLogger milestones

### DIFF
--- a/src/main/java/picard/vcf/LiftoverVcf.java
+++ b/src/main/java/picard/vcf/LiftoverVcf.java
@@ -286,6 +286,19 @@ public class LiftoverVcf extends CommandLineProgram {
     private final Map<String, Long> liftedByDestContig = new TreeMap<>();
     private final Map<String, Long> liftedBySourceContig = new TreeMap<>();
 
+    /**
+     * Formats a one-line rejection-rate summary for the read-phase progress log. Emitted
+     * alongside each {@link ProgressLogger} milestone so operators can monitor the reject rate
+     * live rather than waiting until the run completes to compare INPUT and REJECT record counts.
+     */
+    static String formatRejectionSummary(final long rejected, final long processed) {
+        final NumberFormat numFmt = new DecimalFormat("#,###");
+        final NumberFormat pctFmt = new DecimalFormat("0.00%");
+        final String rate = processed > 0 ? pctFmt.format((double) rejected / processed) : "0.00%";
+        return "Rejected so far: " + numFmt.format(rejected) + " of " + numFmt.format(processed)
+                + " (" + rate + " reject rate)";
+    }
+
     @Override
     protected ReferenceArgumentCollection makeReferenceArgumentCollection() {
         return new ReferenceArgumentCollection() {
@@ -453,7 +466,9 @@ public class LiftoverVcf extends CommandLineProgram {
                     tryToAddVariant(liftedVC, refSeq, ctx);
                 }
             }
-            progress.record(ctx.getContig(), ctx.getStart());
+            if (progress.record(ctx.getContig(), ctx.getStart())) {
+                log.info(formatRejectionSummary(failedLiftover + failedAlleleCheck, total));
+            }
         }
 
         final NumberFormat pfmt = new DecimalFormat("0.0000%");

--- a/src/test/java/picard/vcf/LiftoverVcfRejectionSummaryTest.java
+++ b/src/test/java/picard/vcf/LiftoverVcfRejectionSummaryTest.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package picard.vcf;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for {@link LiftoverVcf#formatRejectionSummary(long, long)}, the helper that produces
+ * the per-milestone "Rejected so far" log line emitted during LiftoverVcf's read phase.
+ */
+public class LiftoverVcfRejectionSummaryTest {
+
+    @DataProvider(name = "rejectionSummaries")
+    public Object[][] rejectionSummaries() {
+        return new Object[][]{
+                // {rejected, processed, expected}
+                {0L, 0L, "Rejected so far: 0 of 0 (0.00% reject rate)"},
+                {0L, 1_000_000L, "Rejected so far: 0 of 1,000,000 (0.00% reject rate)"},
+                {12_345L, 1_000_000L, "Rejected so far: 12,345 of 1,000,000 (1.23% reject rate)"},
+                {1L, 100L, "Rejected so far: 1 of 100 (1.00% reject rate)"},
+                {1_000_000L, 1_000_000L, "Rejected so far: 1,000,000 of 1,000,000 (100.00% reject rate)"},
+        };
+    }
+
+    @Test(dataProvider = "rejectionSummaries")
+    public void testFormatRejectionSummary(final long rejected, final long processed, final String expected) {
+        Assert.assertEquals(LiftoverVcf.formatRejectionSummary(rejected, processed), expected);
+    }
+}


### PR DESCRIPTION
Resolves #2045.

`LiftoverVcf`'s `ProgressLogger` emits "Processed N records … Last read position" lines but doesn't expose the running reject count. On multi-hour liftovers, a bad chain file isn't visible until the run finishes and `INPUT`/`REJECT` counts get compared.

This adds a follow-up `INFO` line after each ProgressLogger milestone in the read phase:

```
INFO ProgressLogger - Read 1,000,000 records.  ... Last read position: chr3:148,946,422
INFO LiftoverVcf - Rejected so far: 12,345 of 1,000,000 (1.23% reject rate)
```

**Design note:** the issue suggested embedding the count inside the existing line. That would require changes in `htsjdk`'s `AbstractProgressLogger.record()` (where the message is assembled). A separate line keeps the change picard-only and fully backwards-compatible with existing parsers of the ProgressLogger format.

**Tests:** `LiftoverVcfRejectionSummaryTest` covers the formatter (zero, normal, 100%, sub-percent rounding, zero-denominator).