### PR TITLE
Migrate Maven Central publishing to the Sonatype Central Portal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ plugins {
     id "com.github.kt3k.coveralls" version '2.6.3'
     id "org.ajoberstar.grgit" version "5.2.0"
     id "org.ajoberstar.git-publish" version "2.1.1"
+    id 'com.gradleup.nmcp' version '1.6.1'
 }
 
 application {
@@ -306,7 +307,8 @@ wrapper {
  * Sign non-snapshot releases with our secret key.  This should never need to be invoked directly.
  */
 signing {
-    required { isRelease && gradle.taskGraph.hasTask("publish") }
+    useGpgCmd() // sign via the gpg command line (gpg2), rather than a secret keyring file
+    required { isRelease }
     sign publishing.publications
 }
 
@@ -366,6 +368,20 @@ publishing {
 publish {
     doFirst {
         System.out.println("Uploading version $version")
+    }
+}
+
+/**
+ * Publish to Maven Central via the Sonatype Central Portal (oss.sonatype.org was retired).
+ * Credentials: generate a user token at https://central.sonatype.com (Account > User Token)
+ * and store as sonatypeUsername/sonatypePassword in ~/.gradle/gradle.properties.
+ * Release: ./gradlew publishAllPublicationsToCentralPortal -Drelease=true
+ */
+nmcp {
+    publishAllPublicationsToCentralPortal {
+        username = project.findProperty("sonatypeUsername")
+        password = project.findProperty("sonatypePassword")
+        publishingType = "AUTOMATIC"
     }
 }
 


### PR DESCRIPTION
### Description

oss.sonatype.org (legacy OSSRH) was retired, so the existing publish target no longer works. 

Add the com.gradleup.nmcp plugin and a nmcp{} block that publishes to the Central Portal (publishAllPublicationsToCentralPortal), and switch signing to useGpgCmd(). 

Mirrors the setup already in htsjdk.


----

### Checklist (never delete this)

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on github actions

#### Review
- [x] Final thumbs-up from reviewer
- [x] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

