### PR TITLE
Update HTSJDK to 5.0.0; fix javadoc to use utf-8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ def ensureBuildPrerequisites(buildPrerequisitesMessage) {
 
 ensureBuildPrerequisites(buildPrerequisitesMessage)
 
-final htsjdkVersion = System.getProperty('htsjdk.version', '4.3.0')
+final htsjdkVersion = System.getProperty('htsjdk.version', '5.0.0')
 final log4jVersion = System.getProperty('log4j.version', '2.20.0')
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -248,8 +248,9 @@ tasks.withType(Test).configureEach {
     }
 
     // set heap size for the test JVM(s)
+    // htsjdk 5.0.0 RANSNx16Encode (CRAM 3.1) requires more heap than previous versions
     minHeapSize = "1G"
-    maxHeapSize = "2G"
+    maxHeapSize = "4G"
     if (System.env.CI == "true") {  //if running under a CI output less into the logs
         int count = 0
 

--- a/build.gradle
+++ b/build.gradle
@@ -134,9 +134,14 @@ tasks.withType(Jar).configureEach {
     }
 }
 
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8' // compile UTF-8 source regardless of platform locale
+}
+
 tasks.withType(Javadoc).configureEach {
     // do this for all javadoc tasks, including gatkDoc
     options.addStringOption('Xdoclint:none')
+    options.encoding = 'UTF-8' // read UTF-8 source regardless of platform locale
 }
 
 javadoc {
@@ -213,6 +218,10 @@ test {
 tasks.withType(Test).configureEach {
     outputs.upToDateWhen { false } // tests will always rerun
     description = "Runs the unit tests"
+
+    // Pin the test JVM charset so tests are locale-independent. DocumentationGenerationIntegrationTest
+    // spawns javadoc in-process, which reads UTF-8 source (e.g. "MAPQ ≥ 20") and errors under an ASCII default charset.
+    defaultCharacterEncoding = 'UTF-8'
 
     jvmArgs += [
             // required for MergeBamAlignmentTest


### PR DESCRIPTION
### Description

Updates Picard's HTSJDK dependency from 4.3.0 to **5.0.0**, and pins the build's
source encoding to UTF-8 so it is locale-independent.

**Changes**
- Bump the default `htsjdk.version` to `5.0.0` (`build.gradle`).
- Set `JavaCompile`, `Javadoc`, and `Test` tasks to use UTF-8 (`build.gradle`).

No source changes were required for the HTSJDK upgrade: Picard already declares
`nashorn-core` directly (so HTSJDK 5.0.0 dropping the transitive Nashorn engine
has no effect), and Picard does not use the SRA reader that was removed upstream.

**Motivation**
HTSJDK 5.0.0 is a major release that adds full CRAM 3.1 write support and
significant BAM/CRAM I/O performance improvements (up to ~50% faster BAM writes,
~35–45% faster CRAM encoding), and slims the dependency tree. This PR brings
those into Picard.

The UTF-8 build change fixes `DocumentationGenerationIntegrationTest`, which
spawns `javadoc` in-process. Picard source contains UTF-8 characters (e.g.
"MAPQ ≥ 20", U+2265, in `AlignmentSummaryMetrics` / `CollectAlignmentSummaryMetrics`
javadoc). On a build machine whose default charset is not UTF-8, `javac`/`javadoc`
emit unmappable-character errors and that test fails. Pinning the tasks to UTF-8
removes the dependency on the machine locale. This is orthogonal to the HTSJDK
bump but was needed to get a clean local test run.

**Downstream / upgrade notes** (HTSJDK 5.0.0 behavior changes)
- Default CRAM write version is now **3.1** (was 3.0); CRAM-3.0-only readers
cannot read the new files unless an explicit version is set.
- HTSJDK's `SAMRecord`/SAM-line string formatting changed (full SAM line, no
trailing newline); Picard's tools were already updated for this in #2043.
- SRA (`.sra`) input support was removed upstream.

**Testing**
Full `test` + `barclayTest` suites pass locally against HTSJDK 5.0.0
(0 failures). Note the plotting tests require R on the build machine.

_Related: HTSJDK 5.0.0 release (https://github.com/samtools/htsjdk/releases/tag/5.0.0)._

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but
please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- N/A: dependency version bump plus a build-config (encoding) change; no new
 functionality to test. Existing suites exercise the HTSJDK code paths and pass.
- [x] Edited the README / documentation (if applicable)
- N/A: no user-facing behavior or build-instruction changes.
- [x] All tests passing on github actions

#### Review
- [x] Final thumbs-up from reviewer
- [x] Rebase, squash and reword as applicable
