### PR TITLE
docs: fix MarkDuplicates option name

### DIFF
--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -95,7 +95,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram imp
             "then unmapped mates and secondary/supplementary reads are not excluded from the duplication test and can be" +
             " marked as duplicate reads.</p>  " +
 
-            "<p>If desired, duplicates can be removed using the REMOVE_DUPLICATE and REMOVE_SEQUENCING_DUPLICATES options.</p>" +
+            "<p>If desired, duplicates can be removed using the REMOVE_DUPLICATES and REMOVE_SEQUENCING_DUPLICATES options.</p>" +
             "" +
             "<h4>Usage example:</h4>" +
             "<pre>" +


### PR DESCRIPTION
### Description

This fixes the `MarkDuplicates` documentation string so it refers to the actual `REMOVE_DUPLICATES` option rather than `REMOVE_DUPLICATE`.

Fixes #2042.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [ ] All tests passing on github actions

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

Tests were not added because this is a one-word documentation string correction. I verified locally with `git diff --check` and `rg` that the documented option name now matches `REMOVE_DUPLICATES`.

AI disclosure: I used OpenAI Codex to help prepare this change.