### PR TITLE
Fixed a critical bug in flow-based-read duplication marking

### DIFF
--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -480,8 +480,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram imp
             sizeInBytes = ReadEndsForMarkDuplicates.getSizeOf();
         }
         MAX_RECORDS_IN_RAM = (int) (Runtime.getRuntime().maxMemory() / sizeInBytes) / 2;
-        //final int maxInMemory = (int) ((Runtime.getRuntime().maxMemory() * SORTING_COLLECTION_SIZE_RATIO) / sizeInBytes);
-        final int maxInMemory = 1000;
+        final int maxInMemory = (int) ((Runtime.getRuntime().maxMemory() * SORTING_COLLECTION_SIZE_RATIO) / sizeInBytes);
         log.info("Will retain up to " + maxInMemory + " data points before spilling to disk.");
 
         final ReadEndsForMarkDuplicatesCodec fragCodec, pairCodec, diskCodec;

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -493,6 +493,9 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram imp
             pairCodec = new ReadEndsForMarkDuplicatesCodec();
             diskCodec = new ReadEndsForMarkDuplicatesCodec();
         }
+
+        //In Illumina the two ends of the fragment are saved only if the read is paired
+        // in flow based sequencing we are interested in both ends of the read
         if (flowBasedArguments.FLOW_USE_END_IN_UNPAIRED_READS){
             fragCodec.setForceSerialization();
             pairCodec.setForceSerialization();

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -480,7 +480,8 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram imp
             sizeInBytes = ReadEndsForMarkDuplicates.getSizeOf();
         }
         MAX_RECORDS_IN_RAM = (int) (Runtime.getRuntime().maxMemory() / sizeInBytes) / 2;
-        final int maxInMemory = (int) ((Runtime.getRuntime().maxMemory() * SORTING_COLLECTION_SIZE_RATIO) / sizeInBytes);
+        //final int maxInMemory = (int) ((Runtime.getRuntime().maxMemory() * SORTING_COLLECTION_SIZE_RATIO) / sizeInBytes);
+        final int maxInMemory = 1000;
         log.info("Will retain up to " + maxInMemory + " data points before spilling to disk.");
 
         final ReadEndsForMarkDuplicatesCodec fragCodec, pairCodec, diskCodec;
@@ -493,13 +494,17 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram imp
             pairCodec = new ReadEndsForMarkDuplicatesCodec();
             diskCodec = new ReadEndsForMarkDuplicatesCodec();
         }
+        if (flowBasedArguments.FLOW_USE_END_IN_UNPAIRED_READS){
+            fragCodec.setForceSerialization();
+            pairCodec.setForceSerialization();
+            diskCodec.setForceSerialization();
+        }
 
         this.pairSort = SortingCollection.newInstance(ReadEndsForMarkDuplicates.class,
                 pairCodec,
                 new ReadEndsMDComparator(useBarcodes),
                 maxInMemory,
                 TMP_DIR);
-
         this.fragSort = SortingCollection.newInstance(ReadEndsForMarkDuplicates.class,
                 fragCodec,
                 new ReadEndsMDComparator(useBarcodes),

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -480,7 +480,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram imp
             sizeInBytes = ReadEndsForMarkDuplicates.getSizeOf();
         }
         MAX_RECORDS_IN_RAM = (int) (Runtime.getRuntime().maxMemory() / sizeInBytes) / 2;
-        final int maxInMemory = (int) ((Runtime.getRuntime().maxMemory() * SORTING_COLLECTION_SIZE_RATIO) / sizeInBytes/100);
+        final int maxInMemory = (int) ((Runtime.getRuntime().maxMemory() * SORTING_COLLECTION_SIZE_RATIO) / sizeInBytes);
         log.info("Will retain up to " + maxInMemory + " data points before spilling to disk.");
 
         final ReadEndsForMarkDuplicatesCodec fragCodec, pairCodec, diskCodec;

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicates.java
@@ -480,7 +480,7 @@ public class MarkDuplicates extends AbstractMarkDuplicatesCommandLineProgram imp
             sizeInBytes = ReadEndsForMarkDuplicates.getSizeOf();
         }
         MAX_RECORDS_IN_RAM = (int) (Runtime.getRuntime().maxMemory() / sizeInBytes) / 2;
