### PR TITLE
MarkDuplicates: add opt-in TAG_DUPLICATE_KEY emitting canonical fragment key (kf)

### DIFF
--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -139,6 +139,32 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram imp
     public static final String DUPLICATE_SET_SIZE_TAG = "DS";
 
     /**
+     * The optional attribute used to store the canonical single-end (fragment) duplicate key that
+     * MarkDuplicates uses to identify duplicates. The value is a printable rendering of the fields
+     * the fragment-level key is built from: {@code lib=<libraryId>;<referenceIndex>:<unclipped5Prime>:<strand>}.
+     * When barcodes/UMIs are in use (any of BARCODE_TAG, READ_ONE_BARCODE_TAG, READ_TWO_BARCODE_TAG), the
+     * barcode sequences that also distinguish duplicates are appended as a single hyphen-joined field, giving
+     * {@code lib=<libraryId>;<referenceIndex>:<unclipped5Prime>:<strand>:<barcodes>}, where {@code barcodes}
+     * joins the present sequences in key order (the top-strand-normalized BARCODE_TAG UMI, then the
+     * READ_ONE_BARCODE_TAG and READ_TWO_BARCODE_TAG values) with hyphens, e.g. {@code ACGT} or {@code ACGT-TTGA}.
+     * It is written, when {@link #TAG_DUPLICATE_KEY} is set, on every primary, mapped record so that an
+     * external tool can recover the exact duplicate sets Picard computed without re-deriving the key.
+     * <p>
+     * Note that this key carries the verbatim barcode sequences, whereas MarkDuplicates compares barcodes
+     * internally as 32-bit hashes ({@link java.util.Objects#hash} of the UMI, {@link String#hashCode} of the
+     * read-one/read-two barcodes). The two agree on every realistic input; only in the astronomically unlikely
+     * event of a hash collision would they differ, and then this key is the more precise one (it distinguishes
+     * sequences Picard's hashes happened to collapse). In other words the key is never coarser than Picard's
+     * duplicate sets, and finer only in that pathological case.
+     * <p>
+     * The tag name is deliberately lowercase: the SAM specification reserves uppercase two-letter tags for
+     * standard, predefined use and sets aside lowercase tags for locally-defined purposes, which is where
+     * this diagnostic key belongs. This is why it does not follow the uppercase convention of the
+     * {@code DT}/{@code DI}/{@code DS} tags above.
+     */
+    public static final String DUPLICATE_KEY_TAG = "kf";
+
+    /**
      * Enum for the possible values that a duplicate read can be tagged with in the DT attribute.
      */
     public enum DuplicateType {
@@ -192,6 +218,22 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram imp
             "record belongs. This identifier is the index-in-file of the representative read that was selected out " +
             "of the duplicate set.", optional = true)
     public boolean TAG_DUPLICATE_SET_MEMBERS = false;
+
+    @Argument(doc = "If true, write the canonical single-end (fragment) duplicate key to the " +
+            "DUPLICATE_KEY_TAG (kf) attribute on every primary, mapped record. The value is a printable " +
+            "rendering of the fields MarkDuplicates keys on at the fragment level: " +
+            "'lib=<libraryId>;<referenceIndex>:<unclipped5Prime>:<strand>'. When barcodes or UMIs are in use " +
+            "(BARCODE_TAG, READ_ONE_BARCODE_TAG, or READ_TWO_BARCODE_TAG), the barcode sequences that also " +
+            "distinguish duplicates are appended as a single hyphen-joined field ':<barcodes>', joining the " +
+            "present sequences (UMI, then read-one and read-two barcodes), e.g. 'ACGT' or 'ACGT-TTGA'. " +
+            "Two reads of a pair each carry " +
+            "their own fragment key, so the canonical pair key can be reconstructed by combining the two " +
+            "ends; an orphan is a duplicate of a pair iff its key matches a pair end's key. This is purely " +
+            "diagnostic output to let external tools recover Picard's exact duplicate sets; it does not " +
+            "affect marking, metrics, or any other tag. This option is not supported with FLOW_MODE, which " +
+            "matches fragments on a flow-adjusted coordinate within an uncertainty window rather than by the " +
+            "exact key rendered here. Default false.", optional = true)
+    public boolean TAG_DUPLICATE_KEY = false;
 
     @Argument(doc = "If true remove 'optical' duplicates and other duplicates that appear to have arisen from the " +
             "sequencing process instead of the library preparation process, even if REMOVE_DUPLICATES is false. " +
@@ -253,6 +295,19 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram imp
      * Then makes a pass through those determining duplicates before re-reading the
      * input file and writing it out with duplication flags set correctly.
      */
+    @Override
+    protected String[] customCommandLineValidation() {
+        // TAG_DUPLICATE_KEY renders the standard unclipped 5' coordinate, but in flow mode MarkDuplicates keys
+        // on a flow-adjusted coordinate and matches fragments within an uncertainty window rather than by exact
+        // equality. The emitted key would therefore not reproduce the duplicate sets flow mode actually marks,
+        // so the two options are mutually exclusive until flow-aware key rendering is implemented.
+        if (TAG_DUPLICATE_KEY && flowBasedArguments.FLOW_MODE) {
+            return new String[]{"TAG_DUPLICATE_KEY is not supported with FLOW_MODE: the canonical fragment key " +
+                    "cannot be rendered for the flow-based, position-uncertain duplicate matching used in flow mode."};
+        }
+        return super.customCommandLineValidation();
+    }
+
     protected int doWork() {
         IOUtil.assertInputsAreValid(INPUT);
         IOUtil.assertFileIsWritable(OUTPUT);
@@ -399,6 +454,13 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram imp
                             representativeQueryName = rec.getReadName();
                         }
                     }
