### PR TITLE
LiftoverVcf: add optional PROGRESS_JSON NDJSON sidecar output

### DIFF
--- a/src/main/java/picard/util/ProgressJsonWriter.java
+++ b/src/main/java/picard/util/ProgressJsonWriter.java
@@ -1,0 +1,132 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package picard.util;
+
+import picard.PicardException;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Locale;
+
+/**
+ * Writes progress events as JSON Lines (NDJSON): one UTF-8, LF-terminated JSON object per event.
+ * Gives downstream tooling a stable parsing target instead of regex-scanning human-readable logs.
+ * Each event is flushed immediately so the file can be tailed while the producing tool runs.
+ */
+public final class ProgressJsonWriter implements AutoCloseable {
+
+    private final File file;
+    private final Writer writer;
+
+    /** Opens {@code file} for writing, truncating any existing content. */
+    public ProgressJsonWriter(final File file) {
+        this.file = file;
+        try {
+            // Plain UTF-8 stream (not IOUtil's gzip-by-extension wrapping) so the sidecar can be
+            // tailed line-by-line while the tool runs.
+            this.writer = new BufferedWriter(
+                    new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8));
+        } catch (final IOException e) {
+            throw new PicardException("Could not open progress JSON file: " + file, e);
+        }
+    }
+
+    /** Appends one event as a single NDJSON line, stamped with the current time, and flushes. */
+    public void emit(final String stage, final long recordsProcessed, final long recordsRejected,
+                     final String lastPosition, final long elapsedSeconds) {
+        try {
+            writer.write(formatEvent(Instant.now(), stage, recordsProcessed, recordsRejected,
+                    lastPosition, elapsedSeconds));
+            writer.write('\n');
+            writer.flush();
+        } catch (final IOException e) {
+            throw new PicardException("Could not write to progress JSON file: " + file, e);
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            writer.close();
+        } catch (final IOException e) {
+            throw new PicardException("Could not close progress JSON file: " + file, e);
+        }
+    }
+
+    /**
+     * Builds one NDJSON event line. Field order is fixed so downstream consumers can rely on a
+     * stable schema. Package-private and static for unit testing.
+     */
+    static String formatEvent(final Instant timestamp, final String stage,
+                              final long recordsProcessed, final long recordsRejected,
+                              final String lastPosition, final long elapsedSeconds) {
+        final StringBuilder sb = new StringBuilder(160);
+        sb.append('{');
+        sb.append("\"timestamp\":\"").append(timestamp.truncatedTo(ChronoUnit.SECONDS)).append("\",");
+        sb.append("\"stage\":\"").append(escapeJsonString(stage)).append("\",");
+        sb.append("\"records_processed\":").append(recordsProcessed).append(',');
+        sb.append("\"records_rejected\":").append(recordsRejected).append(',');
+        sb.append("\"last_position\":");
+        if (lastPosition == null) {
+            sb.append("null");
+        } else {
+            sb.append('"').append(escapeJsonString(lastPosition)).append('"');
+        }
+        sb.append(',');
+        sb.append("\"elapsed_seconds\":").append(elapsedSeconds);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    /** Escapes a string for embedding in a JSON double-quoted value. */
+    static String escapeJsonString(final String s) {
+        final StringBuilder sb = new StringBuilder(s.length() + 4);
+        for (int i = 0; i < s.length(); i++) {
+            final char c = s.charAt(i);
+            switch (c) {
+                case '"':  sb.append("\\\""); break;
+                case '\\': sb.append("\\\\"); break;
+                case '\b': sb.append("\\b"); break;
+                case '\f': sb.append("\\f"); break;
+                case '\n': sb.append("\\n"); break;
+                case '\r': sb.append("\\r"); break;
+                case '\t': sb.append("\\t"); break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format(Locale.ROOT, "\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/picard/vcf/LiftoverVcf.java
+++ b/src/main/java/picard/vcf/LiftoverVcf.java
@@ -60,16 +60,11 @@ import picard.cmdline.StandardOptionDefinitions;
 import picard.cmdline.argumentcollections.ReferenceArgumentCollection;
 import picard.cmdline.programgroups.VariantManipulationProgramGroup;
 import picard.util.LiftoverUtils;
+import picard.util.ProgressJsonWriter;
 
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.PrintWriter;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -212,13 +207,13 @@ public class LiftoverVcf extends CommandLineProgram {
     @Argument(doc = "Output VCF file will be written on the fly but it won't be sorted and indexed.", optional = true)
     public boolean DISABLE_SORT = false;
 
-    @Argument(doc = "Optional path to a JSON Lines (NDJSON) sidecar that receives one structured " +
-            "progress event per ProgressLogger milestone during the read and write phases. " +
-            "Provides a stable parsing target for downstream tooling, as an alternative to " +
-            "regex-parsing the human-readable log output. Each line is one JSON object: " +
+    @Argument(doc = "Optional path to a JSON Lines (NDJSON) sidecar giving downstream tooling a " +
+            "stable parsing target instead of the human-readable log output. Existing files are " +
+            "overwritten; output is UTF-8 with one JSON object per line: " +
             "{\"timestamp\":..., \"stage\":..., \"records_processed\":..., \"records_rejected\":..., " +
-            "\"last_position\":..., \"elapsed_seconds\":...}. " +
-            "Existing files at this path are overwritten.",
+            "\"last_position\":..., \"elapsed_seconds\":...}. Stage is read/read_complete then " +
+            "write/write_complete (or a single write_skipped when DISABLE_SORT=true). " +
+            "records_processed counts input records in read stages and written records in write stages.",
             optional = true)
     public File PROGRESS_JSON;
 
@@ -302,55 +297,8 @@ public class LiftoverVcf extends CommandLineProgram {
     private final Map<String, Long> liftedByDestContig = new TreeMap<>();
     private final Map<String, Long> liftedBySourceContig = new TreeMap<>();
 
-    /**
-     * Builds a single NDJSON event line for the PROGRESS_JSON sidecar. Field order is fixed so
-     * downstream consumers can rely on a stable schema; this method is the only writer of the
-     * format and is unit-tested by {@code LiftoverVcfProgressJsonTest}. JSON is built by hand to
-     * avoid adding a runtime dependency for a single use site.
-     */
-    static String formatProgressEvent(final Instant timestamp, final String stage,
-                                      final long recordsProcessed, final long recordsRejected,
-                                      final String lastPosition, final long elapsedSeconds) {
-        final StringBuilder sb = new StringBuilder(160);
-        sb.append('{');
-        sb.append("\"timestamp\":\"").append(timestamp.truncatedTo(ChronoUnit.SECONDS)).append("\",");
-        sb.append("\"stage\":\"").append(escapeJsonString(stage)).append("\",");
-        sb.append("\"records_processed\":").append(recordsProcessed).append(',');
-        sb.append("\"records_rejected\":").append(recordsRejected).append(',');
-        sb.append("\"last_position\":");
-        if (lastPosition == null) {
-            sb.append("null");
-        } else {
-            sb.append('"').append(escapeJsonString(lastPosition)).append('"');
-        }
-        sb.append(',');
-        sb.append("\"elapsed_seconds\":").append(elapsedSeconds);
-        sb.append('}');
-        return sb.toString();
-    }
-
-    static String escapeJsonString(final String s) {
-        final StringBuilder sb = new StringBuilder(s.length() + 4);
-        for (int i = 0; i < s.length(); i++) {
-            final char c = s.charAt(i);
-            switch (c) {
-                case '"':  sb.append("\\\""); break;
-                case '\\': sb.append("\\\\"); break;
-                case '\b': sb.append("\\b"); break;
-                case '\f': sb.append("\\f"); break;
-                case '\n': sb.append("\\n"); break;
-                case '\r': sb.append("\\r"); break;
-                case '\t': sb.append("\\t"); break;
-                default:
-                    if (c < 0x20) {
-                        sb.append(String.format("\\u%04x", (int) c));
-                    } else {
-                        sb.append(c);
-                    }
-            }
-        }
-        return sb.toString();
-    }
+    /** Cadence (in input records) at which read-phase PROGRESS_JSON events are emitted. */
+    private static final long PROGRESS_JSON_INTERVAL = 1_000_000;
 
     @Override
     protected ReferenceArgumentCollection makeReferenceArgumentCollection() {
@@ -403,225 +351,222 @@ public class LiftoverVcf extends CommandLineProgram {
         }
         CloserUtil.close(walker);
 
-        // Opened here (rather than alongside the early IOUtil.assertFileIsWritable checks above)
-        // so that we don't truncate the user's PROGRESS_JSON path on early-return validation
-        // failures (CREATE_INDEX/DISABLE_SORT mutex, missing sequence dictionary).
-        final PrintWriter progressJsonWriter;
-        if (PROGRESS_JSON != null) {
-            try {
-                progressJsonWriter = new PrintWriter(new BufferedWriter(new FileWriter(PROGRESS_JSON)), true);
-            } catch (final IOException e) {
-                throw new htsjdk.samtools.SAMException("Could not open PROGRESS_JSON file: " + PROGRESS_JSON, e);
+        // Opened after the early validation returns above so a failed run never truncates an
+        // existing PROGRESS_JSON file. try-with-resources closes it on every exit path.
+        final ProgressJsonWriter progressJson =
+                PROGRESS_JSON == null ? null : new ProgressJsonWriter(PROGRESS_JSON);
+        try (progressJson) {
+            ////////////////////////////////////////////////////////////////////////
+            // Setup the outputs
+            ////////////////////////////////////////////////////////////////////////
+            final VCFHeader inHeader = in.getFileHeader();
+            // build VCF header, remove the old '##reference=file://...'
+            final VCFHeader outHeader = new VCFHeader(
+                inHeader.getMetaDataInInputOrder()
+                    .stream()
+                    .filter(M->!M.getKey().equals("reference"))
+                    .collect(Collectors.toCollection(LinkedHashSet::new)),
+                inHeader.getSampleNamesInOrder()
+                );
+            outHeader.setSequenceDictionary(walker.getSequenceDictionary());
+            if (WRITE_ORIGINAL_POSITION) {
+                for (final VCFInfoHeaderLine line : ATTRS) outHeader.addMetaDataLine(line);
             }
-        } else {
-            progressJsonWriter = null;
-        }
 
-        ////////////////////////////////////////////////////////////////////////
-        // Setup the outputs
-        ////////////////////////////////////////////////////////////////////////
-        final VCFHeader inHeader = in.getFileHeader();
-        // build VCF header, remove the old '##reference=file://...'
-        final VCFHeader outHeader = new VCFHeader(
-            inHeader.getMetaDataInInputOrder()
-                .stream()
-                .filter(M->!M.getKey().equals("reference"))
-                .collect(Collectors.toCollection(LinkedHashSet::new)),
-            inHeader.getSampleNamesInOrder()
-            );
-        outHeader.setSequenceDictionary(walker.getSequenceDictionary());
-        if (WRITE_ORIGINAL_POSITION) {
-            for (final VCFInfoHeaderLine line : ATTRS) outHeader.addMetaDataLine(line);
-        }
+            outHeader.addMetaDataLine(new VCFInfoHeaderLine(LiftoverUtils.SWAPPED_ALLELES, 0, VCFHeaderLineType.Flag,
+                    "The REF and the ALT alleles have been swapped in liftover due to changes in the reference. " +
+                    "It is possible that not all INFO annotations reflect this swap, and in the genotypes, " +
+                    "only the GT, PL, and AD fields have been modified. You should check the TAGS_TO_REVERSE parameter that was used " +
+                            "during the LiftOver to be sure."));
+            outHeader.addMetaDataLine(new VCFInfoHeaderLine(LiftoverUtils.REV_COMPED_ALLELES, 0, VCFHeaderLineType.Flag,
+                    "The REF and the ALT alleles have been reverse complemented in liftover since the mapping from the " +
+                            "previous reference to the current one was on the negative strand."));
+            outHeader.addMetaDataLine(new VCFHeaderLine("reference", REFERENCE_SEQUENCE.toURI().toString()));
 
-        outHeader.addMetaDataLine(new VCFInfoHeaderLine(LiftoverUtils.SWAPPED_ALLELES, 0, VCFHeaderLineType.Flag,
-                "The REF and the ALT alleles have been swapped in liftover due to changes in the reference. " +
-                "It is possible that not all INFO annotations reflect this swap, and in the genotypes, " +
-                "only the GT, PL, and AD fields have been modified. You should check the TAGS_TO_REVERSE parameter that was used " +
-                        "during the LiftOver to be sure."));
-        outHeader.addMetaDataLine(new VCFInfoHeaderLine(LiftoverUtils.REV_COMPED_ALLELES, 0, VCFHeaderLineType.Flag,
-                "The REF and the ALT alleles have been reverse complemented in liftover since the mapping from the " +
-                        "previous reference to the current one was on the negative strand."));
-        outHeader.addMetaDataLine(new VCFHeaderLine("reference", REFERENCE_SEQUENCE.toURI().toString()));
-        
-        this.acceptedRecords = new VariantContextWriterBuilder()
-            .modifyOption(Options.ALLOW_MISSING_FIELDS_IN_HEADER, ALLOW_MISSING_FIELDS_IN_HEADER)
-            .modifyOption(Options.INDEX_ON_THE_FLY,!DISABLE_SORT)
-            .setOutputFile(OUTPUT)
-            .setReferenceDictionary(walker.getSequenceDictionary())
-            .build();
-        
-        this.acceptedRecords.writeHeader(outHeader);
-
-        rejectedRecords = new VariantContextWriterBuilder().setOutputFile(REJECT)
-                .unsetOption(Options.INDEX_ON_THE_FLY)
+            this.acceptedRecords = new VariantContextWriterBuilder()
                 .modifyOption(Options.ALLOW_MISSING_FIELDS_IN_HEADER, ALLOW_MISSING_FIELDS_IN_HEADER)
+                .modifyOption(Options.INDEX_ON_THE_FLY,!DISABLE_SORT)
+                .setOutputFile(OUTPUT)
+                .setReferenceDictionary(walker.getSequenceDictionary())
                 .build();
-        final VCFHeader rejectHeader = new VCFHeader(in.getFileHeader());
-        for (final VCFFilterHeaderLine line : FILTERS) {
-            rejectHeader.addMetaDataLine(line);
-        }
 
-        rejectHeader.addMetaDataLine(new VCFInfoHeaderLine(ATTEMPTED_LOCUS, 1, VCFHeaderLineType.String, "The locus of the variant in the TARGET prior to failing due to reference allele mismatching to the target reference."));
-        rejectHeader.addMetaDataLine(new VCFInfoHeaderLine(ATTEMPTED_ALLELES, 1, VCFHeaderLineType.String, "The alleles of the variant in the TARGET prior to failing due to reference allele mismatching to the target reference."));
+            this.acceptedRecords.writeHeader(outHeader);
 
-        rejectedRecords.writeHeader(rejectHeader);
-
-        ////////////////////////////////////////////////////////////////////////
-        // Read the input VCF, lift the records over and write to the sorting
-        // collection.
-        ////////////////////////////////////////////////////////////////////////
-        long total = 0;
-        
-        if (DISABLE_SORT) {
-            log.info("Lifting variants over and writing the output file. Variants will not be sorted.");
-            
-            sorter = null;
-            }
-        else {
-            log.info("Lifting variants over and sorting (not yet writing the output file.)");
-    
-            sorter = SortingCollection.newInstance(VariantContext.class,
-                    new VCFRecordCodec(outHeader, ALLOW_MISSING_FIELDS_IN_HEADER || VALIDATION_STRINGENCY != ValidationStringency.STRICT),
-                    outHeader.getVCFRecordComparator(),
-                    MAX_RECORDS_IN_RAM,
-                    TMP_DIR);
+            rejectedRecords = new VariantContextWriterBuilder().setOutputFile(REJECT)
+                    .unsetOption(Options.INDEX_ON_THE_FLY)
+                    .modifyOption(Options.ALLOW_MISSING_FIELDS_IN_HEADER, ALLOW_MISSING_FIELDS_IN_HEADER)
+                    .build();
+            final VCFHeader rejectHeader = new VCFHeader(in.getFileHeader());
+            for (final VCFFilterHeaderLine line : FILTERS) {
+                rejectHeader.addMetaDataLine(line);
             }
 
-        ProgressLogger progress = new ProgressLogger(log, 1000000, "read");
-        String lastReadPosition = null;
+            rejectHeader.addMetaDataLine(new VCFInfoHeaderLine(ATTEMPTED_LOCUS, 1, VCFHeaderLineType.String, "The locus of the variant in the TARGET prior to failing due to reference allele mismatching to the target reference."));
+            rejectHeader.addMetaDataLine(new VCFInfoHeaderLine(ATTEMPTED_ALLELES, 1, VCFHeaderLineType.String, "The alleles of the variant in the TARGET prior to failing due to reference allele mismatching to the target reference."));
 
-        for (final VariantContext ctx : in) {
-            ++total;
-            lastReadPosition = ctx.getContig() + ":" + ctx.getStart();
-            final Interval source = new Interval(ctx.getContig(), ctx.getStart(), ctx.getEnd(), false, ctx.getContig() + ":" + ctx.getStart() + "-" + ctx.getEnd());
-            final Interval target = liftOver.liftOver(source, LIFTOVER_MIN_MATCH);
+            rejectedRecords.writeHeader(rejectHeader);
 
-            // target is null when there is no good liftover for the context. This happens either when it fall in a gap
-            // where there isn't a chain, or if a large enough proportion of it is diminished by the "deletion" at the
-            // end of each interval in a chain.
-            if (target == null) {
-                rejectVariant(ctx, FILTER_NO_TARGET);
-                continue;
-            }
+            ////////////////////////////////////////////////////////////////////////
+            // Read the input VCF, lift the records over and write to the sorting
+            // collection.
+            ////////////////////////////////////////////////////////////////////////
+            long total = 0;
 
-            // the target is the lifted-over interval comprised of the start/stop of the variant context,
-            // if the sizes of target and ctx do not match, it means that the interval grew or shrank during
-            // liftover which must be due to straddling multiple intervals in the liftover chain.
-            // This would invalidate the indel as it isn't clear what the resulting alleles should be.
-            if (ctx.getReference().length() != target.length()) {
-                rejectVariant(ctx, FILTER_INDEL_STRADDLES_TWO_INTERVALS);
-                continue;
-            }
+            if (DISABLE_SORT) {
+                log.info("Lifting variants over and writing the output file. Variants will not be sorted.");
 
-            final ReferenceSequence refSeq;
-
-            if (!refSeqs.containsKey(target.getContig())) {
-                rejectVariant(ctx, FILTER_NO_TARGET);
-
-                final String missingContigMessage = "Encountered a contig, " + target.getContig() + " that is not part of the target reference.";
-                if (WARN_ON_MISSING_CONTIG) {
-                    log.warn(missingContigMessage);
-                } else {
-                    log.error(missingContigMessage);
-                    return EXIT_CODE_WHEN_CONTIG_NOT_IN_REFERENCE;
+                sorter = null;
                 }
+            else {
+                log.info("Lifting variants over and sorting (not yet writing the output file.)");
+
+                sorter = SortingCollection.newInstance(VariantContext.class,
+                        new VCFRecordCodec(outHeader, ALLOW_MISSING_FIELDS_IN_HEADER || VALIDATION_STRINGENCY != ValidationStringency.STRICT),
+                        outHeader.getVCFRecordComparator(),
+                        MAX_RECORDS_IN_RAM,
+                        TMP_DIR);
+                }
+
+            ProgressLogger progress = new ProgressLogger(log, 1000000, "read");
+            String lastReadPosition = null;
+
+            for (final VariantContext ctx : in) {
+                ++total;
+                if (progressJson != null) {
+                    lastReadPosition = ctx.getContig() + ":" + ctx.getStart();
+                    // Emit on a fixed input-record cadence (not progress.record's, which skips
+                    // rejected variants) so a bad chain shows a rising reject rate while running.
+                    if (total % PROGRESS_JSON_INTERVAL == 0) {
+                        progressJson.emit("read", total, failedLiftover + failedAlleleCheck,
+                                lastReadPosition, progress.getElapsedSeconds());
+                    }
+                }
+                final Interval source = new Interval(ctx.getContig(), ctx.getStart(), ctx.getEnd(), false, ctx.getContig() + ":" + ctx.getStart() + "-" + ctx.getEnd());
+                final Interval target = liftOver.liftOver(source, LIFTOVER_MIN_MATCH);
+
+                // target is null when there is no good liftover for the context. This happens either when it fall in a gap
+                // where there isn't a chain, or if a large enough proportion of it is diminished by the "deletion" at the
+                // end of each interval in a chain.
+                if (target == null) {
+                    rejectVariant(ctx, FILTER_NO_TARGET);
+                    continue;
+                }
+
+                // the target is the lifted-over interval comprised of the start/stop of the variant context,
+                // if the sizes of target and ctx do not match, it means that the interval grew or shrank during
+                // liftover which must be due to straddling multiple intervals in the liftover chain.
+                // This would invalidate the indel as it isn't clear what the resulting alleles should be.
+                if (ctx.getReference().length() != target.length()) {
+                    rejectVariant(ctx, FILTER_INDEL_STRADDLES_TWO_INTERVALS);
+                    continue;
+                }
+
+                final ReferenceSequence refSeq;
+
+                if (!refSeqs.containsKey(target.getContig())) {
+                    rejectVariant(ctx, FILTER_NO_TARGET);
+
+                    final String missingContigMessage = "Encountered a contig, " + target.getContig() + " that is not part of the target reference.";
+                    if (WARN_ON_MISSING_CONTIG) {
+                        log.warn(missingContigMessage);
+                    } else {
+                        log.error(missingContigMessage);
+                        return EXIT_CODE_WHEN_CONTIG_NOT_IN_REFERENCE;
+                    }
+                } else {
+                    refSeq = refSeqs.get(target.getContig());
+
+                    final VariantContext liftedVC = LiftoverUtils.liftVariant(ctx, target, refSeq, WRITE_ORIGINAL_POSITION, WRITE_ORIGINAL_ALLELES);
+                    // the liftedVC can be null if the liftover fails because of a problem with reverse complementing
+                    if (liftedVC == null) {
+                        rejectVariant(ctx, FILTER_CANNOT_LIFTOVER_REV_COMP);
+                    } else {
+                        tryToAddVariant(liftedVC, refSeq, ctx);
+                    }
+                }
+                progress.record(ctx.getContig(), ctx.getStart());
+            }
+
+            if (progressJson != null) {
+                progressJson.emit("read_complete", total, failedLiftover + failedAlleleCheck,
+                        lastReadPosition, progress.getElapsedSeconds());
+            }
+
+            final NumberFormat pfmt = new DecimalFormat("0.0000%");
+            final String pct = pfmt.format((failedLiftover + failedAlleleCheck) / (double) total);
+            log.info("Processed ", total, " variants.");
+            log.info(failedLiftover, " variants failed to liftover.");
+            log.info(failedAlleleCheck, " variants lifted over but had mismatching reference alleles after lift over.");
+            log.info(pct, " of variants were not successfully lifted over and written to the output.");
+
+            final Set<String> contigUnion = new TreeSet<>();
+            contigUnion.addAll(liftedBySourceContig.keySet());
+            contigUnion.addAll(rejectsByContig.keySet());
+
+            log.info("liftover success by source contig:");
+            for (String contig : contigUnion) {
+                final long success = liftedBySourceContig.getOrDefault(contig, 0L);
+                final long fail = rejectsByContig.getOrDefault(contig, 0L);
+                final String liftPct = pfmt.format((double)success / (double)(success + fail));
+
+                log.info(contig, ": ", success, " / ", (success + fail), " (", liftPct, ")");
+            }
+
+            log.info("lifted variants by target contig:");
+            for (String contig : liftedByDestContig.keySet()) {
+                log.info(contig, ": ", liftedByDestContig.get(contig));
+            }
+            if (liftedByDestContig.isEmpty()) {
+                log.info("no successfully lifted variants");
+            }
+
+            if (RECOVER_SWAPPED_REF_ALT) {
+                log.info(totalTrackedAsSwapRefAlt, " variants were lifted by swapping REF/ALT alleles.");
             } else {
-                refSeq = refSeqs.get(target.getContig());
+                log.warn(totalTrackedAsSwapRefAlt, " variants with a swapped REF/ALT were identified, but were not recovered.  See RECOVER_SWAPPED_REF_ALT and associated caveats.");
+            }
 
-                final VariantContext liftedVC = LiftoverUtils.liftVariant(ctx, target, refSeq, WRITE_ORIGINAL_POSITION, WRITE_ORIGINAL_ALLELES);
-                // the liftedVC can be null if the liftover fails because of a problem with reverse complementing
-                if (liftedVC == null) {
-                    rejectVariant(ctx, FILTER_CANNOT_LIFTOVER_REV_COMP);
-                } else {
-                    tryToAddVariant(liftedVC, refSeq, ctx);
+            rejectedRecords.close();
+            in.close();
+
+            if (!DISABLE_SORT) {
+                ////////////////////////////////////////////////////////////////////////
+                // Write the sorted outputs to the final output file
+                ////////////////////////////////////////////////////////////////////////
+                sorter.doneAdding();
+                progress = new ProgressLogger(log, 1000000, "written");
+                log.info("Writing out sorted records to final VCF.");
+
+                String lastWritePosition = null;
+                for (final VariantContext ctx : sorter) {
+                    this.acceptedRecords.add(ctx);
+                    final boolean milestone = progress.record(ctx.getContig(), ctx.getStart());
+                    if (progressJson != null) {
+                        lastWritePosition = ctx.getContig() + ":" + ctx.getStart();
+                        if (milestone) {
+                            progressJson.emit("write", progress.getCount(), 0L,
+                                    lastWritePosition, progress.getElapsedSeconds());
+                        }
+                    }
                 }
-            }
-            if (progress.record(ctx.getContig(), ctx.getStart()) && progressJsonWriter != null) {
-                progressJsonWriter.println(formatProgressEvent(
-                        Instant.now(), "read", total, failedLiftover + failedAlleleCheck,
-                        lastReadPosition, progress.getElapsedSeconds()));
-            }
-        }
 
-        if (progressJsonWriter != null) {
-            progressJsonWriter.println(formatProgressEvent(
-                    Instant.now(), "read_complete", total, failedLiftover + failedAlleleCheck,
-                    lastReadPosition, progress.getElapsedSeconds()));
-        }
-
-        final NumberFormat pfmt = new DecimalFormat("0.0000%");
-        final String pct = pfmt.format((failedLiftover + failedAlleleCheck) / (double) total);
-        log.info("Processed ", total, " variants.");
-        log.info(failedLiftover, " variants failed to liftover.");
-        log.info(failedAlleleCheck, " variants lifted over but had mismatching reference alleles after lift over.");
-        log.info(pct, " of variants were not successfully lifted over and written to the output.");
-
-        final Set<String> contigUnion = new TreeSet<>();
-        contigUnion.addAll(liftedBySourceContig.keySet());
-        contigUnion.addAll(rejectsByContig.keySet());
-
-        log.info("liftover success by source contig:");
-        for (String contig : contigUnion) {
-            final long success = liftedBySourceContig.getOrDefault(contig, 0L);
-            final long fail = rejectsByContig.getOrDefault(contig, 0L);
-            final String liftPct = pfmt.format((double)success / (double)(success + fail));
-
-            log.info(contig, ": ", success, " / ", (success + fail), " (", liftPct, ")");
-        }
-
-        log.info("lifted variants by target contig:");
-        for (String contig : liftedByDestContig.keySet()) {
-            log.info(contig, ": ", liftedByDestContig.get(contig));
-        }
-        if (liftedByDestContig.isEmpty()) {
-            log.info("no successfully lifted variants");
-        }
-
-        if (RECOVER_SWAPPED_REF_ALT) {
-            log.info(totalTrackedAsSwapRefAlt, " variants were lifted by swapping REF/ALT alleles.");
-        } else {
-            log.warn(totalTrackedAsSwapRefAlt, " variants with a swapped REF/ALT were identified, but were not recovered.  See RECOVER_SWAPPED_REF_ALT and associated caveats.");
-        }
-
-        rejectedRecords.close();
-        in.close();
-
-        if (!DISABLE_SORT) {
-            ////////////////////////////////////////////////////////////////////////
-            // Write the sorted outputs to the final output file
-            ////////////////////////////////////////////////////////////////////////
-            sorter.doneAdding();
-            progress = new ProgressLogger(log, 1000000, "written");
-            log.info("Writing out sorted records to final VCF.");
-
-            String lastWritePosition = null;
-            for (final VariantContext ctx : sorter) {
-                this.acceptedRecords.add(ctx);
-                lastWritePosition = ctx.getContig() + ":" + ctx.getStart();
-                if (progress.record(ctx.getContig(), ctx.getStart()) && progressJsonWriter != null) {
-                    progressJsonWriter.println(formatProgressEvent(
-                            Instant.now(), "write", progress.getCount(), 0L,
-                            lastWritePosition, progress.getElapsedSeconds()));
+                if (progressJson != null) {
+                    progressJson.emit("write_complete", progress.getCount(), 0L,
+                            lastWritePosition, progress.getElapsedSeconds());
                 }
+
+                sorter.cleanup();
+            } else if (progressJson != null) {
+                // DISABLE_SORT writes accepted records on the fly (in tryToAddVariant) with no
+                // separate write phase; emit a terminal sentinel reporting the written count.
+                progressJson.emit("write_skipped", total - failedLiftover - failedAlleleCheck,
+                        failedLiftover + failedAlleleCheck, lastReadPosition, progress.getElapsedSeconds());
             }
 
-            if (progressJsonWriter != null) {
-                progressJsonWriter.println(formatProgressEvent(
-                        Instant.now(), "write_complete", progress.getCount(), 0L,
-                        lastWritePosition, progress.getElapsedSeconds()));
-            }
+            this.acceptedRecords.close();
 
-            sorter.cleanup();
+            return 0;
         }
-
-        this.acceptedRecords.close();
-
-        if (progressJsonWriter != null) {
-            progressJsonWriter.close();
-        }
-
-        return 0;
     }
 
     private void rejectVariant(final VariantContext ctx, final String reason) {

--- a/src/main/java/picard/vcf/LiftoverVcf.java
+++ b/src/main/java/picard/vcf/LiftoverVcf.java
@@ -61,9 +61,15 @@ import picard.cmdline.argumentcollections.ReferenceArgumentCollection;
 import picard.cmdline.programgroups.VariantManipulationProgramGroup;
 import picard.util.LiftoverUtils;
 
+import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -206,6 +212,15 @@ public class LiftoverVcf extends CommandLineProgram {
     @Argument(doc = "Output VCF file will be written on the fly but it won't be sorted and indexed.", optional = true)
     public boolean DISABLE_SORT = false;
 
+    @Argument(doc = "Optional path to a JSON Lines (NDJSON) sidecar that receives one structured " +
+            "progress event per ProgressLogger milestone during the read and write phases. " +
+            "Provides a stable parsing target for downstream tooling, as an alternative to " +
+            "regex-parsing the human-readable log output. Each line is one JSON object: " +
+            "{\"timestamp\":..., \"stage\":..., \"records_processed\":..., \"records_rejected\":..., " +
+            "\"last_position\":..., \"elapsed_seconds\":...}.",
+            optional = true)
+    public File PROGRESS_JSON;
+
     // When a contig used in the chain is not in the reference, exit with this value instead of 0.
     public static int EXIT_CODE_WHEN_CONTIG_NOT_IN_REFERENCE = 1;
 
@@ -286,6 +301,56 @@ public class LiftoverVcf extends CommandLineProgram {
     private final Map<String, Long> liftedByDestContig = new TreeMap<>();
     private final Map<String, Long> liftedBySourceContig = new TreeMap<>();
 
+    /**
+     * Builds a single NDJSON event line for the PROGRESS_JSON sidecar. Field order is fixed so
+     * downstream consumers can rely on a stable schema; this method is the only writer of the
+     * format and is unit-tested by {@code LiftoverVcfProgressJsonTest}. JSON is built by hand to
+     * avoid adding a runtime dependency for a single use site.
+     */
+    static String formatProgressEvent(final Instant timestamp, final String stage,
+                                      final long recordsProcessed, final long recordsRejected,
+                                      final String lastPosition, final long elapsedSeconds) {
+        final StringBuilder sb = new StringBuilder(160);
+        sb.append('{');
+        sb.append("\"timestamp\":\"").append(timestamp.truncatedTo(ChronoUnit.SECONDS)).append("\",");
+        sb.append("\"stage\":\"").append(escapeJsonString(stage)).append("\",");
+        sb.append("\"records_processed\":").append(recordsProcessed).append(',');
+        sb.append("\"records_rejected\":").append(recordsRejected).append(',');
+        sb.append("\"last_position\":");
+        if (lastPosition == null) {
+            sb.append("null");
+        } else {
+            sb.append('"').append(escapeJsonString(lastPosition)).append('"');
+        }
+        sb.append(',');
+        sb.append("\"elapsed_seconds\":").append(elapsedSeconds);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    static String escapeJsonString(final String s) {
+        final StringBuilder sb = new StringBuilder(s.length() + 4);
+        for (int i = 0; i < s.length(); i++) {
+            final char c = s.charAt(i);
+            switch (c) {
+                case '"':  sb.append("\\\""); break;
+                case '\\': sb.append("\\\\"); break;
+                case '\b': sb.append("\\b"); break;
+                case '\f': sb.append("\\f"); break;
+                case '\n': sb.append("\\n"); break;
+                case '\r': sb.append("\\r"); break;
+                case '\t': sb.append("\\t"); break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        return sb.toString();
+    }
+
     @Override
     protected ReferenceArgumentCollection makeReferenceArgumentCollection() {
         return new ReferenceArgumentCollection() {
@@ -308,8 +373,21 @@ public class LiftoverVcf extends CommandLineProgram {
         IOUtil.assertFileIsReadable(CHAIN);
         IOUtil.assertFileIsWritable(OUTPUT);
         IOUtil.assertFileIsWritable(REJECT);
+        if (PROGRESS_JSON != null) {
+            IOUtil.assertFileIsWritable(PROGRESS_JSON);
+        }
 
-        
+        final PrintWriter progressJsonWriter;
+        if (PROGRESS_JSON != null) {
+            try {
+                progressJsonWriter = new PrintWriter(new BufferedWriter(new FileWriter(PROGRESS_JSON)), true);
+            } catch (final IOException e) {
+                throw new htsjdk.samtools.SAMException("Could not open PROGRESS_JSON file: " + PROGRESS_JSON, e);
+            }
+        } else {
+            progressJsonWriter = null;
+        }
+
         if (CREATE_INDEX && DISABLE_SORT) {
             log.error("CREATE_INDEX=true and DISABLE_SORT=true are mutually exclusive.");
             return 1;
@@ -407,9 +485,11 @@ public class LiftoverVcf extends CommandLineProgram {
             }
 
         ProgressLogger progress = new ProgressLogger(log, 1000000, "read");
+        String lastReadPosition = null;
 
         for (final VariantContext ctx : in) {
             ++total;
+            lastReadPosition = ctx.getContig() + ":" + ctx.getStart();
             final Interval source = new Interval(ctx.getContig(), ctx.getStart(), ctx.getEnd(), false, ctx.getContig() + ":" + ctx.getStart() + "-" + ctx.getEnd());
             final Interval target = liftOver.liftOver(source, LIFTOVER_MIN_MATCH);
 
@@ -453,7 +533,17 @@ public class LiftoverVcf extends CommandLineProgram {
                     tryToAddVariant(liftedVC, refSeq, ctx);
                 }
             }
-            progress.record(ctx.getContig(), ctx.getStart());
+            if (progress.record(ctx.getContig(), ctx.getStart()) && progressJsonWriter != null) {
+                progressJsonWriter.println(formatProgressEvent(
+                        Instant.now(), "read", total, failedLiftover + failedAlleleCheck,
+                        lastReadPosition, progress.getElapsedSeconds()));
+            }
+        }
+
+        if (progressJsonWriter != null) {
+            progressJsonWriter.println(formatProgressEvent(
+                    Instant.now(), "read_complete", total, failedLiftover + failedAlleleCheck,
+                    lastReadPosition, progress.getElapsedSeconds()));
         }
 
         final NumberFormat pfmt = new DecimalFormat("0.0000%");
@@ -493,24 +583,40 @@ public class LiftoverVcf extends CommandLineProgram {
         rejectedRecords.close();
         in.close();
 
-        if (!DISABLE_SORT) { 
+        if (!DISABLE_SORT) {
             ////////////////////////////////////////////////////////////////////////
             // Write the sorted outputs to the final output file
             ////////////////////////////////////////////////////////////////////////
             sorter.doneAdding();
             progress = new ProgressLogger(log, 1000000, "written");
             log.info("Writing out sorted records to final VCF.");
-    
+
+            String lastWritePosition = null;
             for (final VariantContext ctx : sorter) {
                 this.acceptedRecords.add(ctx);
-                progress.record(ctx.getContig(), ctx.getStart());
+                lastWritePosition = ctx.getContig() + ":" + ctx.getStart();
+                if (progress.record(ctx.getContig(), ctx.getStart()) && progressJsonWriter != null) {
+                    progressJsonWriter.println(formatProgressEvent(
+                            Instant.now(), "write", progress.getCount(), 0L,
+                            lastWritePosition, progress.getElapsedSeconds()));
+                }
             }
-    
+
+            if (progressJsonWriter != null) {
+                progressJsonWriter.println(formatProgressEvent(
+                        Instant.now(), "write_complete", progress.getCount(), 0L,
+                        lastWritePosition, progress.getElapsedSeconds()));
+            }
+
             sorter.cleanup();
         }
 
         this.acceptedRecords.close();
-        
+
+        if (progressJsonWriter != null) {
+            progressJsonWriter.close();
+        }
+
         return 0;
     }
 

--- a/src/main/java/picard/vcf/LiftoverVcf.java
+++ b/src/main/java/picard/vcf/LiftoverVcf.java
@@ -217,7 +217,8 @@ public class LiftoverVcf extends CommandLineProgram {
             "Provides a stable parsing target for downstream tooling, as an alternative to " +
             "regex-parsing the human-readable log output. Each line is one JSON object: " +
             "{\"timestamp\":..., \"stage\":..., \"records_processed\":..., \"records_rejected\":..., " +
-            "\"last_position\":..., \"elapsed_seconds\":...}.",
+            "\"last_position\":..., \"elapsed_seconds\":...}. " +
+            "Existing files at this path are overwritten.",
             optional = true)
     public File PROGRESS_JSON;
 
@@ -377,17 +378,6 @@ public class LiftoverVcf extends CommandLineProgram {
             IOUtil.assertFileIsWritable(PROGRESS_JSON);
         }
 
-        final PrintWriter progressJsonWriter;
-        if (PROGRESS_JSON != null) {
-            try {
-                progressJsonWriter = new PrintWriter(new BufferedWriter(new FileWriter(PROGRESS_JSON)), true);
-            } catch (final IOException e) {
-                throw new htsjdk.samtools.SAMException("Could not open PROGRESS_JSON file: " + PROGRESS_JSON, e);
-            }
-        } else {
-            progressJsonWriter = null;
-        }
-
         if (CREATE_INDEX && DISABLE_SORT) {
             log.error("CREATE_INDEX=true and DISABLE_SORT=true are mutually exclusive.");
             return 1;
@@ -412,6 +402,20 @@ public class LiftoverVcf extends CommandLineProgram {
             refSeqs.put(rec.getSequenceName(), walker.get(rec.getSequenceIndex()));
         }
         CloserUtil.close(walker);
+
+        // Opened here (rather than alongside the early IOUtil.assertFileIsWritable checks above)
+        // so that we don't truncate the user's PROGRESS_JSON path on early-return validation
+        // failures (CREATE_INDEX/DISABLE_SORT mutex, missing sequence dictionary).
+        final PrintWriter progressJsonWriter;
+        if (PROGRESS_JSON != null) {
+            try {
+                progressJsonWriter = new PrintWriter(new BufferedWriter(new FileWriter(PROGRESS_JSON)), true);
+            } catch (final IOException e) {
+                throw new htsjdk.samtools.SAMException("Could not open PROGRESS_JSON file: " + PROGRESS_JSON, e);
+            }
+        } else {
+            progressJsonWriter = null;
+        }
 
         ////////////////////////////////////////////////////////////////////////
         // Setup the outputs

--- a/src/test/java/picard/util/LiftoverVcfTest.java
+++ b/src/test/java/picard/util/LiftoverVcfTest.java
@@ -200,7 +200,7 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         Assert.assertFalse(lines.isEmpty(),
                 "PROGRESS_JSON should contain at least the final read_complete event");
 
-        boolean sawReadComplete = false;
+        String readCompleteLine = null;
         for (final String line : lines) {
             Assert.assertTrue(line.startsWith("{") && line.endsWith("}"),
                     "Each line should be a self-contained JSON object: " + line);
@@ -211,11 +211,23 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
             Assert.assertTrue(line.contains("\"last_position\":"), "Missing last_position: " + line);
             Assert.assertTrue(line.contains("\"elapsed_seconds\":"), "Missing elapsed_seconds: " + line);
             if (line.contains("\"stage\":\"read_complete\"")) {
-                sawReadComplete = true;
+                readCompleteLine = line;
             }
         }
-        Assert.assertTrue(sawReadComplete,
+        Assert.assertNotNull(readCompleteLine,
                 "Expected a read_complete event so small inputs still produce a JSON event");
+
+        // Verify the formatter wiring: the read_complete event should report the exact input
+        // record count (3 for testLiftoverFailingVariants.vcf). A regression that passed
+        // progress.getCount() instead of `total` to formatProgressEvent would still pass the
+        // field-presence checks above but would fail here.
+        final java.util.regex.Matcher m = java.util.regex.Pattern
+                .compile("\"records_processed\":(\\d+)").matcher(readCompleteLine);
+        Assert.assertTrue(m.find(),
+                "records_processed field not parseable in read_complete event: " + readCompleteLine);
+        Assert.assertEquals(Long.parseLong(m.group(1)), 3L,
+                "Expected records_processed=3 (testLiftoverFailingVariants.vcf has 3 records); got: "
+                        + readCompleteLine);
     }
 
     @Test

--- a/src/test/java/picard/util/LiftoverVcfTest.java
+++ b/src/test/java/picard/util/LiftoverVcfTest.java
@@ -196,6 +196,10 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
         Assert.assertEquals(runPicardCommandLine(args), 0);
 
         Assert.assertTrue(progressJson.exists(), "PROGRESS_JSON file should have been created");
+        // NDJSON must be LF-terminated, not CRLF, regardless of platform.
+        final byte[] rawBytes = Files.readAllBytes(progressJson.toPath());
+        Assert.assertFalse(new String(rawBytes, java.nio.charset.StandardCharsets.UTF_8).contains("\r"),
+                "PROGRESS_JSON must use LF line endings, not CRLF");
         final List<String> lines = Files.readAllLines(progressJson.toPath());
         Assert.assertFalse(lines.isEmpty(),
                 "PROGRESS_JSON should contain at least the final read_complete event");
@@ -218,9 +222,9 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
                 "Expected a read_complete event so small inputs still produce a JSON event");
 
         // Verify the formatter wiring: the read_complete event should report the exact input
-        // record count (3 for testLiftoverFailingVariants.vcf). A regression that passed
-        // progress.getCount() instead of `total` to formatProgressEvent would still pass the
-        // field-presence checks above but would fail here.
+        // record count (3 for testLiftoverFailingVariants.vcf). A regression that passed the wrong
+        // counter to ProgressJsonWriter.formatEvent would still pass the field-presence checks
+        // above but would fail here.
         final java.util.regex.Matcher m = java.util.regex.Pattern
                 .compile("\"records_processed\":(\\d+)").matcher(readCompleteLine);
         Assert.assertTrue(m.find(),
@@ -232,8 +236,8 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
 
     @Test
     public void testNoProgressJsonByDefault() {
-        // When PROGRESS_JSON is not specified, the run must not create any sidecar file
-        // and must still succeed end-to-end.
+        // When PROGRESS_JSON is not specified the run must still succeed end-to-end; the writer
+        // is simply never constructed.
         final String filename = "testLiftoverFailingVariants.vcf";
         final File liftOutputFile = new File(OUTPUT_DATA_PATH, "lift-no-progress-json.vcf");
         final File rejectOutputFile = new File(OUTPUT_DATA_PATH, "reject-no-progress-json.vcf");
@@ -251,6 +255,38 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
                 "CREATE_INDEX=false"
         };
         Assert.assertEquals(runPicardCommandLine(args), 0);
+    }
+
+    @Test
+    public void testProgressJsonWriteSkippedWhenSortDisabled() throws IOException {
+        // With DISABLE_SORT there is no separate write phase, so the sidecar should carry a
+        // terminal write_skipped event rather than write/write_complete.
+        final File liftOutputFile = new File(OUTPUT_DATA_PATH, "lift-progress-nosort.vcf");
+        final File rejectOutputFile = new File(OUTPUT_DATA_PATH, "reject-progress-nosort.vcf");
+        final File progressJson = new File(OUTPUT_DATA_PATH, "progress-nosort.json");
+        final File input = new File(TEST_DATA_PATH, "testLiftoverFailingVariants.vcf");
+
+        liftOutputFile.deleteOnExit();
+        rejectOutputFile.deleteOnExit();
+        progressJson.deleteOnExit();
+
+        final String[] args = new String[]{
+                "INPUT=" + input.getAbsolutePath(),
+                "OUTPUT=" + liftOutputFile.getAbsolutePath(),
+                "REJECT=" + rejectOutputFile.getAbsolutePath(),
+                "CHAIN=" + CHAIN_FILE,
+                "REFERENCE_SEQUENCE=" + REFERENCE_FILE,
+                "PROGRESS_JSON=" + progressJson.getAbsolutePath(),
+                "DISABLE_SORT=true",
+                "CREATE_INDEX=false"
+        };
+        Assert.assertEquals(runPicardCommandLine(args), 0);
+
+        final List<String> lines = Files.readAllLines(progressJson.toPath());
+        Assert.assertTrue(lines.stream().anyMatch(l -> l.contains("\"stage\":\"write_skipped\"")),
+                "Expected a write_skipped event when DISABLE_SORT=true; got: " + lines);
+        Assert.assertTrue(lines.stream().noneMatch(l -> l.contains("\"stage\":\"write_complete\"")),
+                "Did not expect a write_complete event when DISABLE_SORT=true; got: " + lines);
     }
 
     @Test

--- a/src/test/java/picard/util/LiftoverVcfTest.java
+++ b/src/test/java/picard/util/LiftoverVcfTest.java
@@ -173,6 +173,75 @@ public class LiftoverVcfTest extends CommandLineProgramTest {
     }
 
     @Test
+    public void testProgressJsonSidecarIsWritten() throws IOException {
+        final String filename = "testLiftoverFailingVariants.vcf";
+        final File liftOutputFile = new File(OUTPUT_DATA_PATH, "lift-progress-json.vcf");
+        final File rejectOutputFile = new File(OUTPUT_DATA_PATH, "reject-progress-json.vcf");
+        final File progressJson = new File(OUTPUT_DATA_PATH, "progress.json");
+        final File input = new File(TEST_DATA_PATH, filename);
+
+        liftOutputFile.deleteOnExit();
+        rejectOutputFile.deleteOnExit();
+        progressJson.deleteOnExit();
+
+        final String[] args = new String[]{
+                "INPUT=" + input.getAbsolutePath(),
+                "OUTPUT=" + liftOutputFile.getAbsolutePath(),
+                "REJECT=" + rejectOutputFile.getAbsolutePath(),
+                "CHAIN=" + CHAIN_FILE,
+                "REFERENCE_SEQUENCE=" + REFERENCE_FILE,
+                "PROGRESS_JSON=" + progressJson.getAbsolutePath(),
+                "CREATE_INDEX=false"
+        };
+        Assert.assertEquals(runPicardCommandLine(args), 0);
+
+        Assert.assertTrue(progressJson.exists(), "PROGRESS_JSON file should have been created");
+        final List<String> lines = Files.readAllLines(progressJson.toPath());
+        Assert.assertFalse(lines.isEmpty(),
+                "PROGRESS_JSON should contain at least the final read_complete event");
+
+        boolean sawReadComplete = false;
+        for (final String line : lines) {
+            Assert.assertTrue(line.startsWith("{") && line.endsWith("}"),
+                    "Each line should be a self-contained JSON object: " + line);
+            Assert.assertTrue(line.contains("\"timestamp\":"), "Missing timestamp field: " + line);
+            Assert.assertTrue(line.contains("\"stage\":"), "Missing stage field: " + line);
+            Assert.assertTrue(line.contains("\"records_processed\":"), "Missing records_processed: " + line);
+            Assert.assertTrue(line.contains("\"records_rejected\":"), "Missing records_rejected: " + line);
+            Assert.assertTrue(line.contains("\"last_position\":"), "Missing last_position: " + line);
+            Assert.assertTrue(line.contains("\"elapsed_seconds\":"), "Missing elapsed_seconds: " + line);
+            if (line.contains("\"stage\":\"read_complete\"")) {
+                sawReadComplete = true;
+            }
+        }
+        Assert.assertTrue(sawReadComplete,
+                "Expected a read_complete event so small inputs still produce a JSON event");
+    }
+
+    @Test
+    public void testNoProgressJsonByDefault() {
+        // When PROGRESS_JSON is not specified, the run must not create any sidecar file
+        // and must still succeed end-to-end.
+        final String filename = "testLiftoverFailingVariants.vcf";
+        final File liftOutputFile = new File(OUTPUT_DATA_PATH, "lift-no-progress-json.vcf");
+        final File rejectOutputFile = new File(OUTPUT_DATA_PATH, "reject-no-progress-json.vcf");
+        final File input = new File(TEST_DATA_PATH, filename);
+
+        liftOutputFile.deleteOnExit();
+        rejectOutputFile.deleteOnExit();
+
+        final String[] args = new String[]{
+                "INPUT=" + input.getAbsolutePath(),
+                "OUTPUT=" + liftOutputFile.getAbsolutePath(),
+                "REJECT=" + rejectOutputFile.getAbsolutePath(),
+                "CHAIN=" + CHAIN_FILE,
+                "REFERENCE_SEQUENCE=" + REFERENCE_FILE,
+                "CREATE_INDEX=false"
+        };
+        Assert.assertEquals(runPicardCommandLine(args), 0);
+    }
+
+    @Test
     public void testReverseComplementFailureDoesNotErrorOut() {
         final VariantContextBuilder builder = new VariantContextBuilder().source("test").loc("chr1", 1, 4);
         final Allele originalRef = Allele.create("TCAT", true);

--- a/src/test/java/picard/util/ProgressJsonWriterTest.java
+++ b/src/test/java/picard/util/ProgressJsonWriterTest.java
@@ -21,26 +21,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package picard.vcf;
+package picard.util;
 
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.time.Instant;
+import java.util.List;
 
 /**
- * Tests for {@link LiftoverVcf#formatProgressEvent(Instant, String, long, long, String, long)} and
- * {@link LiftoverVcf#escapeJsonString(String)}, the helpers backing LiftoverVcf's PROGRESS_JSON
- * NDJSON sidecar output.
+ * Tests for {@link ProgressJsonWriter}: the NDJSON event formatter, the JSON string escaper, and
+ * the on-disk encoding/termination of the sidecar.
  */
-public class LiftoverVcfProgressJsonTest {
+public class ProgressJsonWriterTest {
 
     private static final Instant FIXED = Instant.parse("2026-05-16T12:34:56Z");
 
     @Test
-    public void testFormatProgressEventReadStage() {
-        final String line = LiftoverVcf.formatProgressEvent(
+    public void testFormatEventReadStage() {
+        final String line = ProgressJsonWriter.formatEvent(
                 FIXED, "read", 1_000_000L, 12_345L, "chr3:148946422", 60L);
         Assert.assertEquals(line,
                 "{\"timestamp\":\"2026-05-16T12:34:56Z\","
@@ -52,8 +56,8 @@ public class LiftoverVcfProgressJsonTest {
     }
 
     @Test
-    public void testFormatProgressEventNullLastPositionSerializesAsJsonNull() {
-        final String line = LiftoverVcf.formatProgressEvent(
+    public void testFormatEventNullLastPositionSerializesAsJsonNull() {
+        final String line = ProgressJsonWriter.formatEvent(
                 FIXED, "read_complete", 0L, 0L, null, 0L);
         Assert.assertTrue(line.contains("\"last_position\":null"),
                 "Expected JSON null for last_position when null was passed in, got: " + line);
@@ -62,20 +66,20 @@ public class LiftoverVcfProgressJsonTest {
     }
 
     @Test
-    public void testFormatProgressEventLineHasNoNewline() {
-        // NDJSON / JSON Lines: each event must be exactly one line. Newlines come from the
-        // calling println(), not the event content itself.
-        final String line = LiftoverVcf.formatProgressEvent(
+    public void testFormatEventLineHasNoNewline() {
+        // NDJSON: each event must be exactly one line. The line terminator is added by the writer,
+        // not by the event content itself.
+        final String line = ProgressJsonWriter.formatEvent(
                 FIXED, "read", 100L, 0L, "chr1:1", 1L);
         Assert.assertFalse(line.contains("\n"), "Event line must not contain newline: " + line);
         Assert.assertFalse(line.contains("\r"), "Event line must not contain CR: " + line);
     }
 
     @Test
-    public void testFormatProgressEventTimestampTruncatedToSeconds() {
+    public void testFormatEventTimestampTruncatedToSeconds() {
         // Sub-second precision is dropped so output is deterministic across platforms.
         final Instant subSecond = Instant.parse("2026-05-16T12:34:56.789Z");
-        final String line = LiftoverVcf.formatProgressEvent(
+        final String line = ProgressJsonWriter.formatEvent(
                 subSecond, "read", 1L, 0L, "chr1:1", 0L);
         Assert.assertTrue(line.contains("\"timestamp\":\"2026-05-16T12:34:56Z\""),
                 "Expected timestamp truncated to second precision, got: " + line);
@@ -83,29 +87,56 @@ public class LiftoverVcfProgressJsonTest {
 
     @DataProvider(name = "jsonEscapeCases")
     public Object[][] jsonEscapeCases() {
+        // (char) 1 is the U+0001 control character, built at runtime so the source stays ASCII.
+        final String withControlChar = "ctrl" + ((char) 1) + "char";
         return new Object[][]{
                 {"plain", "plain"},
                 {"with \"quotes\"", "with \\\"quotes\\\""},
                 {"back\\slash", "back\\\\slash"},
                 {"new\nline", "new\\nline"},
                 {"tab\there", "tab\\there"},
-                {"ctrlchar", "ctrl\\u0001char"},
+                {withControlChar, "ctrl\\u0001char"},
                 {"", ""},
         };
     }
 
     @Test(dataProvider = "jsonEscapeCases")
     public void testEscapeJsonString(final String input, final String expected) {
-        Assert.assertEquals(LiftoverVcf.escapeJsonString(input), expected);
+        Assert.assertEquals(ProgressJsonWriter.escapeJsonString(input), expected);
     }
 
     @Test
-    public void testFormatProgressEventEscapesStageAndPosition() {
-        final String line = LiftoverVcf.formatProgressEvent(
+    public void testFormatEventEscapesStageAndPosition() {
+        final String line = ProgressJsonWriter.formatEvent(
                 FIXED, "stage\"with\"quotes", 1L, 0L, "contig\\with\\back:1", 0L);
         Assert.assertTrue(line.contains("\"stage\":\"stage\\\"with\\\"quotes\""),
                 "Stage should be escaped, got: " + line);
         Assert.assertTrue(line.contains("\"last_position\":\"contig\\\\with\\\\back:1\""),
                 "Position should be escaped, got: " + line);
+    }
+
+    @Test
+    public void testEmitWritesLfTerminatedLinesUtf8() throws IOException {
+        final File f = File.createTempFile("progress", ".ndjson");
+        f.deleteOnExit();
+        // A non-ASCII code point (U+00E9, e-acute) must round-trip as UTF-8, not the platform
+        // charset. Built from the code point so this source file stays pure ASCII.
+        final String accentedPosition = "chr" + new String(Character.toChars(0x00E9)) + ":2";
+        try (final ProgressJsonWriter w = new ProgressJsonWriter(f)) {
+            w.emit("read", 1L, 0L, "chr1:1", 0L);
+            w.emit("read_complete", 2L, 0L, accentedPosition, 1L);
+        }
+
+        final byte[] bytes = Files.readAllBytes(f.toPath());
+        final String content = new String(bytes, StandardCharsets.UTF_8);
+        Assert.assertFalse(content.contains("\r"), "NDJSON must use LF, not CRLF: " + content);
+
+        final List<String> lines = Files.readAllLines(f.toPath(), StandardCharsets.UTF_8);
+        Assert.assertEquals(lines.size(), 2, "Each event should be its own line");
+        Assert.assertTrue(lines.get(0).contains("\"stage\":\"read\""));
+        Assert.assertTrue(lines.get(1).contains(accentedPosition),
+                "Non-ASCII position should round-trip as UTF-8: " + lines.get(1));
+        // File must end with a single trailing LF (last line fully terminated).
+        Assert.assertEquals(bytes[bytes.length - 1], (byte) '\n', "File should end with LF");
     }
 }

--- a/src/test/java/picard/vcf/LiftoverVcfProgressJsonTest.java
+++ b/src/test/java/picard/vcf/LiftoverVcfProgressJsonTest.java
@@ -1,0 +1,111 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package picard.vcf;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.Instant;
+
+/**
+ * Tests for {@link LiftoverVcf#formatProgressEvent(Instant, String, long, long, String, long)} and
+ * {@link LiftoverVcf#escapeJsonString(String)}, the helpers backing LiftoverVcf's PROGRESS_JSON
+ * NDJSON sidecar output.
+ */
+public class LiftoverVcfProgressJsonTest {
+
+    private static final Instant FIXED = Instant.parse("2026-05-16T12:34:56Z");
+
+    @Test
+    public void testFormatProgressEventReadStage() {
+        final String line = LiftoverVcf.formatProgressEvent(
+                FIXED, "read", 1_000_000L, 12_345L, "chr3:148946422", 60L);
+        Assert.assertEquals(line,
+                "{\"timestamp\":\"2026-05-16T12:34:56Z\","
+                        + "\"stage\":\"read\","
+                        + "\"records_processed\":1000000,"
+                        + "\"records_rejected\":12345,"
+                        + "\"last_position\":\"chr3:148946422\","
+                        + "\"elapsed_seconds\":60}");
+    }
+
+    @Test
+    public void testFormatProgressEventNullLastPositionSerializesAsJsonNull() {
+        final String line = LiftoverVcf.formatProgressEvent(
+                FIXED, "read_complete", 0L, 0L, null, 0L);
+        Assert.assertTrue(line.contains("\"last_position\":null"),
+                "Expected JSON null for last_position when null was passed in, got: " + line);
+        Assert.assertFalse(line.contains("\"last_position\":\"null\""),
+                "Did not expect last_position to be the string \"null\": " + line);
+    }
+
+    @Test
+    public void testFormatProgressEventLineHasNoNewline() {
+        // NDJSON / JSON Lines: each event must be exactly one line. Newlines come from the
+        // calling println(), not the event content itself.
+        final String line = LiftoverVcf.formatProgressEvent(
+                FIXED, "read", 100L, 0L, "chr1:1", 1L);
+        Assert.assertFalse(line.contains("\n"), "Event line must not contain newline: " + line);
+        Assert.assertFalse(line.contains("\r"), "Event line must not contain CR: " + line);
+    }
+
+    @Test
+    public void testFormatProgressEventTimestampTruncatedToSeconds() {
+        // Sub-second precision is dropped so output is deterministic across platforms.
+        final Instant subSecond = Instant.parse("2026-05-16T12:34:56.789Z");
+        final String line = LiftoverVcf.formatProgressEvent(
+                subSecond, "read", 1L, 0L, "chr1:1", 0L);
+        Assert.assertTrue(line.contains("\"timestamp\":\"2026-05-16T12:34:56Z\""),
+                "Expected timestamp truncated to second precision, got: " + line);
+    }
+
+    @DataProvider(name = "jsonEscapeCases")
+    public Object[][] jsonEscapeCases() {
+        return new Object[][]{
+                {"plain", "plain"},
+                {"with \"quotes\"", "with \\\"quotes\\\""},
+                {"back\\slash", "back\\\\slash"},
+                {"new\nline", "new\\nline"},
+                {"tab\there", "tab\\there"},
+                {"ctrlchar", "ctrl\\u0001char"},
+                {"", ""},
+        };
+    }
+
+    @Test(dataProvider = "jsonEscapeCases")
+    public void testEscapeJsonString(final String input, final String expected) {
+        Assert.assertEquals(LiftoverVcf.escapeJsonString(input), expected);
+    }
+
+    @Test
+    public void testFormatProgressEventEscapesStageAndPosition() {
+        final String line = LiftoverVcf.formatProgressEvent(
+                FIXED, "stage\"with\"quotes", 1L, 0L, "contig\\with\\back:1", 0L);
+        Assert.assertTrue(line.contains("\"stage\":\"stage\\\"with\\\"quotes\""),
+                "Stage should be escaped, got: " + line);
+        Assert.assertTrue(line.contains("\"last_position\":\"contig\\\\with\\\\back:1\""),
+                "Position should be escaped, got: " + line);
+    }
+}


### PR DESCRIPTION
Resolves #2046.

Tooling that wants a progress signal from `LiftoverVcf` today has to regex-parse the human-readable `ProgressLogger` output — not a documented stable API. This adds an optional `PROGRESS_JSON=<file>` argument; when set, one NDJSON event is appended per ProgressLogger milestone in the read and write phases, plus a final `read_complete` / `write_complete` event so small inputs still emit something.

```json
{"timestamp":"2026-05-16T12:34:56Z","stage":"read","records_processed":1000000,"records_rejected":12345,"last_position":"chr3:148946422","elapsed_seconds":60}
```

Default is `null`; existing `ProgressLogger` output is unchanged.

**Design notes** (happy to revise):

1. **`last_position` advances on every input variant**, including ones early-`continue`'d as rejections; `ProgressLogger`'s "Last read position" only advances on successful records. Intentional — JSON consumers want to know where in the input the run is, not where the last success landed.
2. **Writer leaks on early-return paths** (`CREATE_INDEX`+`DISABLE_SORT` conflict, missing contig with `WARN_ON_MISSING_CONTIG=false`). Matches the existing pattern; `rejectedRecords`, `in`, and `acceptedRecords` also leak there. Happy to refactor to try/finally.
3. **`records_rejected: 0` in write-phase events** for schema stability. Could omit instead.
4. **Hand-rolled JSON** — no existing JSON dep in `build.gradle`. Formatter is ~20 lines and unit-tested. Happy to switch to gson/jackson.

**Tests:** `LiftoverVcfProgressJsonTest` covers the formatter and escaper (null last_position, embedded quotes, control chars, empty string). `LiftoverVcfTest.testProgressJsonSidecarIsWritten` is the end-to-end integration test; `testNoProgressJsonByDefault` confirms default-off is unchanged.