-        final int maxInMemory = (int) ((Runtime.getRuntime().maxMemory() * SORTING_COLLECTION_SIZE_RATIO) / sizeInBytes);
+        final int maxInMemory = (int) ((Runtime.getRuntime().maxMemory() * SORTING_COLLECTION_SIZE_RATIO) / sizeInBytes/100);
         log.info("Will retain up to " + maxInMemory + " data points before spilling to disk.");
 
         final ReadEndsForMarkDuplicatesCodec fragCodec, pairCodec, diskCodec;

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelper.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelper.java
@@ -177,6 +177,7 @@ public class MarkDuplicatesForFlowHelper implements MarkDuplicatesHelper {
         ends.read1Coordinate = getReadEndCoordinate(rec, !rec.getReadNegativeStrandFlag(), true, md.flowBasedArguments);
         if (md.flowBasedArguments.FLOW_USE_END_IN_UNPAIRED_READS) {
             ends.read2Coordinate = getReadEndCoordinate(rec, rec.getReadNegativeStrandFlag(), false, md.flowBasedArguments);
+            ends.read2CoordinateRequiresSerialize = true;
         }
 
         // adjust score

--- a/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelper.java
+++ b/src/main/java/picard/sam/markduplicates/MarkDuplicatesForFlowHelper.java
@@ -66,7 +66,6 @@ public class MarkDuplicatesForFlowHelper implements MarkDuplicatesHelper {
 
     public MarkDuplicatesForFlowHelper(final MarkDuplicates md) {
         this.md = md;
-
         validateFlowParameteres();
     }
 
@@ -177,7 +176,6 @@ public class MarkDuplicatesForFlowHelper implements MarkDuplicatesHelper {
         ends.read1Coordinate = getReadEndCoordinate(rec, !rec.getReadNegativeStrandFlag(), true, md.flowBasedArguments);
         if (md.flowBasedArguments.FLOW_USE_END_IN_UNPAIRED_READS) {
             ends.read2Coordinate = getReadEndCoordinate(rec, rec.getReadNegativeStrandFlag(), false, md.flowBasedArguments);
-            ends.read2CoordinateRequiresSerialize = true;
         }
 
         // adjust score

--- a/src/main/java/picard/sam/markduplicates/util/ReadEndsForMarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/util/ReadEndsForMarkDuplicates.java
@@ -49,7 +49,6 @@ public class ReadEndsForMarkDuplicates extends ReadEnds implements Cloneable {
     }
 
     public short score = 0;
-    public boolean read2CoordinateRequiresSerialize = false;
     public long read1IndexInFile = -1;
     public long read2IndexInFile = -1;
     public int duplicateSetSize = -1;
@@ -63,7 +62,6 @@ public class ReadEndsForMarkDuplicates extends ReadEnds implements Cloneable {
         this.read1Coordinate = read.read1Coordinate;
         this.read2ReferenceIndex = read.read2ReferenceIndex;
         this.read2Coordinate = read.read2Coordinate;
-        this.read2CoordinateRequiresSerialize = read.read2CoordinateRequiresSerialize;
         this.readGroup = read.getReadGroup();
         this.tile = read.getTile();
         this.x = read.x;

--- a/src/main/java/picard/sam/markduplicates/util/ReadEndsForMarkDuplicates.java
+++ b/src/main/java/picard/sam/markduplicates/util/ReadEndsForMarkDuplicates.java
@@ -49,6 +49,7 @@ public class ReadEndsForMarkDuplicates extends ReadEnds implements Cloneable {
     }
 
     public short score = 0;
+    public boolean read2CoordinateRequiresSerialize = false;
     public long read1IndexInFile = -1;
     public long read2IndexInFile = -1;
     public int duplicateSetSize = -1;
@@ -62,7 +63,7 @@ public class ReadEndsForMarkDuplicates extends ReadEnds implements Cloneable {
         this.read1Coordinate = read.read1Coordinate;
         this.read2ReferenceIndex = read.read2ReferenceIndex;
         this.read2Coordinate = read.read2Coordinate;
-
+        this.read2CoordinateRequiresSerialize = read.read2CoordinateRequiresSerialize;
         this.readGroup = read.getReadGroup();
         this.tile = read.getTile();
         this.x = read.x;

--- a/src/main/java/picard/sam/markduplicates/util/ReadEndsForMarkDuplicatesCodec.java
+++ b/src/main/java/picard/sam/markduplicates/util/ReadEndsForMarkDuplicatesCodec.java
@@ -54,12 +54,13 @@ public class ReadEndsForMarkDuplicatesCodec implements SortingCollection.Codec<R
             this.out.writeShort(read.score);
             this.out.writeShort(read.libraryId);
             this.out.writeByte(read.orientation);
+            this.out.writeByte(read.read2CoordinateRequiresSerialize ? 1 : 0);
             this.out.writeInt(read.read1ReferenceIndex);
             this.out.writeInt(read.read1Coordinate);
             this.out.writeLong(read.read1IndexInFile);
             this.out.writeInt(read.read2ReferenceIndex);
 
-            if (read.orientation > ReadEnds.R) {
+            if ((read.orientation > ReadEnds.R) || (read.read2CoordinateRequiresSerialize)) {
                 this.out.writeInt(read.read2Coordinate);
                 this.out.writeLong(read.read2IndexInFile);
             }
@@ -87,12 +88,13 @@ public class ReadEndsForMarkDuplicatesCodec implements SortingCollection.Codec<R
 
             read.libraryId = this.in.readShort();
             read.orientation = this.in.readByte();
+            read.read2CoordinateRequiresSerialize = this.in.readByte() == 1;
             read.read1ReferenceIndex = this.in.readInt();
             read.read1Coordinate = this.in.readInt();
             read.read1IndexInFile = this.in.readLong();
             read.read2ReferenceIndex = this.in.readInt();
 
-            if (read.orientation > ReadEnds.R) {
+            if ((read.orientation > ReadEnds.R)|| (read.read2CoordinateRequiresSerialize)) {
                 read.read2Coordinate = this.in.readInt();
                 read.read2IndexInFile = this.in.readLong();
             }

--- a/src/main/java/picard/sam/markduplicates/util/ReadEndsForMarkDuplicatesCodec.java
+++ b/src/main/java/picard/sam/markduplicates/util/ReadEndsForMarkDuplicatesCodec.java
@@ -32,9 +32,15 @@ import java.io.*;
 public class ReadEndsForMarkDuplicatesCodec implements SortingCollection.Codec<ReadEndsForMarkDuplicates> {
     protected DataInputStream in;
     protected DataOutputStream out;
+    protected boolean forceSerialization = false;
 
     public SortingCollection.Codec<ReadEndsForMarkDuplicates> clone() {
-        return new ReadEndsForMarkDuplicatesCodec();
+
+        ReadEndsForMarkDuplicatesCodec result = new ReadEndsForMarkDuplicatesCodec();
+        if(this.forceSerialization){
+            result.setForceSerialization();
+        }
+        return result;
     }
 
     public void setOutputStream(final OutputStream os) { this.out = new DataOutputStream(os); }
@@ -48,19 +54,23 @@ public class ReadEndsForMarkDuplicatesCodec implements SortingCollection.Codec<R
     public DataOutputStream getOutputStream() {
         return out;
     }
-
+    public void setForceSerialization(){
+        forceSerialization = true;
+    }
+    public void unsetForceSerialization(){
+        forceSerialization = false;
+    }
     public void encode(final ReadEndsForMarkDuplicates read) {
         try {
             this.out.writeShort(read.score);
             this.out.writeShort(read.libraryId);
             this.out.writeByte(read.orientation);
-            this.out.writeByte(read.read2CoordinateRequiresSerialize ? 1 : 0);
             this.out.writeInt(read.read1ReferenceIndex);
             this.out.writeInt(read.read1Coordinate);
             this.out.writeLong(read.read1IndexInFile);
             this.out.writeInt(read.read2ReferenceIndex);
 
-            if ((read.orientation > ReadEnds.R) || (read.read2CoordinateRequiresSerialize)) {
+            if ((read.orientation > ReadEnds.R) || (forceSerialization)) {
                 this.out.writeInt(read.read2Coordinate);
                 this.out.writeLong(read.read2IndexInFile);
             }
@@ -88,13 +98,12 @@ public class ReadEndsForMarkDuplicatesCodec implements SortingCollection.Codec<R
 
             read.libraryId = this.in.readShort();
             read.orientation = this.in.readByte();
-            read.read2CoordinateRequiresSerialize = this.in.readByte() == 1;
             read.read1ReferenceIndex = this.in.readInt();
             read.read1Coordinate = this.in.readInt();
             read.read1IndexInFile = this.in.readLong();
             read.read2ReferenceIndex = this.in.readInt();
 
-            if ((read.orientation > ReadEnds.R)|| (read.read2CoordinateRequiresSerialize)) {
+            if ((read.orientation > ReadEnds.R)|| (forceSerialization)) {
                 read.read2Coordinate = this.in.readInt();
                 read.read2IndexInFile = this.in.readLong();
             }


### PR DESCRIPTION
### Description

This PR fixes a critical bug we found when MarkDuplicates on flow-based-read spills the reads into the disk. In the previous version, if the reads were spilled to disk, the end of the read was effectively ignored. 

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below. 

I was not able to add a test to this fix, since it required using a large BAM/CRAM to make it not fit into the memory

#### Content
- [ ] Added or modified tests to cover changes and any new functionality
- [ ] Edited the README / documentation (if applicable)
- [x] All tests passing on github actions

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