+                }
+
+                // Optionally write the canonical fragment duplicate key on every primary, mapped record so
+                // that external tools can recover Picard's exact duplicate sets. Guarded by the same
+                // primary-and-mapped condition MarkDuplicates uses when building its own ReadEnds keys.
+                if (TAG_DUPLICATE_KEY && !rec.getReadUnmappedFlag() && !rec.isSecondaryOrSupplementary()) {
+                    rec.setAttribute(DUPLICATE_KEY_TAG, buildDuplicateKeyTag(rec, useBarcodes));
                 }
 
                 // Set MOLECULAR_IDENTIFIER_TAG for SAMRecord rec
@@ -710,6 +772,74 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram imp
         }
 
         return ends;
+    }
+
+    /**
+     * Renders the canonical fragment-level duplicate key for a single record. The fields are exactly those
+     * {@link #buildReadEnds} uses to populate a {@link ReadEndsForMarkDuplicates}: library id, reference
+     * index, unclipped 5' coordinate (read end for reverse-strand reads, read start otherwise), and strand.
+     * When {@code useBarcodes} is true the barcode sequences that additionally distinguish duplicates are
+     * appended as a single hyphen-joined positional field ({@code :<barcodes>}, e.g. {@code :ACGT} or
+     * {@code :ACGT-TTGA}, the same string values {@link #buildReadEnds} keys on), so the rendered key reproduces
+     * the duplicate sets Picard marks even under UMI-aware duplicate marking (see {@link #DUPLICATE_KEY_TAG} for
+     * the one pathological exception, a barcode hash collision, where this key is the more precise of the two).
+     * The result is written to {@link #DUPLICATE_KEY_TAG} when {@link #TAG_DUPLICATE_KEY} is enabled.
+     * <p>
+     * Two reads of a pair each carry their own fragment key, so the canonical pair key can be reconstructed
+     * downstream by ordering the two ends; an orphan is a duplicate of a pair iff its key matches a pair
+     * end's key. The caller must ensure the record is primary and mapped.
+     *
+     * @param rec a primary, mapped record
+     * @param useBarcodes whether barcode/UMI tags are in use, in which case the barcode sequences are appended
+     * @return the printable key {@code lib=<libraryId>;<referenceIndex>:<unclipped5Prime>:<F|R>}, with an
+     *         optional {@code :<barcodes>} suffix (the present barcode sequences joined with hyphens) when
+     *         {@code useBarcodes}
+     */
+    private String buildDuplicateKeyTag(final SAMRecord rec, final boolean useBarcodes) {
+        final short libraryId = this.libraryIdGenerator.getLibraryId(rec);
+        final boolean negativeStrand = rec.getReadNegativeStrandFlag();
+        final int unclipped5Prime = negativeStrand ? rec.getUnclippedEnd() : rec.getUnclippedStart();
+        final char strand = negativeStrand ? 'R' : 'F';
+        final StringBuilder key = new StringBuilder("lib=").append(libraryId).append(';')
+                .append(rec.getReferenceIndex()).append(':').append(unclipped5Prime).append(':').append(strand);
+
+        // Mirror buildReadEnds: when barcodes/UMIs are in use they are part of the duplicate key, so the key
+        // must include them or it would conflate reads Picard keeps in separate duplicate sets. We emit the
+        // underlying barcode sequences rather than Picard's internal int hashes so the values are human-readable
+        // and an external tool can reproduce them. The present sequences are joined, in the order MarkDuplicates
+        // keys on them, with hyphens (the usual UMI rendering) and appended as a single positional field: the
+        // top-strand-normalized UMI (the raw BARCODE_TAG value except for strand-canonicalized duplex UMIs),
+        // then the read-one and read-two barcodes. At most the UMI plus one read-specific barcode are present.
+        if (useBarcodes) {
+            final String umi = UmiUtil.getTopStrandNormalizedUmi(rec, BARCODE_TAG, DUPLEX_UMI);
+            final boolean isReadOne = !rec.getReadPairedFlag() || rec.getFirstOfPairFlag();
+            final String readOneBarcode = isReadOne ? barcodeStringOrEmpty(rec, READ_ONE_BARCODE_TAG) : "";
+            final String readTwoBarcode = isReadOne ? "" : barcodeStringOrEmpty(rec, READ_TWO_BARCODE_TAG);
+
+            final StringBuilder barcodes = new StringBuilder();
+            for (final String sequence : new String[]{umi, readOneBarcode, readTwoBarcode}) {
+                if (sequence != null && !sequence.isEmpty()) {
+                    if (barcodes.length() > 0) {
+                        barcodes.append('-');
+                    }
+                    barcodes.append(sequence);
+                }
+            }
+            if (barcodes.length() > 0) {
+                key.append(':').append(barcodes);
+            }
+        }
+
+        return key.toString();
+    }
+
+    /** Returns the string value of {@code tag} on the record, or the empty string if the tag is unset or absent. */
+    private String barcodeStringOrEmpty(final SAMRecord rec, final String tag) {
+        if (tag == null) {
+            return "";
+        }
+        final String value = rec.getStringAttribute(tag);
+        return value == null ? "" : value;
     }
 
     /**

--- a/src/test/java/picard/sam/markduplicates/MarkDuplicatesTagDuplicateKeyTest.java
+++ b/src/test/java/picard/sam/markduplicates/MarkDuplicatesTagDuplicateKeyTest.java
@@ -1,0 +1,529 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package picard.sam.markduplicates;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMRecordSetBuilder;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Tests for the opt-in {@code TAG_DUPLICATE_KEY} argument, which writes the canonical fragment duplicate
+ * key to the {@code kf} attribute on every primary, mapped record.
+ * <p>
+ * The load-bearing property is that the emitted keys reflect the key MarkDuplicates actually marks on: the
+ * partition of templates induced by their {@code kf} key(s) must be identical to the partition induced by
+ * the {@code DI} (duplicate-set-index) tag. If that holds, an external tool can recover Picard's exact
+ * duplicate sets from the tags without re-deriving Picard's clipping/coordinate conventions.
+ */
+public class MarkDuplicatesTagDuplicateKeyTest {
+
+    private static final int READ_LENGTH = 36;
+    private static final int BASE_QUALITY = 30;
+    /** The SAM tag used to carry UMIs in the barcode-aware tests. */
+    private static final String UMI_TAG = "RX";
+
+    /** Builds a coordinate-sorted SAMRecordSetBuilder ready for adding reads. */
+    private SAMRecordSetBuilder newBuilder() {
+        final SAMRecordSetBuilder builder = new SAMRecordSetBuilder(true, SAMFileHeader.SortOrder.coordinate);
+        builder.setReadLength(READ_LENGTH);
+        return builder;
+    }
+
+    /** Materializes the builder's (sorted) records into a temp BAM file. */
+    private File writeToBam(final SAMRecordSetBuilder builder) throws IOException {
+        return writeToBam(builder, null);
+    }
+
+    /**
+     * Materializes the builder's (sorted) records into a temp BAM file, optionally stamping each record with a
+     * UMI in the {@link #UMI_TAG} attribute looked up by read name (both ends of a template get the same UMI).
+     */
+    private File writeToBam(final SAMRecordSetBuilder builder, final Map<String, String> umiByName) throws IOException {
+        final File bam = File.createTempFile("tag_dup_key.input.", ".bam");
+        bam.deleteOnExit();
+        try (final SamReader reader = builder.getSamReader();
+             final SAMFileWriter writer = new SAMFileWriterFactory().makeWriter(reader.getFileHeader(), true, bam, null)) {
+            for (final SAMRecord rec : reader) {
+                if (umiByName != null) {
+                    final String umi = umiByName.get(rec.getReadName());
+                    if (umi != null) {
+                        rec.setAttribute(UMI_TAG, umi);
+                    }
+                }
+                writer.addAlignment(rec);
+            }
+        }
+        return bam;
+    }
+
+    /** Runs MarkDuplicates on the input, returning the output BAM. DI tagging is always on; kf tagging is optional. */
+    private File runMarkDuplicates(final File input, final boolean tagDuplicateKey) throws IOException {
+        return runMarkDuplicates(input, tagDuplicateKey, null);
+    }
+
+    /**
+     * Runs MarkDuplicates on the input, returning the output BAM. DI tagging is always on; kf tagging is
+     * optional. When {@code barcodeTag} is non-null it is passed as BARCODE_TAG so duplicate marking (and the
+     * kf key) become UMI-aware.
+     */
+    private File runMarkDuplicates(final File input, final boolean tagDuplicateKey, final String barcodeTag) throws IOException {
+        final File output = File.createTempFile("tag_dup_key.output.", ".bam");
+        final File metrics = File.createTempFile("tag_dup_key.metrics.", ".txt");
+        output.deleteOnExit();
+        metrics.deleteOnExit();
+
+        final List<String> args = new ArrayList<>();
+        args.add("INPUT=" + input.getAbsolutePath());
+        args.add("OUTPUT=" + output.getAbsolutePath());
+        args.add("METRICS_FILE=" + metrics.getAbsolutePath());
+        // PROGRAM_RECORD_ID=null avoids the jar-manifest version lookup that fails when running outside a jar.
+        args.add("PROGRAM_RECORD_ID=null");
+        args.add("TAG_DUPLICATE_SET_MEMBERS=true");
+        if (tagDuplicateKey) {
+            args.add("TAG_DUPLICATE_KEY=true");
+        }
+        if (barcodeTag != null) {
+            args.add("BARCODE_TAG=" + barcodeTag);
+        }
+        Assert.assertEquals(new MarkDuplicates().instanceMain(args.toArray(new String[0])), 0);
+        return output;
+    }
+
+    /** Reads all records from a BAM into a list. */
+    private List<SAMRecord> readAll(final File bam) {
+        final List<SAMRecord> records = new ArrayList<>();
+        try (final SamReader reader = SamReaderFactory.makeDefault().open(bam)) {
+            for (final SAMRecord rec : reader) {
+                records.add(rec);
+            }
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+        return records;
+    }
+
+    /**
+     * Computes a template's group key from its primary, mapped records' {@code kf} tags. For a pair this is
+     * the (sorted) combination of the two ends' fragment keys, which is a faithful proxy for Picard's
+     * canonical pair key; for an orphan it is the single fragment key.
+     */
+    private String groupKeyFor(final List<String> fragmentKeys) {
+        final List<String> sorted = new ArrayList<>(fragmentKeys);
+        Collections.sort(sorted);
+        return String.join("|", sorted);
+    }
+
+    /**
+     * The headline assertion: the partition of templates induced by their kf key(s) equals the partition
+     * induced by DI. Asserts over the output of a run that has both tags enabled.
+     */
+    private void assertKeyPartitionEqualsDuplicateIndexPartition(final File output) {
+        final List<SAMRecord> records = readAll(output);
+
+        // Collect, per read name (template), its fragment keys and its DI (if any).
+        final Map<String, List<String>> fragmentKeysByName = new HashMap<>();
+        final Map<String, Integer> diByName = new HashMap<>();
+        for (final SAMRecord rec : records) {
+            if (rec.getReadUnmappedFlag() || rec.isSecondaryOrSupplementary()) {
+                continue;
+            }
+            final String kf = rec.getStringAttribute(MarkDuplicates.DUPLICATE_KEY_TAG);
+            Assert.assertNotNull(kf, "every primary mapped record must carry a kf tag: " + rec.getReadName());
+            fragmentKeysByName.computeIfAbsent(rec.getReadName(), k -> new ArrayList<>()).add(kf);
+
+            final Integer di = rec.getIntegerAttribute(MarkDuplicates.DUPLICATE_SET_INDEX_TAG);
+            if (di != null) {
+                diByName.put(rec.getReadName(), di);
+            }
+        }
+
+        // Partition templates by group key (from kf) and by DI.
+        final Map<String, Set<String>> namesByGroupKey = new HashMap<>();
+        for (final Map.Entry<String, List<String>> e : fragmentKeysByName.entrySet()) {
+            namesByGroupKey.computeIfAbsent(groupKeyFor(e.getValue()), k -> new HashSet<>()).add(e.getKey());
+        }
+        final Map<Integer, Set<String>> namesByDuplicateIndex = new HashMap<>();
+        for (final Map.Entry<String, Integer> e : diByName.entrySet()) {
+            namesByDuplicateIndex.computeIfAbsent(e.getValue(), k -> new HashSet<>()).add(e.getKey());
+        }
+
+        // DI only appears on members of a duplicate set (size >= 2); the group-key partition additionally
+        // contains the singletons. So compare the DI partition against the multi-member group-key classes.
+        final Set<Set<String>> duplicateIndexPartition = new HashSet<>(namesByDuplicateIndex.values());
+        final Set<Set<String>> multiMemberGroupKeyPartition = new HashSet<>();
+        for (final Set<String> names : namesByGroupKey.values()) {
+            if (names.size() >= 2) {
+                multiMemberGroupKeyPartition.add(names);
+            }
+        }
+        Assert.assertEquals(multiMemberGroupKeyPartition, duplicateIndexPartition,
+                "kf-induced duplicate sets must equal DI-induced duplicate sets");
+    }
+
+    /** Maps each template's read name to the kf key of its first-of-pair (read one) primary, mapped record. */
+    private Map<String, String> read1FragmentKeyByName(final File output) {
+        final Map<String, String> keys = new HashMap<>();
+        for (final SAMRecord rec : readAll(output)) {
+            if (rec.getReadUnmappedFlag() || rec.isSecondaryOrSupplementary()) {
+                continue;
+            }
+            if (rec.getReadPairedFlag() && !rec.getFirstOfPairFlag()) {
+                continue;
+            }
+            keys.put(rec.getReadName(), rec.getStringAttribute(MarkDuplicates.DUPLICATE_KEY_TAG));
+        }
+        return keys;
+    }
+
+    @Test
+    public void kfKeysInduceTheSameDuplicateSetsAsDuplicateIndex() throws IOException {
+        final SAMRecordSetBuilder builder = newBuilder();
+        // Duplicate set of 2 on chr1.
+        builder.addPair("dupA_rep", 0, 1000, 1200, false, false, "36M", "36M", false, true, BASE_QUALITY);
+        builder.addPair("dupA_dup", 0, 1000, 1200, false, false, "36M", "36M", false, true, BASE_QUALITY);
+        // Duplicate set of 3 on chr2.
+        builder.addPair("dupB_rep", 1, 5000, 5300, false, false, "36M", "36M", false, true, BASE_QUALITY);
+        builder.addPair("dupB_dup1", 1, 5000, 5300, false, false, "36M", "36M", false, true, BASE_QUALITY);
+        builder.addPair("dupB_dup2", 1, 5000, 5300, false, false, "36M", "36M", false, true, BASE_QUALITY);
+        // A unique pair (singleton): must still carry kf, but no DI.
+        builder.addPair("unique", 0, 8000, 8200, false, false, "36M", "36M", false, true, BASE_QUALITY);
+
+        final File output = runMarkDuplicates(writeToBam(builder), true);
+        assertKeyPartitionEqualsDuplicateIndexPartition(output);
+
+        // The unique pair has no DI but must still carry kf on both ends.
+        int uniqueKfCount = 0;
+        for (final SAMRecord rec : readAll(output)) {
+            if (rec.getReadName().equals("unique")) {
+                Assert.assertNull(rec.getIntegerAttribute(MarkDuplicates.DUPLICATE_SET_INDEX_TAG));
+                Assert.assertNotNull(rec.getStringAttribute(MarkDuplicates.DUPLICATE_KEY_TAG));
+                uniqueKfCount++;
+            }
+        }
+        Assert.assertEquals(uniqueKfCount, 2, "singleton pair should have kf on both ends");
+    }
+
+    @Test
+    public void kfPartitionMatchesDuplicateIndexAcrossOrientationsAndChromosomes() throws IOException {
+        // The pair-key proxy (sorted kf strings) must reproduce Picard's duplicate
+        // sets even where the canonicalization is non-trivial: differing per-end
+        // strand/orientation, FF/RR orientations, and inter-chromosomal pairs. The
+        // assertion verifies the kf-induced partition equals the DI partition, so a
+        // wrong merge (e.g. ignoring orientation) or split would fail it.
+        final SAMRecordSetBuilder builder = newBuilder();
+
+        // FR dup set (read1 forward, read2 reverse) on chr1.
+        builder.addPair("fr_rep", 0, 1000, 1500, false, false, "36M", "36M", false, true, BASE_QUALITY);
+        builder.addPair("fr_dup", 0, 1000, 1500, false, false, "36M", "36M", false, true, BASE_QUALITY);
+
+        // RF dup set (read1 reverse, read2 forward) at the SAME starts: a different
+        // orientation, so Picard keeps it as a separate set — kf must NOT merge it
+        // with the FR set above.
+        builder.addPair("rf_rep", 0, 1000, 1500, false, false, "36M", "36M", true, false, BASE_QUALITY);
+        builder.addPair("rf_dup", 0, 1000, 1500, false, false, "36M", "36M", true, false, BASE_QUALITY);
+
+        // FF dup set (both forward) on chr2.
+        builder.addPair("ff_rep", 1, 2000, 2400, false, false, "36M", "36M", false, false, BASE_QUALITY);
+        builder.addPair("ff_dup", 1, 2000, 2400, false, false, "36M", "36M", false, false, BASE_QUALITY);
+
+        // Inter-chromosomal dup set: read1 on chr1, read2 on chr2 (14-arg addPair
+        // with two reference indexes).
+        builder.addPair("ic_rep", 0, 1, 7000, 8000, false, false, "36M", "36M", false, true, false, false, BASE_QUALITY);
+        builder.addPair("ic_dup", 0, 1, 7000, 8000, false, false, "36M", "36M", false, true, false, false, BASE_QUALITY);
+
+        // Two genuinely different keys (read1 at different positions) must NOT merge.
+        builder.addPair("uniqA", 0, 9000, 9300, false, false, "36M", "36M", false, true, BASE_QUALITY);
+        builder.addPair("uniqB", 0, 9100, 9300, false, false, "36M", "36M", false, true, BASE_QUALITY);
+
+        final File output = runMarkDuplicates(writeToBam(builder), true);
+        assertKeyPartitionEqualsDuplicateIndexPartition(output);
+
+        // Explicit over-merge guard: the FR and RF sets at the same starts must
+        // carry distinct kf-derived pair keys (different orientation -> different key).
+        final java.util.Map<String, String> pairKeyByName = new HashMap<>();
+        for (final SAMRecord rec : readAll(output)) {
+            if (rec.getReadUnmappedFlag() || rec.isSecondaryOrSupplementary()) {
+                continue;
+            }
+            final String kf = rec.getStringAttribute(MarkDuplicates.DUPLICATE_KEY_TAG);
+            pairKeyByName.merge(rec.getReadName(), kf, (a, b) -> {
+                final String[] ends = {a, b};
+                java.util.Arrays.sort(ends);
+                return ends[0] + "|" + ends[1];
+            });
+        }
+        Assert.assertNotEquals(
+                pairKeyByName.get("fr_rep"), pairKeyByName.get("rf_rep"),
+                "FR and RF pairs at the same starts must not share a kf pair key");
+    }
+
+    @Test
+    public void orphanKeyMatchesPairEndKeyAndOrphanIsMarkedDuplicate() throws IOException {
+        final SAMRecordSetBuilder builder = newBuilder();
+        // A pair whose forward end starts at chr1:2000.
+        builder.addPair("pair", 0, 2000, 2300, false, false, "36M", "36M", false, true, BASE_QUALITY);
+        // A mapped orphan (mate unmapped) at the same forward position: its fragment key must equal the
+        // pair's forward-end key, and Picard must mark the orphan as a duplicate ("fragments don't beat pairs").
+        builder.addPair("orphan", 0, 2000, 2000, false, true, "36M", "36M", false, false, BASE_QUALITY);
+
+        final File output = runMarkDuplicates(writeToBam(builder), true);
+        final List<SAMRecord> records = readAll(output);
+
+        final Set<String> pairKeys = new HashSet<>();
+        String orphanKey = null;
+        boolean orphanMarkedDuplicate = false;
+        for (final SAMRecord rec : records) {
+            if (rec.getReadUnmappedFlag() || rec.isSecondaryOrSupplementary()) {
+                continue;
+            }
+            final String kf = rec.getStringAttribute(MarkDuplicates.DUPLICATE_KEY_TAG);
+            if (rec.getReadName().equals("pair")) {
+                pairKeys.add(kf);
+            } else if (rec.getReadName().equals("orphan")) {
+                orphanKey = kf;
+                orphanMarkedDuplicate = rec.getDuplicateReadFlag();
+            }
+        }
+        Assert.assertNotNull(orphanKey);
+        Assert.assertTrue(pairKeys.contains(orphanKey),
+                "orphan fragment key " + orphanKey + " should match a pair end key " + pairKeys);
+        Assert.assertTrue(orphanMarkedDuplicate, "orphan should be marked duplicate as a fragment dup of the pair");
+    }
+
+    @Test
+    public void umiDuplicateSetsMatchDuplicateIndexWhenBarcodeTagSet() throws IOException {
+        // Three pairs at identical coordinates. Under UMI-aware marking, only the two sharing a UMI are
+        // duplicates; the third (different UMI) stays a singleton despite the identical position. This is the
+        // exact case a barcode-less key got wrong, so the partition-equality assertion is the regression guard.
+        final SAMRecordSetBuilder builder = newBuilder();
+        builder.addPair("umiA_rep", 0, 1000, 1200, false, false, "36M", "36M", false, true, BASE_QUALITY);
+        builder.addPair("umiA_dup", 0, 1000, 1200, false, false, "36M", "36M", false, true, BASE_QUALITY);
+        builder.addPair("umiB",     0, 1000, 1200, false, false, "36M", "36M", false, true, BASE_QUALITY);
+
+        final Map<String, String> umiByName = new HashMap<>();
+        umiByName.put("umiA_rep", "AAAAAAAA");
+        umiByName.put("umiA_dup", "AAAAAAAA");
+        umiByName.put("umiB", "CCCCCCCC");
+
+        final File output = runMarkDuplicates(writeToBam(builder, umiByName), true, UMI_TAG);
+        assertKeyPartitionEqualsDuplicateIndexPartition(output);
+
+        // umiB shares its position with the umiA set but, having a distinct UMI, must remain a singleton (no DI).
+        for (final SAMRecord rec : readAll(output)) {
+            if (rec.getReadName().equals("umiB")) {
+                Assert.assertNull(rec.getIntegerAttribute(MarkDuplicates.DUPLICATE_SET_INDEX_TAG),
+                        "umiB has a distinct UMI and must not join the umiA duplicate set");
+            }
+        }
+    }
+
+    @Test
+    public void kfIncludesBarcodeFieldsOnlyWhenBarcodeTagSet() throws IOException {
+        // Two pairs at identical coordinates but with different UMIs.
+        final SAMRecordSetBuilder builder = newBuilder();
+        builder.addPair("p1", 0, 1000, 1200, false, false, "36M", "36M", false, true, BASE_QUALITY);
+        builder.addPair("p2", 0, 1000, 1200, false, false, "36M", "36M", false, true, BASE_QUALITY);
+        final Map<String, String> umiByName = new HashMap<>();
+        umiByName.put("p1", "AAAAAAAA");
+        umiByName.put("p2", "CCCCCCCC");
+        final File input = writeToBam(builder, umiByName);
+
+        // With BARCODE_TAG: the readable UMI is appended as a single positional field (lib=..;..:..:strand:<umi>),
+        // so the key carries the verbatim UMI and the two different UMIs produce different keys.
+        final Map<String, String> withBarcode = read1FragmentKeyByName(runMarkDuplicates(input, true, UMI_TAG));
+        Assert.assertTrue(withBarcode.get("p1").endsWith(":AAAAAAAA"),
+                "kf must append the verbatim UMI when BARCODE_TAG is set: " + withBarcode.get("p1"));
+        Assert.assertEquals(fieldsAfterLibrary(withBarcode.get("p1")), 4,
+                "barcode-aware key must have referenceIndex:coord:strand plus the joined barcode field");
+        Assert.assertNotEquals(withBarcode.get("p1"), withBarcode.get("p2"),
+                "reads at the same position with different UMIs must get different kf keys");
+
+        // Without BARCODE_TAG: no barcode fields (backward compatible) and the position-identical ends share a key.
+        final Map<String, String> noBarcode = read1FragmentKeyByName(runMarkDuplicates(input, true));
+        Assert.assertEquals(fieldsAfterLibrary(noBarcode.get("p1")), 3,
+                "barcode-free key must be just referenceIndex:coord:strand: " + noBarcode.get("p1"));
+        Assert.assertFalse(noBarcode.get("p1").contains("AAAAAAAA"),
+                "kf must not include the UMI when no BARCODE_TAG is set: " + noBarcode.get("p1"));
+        Assert.assertEquals(noBarcode.get("p1"), noBarcode.get("p2"),
+                "without UMIs, identical-position read-one ends must share a kf key");
+    }
+
+    /** Counts the colon-separated fields after the {@code lib=...;} prefix of a kf key. */
+    private int fieldsAfterLibrary(final String key) {
+        final String afterLibrary = key.substring(key.indexOf(';') + 1);
+        return afterLibrary.split(":", -1).length;
+    }
+
+    @Test
+    public void kfJoinsMultipleBarcodeSequencesWithHyphens() throws IOException {
+        // With both a UMI (RX) and a read-one barcode (BC) present, the two non-empty sequences are joined in
+        // key order with a single hyphen ('<umi>-<readOneBarcode>'), with no extra hyphens or colons.
+        final SAMRecordSetBuilder builder = newBuilder();
+        builder.addPair("p", 0, 1000, 1200, false, false, "36M", "36M", false, true, BASE_QUALITY);
+
+        final File input = File.createTempFile("tag_dup_key.input.", ".bam");
+        input.deleteOnExit();
+        try (final SamReader reader = builder.getSamReader();
+             final SAMFileWriter writer = new SAMFileWriterFactory().makeWriter(reader.getFileHeader(), true, input, null)) {
+            for (final SAMRecord rec : reader) {
+                rec.setAttribute("RX", "ACTG");
+                rec.setAttribute("BC", "TTGA");
+                writer.addAlignment(rec);
+            }
+        }
+
+        final File output = File.createTempFile("tag_dup_key.output.", ".bam");
+        final File metrics = File.createTempFile("tag_dup_key.metrics.", ".txt");
+        output.deleteOnExit();
+        metrics.deleteOnExit();
+        Assert.assertEquals(new MarkDuplicates().instanceMain(new String[]{
+                "INPUT=" + input.getAbsolutePath(),
+                "OUTPUT=" + output.getAbsolutePath(),
+                "METRICS_FILE=" + metrics.getAbsolutePath(),
+                "PROGRAM_RECORD_ID=null",
+                "TAG_DUPLICATE_KEY=true",
+                "BARCODE_TAG=RX",
+                "READ_ONE_BARCODE_TAG=BC"}), 0);
+
+        // Read one carries both the UMI and the read-one barcode -> 'ACTG-TTGA'.
+        final String read1Key = read1FragmentKeyByName(output).get("p");
+        Assert.assertTrue(read1Key.endsWith(":ACTG-TTGA"),
+                "read-one key must join UMI and read-one barcode with a single hyphen: " + read1Key);
+        Assert.assertEquals(fieldsAfterLibrary(read1Key), 4,
+                "the joined barcodes must be a single field, not split across colons: " + read1Key);
+    }
+
+    @Test
+    public void readTwoBarcodeIsRenderedAndDistinguishesDuplicates() throws IOException {
+        // Three pairs at identical coordinates, distinguished only by a read-two barcode (READ_TWO_BARCODE_TAG),
+        // which populates the readTwoBarcode field on second-of-pair records. Two pairs share the barcode (so
+        // they are duplicates), the third differs (singleton); the kf-induced partition must still match DI.
+        final SAMRecordSetBuilder builder = newBuilder();
+        builder.addPair("pA", 0, 1000, 1200, false, false, "36M", "36M", false, true, BASE_QUALITY);
+        builder.addPair("pB", 0, 1000, 1200, false, false, "36M", "36M", false, true, BASE_QUALITY);
+        builder.addPair("pC", 0, 1000, 1200, false, false, "36M", "36M", false, true, BASE_QUALITY);
+
+        final Map<String, String> readTwoBarcodeByName = new HashMap<>();
+        readTwoBarcodeByName.put("pA", "ACAC");
+        readTwoBarcodeByName.put("pB", "ACAC");
+        readTwoBarcodeByName.put("pC", "GTGT");
+
+        final File input = File.createTempFile("tag_dup_key.input.", ".bam");
+        input.deleteOnExit();
+        try (final SamReader reader = builder.getSamReader();
+             final SAMFileWriter writer = new SAMFileWriterFactory().makeWriter(reader.getFileHeader(), true, input, null)) {
+            for (final SAMRecord rec : reader) {
+                // READ_TWO_BARCODE_TAG applies only to the second-of-pair read.
+                if (rec.getReadPairedFlag() && !rec.getFirstOfPairFlag()) {
+                    rec.setAttribute("BC", readTwoBarcodeByName.get(rec.getReadName()));
+                }
+                writer.addAlignment(rec);
+            }
+        }
+
+        final File output = File.createTempFile("tag_dup_key.output.", ".bam");
+        final File metrics = File.createTempFile("tag_dup_key.metrics.", ".txt");
+        output.deleteOnExit();
+        metrics.deleteOnExit();
+        Assert.assertEquals(new MarkDuplicates().instanceMain(new String[]{
+                "INPUT=" + input.getAbsolutePath(),
+                "OUTPUT=" + output.getAbsolutePath(),
+                "METRICS_FILE=" + metrics.getAbsolutePath(),
+                "PROGRAM_RECORD_ID=null",
+                "TAG_DUPLICATE_SET_MEMBERS=true",
+                "TAG_DUPLICATE_KEY=true",
+                "READ_TWO_BARCODE_TAG=BC"}), 0);
+
+        assertKeyPartitionEqualsDuplicateIndexPartition(output);
+
+        // The read-two end carries its barcode in the key, and pC's distinct barcode keeps it out of the pA/pB set.
+        for (final SAMRecord rec : readAll(output)) {
+            if (rec.getReadUnmappedFlag() || rec.isSecondaryOrSupplementary()) {
+                continue;
+            }
+            final boolean isReadTwo = rec.getReadPairedFlag() && !rec.getFirstOfPairFlag();
+            if (isReadTwo && rec.getReadName().equals("pA")) {
+                Assert.assertTrue(rec.getStringAttribute(MarkDuplicates.DUPLICATE_KEY_TAG).endsWith(":ACAC"),
+                        "read-two end must carry its barcode in the key: " + rec.getStringAttribute(MarkDuplicates.DUPLICATE_KEY_TAG));
+            }
+            if (rec.getReadName().equals("pC")) {
+                Assert.assertNull(rec.getIntegerAttribute(MarkDuplicates.DUPLICATE_SET_INDEX_TAG),
+                        "pC has a distinct read-two barcode and must not join the pA/pB duplicate set");
+            }
+        }
+    }
+
+    @Test
+    public void tagDuplicateKeyIsRejectedWithFlowMode() throws IOException {
+        // The fragment key cannot faithfully represent flow mode's position-uncertain matching, so combining
+        // the two options must fail command-line validation (non-zero exit) rather than emit a misleading key.
+        final SAMRecordSetBuilder builder = newBuilder();
+        builder.addPair("a", 0, 1000, 1200, false, false, "36M", "36M", false, true, BASE_QUALITY);
+        final File input = writeToBam(builder);
+
+        final File output = File.createTempFile("tag_dup_key.output.", ".bam");
+        final File metrics = File.createTempFile("tag_dup_key.metrics.", ".txt");
+        output.deleteOnExit();
+        metrics.deleteOnExit();
+
+        final int returnCode = new MarkDuplicates().instanceMain(new String[]{
+                "INPUT=" + input.getAbsolutePath(),
+                "OUTPUT=" + output.getAbsolutePath(),
+                "METRICS_FILE=" + metrics.getAbsolutePath(),
+                "PROGRAM_RECORD_ID=null",
+                "TAG_DUPLICATE_KEY=true",
+                "FLOW_MODE=true"});
+        Assert.assertNotEquals(returnCode, 0, "TAG_DUPLICATE_KEY combined with FLOW_MODE must fail validation");
+    }
+
+    @Test
+    public void noKeyTagWhenArgumentIsOff() throws IOException {
+        final SAMRecordSetBuilder builder = newBuilder();
+        builder.addPair("a", 0, 1000, 1200, false, false, "36M", "36M", false, true, BASE_QUALITY);
+        builder.addPair("b", 0, 1000, 1200, false, false, "36M", "36M", false, true, BASE_QUALITY);
+
+        final File output = runMarkDuplicates(writeToBam(builder), false);
+        for (final SAMRecord rec : readAll(output)) {
+            Assert.assertNull(rec.getStringAttribute(MarkDuplicates.DUPLICATE_KEY_TAG),
+                    "kf must not be written when TAG_DUPLICATE_KEY is false");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a default-off `TAG_DUPLICATE_KEY` option to `MarkDuplicates` that writes the **canonical single-end (fragment) duplicate key** to a new `kf` tag on every primary, mapped record. The value is a printable rendering of exactly the fields MarkDuplicates keys on at the fragment level, so an external tool can recover Picard's exact duplicate sets from the output BAM without re-deriving Picard's clipping/coordinate conventions.

This is **purely diagnostic**: it does not change duplicate marking, metrics, or any existing tag.

## Motivation

Downstream tooling sometimes needs to know *why* Picard grouped reads into a duplicate set — i.e. the key it actually compared on — rather than just the resulting flags or the opaque `DI`/`DS` set indices. Re-deriving that key externally means re-implementing Picard's unclipped-5′ coordinate, strand, library, and barcode conventions exactly. Emitting the key directly removes that fragile duplication of logic.

## The `kf` value

```
lib=<libraryId>;<referenceIndex>:<unclipped5Prime>:<strand>[:<barcodes>]
```

- `<strand>` is `F` (forward) or `R` (reverse).
- `<unclipped5Prime>` is the unclipped read end for reverse-strand reads, the unclipped read start otherwise — matching `buildReadEnds`.
- When barcodes/UMIs are in use (`BARCODE_TAG`, `READ_ONE_BARCODE_TAG`, or `READ_TWO_BARCODE_TAG`), the present barcode **sequences** are appended as a single hyphen-joined positional field, in the order MarkDuplicates keys on them (top-strand-normalized UMI, then read-one, then read-two barcode).

Examples:

| Configuration | `kf` |
|---|---|
| No barcodes (default) | `lib=1;0:1000:F` |
| `BARCODE_TAG` UMI `ACGTACGT` | `lib=1;0:1000:F:ACGTACGT` |
| UMI + read-one barcode | `lib=1;0:1000:F:ACTG-TTGA` |

Two reads of a pair each carry their own fragment key, so the canonical **pair** key is just the combination of the two ends; an orphan (mate unmapped) is a duplicate of a pair iff its key matches a pair end's key.

### Readable strings, not internal hashes

MarkDuplicates compares barcodes internally as 32-bit hashes. The `kf` tag deliberately emits the **verbatim sequences** instead, so the values are human-readable and reproducible by an external tool. The two representations agree on every realistic input; only on an astronomically unlikely hash collision would they differ, and in that case `kf` is the *more precise* of the two (it never produces sets coarser than Picard's, only — in that pathological case — finer).

### Tag name

`kf` is intentionally **lowercase**. The SAM specification reserves uppercase two-letter tags for standard, predefined use and sets aside lowercase tags for locally-defined purposes, which is where this diagnostic key belongs. (It therefore does not follow the uppercase convention of `DT`/`DI`/`DS`.)

## Behavior details

- **Default off.** When `TAG_DUPLICATE_KEY=false` (the default) no `kf` tag is written and behavior is unchanged.
- Written on exactly the records that participate in fragment keying — primary and mapped (`!readUnmappedFlag && !isSecondaryOrSupplementary`), the same guard MarkDuplicates uses when building its own `ReadEnds`.
- **Not supported with `FLOW_MODE`.** Flow mode matches fragments on a flow-adjusted coordinate within an uncertainty window rather than by the exact key rendered here, so combining the two options fails command-line validation with a clear message rather than emitting a misleading key. (Flow-aware key rendering could be added later.)

## Testing

New `MarkDuplicatesTagDuplicateKeyTest` (all test data built programmatically), covering:

- kf-induced duplicate-set partition equals the `DI`-induced partition (the load-bearing correctness property).
- Non-trivial canonicalization: differing per-end orientations, FF/RR, and inter-chromosomal pairs; explicit over-merge guard for FR vs RF at the same starts.
- Orphan (mate-unmapped) key matches a pair end's key and is marked duplicate.
- UMI-aware marking: reads at the same position with different UMIs stay in separate duplicate sets.
- Barcode fields appear only when a barcode tag is set; multiple barcode sequences are hyphen-joined into a single field.
- `READ_TWO_BARCODE_TAG` path renders the read-two barcode and distinguishes duplicates.
- `TAG_DUPLICATE_KEY` + `FLOW_MODE` is rejected.
- No `kf` tag is written when the option is off.

## Notes / limitations

- Diagnostic only — no change to marking, metrics, or existing tags.
- Not supported with `FLOW_MODE` (rejected at validation).
- The emitted key uses the per-run library configuration; a library has a single UMI/barcode configuration, so the hyphen-joined barcode rendering is unambiguous in practice.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [ ] All tests passing on github actions

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

